### PR TITLE
fix: circular import issues in WORKFLOW_CLASS_MAPPING

### DIFF
--- a/rllm/workflows/cumulative_workflow.py
+++ b/rllm/workflows/cumulative_workflow.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from rllm.agents.agent import Episode
 from rllm.engine.rollout.rollout_engine import ModelOutput
-from rllm.trainer.env_agent_mappings import AGENT_CLASS_MAPPING, ENV_CLASS_MAPPING
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 
 
@@ -16,6 +15,8 @@ class CumulativeWorkflow(Workflow):
         max_steps=5,
         **kwargs,
     ):
+        from rllm.trainer.env_agent_mappings import AGENT_CLASS_MAPPING, ENV_CLASS_MAPPING
+
         super().__init__(**kwargs)
 
         agent_cls = AGENT_CLASS_MAPPING[agent_cls] if isinstance(agent_cls, str) else agent_cls

--- a/rllm/workflows/multi_turn_workflow.py
+++ b/rllm/workflows/multi_turn_workflow.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from rllm.agents.agent import Episode
 from rllm.engine.rollout.rollout_engine import ModelOutput
-from rllm.trainer.env_agent_mappings import AGENT_CLASS_MAPPING, ENV_CLASS_MAPPING
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 
 
@@ -16,6 +15,8 @@ class MultiTurnWorkflow(Workflow):
         max_steps=5,
         **kwargs,
     ):
+        from rllm.trainer.env_agent_mappings import AGENT_CLASS_MAPPING, ENV_CLASS_MAPPING
+
         super().__init__(**kwargs)
 
         agent_cls = AGENT_CLASS_MAPPING[agent_cls] if isinstance(agent_cls, str) else agent_cls

--- a/rllm/workflows/single_turn_workflow.py
+++ b/rllm/workflows/single_turn_workflow.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from rllm.agents.agent import Episode
 from rllm.engine.rollout.rollout_engine import ModelOutput
-from rllm.trainer.env_agent_mappings import AGENT_CLASS_MAPPING, ENV_CLASS_MAPPING
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 
 
@@ -15,6 +14,8 @@ class SingleTurnWorkflow(Workflow):
         env_args=None,
         **kwargs,
     ):
+        from rllm.trainer.env_agent_mappings import AGENT_CLASS_MAPPING, ENV_CLASS_MAPPING
+
         super().__init__(**kwargs)
 
         agent_cls = AGENT_CLASS_MAPPING[agent_cls] if isinstance(agent_cls, str) else agent_cls


### PR DESCRIPTION
This PR addressses the issue mentioned in #259.

The fix is straightforward: for any workflow that imports from `env_agent_mappings.py`, (i.e. `single_turn_workflow`, `multi_turn_workflow`, and `cumulative_workflow`), we delay the lazy import inside the workflow `__init__` function.

Note: even though the original issue only mentions the missing of `single_turn_workflow`, the issue actually causes the **first workflow without lazy importing to throw an error and return `None`** -- so we need to patch for all workflows involved.