### PR TITLE
Remove unnecessary free_cache_engine checks.

### DIFF
--- a/rllm/engine/agent_execution_engine.py
+++ b/rllm/engine/agent_execution_engine.py
@@ -506,12 +506,10 @@ class AgentExecutionEngine:
         assert all(env is not None and isinstance(env, BaseEnv) for env in self.envs), "All environments must be inheriting from BaseEnv"
         assert all(env.is_multithread_safe() for env in self.envs), "All environments must be multithread safe for async engine"  # type: ignore
         max_concurrency = self.n_parallel_agents
-        if self.engine_name == "verl":
-            free_cache_engine = self.config.actor_rollout_ref.rollout.free_cache_engine if self.config else False
 
         self.executor = ThreadPoolExecutor(max_workers=max_concurrency)
 
-        if self.engine_name == "verl" and free_cache_engine:
+        if self.engine_name == "verl":
             await self.rollout_engine.wake_up()  # type: ignore
 
         semaphore = asyncio.Semaphore(self.n_parallel_agents)
@@ -548,7 +546,7 @@ class AgentExecutionEngine:
             except Exception as e:
                 raise e
 
-        if self.engine_name == "verl" and free_cache_engine:
+        if self.engine_name == "verl":
             await self.rollout_engine.sleep()  # type: ignore
 
         self.executor.shutdown(wait=False, cancel_futures=True)

--- a/rllm/engine/agent_sdk_engine.py
+++ b/rllm/engine/agent_sdk_engine.py
@@ -398,13 +398,11 @@ class AgentSdkEngine:
         Returns:
             DataProto with training-ready tensors (prompts, responses, rewards, masks).
         """
-        free_cache_engine = self.config.actor_rollout_ref.rollout.free_cache_engine if self.config else False
-        if free_cache_engine:
-            # TODO: later probably should make the `wake_up` and `sleep` methods in base class to be async
-            if isinstance(self.rollout_engine, VerlEngine):
-                await self.rollout_engine.wake_up()
-            else:
-                self.rollout_engine.wake_up()
+        # TODO: later probably should make the `wake_up` and `sleep` methods in base class to be async
+        if isinstance(self.rollout_engine, VerlEngine):
+            await self.rollout_engine.wake_up()
+        else:
+            self.rollout_engine.wake_up()
 
         if batch.meta_info.get("validate", False):
             self.rollout_engine.validate = True
@@ -413,11 +411,10 @@ class AgentSdkEngine:
         episodes = await self.execute_tasks(tasks, task_ids, **kwargs)  # list of Episodes
         self.rollout_engine.validate = False
 
-        if free_cache_engine:
-            if isinstance(self.rollout_engine, VerlEngine):
-                await self.rollout_engine.sleep()
-            else:
-                self.rollout_engine.sleep()
+        if isinstance(self.rollout_engine, VerlEngine):
+            await self.rollout_engine.sleep()
+        else:
+            self.rollout_engine.sleep()
         return self.transform_results_for_verl(episodes, task_ids)
 
     def transform_results_for_verl(self, episodes: list[Episode], task_ids: np.ndarray) -> "DataProto":

--- a/rllm/engine/agent_workflow_engine.py
+++ b/rllm/engine/agent_workflow_engine.py
@@ -198,13 +198,11 @@ class AgentWorkflowEngine:
         Returns:
             DataProto: Transformed results compatible with Verl training.
         """
-        free_cache_engine = self.config.actor_rollout_ref.rollout.free_cache_engine if self.config else False
-        if free_cache_engine:
-            # TODO: later probably should make the `wake_up` and `sleep` methods in base class to be async
-            if isinstance(self.rollout_engine, VerlEngine):
-                await self.rollout_engine.wake_up()
-            else:
-                self.rollout_engine.wake_up()
+        # TODO: later probably should make the `wake_up` and `sleep` methods in base class to be async
+        if isinstance(self.rollout_engine, VerlEngine):
+            await self.rollout_engine.wake_up()
+        else:
+            self.rollout_engine.wake_up()
 
         is_validation = batch.meta_info.get("validate", False)
         if is_validation:
@@ -216,11 +214,12 @@ class AgentWorkflowEngine:
         task_ids = batch.non_tensor_batch["task_ids"].tolist()
         results = await self.execute_tasks(tasks, task_ids, **kwargs)  # list of Episodes
         self.rollout_engine.validate = False
-        if free_cache_engine:
-            if isinstance(self.rollout_engine, VerlEngine):
-                await self.rollout_engine.sleep()
-            else:
-                self.rollout_engine.sleep()
+
+        if isinstance(self.rollout_engine, VerlEngine):
+            await self.rollout_engine.sleep()
+        else:
+            self.rollout_engine.sleep()
+
         self.current_mode = "train"
         return self.transform_results_for_verl(results, task_ids)
 


### PR DESCRIPTION
## What does this PR do?

This PR directly addresses #291, the approach is directly following `verl`'s recent commit [here](https://github.com/volcengine/verl/pull/4248).

The main idea is that for all our engines, when working with `verl`, there's no need to check `free_cache_engine` config when calling the `wake_up()`/`sleep()` methods of the rollout engine.

Extensive experiments have been done in the `verl` commit -- which should also contain enough details and checks for this PR's validity.