### PR TITLE
[Draft] Fix free cache engine weight sync

### DIFF
--- a/rllm/trainer/verl/agent_ppo_trainer.py
+++ b/rllm/trainer/verl/agent_ppo_trainer.py
@@ -82,6 +82,10 @@ class AgentPPOTrainer(RayPPOTrainer):
             **self.config.rllm.agent.get("engine_args", {}),
         )
 
+        # If `free_cache_engine` is False, we need to manually `sleep` at the start
+        if self.config.actor_rollout_ref.rollout.get("free_cache_engine", False):
+            self.async_rollout_manager.sleep()
+
     def init_envs_and_agents(self, batch):
         """
         Initialize environment depending on env_class with the necessary extra_info, also set uid of the batch.


### PR DESCRIPTION
This is a tentative fix to the issue #291: where the weight sync between rollout engine and trainer engine **is completely missing** (an obvious issue that `verl` also hasn't fixed yet) when config `actor_rollout_ref.rollout.free_cache_engine=False`.

Fortunately this seems fixable without patching `verl` as in `rLLM` we implement our own rollout trajectory generation logic. In fact, the `rollout_engine.wake_up()/sleep()` method should be run **regardless of the `free_cache_engine`** flag -- the flag will be checked again anyway during the `wake_up/sleep` call anyway. For instance, the release of `kv-cache` in the inference engine will do an extra check [here](https://github.com/volcengine/verl/blob/60d8a62c0d810be1c3e9134c14ac188c20342a42/verl/workers/fsdp_workers.py#L698).

This PR should **not affect the usual case when `free_cache_engine = True` at all**. Some experiments are on-going to see if there is any side-effect when `free_cache_engine = False` (so this PR is still under draft)