### PR TITLE
[hotfix][miniwob] Fix gymnasium.error.NameNotFound

### DIFF
--- a/rllm/environments/browsergym/browsergym.py
+++ b/rllm/environments/browsergym/browsergym.py
@@ -13,6 +13,12 @@ class BrowserGymEnv(BaseEnv):
         self.process.start()
 
     def _worker(self, conn, env_id, task, env_kwargs):
+        # Import browsergym modules in the worker process to register environments
+        try:
+            import browsergym.miniwob
+        except ImportError:
+            pass  
+        
         env = (
             gym.make(
                 env_id,

--- a/rllm/environments/browsergym/browsergym.py
+++ b/rllm/environments/browsergym/browsergym.py
@@ -15,7 +15,7 @@ class BrowserGymEnv(BaseEnv):
     def _worker(self, conn, env_id, task, env_kwargs):
         # Import browsergym modules in the worker process to register environments
         try:
-            import browsergym.miniwob
+            import browsergym.miniwob # noqa: F401
         except ImportError:
             pass  
         

--- a/rllm/environments/browsergym/browsergym.py
+++ b/rllm/environments/browsergym/browsergym.py
@@ -15,10 +15,10 @@ class BrowserGymEnv(BaseEnv):
     def _worker(self, conn, env_id, task, env_kwargs):
         # Import browsergym modules in the worker process to register environments
         try:
-            import browsergym.miniwob # noqa: F401
+            import browsergym.miniwob  # noqa: F401
         except ImportError:
-            pass  
-        
+            pass
+
         env = (
             gym.make(
                 env_id,


### PR DESCRIPTION
Fixed the error that occurred when training the MiniWob agent：`gymnasium.error.NameNotFound: Environment "miniwob.number-checkboxes" doesn't exist in namespace browsergym.`
