### PR TITLE
Unblock sdk installation by overriding dependices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,12 @@ code-tools = [
     "together>=1.4",
 ]
 
+[tool.uv]
+override-dependencies = [
+    "litellm[proxy]>=1.80.0",
+    "rich>=13.9.4",
+]
+
 [tool.uv.extra-build-dependencies]
 flash-attn = [
     { requirement = "torch", match-runtime = true },


### PR DESCRIPTION
Resolved `uv` resolution errors caused by conflicting transitive dependencies.

Fixed: `eval-protocol` was forcing an outdated `litellm version (1.9.4)` that lacked proxy support.

Fixed: `smolagents` and `litellm` had conflicting requirements for the `rich` library.

Changes applied via `[tool.uv] override-dependencies` to force compatible versions of `litellm` and `rich`. Verified with `uv sync --all-extras`.