### PR TITLE
Fix broken prompt length filtering

### DIFF
--- a/rllm/data/dataset.py
+++ b/rllm/data/dataset.py
@@ -385,8 +385,13 @@ class DatasetRegistry:
         """
         processed_data = []
         for entry in data:
+            # Extract the actual question for VERL filtering to work correctly
+            # Try common field names: question, prompt, instruction, input
+            question = entry.get("question") or entry.get("prompt") or entry.get("instruction") or entry.get("input") or "placeholder"
+
             processed_entry = {
-                "prompt": [{"role": "user", "content": "placeholder"}],
+                # Use actual question so VERL's length filtering works correctly
+                "prompt": [{"role": "user", "content": question}],
                 "reward_model": {
                     "style": "rule",
                     "ground_truth": None,


### PR DESCRIPTION
## Fix: VERL prompt length filtering for agent training

### Problem
- Dataset registration used placeholder prompts in VERL format
- VERL's `filter_overlong_prompts` filtered placeholders instead of actual task questions
- Long prompts (>max_prompt_length) caused training crashes at runtime

### Solution
- Modified `apply_verl_postprocessing()` to use actual task questions
- Added better error logging for prompt length issues
- Updated comments to explain when length errors can occur

### Breaking Change
**Important**: If resuming from old checkpoints, delete `data.pt` from checkpoint directories:
```bash
find checkpoints/ -name "data.pt" -delete
```
Old checkpoints contain cached datasets with placeholder prompts.