### PR TITLE
Fix color print display issue

### DIFF
--- a/rllm/engine/agent_execution_engine.py
+++ b/rllm/engine/agent_execution_engine.py
@@ -17,8 +17,8 @@ from rllm.environments.env_utils import (
     compute_mc_return,
     compute_trajectory_reward,
 )
-from rllm.misc import colorful_print
 from rllm.parser import ChatTemplateParser
+from rllm.utils import colorful_print
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/engine/agent_workflow_engine.py
+++ b/rllm/engine/agent_workflow_engine.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 
 from rllm.agents.agent import Episode
 from rllm.engine.rollout import ModelOutput, RolloutEngine
-from rllm.misc import colorful_print
+from rllm.utils import colorful_print
 from rllm.workflows.workflow import TerminationReason, Workflow
 
 # Avoid hard dependency on verl at import time; only for typing

--- a/rllm/misc.py
+++ b/rllm/misc.py
@@ -3,20 +3,9 @@ Miscellaneous Utility Functions
 """
 
 import random
-import warnings
 
-import click
 import numpy as np
 from PIL import Image
-
-
-def colorful_print(string: str, *args, **kwargs) -> None:
-    end = kwargs.pop("end", "\n")
-    print(click.style(string, *args, **kwargs), end=end, flush=True)
-
-
-def colorful_warning(string: str, *args, **kwargs) -> None:
-    warnings.warn(click.style(string, *args, **kwargs), stacklevel=2)
 
 
 def get_image(image_path):

--- a/rllm/trainer/verl/agent_ppo_trainer.py
+++ b/rllm/trainer/verl/agent_ppo_trainer.py
@@ -710,107 +710,24 @@ class AgentPPOTrainer(RayPPOTrainer):
 
     def visualize_trajectory(self, tensor_batch, sample_idx=0, max_samples=1, mask_key="response_mask"):
         """
-        Visualize the trajectory from tensor_batch by detokenizing prompts and responses,
-        and highlighting the masked parts with color.
-
-        Args:
-            tensor_batch: The tensor batch containing trajectory data
-            sample_idx: Starting index of samples to visualize
-            max_samples: Maximum number of samples to visualize
+        Visualize the trajectory from tensor_batch using the shared visualization utility.
         """
-        from rllm.misc import colorful_print
+        from rllm.utils.visualization import visualize_trajectories
 
-        # Get the relevant tensors
-        prompts = tensor_batch.batch["prompts"]
-        responses = tensor_batch.batch["responses"]
-        traj_mask = tensor_batch.batch[mask_key]
-        token_level_scores = tensor_batch.batch["token_level_scores"]
+        if len(tensor_batch) == 0:
+            return
 
-        # Full attention mask (covers prompt + response); split it into prompt and response parts
-        full_attn_mask = tensor_batch.batch["attention_mask"]
-        prompt_len = prompts.shape[1]
-        resp_len = responses.shape[1]
-        prompt_attn_mask = full_attn_mask[:, :prompt_len]
-        response_attn_mask = full_attn_mask[:, -resp_len:]
+        end_idx = min(sample_idx + max_samples, len(tensor_batch))
+        indices = list(range(sample_idx, end_idx))
 
-        batch_size = prompts.shape[0]
-        end_idx = min(sample_idx + max_samples, batch_size)
-
-        for i in range(sample_idx, end_idx):
-            colorful_print("\n" + "=" * 60, fg="cyan", bold=True)
-            colorful_print(f"Sample {i}", fg="cyan", bold=True)
-
-            # Legend before the example
-            legend = " ".join(
-                [
-                    "\x1b[40mwhite=masked\x1b[0m",
-                    "\x1b[34mblue=unmasked\x1b[0m",
-                    "\x1b[42m green bg=reward>0 \x1b[0m",
-                    "\x1b[41m red bg=reward<=0 \x1b[0m",
-                ]
-            )
-            print(f"[{legend}]")
-
-            # Detokenize prompt
-            prompt_tokens = prompts[i]
-            prompt_valid_mask = prompt_attn_mask[i].bool()
-            # Build one-line colored prompt (prompt is always masked-from-loss => white)
-            prompt_parts = []
-            for tok_id, is_valid in zip(prompt_tokens.tolist(), prompt_valid_mask.tolist(), strict=False):
-                if not is_valid:
-                    continue
-                tok = self.tokenizer.decode([tok_id]).replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-                prompt_parts.append(f"\x1b[40m{tok}\x1b[0m")  # white
-            print("".join(prompt_parts))
-
-            # Separator line between prompt and response for readability
-            print("----------------")
-
-            # Detokenize response with token-level highlighting
-            resp_tokens = responses[i]
-            resp_valid_mask = response_attn_mask[i].bool()
-            loss_mask = traj_mask[i]
-            rewards = token_level_scores[i]
-
-            # Pre-compute reward positions (typically only the last valid resp token has nonzero reward)
-            reward_idx = None
-            reward_value = 0.0
-            if rewards is not None:
-                # consider only valid response positions
-                for j, is_valid in enumerate(resp_valid_mask.tolist()):
-                    if not is_valid:
-                        continue
-                    val = float(rewards[j].item()) if hasattr(rewards[j], "item") else float(rewards[j])
-                    if abs(val) > 1e-9:
-                        reward_idx = j
-                        reward_value = val
-
-            # Fallback: if no nonzero reward found, use the last valid response token
-            if reward_idx is None:
-                valid_indices = [idx for idx, v in enumerate(resp_valid_mask.tolist()) if v]
-                if valid_indices:
-                    reward_idx = valid_indices[-1]
-                    if rewards is not None:
-                        val = float(rewards[reward_idx].item()) if hasattr(rewards[reward_idx], "item") else float(rewards[reward_idx])
-                        reward_value = val
-
-            # Colors: white for masked-from-loss; blue for contributes-to-loss; overlay background red/green if reward token
-            response_parts = []
-            for j, tok_id in enumerate(resp_tokens.tolist()):
-                if not bool(resp_valid_mask[j].item() if hasattr(resp_valid_mask[j], "item") else resp_valid_mask[j]):
-                    continue
-                tok = self.tokenizer.decode([tok_id]).replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-
-                contributes = bool(loss_mask[j].item()) if hasattr(loss_mask[j], "item") else bool(loss_mask[j])
-                fg = "\x1b[34m" if contributes else "\x1b[40m"  # blue if in loss, else white
-
-                bg = ""
-                if reward_idx is not None and j == reward_idx:
-                    bg = "\x1b[42m" if reward_value > 0 else "\x1b[41m"  # green background for positive, red for negative/zero
-
-                response_parts.append(f"{bg}{fg}{tok}\x1b[0m")
-
-            print("".join(response_parts))
+        visualize_trajectories(
+            batch=tensor_batch,
+            tokenizer=self.tokenizer,
+            sample_indices=indices,
+            mask_key=mask_key,
+            reward_key="token_level_scores",
+            show_workflow_metadata=False,
+        )
 
     def generate_agent_trajectories_async(self, timing_raw=None, meta_info=None, mode="Token"):
         """

--- a/rllm/trainer/verl/agent_workflow_trainer.py
+++ b/rllm/trainer/verl/agent_workflow_trainer.py
@@ -662,13 +662,9 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
 
     def visualize_trajectory_last_step(self, tensor_batch, sample_idx=0, max_samples=1):
         """
-        Visualize last steps from a workflow rollout:
-        - detokenize prompts/responses
-        - show token usage mask
-        - show reward tokens (placed at the last response token)
-        - print Correct/Incorrect using `is_correct` from non_tensors
+        Visualize last steps from a workflow rollout using the shared visualization utility.
         """
-        from rllm.misc import colorful_print
+        from rllm.utils.visualization import visualize_trajectories
 
         # Select only last steps if stepwise-advantage is enabled
         if "is_last_step" in tensor_batch.non_tensor_batch:
@@ -676,112 +672,17 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
             if is_last is not None and len(is_last) == len(tensor_batch):
                 tensor_batch = tensor_batch[is_last]
 
-        prompts = tensor_batch.batch["prompts"]
-        responses = tensor_batch.batch["responses"]
-        # Full attention mask (covers prompt + response); split it into prompt and response parts
-        full_attn_mask = tensor_batch.batch["attention_mask"]
-        prompt_len = prompts.shape[1]
-        resp_len = responses.shape[1]
-        prompt_attn_mask = full_attn_mask[:, :prompt_len]
-        response_attn_mask = full_attn_mask[:, -resp_len:]
+        if len(tensor_batch) == 0:
+            return
 
-        # Loss mask over the response tokens only
-        response_loss_mask = tensor_batch.batch.get("response_mask")
+        end_idx = min(sample_idx + max_samples, len(tensor_batch))
+        indices = list(range(sample_idx, end_idx))
 
-        # Rewards aligned to response tokens
-        token_level_scores = tensor_batch.batch.get("step_rewards" if self.config.rllm.stepwise_advantage.enable and self.config.rllm.stepwise_advantage.mode == "per_step" else "traj_rewards")
-
-        # Optional meta to print outcome
-        is_correct = tensor_batch.non_tensor_batch.get("is_correct", None)
-        term_reasons = tensor_batch.non_tensor_batch.get("termination_reasons", None)
-        episode_ids = tensor_batch.non_tensor_batch.get("episode_ids", None)
-        trajectory_ids = tensor_batch.non_tensor_batch.get("trajectory_ids", None)
-
-        bsz = prompts.shape[0]
-        end_idx = min(sample_idx + max_samples, bsz)
-
-        for i in range(sample_idx, end_idx):
-            colorful_print("\n" + "=" * 60, fg="cyan", bold=True)
-            # Header with ids
-            if episode_ids is not None or trajectory_ids is not None:
-                colorful_print(f"Episode: {episode_ids[i] if episode_ids is not None else '?'}  | Traj: {trajectory_ids[i] if trajectory_ids is not None else '?'}", fg="cyan", bold=True)
-
-            # Outcome line
-            if is_correct is not None:
-                ok = bool(is_correct[i])
-                colorful_print(f"Outcome: {'✓ Correct' if ok else '✗ Incorrect'}", fg=("green" if ok else "red"), bold=True)
-
-            if term_reasons is not None:
-                colorful_print(f"Termination: {term_reasons[i]}", fg="yellow")
-
-            # Legend before the example
-            legend = " ".join(
-                [
-                    "\x1b[40mwhite=masked\x1b[0m",
-                    "\x1b[34mblue=unmasked\x1b[0m",
-                    "\x1b[42m green bg=reward>0 \x1b[0m",
-                    "\x1b[41m red bg=reward<=0 \x1b[0m",
-                ]
-            )
-            print(f"[{legend}]")
-
-            # Detokenize prompt
-            prompt_tokens = prompts[i]
-            prompt_valid_mask = prompt_attn_mask[i].bool()
-            # Build one-line colored prompt (prompt is always masked-from-loss => white)
-            prompt_parts = []
-            for tok_id, is_valid in zip(prompt_tokens.tolist(), prompt_valid_mask.tolist(), strict=False):
-                if not is_valid:
-                    continue
-                tok = self.tokenizer.decode([tok_id]).replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-                prompt_parts.append(f"\x1b[40m{tok}\x1b[0m")  # white
-            print("".join(prompt_parts))
-
-            # Separator line between prompt and response for readability
-            print("----------------")
-
-            # Detokenize response with token-level highlighting
-            resp_tokens = responses[i]
-            resp_valid_mask = response_attn_mask[i].bool()
-            loss_mask = response_loss_mask[i] if response_loss_mask is not None else resp_valid_mask
-            rewards = token_level_scores[i] if token_level_scores is not None else None
-
-            # Pre-compute reward positions (typically only the last valid resp token has nonzero reward)
-            reward_idx = None
-            reward_value = 0.0
-            if rewards is not None:
-                # consider only valid response positions
-                for j, is_valid in enumerate(resp_valid_mask.tolist()):
-                    if not is_valid:
-                        continue
-                    val = float(rewards[j].item()) if hasattr(rewards[j], "item") else float(rewards[j])
-                    if abs(val) > 1e-9:
-                        reward_idx = j
-                        reward_value = val
-
-            # Fallback: if no nonzero reward found, use the last valid response token
-            if reward_idx is None:
-                valid_indices = [idx for idx, v in enumerate(resp_valid_mask.tolist()) if v]
-                if valid_indices:
-                    reward_idx = valid_indices[-1]
-                    if rewards is not None:
-                        val = float(rewards[reward_idx].item()) if hasattr(rewards[reward_idx], "item") else float(rewards[reward_idx])
-                        reward_value = val
-
-            # Colors: white for masked-from-loss; blue for contributes-to-loss; overlay background red/green if reward token
-            response_parts = []
-            for j, tok_id in enumerate(resp_tokens.tolist()):
-                if not bool(resp_valid_mask[j].item() if hasattr(resp_valid_mask[j], "item") else resp_valid_mask[j]):
-                    continue
-                tok = self.tokenizer.decode([tok_id]).replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-
-                contributes = bool(loss_mask[j].item()) if hasattr(loss_mask[j], "item") else bool(loss_mask[j])
-                fg = "\x1b[34m" if contributes else "\x1b[40m"  # blue if in loss, else white
-
-                bg = ""
-                if reward_idx is not None and j == reward_idx:
-                    bg = "\x1b[42m" if reward_value > 0 else "\x1b[41m"  # green background for positive, red for negative/zero
-
-                response_parts.append(f"{bg}{fg}{tok}\x1b[0m")
-
-            print("".join(response_parts))
+        visualize_trajectories(
+            batch=tensor_batch,
+            tokenizer=self.tokenizer,
+            sample_indices=indices,
+            mask_key="response_mask",
+            reward_key="step_rewards" if self.config.rllm.stepwise_advantage.enable and self.config.rllm.stepwise_advantage.mode == "per_step" else "traj_rewards",
+            show_workflow_metadata=True,
+        )

--- a/rllm/utils/__init__.py
+++ b/rllm/utils/__init__.py
@@ -2,5 +2,6 @@
 
 from rllm.utils.compute_pass_at_k import compute_pass_at_k
 from rllm.utils.episode_logger import EpisodeLogger
+from rllm.utils.visualization import VisualizationConfig, colorful_print, colorful_warning, visualize_trajectories
 
-__all__ = ["EpisodeLogger", "compute_pass_at_k"]
+__all__ = ["EpisodeLogger", "compute_pass_at_k", "visualize_trajectories", "VisualizationConfig", "colorful_print", "colorful_warning"]

--- a/rllm/utils/visualization.py
+++ b/rllm/utils/visualization.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:
+    from verl import DataProto
+
+
+@dataclass
+class VisualizationConfig:
+    """Configuration for trajectory visualization colors and styles."""
+
+    # Colors for different elements
+    masked_token_style: dict[str, Any] = field(default_factory=lambda: {"dim": True})
+    unmasked_token_style: dict[str, Any] = field(default_factory=lambda: {"fg": "blue"})
+    reward_pos_style: dict[str, Any] = field(default_factory=lambda: {"bg": "green"})
+    reward_neg_style: dict[str, Any] = field(default_factory=lambda: {"bg": "red"})
+
+    header_style: dict[str, Any] = field(default_factory=lambda: {"fg": "cyan", "bold": True})
+    label_style: dict[str, Any] = field(default_factory=lambda: {"fg": "yellow"})
+
+    success_style: dict[str, Any] = field(default_factory=lambda: {"fg": "green", "bold": True})
+    failure_style: dict[str, Any] = field(default_factory=lambda: {"fg": "red", "bold": True})
+
+
+def _format_token(token: str, style: dict[str, Any]) -> str:
+    """Formats a token string with the given click style."""
+    # Escape special characters for display
+    display_token = token.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    return click.style(display_token, **style)
+
+
+def _visualize_metadata(batch: DataProto, sample_idx: int, config: VisualizationConfig):
+    """
+    Visualizes workflow metadata for a given sample index.
+    """
+    header_parts = []
+    if "episode_ids" in batch.non_tensor_batch:
+        eid = batch.non_tensor_batch["episode_ids"][sample_idx]
+        header_parts.append(f"Episode: {eid}")
+    if "trajectory_ids" in batch.non_tensor_batch:
+        tid = batch.non_tensor_batch["trajectory_ids"][sample_idx]
+        header_parts.append(f"Trajectory: {tid}")
+
+    colorful_print(" | ".join(header_parts), **config.header_style)
+
+    if "is_correct" in batch.non_tensor_batch:
+        is_correct = batch.non_tensor_batch["is_correct"][sample_idx]
+        style = config.success_style if is_correct else config.failure_style
+        colorful_print(f"Outcome: {'✓ Correct' if is_correct else '✗ Incorrect'}", **style)
+    if "termination_reasons" in batch.non_tensor_batch:
+        termination_reason = batch.non_tensor_batch["termination_reasons"][sample_idx]
+        colorful_print(f"Termination: {termination_reason}", **config.label_style)
+
+
+def colorful_print(string: str, *args, **kwargs) -> None:
+    end = kwargs.pop("end", "\n")
+    print(click.style(string, *args, **kwargs), end=end, flush=True)
+
+
+def colorful_warning(string: str, *args, **kwargs) -> None:
+    warnings.warn(click.style(string, *args, **kwargs), stacklevel=2)
+
+
+def visualize_trajectories(
+    batch: DataProto,
+    tokenizer,
+    sample_indices: list[int],
+    mask_key: str = "response_mask",
+    reward_key: str = "token_level_scores",
+    show_workflow_metadata: bool = True,
+    config: VisualizationConfig | None = None,
+):
+    """
+    Visualizes trajectories from a DataProto batch.
+
+    Args:
+        batch: The DataProto batch containing trajectory data.
+        tokenizer: Tokenizer for decoding.
+        sample_indices: Specific indices to visualize. Overrides num_samples.
+        mask_key: Key for the response mask (loss mask) in the batch.
+        reward_key: Key for token-level scores/rewards.
+        show_workflow_metadata: Whether to show workflow metadata (episode_ids, trajectory_ids, etc.).
+        config: VisualizationConfig for colors.
+    """
+    if config is None:
+        config = VisualizationConfig()
+
+    # Extract Tensors
+    prompts = batch.batch["prompts"]
+    responses = batch.batch["responses"]
+    full_attn_mask = batch.batch["attention_mask"]
+
+    # Optional Tensors
+    masks = batch.batch.get(mask_key)
+    rewards_tensor = batch.batch.get(reward_key)
+
+    # Dimensions
+    prompt_len = prompts.shape[1]
+    resp_len = responses.shape[1]
+
+    prompt_attn_mask = full_attn_mask[:, :prompt_len]
+    response_attn_mask = full_attn_mask[:, -resp_len:]
+
+    batch_size = prompts.shape[0]
+    for idx in sample_indices:
+        if idx >= batch_size:
+            continue
+
+        colorful_print("\n" + "=" * 60 + f"\nSample {idx}", **config.header_style)
+
+        # 1. [Optional] Print Workflow Metadata
+        if show_workflow_metadata:
+            _visualize_metadata(batch, idx, config)
+
+        # 2. Print Legend (simplified)
+        legend = " ".join([_format_token("masked", config.masked_token_style), _format_token("unmasked", config.unmasked_token_style), _format_token("reward > 0", config.reward_pos_style), _format_token("reward <= 0", config.reward_neg_style)])
+        print(f"[{legend}]")
+
+        # 3. Render Prompt
+        prompt_tokens = prompts[idx]
+        prompt_valid = prompt_attn_mask[idx].bool()
+
+        prompt_str_parts = []
+        for t_id, is_valid in zip(prompt_tokens.tolist(), prompt_valid.tolist(), strict=False):
+            if not is_valid:
+                continue
+            token_str = tokenizer.decode([t_id])
+            prompt_str_parts.append(_format_token(token_str, config.masked_token_style))
+
+        print("".join(prompt_str_parts))
+        print("----------------")
+
+        # 4. Render Response
+        resp_tokens = responses[idx]
+        resp_valid = response_attn_mask[idx].bool()
+        loss_mask = masks[idx] if masks is not None else resp_valid
+        token_rewards = rewards_tensor[idx] if rewards_tensor is not None else None
+
+        # Determine reward highlight position
+        reward_idx = None
+        reward_val = 0.0
+
+        if token_rewards is not None:
+            # Find last valid token with non-zero reward or just last valid token
+            valid_indices = [i for i, v in enumerate(resp_valid.tolist()) if v]
+
+            if valid_indices:
+                # Try to find non-zero reward
+                for i in valid_indices:
+                    val = float(token_rewards[i].item()) if hasattr(token_rewards[i], "item") else float(token_rewards[i])
+                    if abs(val) > 1e-9:
+                        reward_idx = i
+                        reward_val = val
+
+                # Fallback to last valid token if no reward found
+                if reward_idx is None:
+                    reward_idx = valid_indices[-1]
+                    val = float(token_rewards[reward_idx].item()) if hasattr(token_rewards[reward_idx], "item") else float(token_rewards[reward_idx])
+                    reward_val = val
+
+        response_str_parts = []
+        for i, t_id in enumerate(resp_tokens.tolist()):
+            if not bool(resp_valid[i].item() if hasattr(resp_valid[i], "item") else resp_valid[i]):
+                continue
+
+            token_str = tokenizer.decode([t_id])
+
+            # Determine Style
+            is_in_loss = bool(loss_mask[i].item()) if hasattr(loss_mask[i], "item") else bool(loss_mask[i])
+
+            style = config.unmasked_token_style if is_in_loss else config.masked_token_style
+
+            # Update background color for reward token
+            if reward_idx is not None and i == reward_idx:
+                style.update(config.reward_pos_style if reward_val > 0 else config.reward_neg_style)
+
+            response_str_parts.append(_format_token(token_str, style))
+
+        print("".join(response_str_parts))


### PR DESCRIPTION
## What does this PR do?

This PR is first motivated by the **issue with the white background masked token display** (see below for an example in `wandb`) for loggers such as `wandb` & `trackio`.

<img width="1106" height="277" alt="image" src="https://github.com/user-attachments/assets/b1f0a5a2-61d7-43b5-812e-00c5f6bd4248" />

_Note:_ the issue remains even after turning on "dark mode" on these loggers.

Instead of simply modify the color/style for the masked tokens, this PR further enhances code organization & readability through:

1.  Extracting common logics of visualizing & logging trajectories into the new `rllm/utils/visualization.py` file, whose `visualize_trajectories` function now greatly simplify the trainer codes.
2. The visualization-related functions in `misc.py` are also merged into the above utility file. (In fact, after this change it seems that there's no function in `misc.py` that's being used at all -- maybe can be safely deleted?)
3. The visualization of trajectory can be easily modified through the `VisualizationConfig` and the color rendering is handled uniformly by `click.style` -- no more hand-written ASCII color codes needed.

Following the change, the trajectories can be visualized as expected for **both workflow and ppo agents**:

### Workflow trajectory visualization:
<img width="1221" height="301" alt="image" src="https://github.com/user-attachments/assets/49b682ef-9d88-47cb-a6fd-56d7aef1c6bc" />

### Agent-env trajectory visualization:
<img width="1043" height="228" alt="image" src="https://github.com/user-attachments/assets/84c922f2-2de3-423e-bbd4-be249c903fd7" />
