### PR TITLE
fix: keyerror completion_ids

### DIFF
--- a/rllm/engine/agent_execution_engine.py
+++ b/rllm/engine/agent_execution_engine.py
@@ -250,7 +250,7 @@ class AgentExecutionEngine:
                 "prompt": self.chat_parser.parse(prompt_messages, add_generation_prompt=True, is_first_msg=True),
                 "response": response,
                 "prompt_ids": model_output.prompt_ids,
-                "response_ids": model_output.completion_ids,
+                "completion_ids": model_output.completion_ids,
                 "logprobs": model_output.logprobs,
             }
             episode_steps.append(prompt_response_pair)


### PR DESCRIPTION
rllm v0.2.1 encounters
```
File "envs/rllm2/lib/python3.11/asyncio/tasks.py", line 489, in wait_for
  return fut.result()
     ^^^^^^^^^^^^
 File "RL/rllm/rllm/engine/agent_execution_engine.py", line 394, in run_agent_trajectory_async
   prompt_tokens, response_tokens, response_masks, is_valid_trajectory = self.assemble_steps(episode_steps)                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "RL/rllm/rllm/engine/agent_execution_engine.py", line 453, in assemble_steps
   current_completion_ids = step["completion_ids"]
                        ~~~~^^^^^^^^^^^^^^^^^^
 KeyError: 'completion_ids'
```
Fix this problem.