### PR TITLE
[FIX] Fix tool calling result parsing problem in tranjectory visualizer & MCP tool name fixing

### DIFF
--- a/rllm/environments/tools/mcp_env.py
+++ b/rllm/environments/tools/mcp_env.py
@@ -140,10 +140,12 @@ class MCPConnectionManager:
 
             self.tool_map = {}
             for tool in tools:
-                mcp_tool = MCPTool(session=self.session, tool_name=tool.name, tool_description=tool.description, tool_schema=tool.inputSchema)  # type: ignore
+                mcp_tool = MCPTool(session=self.session, tool_name=tool.name, tool_description=tool.description, tool_schema=tool.inputSchema)
                 self.tool_map[tool.name] = mcp_tool
-
-            print(f"Initialized {len(self.tool_map)} MCP tools")
+                mapped_name = tool.name.replace("-", "_")
+                if mapped_name != tool.name:
+                    mapped_tool = MCPTool(session=self.session, tool_name=tool.name, tool_description=tool.description, tool_schema=tool.inputSchema)
+                    self.tool_map[mapped_name] = mapped_tool
 
     async def _execute_tools(self, tool_calls: list[dict[str, Any]]) -> dict[str, str]:
         """Execute tool calls."""

--- a/rllm/tools/__init__.py
+++ b/rllm/tools/__init__.py
@@ -2,6 +2,15 @@ from rllm.tools.code_tools import (
     PythonInterpreter,
 )
 from rllm.tools.registry import ToolRegistry
+from rllm.tools.request_manager import (
+    ToolRequestManager, 
+    BaseScheduler, 
+    FIFOScheduler,
+    ToolManagerRegistry,
+    tool_manager_registry,
+    get_tool_manager,
+    submit_tool_request
+)
 from rllm.tools.web_tools import (
     FirecrawlTool,
     GoogleSearchTool,
@@ -14,8 +23,8 @@ DEFAULT_TOOLS = {
     "python": PythonInterpreter,
     "google_search": GoogleSearchTool,
     "firecrawl": FirecrawlTool,
-    "tavily_extract": TavilyExtractTool,
-    "tavily_search": TavilySearchTool,
+    "tavily-extract": TavilyExtractTool,
+    "tavily-search": TavilySearchTool,
 }
 
 # Create the singleton registry instance and register all default tools
@@ -31,4 +40,11 @@ __all__ = [
     "TavilySearchTool",
     "ToolRegistry",
     "tool_registry",
+    "ToolRequestManager",
+    "BaseScheduler",
+    "FIFOScheduler",
+    "ToolManagerRegistry",
+    "tool_manager_registry",
+    "get_tool_manager",
+    "submit_tool_request",
 ]

--- a/rllm/tools/__init__.py
+++ b/rllm/tools/__init__.py
@@ -2,12 +2,6 @@ from rllm.tools.code_tools import (
     PythonInterpreter,
 )
 from rllm.tools.registry import ToolRegistry
-from rllm.tools.request_manager import (
-    ToolRequestManager, 
-    BaseScheduler, 
-    FIFOScheduler,
-    ToolManagerRegistry
-)
 from rllm.tools.web_tools import (
     FirecrawlTool,
     GoogleSearchTool,
@@ -36,9 +30,5 @@ __all__ = [
     "TavilyExtractTool",
     "TavilySearchTool",
     "ToolRegistry",
-    "tool_registry",
-    "ToolRequestManager",
-    "BaseScheduler",
-    "FIFOScheduler",
-    "ToolManagerRegistry"
+    "tool_registry"
 ]

--- a/rllm/tools/__init__.py
+++ b/rllm/tools/__init__.py
@@ -22,13 +22,4 @@ DEFAULT_TOOLS = {
 tool_registry = ToolRegistry()
 tool_registry.register_all(DEFAULT_TOOLS)
 
-__all__ = [
-    "PythonInterpreter",
-    "LocalRetrievalTool",
-    "GoogleSearchTool",
-    "FirecrawlTool",
-    "TavilyExtractTool",
-    "TavilySearchTool",
-    "ToolRegistry",
-    "tool_registry"
-]
+__all__ = ["PythonInterpreter", "LocalRetrievalTool", "GoogleSearchTool", "FirecrawlTool", "TavilyExtractTool", "TavilySearchTool", "ToolRegistry", "tool_registry"]

--- a/rllm/tools/__init__.py
+++ b/rllm/tools/__init__.py
@@ -6,10 +6,7 @@ from rllm.tools.request_manager import (
     ToolRequestManager, 
     BaseScheduler, 
     FIFOScheduler,
-    ToolManagerRegistry,
-    tool_manager_registry,
-    get_tool_manager,
-    submit_tool_request
+    ToolManagerRegistry
 )
 from rllm.tools.web_tools import (
     FirecrawlTool,
@@ -43,8 +40,5 @@ __all__ = [
     "ToolRequestManager",
     "BaseScheduler",
     "FIFOScheduler",
-    "ToolManagerRegistry",
-    "tool_manager_registry",
-    "get_tool_manager",
-    "submit_tool_request",
+    "ToolManagerRegistry"
 ]

--- a/rllm/tools/web_tools/tavily_tool.py
+++ b/rllm/tools/web_tools/tavily_tool.py
@@ -13,7 +13,7 @@ class TavilyExtractTool(Tool):
 
     def __init__(self):
         self._init_client()
-        super().__init__(name="tavily_extract", description="Extract web page content from one or more specified URLs")
+        super().__init__(name="tavily-extract", description="Extract web page content from one or more specified URLs")
 
     @property
     def json(self):
@@ -51,13 +51,12 @@ class TavilyExtractTool(Tool):
             response = self.client.post(url=TAVILY_EXTRACT_ENDPOINT, json=params, headers=headers)
 
             if not response.is_success:
-                return ToolOutput(name=self.name or "tavily_extract", error=f"Error: {response.status_code} - {response.text}")
+                return ToolOutput(name=self.name or "tavily-extract", error=f"Error: {response.status_code} - {response.text}")
 
-            results = response.json()["results"]
-            output = {res["url"]: res["raw_content"] for res in results}
-            return ToolOutput(name=self.name or "tavily_extract", output=output)
+            output = response.json()
+            return ToolOutput(name=self.name or "tavily-extract", output=output)
         except Exception as e:
-            return ToolOutput(name=self.name or "tavily_extract", error=f"{type(e).__name__} - {str(e)}")
+            return ToolOutput(name=self.name or "tavily-extract", error=f"{type(e).__name__} - {str(e)}")
 
     def __del__(self):
         """Clean up resources when the tool is garbage collected."""
@@ -69,7 +68,7 @@ class TavilySearchTool(Tool):
 
     def __init__(self):
         self._init_client()
-        super().__init__(name="tavily_search", description="Search the web for information on a specific query")
+        super().__init__(name="tavily-search", description="Search the web for information on a specific query")
 
     @property
     def json(self):
@@ -134,12 +133,12 @@ class TavilySearchTool(Tool):
             response = self.client.post(url=TAVILY_SEARCH_ENDPOINT, json=params, headers=headers)
 
             if not response.is_success:
-                return ToolOutput(name=self.name or "tavily_search", error=f"Error: {response.status_code} - {response.text}")
+                return ToolOutput(name=self.name or "tavily-search", error=f"Error: {response.status_code} - {response.text}")
 
             result = response.json()
-            return ToolOutput(name=self.name or "tavily_search", output=result)
+            return ToolOutput(name=self.name or "tavily-search", output=result)
         except Exception as e:
-            return ToolOutput(name=self.name or "tavily_search", error=f"{type(e).__name__} - {str(e)}")
+            return ToolOutput(name=self.name or "tavily-search", error=f"{type(e).__name__} - {str(e)}")
 
     def __del__(self):
         """Clean up resources when the tool is garbage collected."""

--- a/rllm/trajectory_visualizer.py
+++ b/rllm/trajectory_visualizer.py
@@ -274,11 +274,17 @@ def main(trajectory_file: str = "./trajectories/sample_trajectories/search_traje
         # Handle outputs - be more flexible with field access
         if task_type == "search":
             # Try multiple ways to get tool outputs for search tasks
-            next_obs = getattr(step, "next_observation", None)
-            if next_obs and isinstance(next_obs, dict):
-                tool_outputs = next_obs.get("tool_outputs", {})
+            current_obs = getattr(step, "observation", None)
+            if current_obs and isinstance(current_obs, dict):
+                tool_outputs = current_obs.get("tool_outputs", {})
                 if tool_outputs:
                     outputs_text = format_tool_outputs(tool_outputs)
+            elif hasattr(step, "next_observation"):
+                next_obs = getattr(step, "next_observation", None)
+                if next_obs and isinstance(next_obs, dict):
+                    tool_outputs = next_obs.get("tool_outputs", {})
+                    if tool_outputs:
+                        outputs_text = format_tool_outputs(tool_outputs)
             # Also check if outputs are in the current step's info
             elif hasattr(step, "info") and isinstance(step.info, dict):
                 tool_outputs = step.info.get("tool_outputs", {})


### PR DESCRIPTION
[UPD] update tavily tool name since tavily server returns mismatch tool names. Also had a tool calling result visualization problem on tranjectory visualizer.


Tavily MCP server running on stdio

Connected to MCP server with tools: ['tavily-search', 'tavily-extract', 'tavily-crawl', 'tavily-map']
Initialized 4 MCP tools
Available tools: ['tavily-search', 'tavily-extract', 'tavily-crawl', 'tavily-map']

Before the change list:
<img width="1277" height="255" alt="image" src="https://github.com/user-attachments/assets/eca4e451-891b-458a-a52f-26d6417a4fbf" />


After the change list:
<img width="1345" height="409" alt="image" src="https://github.com/user-attachments/assets/fd1dd4c9-1bc3-4e3f-9056-673c34c6ace6" />
