### PR TITLE
Fix : Prevent KeyError in _pad_dataproto_to_world_size

### DIFF
--- a/rllm/trainer/verl/agent_ppo_trainer.py
+++ b/rllm/trainer/verl/agent_ppo_trainer.py
@@ -1040,8 +1040,10 @@ class AgentPPOTrainer(RayPPOTrainer):
         # for the padded dataproto, make the traj mask to 0. is_last_step also False
         for i in range(pad_size):
             idx = original_batch_size + i
-            batch.non_tensor_batch["is_last_step"][idx] = False
-            batch.non_tensor_batch["is_pad_step"][idx] = True
+            if "is_last_step" in batch.non_tensor_batch:
+                batch.non_tensor_batch["is_last_step"][idx] = False
+            if "is_pad_step" in batch.non_tensor_batch:
+                batch.non_tensor_batch["is_pad_step"][idx] = True
 
         return batch
 


### PR DESCRIPTION
**Bug:** With `stepwise_advantage.disable`, trajectory-level batches may omit `is_last_step` / `is_pad_step`, causing a `KeyError` during padding

**Fix:** Before padding, check that each non-tensor key exists 