### PR TITLE
Fix fireworks dependency

### DIFF
--- a/rllm/trainer/agent_trainer.py
+++ b/rllm/trainer/agent_trainer.py
@@ -5,7 +5,6 @@ import ray
 from rllm.data import Dataset
 from rllm.trainer.verl.ray_runtime_env import get_ppo_ray_runtime_env
 from rllm.trainer.verl.train_agent_ppo import TaskRunner
-from rllm.trainer.verl.train_workflow_pipeline import PipelineTaskRunner
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env as get_fireworks_ray_runtime_env
 
 
@@ -133,6 +132,9 @@ class AgentTrainer:
         """
         if not ray.is_initialized():
             ray.init(runtime_env=get_fireworks_ray_runtime_env(), num_cpus=self.config.ray_init.num_cpus)
+
+        # Lazy import to avoid requiring fireworks package for users who don't use it
+        from rllm.trainer.verl.train_workflow_pipeline import PipelineTaskRunner
 
         runner = PipelineTaskRunner.remote()
 

--- a/rllm/trainer/verl/agent_workflow_trainer_fireworks.py
+++ b/rllm/trainer/verl/agent_workflow_trainer_fireworks.py
@@ -10,7 +10,12 @@ import torch
 from omegaconf import OmegaConf
 
 from rllm.engine.agent_workflow_engine import AgentWorkflowEngine
-from rllm.engine.rollout.fireworks_engine import FireworksEngine
+
+try:
+    from rllm.engine.rollout.fireworks_engine import FireworksEngine
+except ImportError as e:
+    raise ImportError("The 'fireworks' package is required to use the Fireworks backend. Please install it with: pip install fireworks-ai") from e
+
 from rllm.trainer.verl.agent_workflow_trainer import AgentWorkflowPPOTrainer
 from rllm.workflows.workflow import TerminationReason
 from verl import DataProto


### PR DESCRIPTION
This PR simply fixes the import logic so the users who are not using the `fireworks` backend (i.e. who has not installed the `fireworks` package) will not receive the `ImportError` currently affecting any import of the (backend-neutral) `agent_trainer.py`. 

An additional import check & warning is also put onto the `agent_workflow_trainer_fireworks.py`.