### PR TITLE
[v0.2] Add lazy import to fix circular import and ray init config support

### DIFF
--- a/rllm/engine/__init__.py
+++ b/rllm/engine/__init__.py
@@ -4,7 +4,6 @@ This module contains the core execution infrastructure for agent trajectory roll
 """
 
 from .agent_execution_engine import AgentExecutionEngine, AsyncAgentExecutionEngine
-from .agent_workflow_engine import AgentWorkflowEngine
 from .rollout.openai_engine import OpenAIEngine
 from .rollout.rollout_engine import RolloutEngine
 
@@ -23,3 +22,11 @@ try:
     __all__.append("VerlEngine")
 except Exception:
     VerlEngine = None
+
+
+def __getattr__(name):
+    if name == "AgentWorkflowEngine":
+        from .agent_workflow_engine import AgentWorkflowEngine as _AgentWorkflowEngine
+
+        return _AgentWorkflowEngine
+    raise AttributeError(name)

--- a/rllm/trainer/agent_trainer.py
+++ b/rllm/trainer/agent_trainer.py
@@ -56,7 +56,12 @@ class AgentTrainer:
 
     def train(self):
         if not ray.is_initialized():
-            ray.init(runtime_env=get_ppo_ray_runtime_env(), num_cpus=self.config.ray_init.num_cpus)
+            # read off all the `ray_init` settings from the config
+            if self.config is not None and hasattr(self.config, "ray_init"):
+                ray_init_settings = {k: v for k, v in self.config.ray_init.items() if v is not None}
+            else:
+                ray_init_settings = {}
+            ray.init(runtime_env=get_ppo_ray_runtime_env(), **ray_init_settings)
 
         runner = TaskRunner.remote()
 


### PR DESCRIPTION
## Description

This PR merges two issues encountered when testing the `examples/math_tools/train_math_with_tool.sh` script.

1. Circular import issue between `engine` and `workflows` modules 
    **Previous cycling pattern:**
    `workflows/__init__.py → workflows/workflow.py → 
    engine/rollout/rollout_engine.py → engine/__init__.py → 
    engine/agent_workflow_engine.py → workflows/workflow.py ← CYCLE!`

3. Improves Ray initialization (`ray.init`) configuration to allow more arguments other than `num_cpus`.

    Now it's easier to specify arguments like (`_temp_dir`, `address`, `logging_level`) under the `ray_init` fields.
  
## Changes Made
- Implemented lazy import for `AgentWorkflowEngine` in `engine/__init__.py` using `__getattr__()` pattern (similar to `workflows/__init__.py`.
- Added None value filtering in `agent_trainer.py` before passing config to `ray.init()`

## Motivation
The circular import prevented the engine module from being imported successfully, causing the training to fail on initialization. The ray configuration improvements allow users to properly configure Ray's temporary directory and other settings through Hydra configuration.

## Testing
- [ ] Pass the pytests (a couple of seemingly unrelated errors in `tests/agents/test_math_agent.py`)
- [x] Tested locally (with `examples/math_tools/train_math_with_tool.sh`) with multi-GPU training setup
- [x] Verified circular import is resolved
- [x] Confirmed Ray initialization works with custom configurations (e.g. `_temp_dir`)