### PR TITLE
make rllm-specific configs applied correctly and robustly

### DIFF
--- a/rllm/engine/agent_execution_engine.py
+++ b/rllm/engine/agent_execution_engine.py
@@ -70,6 +70,7 @@ class AgentExecutionEngine:
         self.max_response_length = max_response_length
         self.max_prompt_length = max_prompt_length
         self.enforce_max_prompt_length = enforce_max_prompt_length
+        self.disable_thinking = self.config.get("rllm", {}).get("disable_thinking", False)
 
         self.agent_class = agent_class
         self.agent_args = agent_args
@@ -87,7 +88,7 @@ class AgentExecutionEngine:
             assert env_class.is_multithread_safe(), "Environment must be multithread safe for async engine"
 
         if chat_parser is None:
-            self.chat_parser = ChatTemplateParser.get_parser(self.tokenizer, disable_thinking=kwargs.get("disable_thinking", False))
+            self.chat_parser = ChatTemplateParser.get_parser(self.tokenizer, disable_thinking=self.disable_thinking)
         else:
             self.chat_parser = chat_parser
 
@@ -104,7 +105,7 @@ class AgentExecutionEngine:
                 tokenizer=self.tokenizer,
                 max_prompt_length=self.max_prompt_length,
                 max_response_length=self.max_response_length,
-                disable_thinking=kwargs.get("disable_thinking", False),
+                disable_thinking=self.disable_thinking,
             )
         elif self.engine_name == "verl":
             from rllm.engine.rollout.verl_engine import VerlEngine
@@ -113,7 +114,7 @@ class AgentExecutionEngine:
                 config=self.config,
                 rollout_manager=rollout_engine,
                 tokenizer=self.tokenizer,
-                disable_thinking=self.config.rllm.disable_thinking,
+                disable_thinking=self.disable_thinking,
             )
 
         # Create a thread pool executor for environment interactions (i.e. step, reset, close)

--- a/rllm/engine/rollout/verl_engine.py
+++ b/rllm/engine/rollout/verl_engine.py
@@ -16,10 +16,11 @@ class VerlEngine(RolloutEngine):
         self.rollout_manager = rollout_manager
         self.server_manager = AsyncLLMServerManager(config, rollout_manager.async_llm_servers)
         self.tokenizer = tokenizer
-        self.chat_parser = ChatTemplateParser.get_parser(tokenizer, disable_thinking=config.rllm.disable_thinking)
+        self.chat_parser = ChatTemplateParser.get_parser(tokenizer, disable_thinking=config.get("rllm", {}).get("disable_thinking", False))
 
         self.max_prompt_length = config.data.max_prompt_length
         self.max_response_length = config.data.max_response_length
+        self.accumulate_reasoning = config.get("rllm", {}).get("accumulate_reasoning", False)
 
         self.train_sampling_params = dict(
             temperature=0.0 if config.actor_rollout_ref.rollout.do_sample is False else config.actor_rollout_ref.rollout.temperature,
@@ -45,7 +46,7 @@ class VerlEngine(RolloutEngine):
 
         # these go to the parser
         tools = kwargs.pop("tools", [])
-        accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.config.rllm.accumulate_reasoning)
+        accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.accumulate_reasoning)
 
         sampling_params = self.val_sampling_params.copy() if self.validate or validate else self.train_sampling_params.copy()
         sampling_params.update(kwargs)

--- a/rllm/trainer/config/agent_ppo_trainer_megatron.yaml
+++ b/rllm/trainer/config/agent_ppo_trainer_megatron.yaml
@@ -44,6 +44,7 @@ rllm:
     n_parallel_tasks: 256
     retry_limit: 3
   disable_thinking: False
+  accumulate_reasoning: False
   mask_truncated_samples: False
   stepwise_advantage:
     enable: False


### PR DESCRIPTION
This PR addresses several (potential) issues related to applying rLLM-specific configurations — `disable_thinking` and `accumulate_reasoning`:

- Fixes #255 by adding the missing key (`accumulate_reasoning`) to `agent_ppo_trainer_megatron.yaml`.
- Improves robustness by allowing `accumulate_reasoning` to be absent in custom config files, defaulting to `False` when missing.
- Corrects `AsyncAgentExecutionEngine` initialization, which previously attempted to read `disable_thinking` from `kwargs`. This field is reserved for `config.rllm.agent.engine_args` (often empty). The fix ensures `disable_thinking` is now properly read from the `rllm` config with appropriate fallback handling.

_Note: Extra care was taken to ensure compatibility with cases where users reuse `verl` configs that may omit the `config.rllm` fields (while other fields are usually present in these cases)_
