### PR TITLE
Standalone inference: remove hard verl dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ dependencies = [
     "PyYAML",
     "pydantic",
 
+    # Inference backends
+    "vllm",
+    "sglang",
+
     # Development and testing
     "pytest",
     "pre-commit",

--- a/rllm/__init__.py
+++ b/rllm/__init__.py
@@ -5,7 +5,7 @@ Main package for the rLLM framework.
 
 # Import commonly used classes
 from .agents import Action, BaseAgent, Episode, Step, Trajectory
-from .engine import AgentWorkflowEngine, OpenAIEngine, RolloutEngine, VerlEngine
+from .engine import AgentWorkflowEngine, OpenAIEngine, RolloutEngine
 
 __all__ = [
     "BaseAgent",
@@ -16,5 +16,12 @@ __all__ = [
     "AgentWorkflowEngine",
     "RolloutEngine",
     "OpenAIEngine",
-    "VerlEngine",
 ]
+
+# VerlEngine is optional; only export if verl is installed
+try:
+    from .engine import VerlEngine
+
+    __all__.append("VerlEngine")
+except Exception:
+    VerlEngine = None

--- a/rllm/engine/__init__.py
+++ b/rllm/engine/__init__.py
@@ -7,13 +7,19 @@ from .agent_execution_engine import AgentExecutionEngine, AsyncAgentExecutionEng
 from .agent_workflow_engine import AgentWorkflowEngine
 from .rollout.openai_engine import OpenAIEngine
 from .rollout.rollout_engine import RolloutEngine
-from .rollout.verl_engine import VerlEngine
 
 __all__ = [
     "AgentExecutionEngine",
     "AsyncAgentExecutionEngine",
     "AgentWorkflowEngine",
     "RolloutEngine",
-    "VerlEngine",
     "OpenAIEngine",
 ]
+
+# VerlEngine is optional; only export if verl is installed
+try:
+    from .rollout.verl_engine import VerlEngine
+
+    __all__.append("VerlEngine")
+except Exception:
+    VerlEngine = None

--- a/rllm/engine/agent_workflow_engine.py
+++ b/rllm/engine/agent_workflow_engine.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -11,8 +12,10 @@ from tqdm import tqdm
 from rllm.agents.agent import Episode
 from rllm.engine.rollout.rollout_engine import RolloutEngine
 from rllm.workflows.workflow import TerminationReason, Workflow
-from verl import DataProto
-from verl.utils.torch_functional import pad_sequence_to_length
+
+# Avoid hard dependency on verl at import time; only for typing
+if TYPE_CHECKING:
+    from verl import DataProto
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +101,7 @@ class AgentWorkflowEngine:
 
         return results
 
-    async def execute_tasks_verl(self, batch: DataProto, workflow_id: str | None = None, **kwargs) -> DataProto:
+    async def execute_tasks_verl(self, batch: "DataProto", workflow_id: str | None = None, **kwargs) -> "DataProto":
         self.rollout_engine.wake_up()
         if batch.meta_info.get("validate", False):
             self.rollout_engine.validate = True
@@ -109,7 +112,11 @@ class AgentWorkflowEngine:
         self.rollout_engine.sleep()
         return self._transform_results_for_verl(results, task_ids)
 
-    def _transform_results_for_verl(self, episodes: list[Episode], task_ids: np.ndarray) -> DataProto:
+    def _transform_results_for_verl(self, episodes: list[Episode], task_ids: np.ndarray) -> "DataProto":
+        # Local import to keep verl optional
+        from verl import DataProto  # type: ignore
+        from verl.utils.torch_functional import pad_sequence_to_length  # type: ignore
+
         prompts = []
         responses = []
         traj_rewards = []

--- a/rllm/engine/agent_workflow_engine.py
+++ b/rllm/engine/agent_workflow_engine.py
@@ -114,8 +114,8 @@ class AgentWorkflowEngine:
 
     def _transform_results_for_verl(self, episodes: list[Episode], task_ids: np.ndarray) -> "DataProto":
         # Local import to keep verl optional
-        from verl import DataProto  # type: ignore
-        from verl.utils.torch_functional import pad_sequence_to_length  # type: ignore
+        from verl import DataProto
+        from verl.utils.torch_functional import pad_sequence_to_length
 
         prompts = []
         responses = []

--- a/rllm/workflows/__init__.py
+++ b/rllm/workflows/__init__.py
@@ -3,8 +3,6 @@
 This module contains the core execution infrastructure for agent trajectory rollout.
 """
 
-from .multi_turn_workflow import MultiTurnWorkflow
-from .single_turn_workflow import SingleTurnWorkflow
 from .workflow import TerminationEvent, TerminationReason, Workflow
 
 __all__ = [
@@ -14,3 +12,15 @@ __all__ = [
     "SingleTurnWorkflow",
     "MultiTurnWorkflow",
 ]
+
+
+def __getattr__(name):
+    if name == "SingleTurnWorkflow":
+        from .single_turn_workflow import SingleTurnWorkflow as _Single
+
+        return _Single
+    if name == "MultiTurnWorkflow":
+        from .multi_turn_workflow import MultiTurnWorkflow as _Multi
+
+        return _Multi
+    raise AttributeError(name)


### PR DESCRIPTION
- Make verl optional using lazy imports and TYPE_CHECKING.
- Add vllm and sglang to pyproject.toml.
- Inference runs without verl, and training is unchanged when verl is installed.