### PR TITLE
proper handling the case that  next_observation is empty dict

### DIFF
--- a/rllm/agents/math_agent.py
+++ b/rllm/agents/math_agent.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
 
+
 class MathAgent(BaseAgent):
     """
     A math agent that solves mathematical problems step by step, following the BaseAgent interface.
@@ -18,7 +19,7 @@ class MathAgent(BaseAgent):
 
     def update_from_env(self, observation: Any, reward: float, done: bool, info: dict, **kwargs):
         """Process environment feedback and update internal state."""
-        
+
         # Reward update for existing step (None OR empty dict)
         if observation is None or (isinstance(observation, dict) and observation == {}):
             if self.trajectory.steps:

--- a/rllm/agents/math_agent.py
+++ b/rllm/agents/math_agent.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
 
-
 class MathAgent(BaseAgent):
     """
     A math agent that solves mathematical problems step by step, following the BaseAgent interface.
@@ -19,9 +18,9 @@ class MathAgent(BaseAgent):
 
     def update_from_env(self, observation: Any, reward: float, done: bool, info: dict, **kwargs):
         """Process environment feedback and update internal state."""
-
-        # If observation is None, this is a reward update for the existing step
-        if observation is None:
+        
+        # Reward update for existing step (None OR empty dict)
+        if observation is None or (isinstance(observation, dict) and observation == {}):
             if self.trajectory.steps:
                 cur_step = self.get_current_state()
                 cur_step.reward = reward
@@ -31,7 +30,9 @@ class MathAgent(BaseAgent):
 
         # This is a new observation, create a new step
         if isinstance(observation, dict):
-            formatted_observation = observation.get("question", " ")
+            if "question" not in observation:
+                raise ValueError(f"Observation dict missing required 'question' field: {observation}")
+            formatted_observation = observation["question"]
         elif isinstance(observation, str):
             formatted_observation = observation
         else:


### PR DESCRIPTION
We need to handle empty dicts of observation as reward updates.

In single-turn environments:
First call: observation = {"question": "What is 15 + 27?"} → Creates new step
Second call: observation = {} → Should update reward of existing step, not create new step
