### PR TITLE
v0.2 masking/parsing fix

### DIFF
--- a/rllm/parser/chat_template_parser.py
+++ b/rllm/parser/chat_template_parser.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import requests
 import torch
 
-from .utils import PARSER_TEST_MESSAGES, fix_pad_token
+from .utils import PARSER_TEST_MESSAGES
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +14,6 @@ class ChatTemplateParser:
         self.tokenizer = tokenizer
         self.assistant_token = ""
         self.generation_prompt_ids = self._get_generation_prompt_ids(tokenizer)
-
-        # Fix pad_token if it's the same as eos_token
-        fix_pad_token(self.tokenizer)
 
     def _get_generation_prompt_ids(self, tokenizer):
         """Return the generation prompt tokens (ids, tokens, decoded string)."""
@@ -162,7 +159,7 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
         self.system_token = ""
         self.user_token = "<｜User｜>"
         self.assistant_token = "<｜Assistant｜>"
-        self.generation_prompt = self.eos_token + self.assistant_token + "<think>\n"
+        self.generation_prompt = self.assistant_token + "<think>\n"
 
     def parse(self, messages, add_generation_prompt=False, is_first_msg=False, **kwargs) -> str:
         result = ""

--- a/rllm/parser/utils.py
+++ b/rllm/parser/utils.py
@@ -6,32 +6,3 @@ PARSER_TEST_MESSAGES = [
     {"role": "user", "content": "What about Java?"},
     {"role": "assistant", "content": "Let me search for Java information.", "tool_calls": [{"function": {"name": "search", "arguments": '{"query": "Java programming"}'}}]},
 ]
-
-
-def fix_pad_token(tokenizer):
-    """Fix pad_token if it's the same as eos_token.
-
-    This is important because having pad_token == eos_token can cause issues during training
-    where the model might learn to ignore the eos_token if it sees it used for padding.
-
-    Args:
-        tokenizer: The tokenizer to fix
-
-    Returns:
-        None (modifies tokenizer in place)
-    """
-
-    if tokenizer.pad_token is None or tokenizer.pad_token == tokenizer.eos_token:
-        # Try to use unk_token first, otherwise use bos_token
-        if tokenizer.unk_token is not None and tokenizer.unk_token != tokenizer.eos_token:
-            tokenizer.pad_token = tokenizer.unk_token
-            print(f"Set pad_token to unk_token: {tokenizer.pad_token}")
-        elif tokenizer.bos_token is not None and tokenizer.bos_token != tokenizer.eos_token:
-            tokenizer.pad_token = tokenizer.bos_token
-            print(f"Set pad_token to bos_token: {tokenizer.pad_token}")
-        else:
-            # Add a new special token for padding
-            tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
-            print(f"Added new pad_token: {tokenizer.pad_token}")
-
-    assert tokenizer.pad_token_id != tokenizer.eos_token_id, "pad_token_id and eos_token_id are the same, eos_token will get masked out during training and could impact the model's performance"

--- a/rllm/trainer/verl/train_agent_ppo.py
+++ b/rllm/trainer/verl/train_agent_ppo.py
@@ -93,10 +93,6 @@ class TaskRunner:
         # Used for multimodal LLM, could be None
         # processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
 
-        from rllm.parser.utils import fix_pad_token
-
-        fix_pad_token(tokenizer)
-
         # Define worker classes based on the actor strategy.
         if config.actor_rollout_ref.actor.strategy in {"fsdp", "fsdp2"}:
             assert config.critic.strategy in {"fsdp", "fsdp2"}


### PR DESCRIPTION
This pr:
1. Corrects DeepseekQwenChatTemplateParser.generation_prompt by removing the leading eos token.
2. Rollsback the pad_token fix to #226, and replaces the attention_mask construction in AgentPPOTrainer to use the pre-padding prompt/response lengths instead of the pad_token.

Note: we can keep the pad_token fix, but it has no effect on the masking anymore. Probably should remove to avoid any downstream issues with verl (i.e., our tokenizer uses a different pad_token than verl's does).

Confirmed the attention_mask, response_mask, and reward placement are correct for the simple_math example.