### PR TITLE
[feature] add support for on policy distillation

### DIFF
--- a/examples/countdown/run_countdown.py
+++ b/examples/countdown/run_countdown.py
@@ -1,0 +1,128 @@
+import asyncio
+import json
+import os
+import sys
+from copy import deepcopy
+
+from transformers import AutoTokenizer
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.engine import OpenAIEngine
+from rllm.engine.agent_workflow_engine import AgentWorkflowEngine
+from rllm.rewards.countdown_reward import countdown_reward_fn
+from rllm.workflows.simple_workflow import SimpleWorkflow
+
+# Add countdown directory to path for prepare_countdown_data import
+sys.path.append(os.path.dirname(__file__))
+
+
+def load_data(n=1):
+    """Load countdown data using the Dataset interface."""
+    dataset = DatasetRegistry.load_dataset("countdown", "test")
+    if dataset is None:
+        print("Dataset not found, preparing dataset...")
+        from prepare_countdown_data import prepare_countdown_data
+
+        _, dataset, _, _ = prepare_countdown_data()
+
+    data = []
+    for idx, example in enumerate(dataset):
+        processed = process_countdown_fn(example, idx)
+        for i in range(n):
+            data.append(deepcopy(processed))
+    return data
+
+
+def process_countdown_fn(example, idx):
+    """Process countdown example into the expected format."""
+    question = example["question"]
+    target = example["target"]
+    nums = example["nums"]
+
+    # Create ground truth in the format expected by countdown_reward_fn
+    ground_truth = {"target": target, "numbers": nums}
+
+    task = {"question": question, "ground_truth": ground_truth, "idx": idx, "data_source": "countdown", "target": target, "nums": nums}
+    return task
+
+
+def evaluate_results(results):
+    """Evaluate the results and compute pass@k metrics."""
+    from collections import defaultdict
+
+    # Create a map to store correct answers per problem
+    problem_correct_map = defaultdict(int)
+    problem_total_map = defaultdict(int)
+
+    # Count correct answers for each problem
+    for episode in results:
+        problem = episode.task["question"]
+
+        # Use the episode-level is_correct flag set by the workflow
+        is_correct = episode.is_correct
+
+        problem_correct_map[problem] += int(is_correct)
+        problem_total_map[problem] += 1
+
+    # Calculate pass@1 and pass@k
+    k = max(problem_total_map.values()) if problem_total_map else 1
+    total_problems = len(problem_correct_map)
+
+    if total_problems > 0:
+        pass_at_1 = sum(problem_correct_map.values()) / sum(problem_total_map.values())
+        pass_at_k = sum(1 for problem, correct in problem_correct_map.items() if correct > 0) / total_problems
+    else:
+        pass_at_1 = 0.0
+        pass_at_k = 0.0
+
+    print("Total unique problems:", total_problems)
+    print("Average Pass@1 Accuracy:", pass_at_1)
+    print(f"Average Pass@{k} Accuracy:", pass_at_k)
+
+
+if __name__ == "__main__":
+    os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+    # Configuration
+    n_parallel_tasks = 128
+
+    model_name = "Qwen/Qwen3-0.6B"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    rollout_engine = OpenAIEngine(
+        model=model_name,
+        tokenizer=tokenizer,
+        max_prompt_length=2048,
+        max_response_length=1024,
+        base_url="http://localhost:30000/v1",
+        api_key="None",
+        sampling_params={"temperature": 0.6, "top_p": 0.95},
+    )
+
+    engine = AgentWorkflowEngine(
+        workflow_cls=SimpleWorkflow,
+        workflow_args={
+            "reward_function": countdown_reward_fn,
+        },
+        rollout_engine=rollout_engine,
+        config=None,
+        n_parallel_tasks=n_parallel_tasks,
+        retry_limit=1,
+    )
+
+    # Load countdown tasks
+    tasks = load_data(n=1)
+    print(f"Loaded {len(tasks)} countdown tasks")
+
+    results = asyncio.run(engine.execute_tasks(tasks))
+
+    # Evaluate results (rewards are already assigned in the workflow)
+    print("Evaluating results...")
+    evaluate_results(results)
+
+    # Save results
+    os.makedirs("logs", exist_ok=True)
+    with open("logs/countdown.json", "w") as f:
+        json.dump([episode.to_dict() for episode in results], f, indent=4)
+
+    print("\nResults saved to logs/countdown.json")

--- a/examples/countdown/train_countdown_distill.sh
+++ b/examples/countdown/train_countdown_distill.sh
@@ -5,7 +5,7 @@ export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
 export VLLM_USE_V1=1
 export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 export VLLM_ENGINE_ITERATION_TIMEOUT_S=100000000000
-export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export CUDA_VISIBLE_DEVICES=0,1,2,3
 python3 -m examples.countdown.train_countdown \
     data.train_batch_size=64 \
     data.max_prompt_length=2048 \
@@ -51,14 +51,19 @@ python3 -m examples.countdown.train_countdown \
     trainer.critic_warmup=0 \
     trainer.logger=['console','wandb'] \
     trainer.project_name='rllm-agent' \
-    trainer.experiment_name='countdown' \
+    trainer.experiment_name='countdown-distill' \
     trainer.val_before_train=True \
-    trainer.n_gpus_per_node=8 \
+    trainer.n_gpus_per_node=4 \
     trainer.nnodes=1 \
     trainer.save_freq=1000 \
     trainer.test_freq=10 \
     trainer.default_hdfs_dir=null \
     trainer.total_epochs=100 \
-    rllm.workflow.use_workflow=True
+    rllm.workflow.use_workflow=True \
+    rllm.distill.enable=True \
+    rllm.distill.shared_tokenizer=True \
+    rllm.distill.teacher_rollout_args.model=kylemontgomery/countdown-solver-0.6b \
+    rllm.distill.teacher_rollout_args.base_url=http://localhost:32000/v1 \
+    rllm.distill.teacher_rollout_args.api_key=EMPTY
 
 pkill -9 -f 'ray::WorkerDict' 

--- a/examples/countdown/train_countdown_distill_tinker.sh
+++ b/examples/countdown/train_countdown_distill_tinker.sh
@@ -1,0 +1,27 @@
+set -x
+
+python -m examples.countdown.train_countdown_tinker \
+    model.name=Qwen/Qwen3-8B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=4e-5 \
+    sampling.temperature=1.0 \
+    sampling.top_p=1.0 \
+    algorithm.adv_estimator=distill \
+    algorithm.shared_tokenizer=True \
+    algorithm.teacher_rollout_args.model=kylemontgomery/countdown-solver-8b \
+    algorithm.teacher_rollout_args.base_url=http://localhost:32000/v1 \
+    algorithm.teacher_rollout_args.api_key=EMPTY \
+    data.max_prompt_length=2048 \
+    data.max_response_length=1024 \
+    data.train_batch_size=64 \
+    data.val_batch_size=1024 \
+    trainer.total_epochs=100 \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name='rllm-agent' \
+    trainer.experiment_name='countdown-distill-tinker-8b' \
+    trainer.val_before_train=True \
+    trainer.test_freq=10 \
+    trainer.save_freq=1000 \
+    trainer.default_local_dir='./outputs/countdown-distill-tinker-8b' \
+    rollout_engine.bypass_render_with_parser=True

--- a/examples/countdown/train_countdown_tinker.py
+++ b/examples/countdown/train_countdown_tinker.py
@@ -1,0 +1,28 @@
+import hydra
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.rewards.countdown_reward import countdown_reward_fn
+from rllm.trainer import AgentTrainer
+from rllm.workflows.simple_workflow import SimpleWorkflow
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="tinker_rl_trainer", version_base=None)
+def main(config):
+    train_dataset = DatasetRegistry.load_dataset("countdown", "train")
+    test_dataset = DatasetRegistry.load_dataset("countdown", "test")
+
+    trainer = AgentTrainer(
+        workflow_class=SimpleWorkflow,
+        workflow_args={
+            "reward_function": countdown_reward_fn,
+        },
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=test_dataset,
+        backend="tinker",
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/rllm/engine/rollout/rollout_engine.py
+++ b/rllm/engine/rollout/rollout_engine.py
@@ -12,7 +12,8 @@ class ModelOutput:
     prompt_ids: list[int] | None = None
     completion_ids: list[int] | None = None
     multi_modal_inputs: dict[str, list] | None = None
-    logprobs: list[float] | None = None
+    logprobs: list[float] | None = None  # completion logprobs
+    prompt_logprobs: list[float] | None = None  # prompt logprobs aligned to prompt_ids
     prompt_length: int = 0
     completion_length: int = 0
     finish_reason: str | None = None
@@ -27,6 +28,7 @@ class ModelOutput:
             "completion_ids": self.completion_ids,
             "multi_modal_inputs": self.multi_modal_inputs,
             "logprobs": self.logprobs,
+            "prompt_logprobs": self.prompt_logprobs,
             "prompt_length": self.prompt_length,
             "completion_length": self.completion_length,
             "finish_reason": self.finish_reason,
@@ -43,6 +45,7 @@ class ModelOutput:
             completion_ids=data.get("completion_ids"),
             multi_modal_inputs=data.get("multi_modal_inputs"),
             logprobs=data.get("logprobs"),
+            prompt_logprobs=data.get("prompt_logprobs"),
             prompt_length=data.get("prompt_length", 0),
             completion_length=data.get("completion_length", 0),
             finish_reason=data.get("finish_reason"),

--- a/rllm/engine/rollout/verl_engine.py
+++ b/rllm/engine/rollout/verl_engine.py
@@ -30,12 +30,14 @@ class VerlEngine(RolloutEngine):
             temperature=0.0 if config.actor_rollout_ref.rollout.do_sample is False else config.actor_rollout_ref.rollout.temperature,
             top_k=config.actor_rollout_ref.rollout.top_k,
             top_p=config.actor_rollout_ref.rollout.top_p,
+            logprobs=1,
         )
 
         self.val_sampling_params = dict(
             temperature=0.0 if config.actor_rollout_ref.rollout.val_kwargs.do_sample is False else config.actor_rollout_ref.rollout.val_kwargs.temperature,
             top_k=config.actor_rollout_ref.rollout.val_kwargs.top_k,
             top_p=config.actor_rollout_ref.rollout.val_kwargs.top_p,
+            logprobs=1,
         )
 
         print(f"train_sampling_params: {self.train_sampling_params}")
@@ -77,11 +79,13 @@ class VerlEngine(RolloutEngine):
 
         token_output: TokenOutput = await self.server_manager.generate(request_id=application_id, prompt_ids=request_prompt_ids, image_data=image_data, sampling_params=sampling_params)  # type: ignore
         completion_ids: list[int] = token_output.token_ids
+        logprobs: list[float] = token_output.log_probs
 
         finish_reason = "stop"
         if len(completion_ids) >= max_tokens:
             finish_reason = "length"
             completion_ids = completion_ids[:max_tokens]
+            logprobs = logprobs[:max_tokens]
 
         completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=True)
         # TODO: implement parse_completion for the standard parser
@@ -95,7 +99,7 @@ class VerlEngine(RolloutEngine):
             prompt_ids=prompt_ids,
             completion_ids=completion_ids,
             multi_modal_inputs=multi_modal_inputs,
-            logprobs=[],
+            logprobs=logprobs,
             prompt_length=prompt_length,
             completion_length=len(completion_ids),
             finish_reason=finish_reason,

--- a/rllm/parser/chat_template_parser.py
+++ b/rllm/parser/chat_template_parser.py
@@ -94,14 +94,21 @@ class ChatTemplateParser:
             tokenizer_cls = tokenizer.__class__.__name__.lower()
             logger.info(f"model_name: {model_name}, tokenizer_cls: {tokenizer_cls}")
             if any(x in model_name for x in ("deepseek", "deepscaler", "deepcoder")) and "llama" in tokenizer_cls:
-                logger.info(f"Using DeepseekQwenChatTemplateParser for {tokenizer.name_or_path}")
-                return DeepseekQwenChatTemplateParser(tokenizer)
+                if "deepseek-math-v2" in model_name or "deepseek-v3.2-exp" in model_name:
+                    logger.info(f"Using DeepSeekV32ExpChatTemplateParser for {tokenizer.name_or_path}")
+                    return DeepSeekV32ExpChatTemplateParser(tokenizer, disable_thinking=disable_thinking)
+                else:
+                    logger.info(f"Using DeepseekQwenChatTemplateParser for {tokenizer.name_or_path}")
+                    return DeepseekQwenChatTemplateParser(tokenizer, disable_thinking=disable_thinking)
             elif "qwen" in model_name or "r2e" in model_name or "deepswe" in model_name or "qwen" in tokenizer_cls:
                 logger.info(f"Using QwenChatTemplateParser for {tokenizer.name_or_path}")
                 return QwenChatTemplateParser(tokenizer, processor=processor, disable_thinking=disable_thinking)
             elif "llama" in model_name:
                 logger.info(f"Using LlamaChatTemplateParser for {tokenizer.name_or_path}")
                 return LlamaChatTemplateParser(tokenizer)
+            elif "gpt-oss" in model_name or "imo" in model_name:
+                logger.info(f"Using HarmonyChatTemplateParser for {tokenizer.name_or_path}")
+                return HarmonyChatTemplateParser()
 
         # Default to the standard parser if no specific match
         parser = ChatTemplateParser(tokenizer, processor=processor)
@@ -247,7 +254,9 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
             result = self.assistant_token
 
             if reasoning and accumulate_reasoning:
-                result += "<think>\n" + reasoning + "\n</think>\n\n"
+                result += "<think>\n" + reasoning
+                if content:
+                    result += "\n</think>\n\n"
 
             if content:
                 result += content
@@ -314,32 +323,27 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
 
         if completion_text.count("</think>") == 1:
             reasoning, _, content = completion_text.partition("</think>")
-            if reasoning.startswith("<think>"):
-                reasoning = reasoning[len("<think>") :]
             if content.endswith(self.eos_token):
                 content = content[: -len(self.eos_token)]
             reasoning = reasoning.strip()
             content = content.strip()
         else:
-            reasoning = None
-            content = completion_text
-            if content.startswith("<think>"):
-                content = content[len("<think>") :]
-            if content.endswith(self.eos_token):
-                content = content[: -len(self.eos_token)]
+            # DeepSeekQwen should always have reasoning
+            reasoning = completion_text.strip()
+            content = ""
+
+        if content:
+            # parse tool calls from content
+            tool_calls = self.tool_parser.parse(content)
+            begin_pattern = re.escape(self.tool_parser.tool_call_begin)
+            end_pattern = re.escape(self.tool_parser.tool_call_end)
+            wrapper_begin_pattern = re.escape(self.tool_parser.tool_calls_begin)
+            wrapper_end_pattern = re.escape(self.tool_parser.tool_calls_end)
+            content = re.sub(f"{begin_pattern}.*?{end_pattern}", "", content, flags=re.DOTALL)
+            content = re.sub(f"{wrapper_begin_pattern}.*?{wrapper_end_pattern}", "", content, flags=re.DOTALL)
             content = content.strip()
-
-        tool_calls = self.tool_parser.parse(completion_text)
-
-        begin_pattern = re.escape(self.tool_parser.tool_call_begin)
-        end_pattern = re.escape(self.tool_parser.tool_call_end)
-        content = re.sub(f"{begin_pattern}.*?{end_pattern}", "", content, flags=re.DOTALL)
-
-        wrapper_begin_pattern = re.escape(self.tool_parser.tool_calls_begin)
-        wrapper_end_pattern = re.escape(self.tool_parser.tool_calls_end)
-        content = re.sub(f"{wrapper_begin_pattern}.*?{wrapper_end_pattern}", "", content, flags=re.DOTALL)
-
-        content = content.strip()
+        else:
+            tool_calls = []
 
         return {
             "content": content,
@@ -351,6 +355,7 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
 class QwenChatTemplateParser(ChatTemplateParser):
     def __init__(self, tokenizer, processor=None, disable_thinking=False):
         super().__init__(tokenizer, processor=processor)
+        self.disable_thinking = disable_thinking
         self.bos_token = tokenizer.bos_token
         self.eos_token = tokenizer.eos_token
         self.eot_token = "<|im_end|>\n"
@@ -439,9 +444,10 @@ class QwenChatTemplateParser(ChatTemplateParser):
 
         else:
             result = self.assistant_token
-
             if reasoning and accumulate_reasoning:
-                result += "<think>\n" + reasoning + "\n</think>\n\n"
+                result += "<think>\n" + reasoning
+                if content:
+                    result += "\n</think>\n\n"
 
             if content:
                 result += content
@@ -513,23 +519,32 @@ class QwenChatTemplateParser(ChatTemplateParser):
                 content = content[: -len(self.eot_token)]
             reasoning = reasoning.strip()
             content = content.strip()
+        elif not self.disable_thinking:
+            # generation was cut short during reasoning
+            reasoning = completion_text
+            if reasoning.startswith("<think>"):
+                reasoning = reasoning[len("<think>") :]
+            reasoning = reasoning.strip()
+            content = ""
         else:
-            reasoning = None
+            # thinking is disabled, so everything is content
+            reasoning = ""
             content = completion_text
-            if content.startswith("<think>"):
-                content = content[len("<think>") :]
             if content.endswith(self.eos_token):
                 content = content[: -len(self.eos_token)]
             if content.endswith(self.eot_token):
                 content = content[: -len(self.eot_token)]
             content = content.strip()
 
-        tool_calls = self.tool_parser.parse(content)
-
-        begin_pattern = re.escape(self.tool_parser.tool_call_begin)
-        end_pattern = re.escape(self.tool_parser.tool_call_end)
-        content = re.sub(f"{begin_pattern}.*?{end_pattern}", "", content, flags=re.DOTALL)
-        content = content.strip()
+        if content:
+            # parse tool calls from content
+            tool_calls = self.tool_parser.parse(content)
+            begin_pattern = re.escape(self.tool_parser.tool_call_begin)
+            end_pattern = re.escape(self.tool_parser.tool_call_end)
+            content = re.sub(f"{begin_pattern}.*?{end_pattern}", "", content, flags=re.DOTALL)
+            content = content.strip()
+        else:
+            tool_calls = []
 
         return {
             "content": content,
@@ -610,3 +625,193 @@ class LlamaChatTemplateParser(ChatTemplateParser):
     def parse_completion(self, completion_ids):
         # TODO: add parse_completion for llama
         raise NotImplementedError("LLamaChatTemplateParser does not support parse_completion")
+
+
+class HarmonyChatTemplateParser(ChatTemplateParser):
+    def __init__(self, tokenizer=None):
+        from openai_harmony import (
+            HarmonyEncodingName,
+            load_harmony_encoding,
+        )
+
+        self.enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+        self.generation_prompt = "<|start|>assistant"
+        self.stop_sequences = [200002, 199999, 200012]  # <|endoftext|>, <|return|>, <|call|>
+
+    def parse(self, messages, add_generation_prompt=False, is_first_msg=False, **kwargs) -> str:
+        return self.parse_prompt_from_messages(messages, add_generation_prompt=add_generation_prompt, is_first_msg=is_first_msg, **kwargs)
+
+    def parse_prompt_from_messages(self, messages, add_generation_prompt=False, is_first_msg=False, **kwargs):
+        from openai_harmony import Conversation, DeveloperContent, Message, ReasoningEffort, RenderConversationConfig, Role, SystemContent
+
+        # messages is a list[dict], where each dict is of the following structure:
+        # {
+        #     "role": str,
+        #     "content": str,
+        #     "reasoning": str, # optional
+        # }
+
+        messages = deepcopy(messages)
+        harmony_messages: list[Message] = []
+
+        if is_first_msg:
+            # 1. system prompt
+            reasoning_effort = ReasoningEffort(kwargs.get("reasoning_effort", "medium").capitalize())
+            system_message = SystemContent.new().with_reasoning_effort(reasoning_effort)
+            harmony_messages.append(Message.from_role_and_content(Role.SYSTEM, system_message))
+
+            # 2. developer prompt
+            if messages[0]["role"] == "system":
+                instructions = messages.pop(0).get("content")
+                developer_message = DeveloperContent.new().with_instructions(instructions)
+                harmony_messages.append(Message.from_role_and_content(Role.DEVELOPER, developer_message))
+
+        # 3. the rest of the messages
+        for message in messages:
+            if message["role"] == "user":
+                harmony_messages.append(Message.from_role_and_content(Role.USER, message["content"]))
+            elif message["role"] == "assistant":
+                reasoning = message.get("reasoning", None)
+                content = message.get("content", None)
+                if reasoning:
+                    harmony_messages.append(Message.from_role_and_content(Role.ASSISTANT, reasoning).with_channel("analysis"))
+                if content:
+                    harmony_messages.append(Message.from_role_and_content(Role.ASSISTANT, content).with_channel("final"))
+            elif message["role"] == "tool":
+                raise NotImplementedError("Tool messages are not supported yet")
+            else:
+                raise NotImplementedError(f"Unsupported message role: {message['role']}")
+
+        conv = Conversation.from_messages(harmony_messages)
+        accumulate_thinking = kwargs.get("accumulate_thinking", False)
+        config = RenderConversationConfig(auto_drop_analysis=not accumulate_thinking)
+        prompt_ids: list[int] = self.enc.render_conversation(conv, config)
+
+        try:
+            prompt: str = self.enc.decode_utf8(prompt_ids)
+        except UnicodeDecodeError:
+            prompt: str = self.enc.decode(prompt_ids)
+            print(f"Warning: UnicodeDecodeError when decoding prompt: {prompt[:1000]}...")
+
+        if add_generation_prompt:
+            prompt += self.generation_prompt
+
+        return prompt
+
+    def parse_completion(self, completion_ids: list[int], **kwargs) -> dict[str, str | list]:
+        from openai_harmony import Role
+
+        # NOTE: harmony will throw an error if the sequence ends during the header (e.g., due to length)
+        harmony_messages = self.enc.parse_messages_from_completion_tokens(completion_ids, role=Role.ASSISTANT)
+
+        analysis = ""
+        final = ""
+        for message in harmony_messages:
+            content = message.content[0].text
+            channel = message.channel
+
+            if channel == "analysis":
+                analysis += content
+            elif channel == "final":
+                final += content
+
+        # TODO: handle tool calls
+
+        return {
+            "content": final,
+            "reasoning": analysis,
+            "tool_calls": [],
+        }
+
+
+class DeepSeekV32ExpChatTemplateParser(ChatTemplateParser):
+    def __init__(self, tokenizer, disable_thinking=False):
+        self.tokenizer = tokenizer
+        self.disable_thinking = disable_thinking
+        self.bos_token = "<｜begin▁of▁sentence｜>"
+        self.eos_token = "<｜end▁of▁sentence｜>"
+        self.system_token = ""
+        self.user_token = "<｜User｜>"
+        self.assistant_token = "<｜Assistant｜>"
+        if disable_thinking:
+            self.generation_prompt = self.assistant_token + "</think>"
+        else:
+            self.generation_prompt = self.assistant_token + "<think>"
+
+    def parse(self, messages, add_generation_prompt=False, is_first_msg=False, tools: list[Tool | dict] = None, accumulate_reasoning: bool = False, **kwargs) -> str:
+        if tools:
+            raise NotImplementedError("Tools are not supported yet")
+
+        result = ""
+
+        if is_first_msg:
+            result += self.bos_token
+
+        for message in messages:
+            if message["role"] == "system":
+                result += self.parse_system(message)
+            elif message["role"] == "user":
+                result += self.parse_user(message)
+            elif message["role"] == "assistant":
+                result += self.parse_assistant(message, accumulate_reasoning=accumulate_reasoning)
+            elif message["role"] == "tool":
+                result += self.parse_tool(message)
+            else:
+                raise NotImplementedError(f"Unsupported message role: {message['role']}")
+
+        if add_generation_prompt:
+            result += self.generation_prompt
+
+        return result
+
+    def parse_system(self, message):
+        return self.system_token + message["content"]
+
+    def parse_user(self, message):
+        return self.user_token + message["content"]
+
+    def parse_assistant(self, message, accumulate_reasoning=False):
+        reasoning = message.get("reasoning", None)
+        content = message.get("content", None)
+
+        result = self.assistant_token
+        if reasoning and accumulate_reasoning:
+            result += "<think>" + reasoning
+        if content:
+            result += "</think>" + content
+        result += self.eos_token
+
+        return result
+
+    def parse_tool(self, message):
+        raise NotImplementedError("Tools are not supported yet")
+
+    def parse_completion(self, completion_ids):
+        completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=False)
+
+        if completion_text.count("</think>") == 1:
+            reasoning, _, content = completion_text.partition("</think>")
+            if content.endswith(self.eos_token):
+                content = content[: -len(self.eos_token)]
+            reasoning = reasoning.strip()
+            content = content.strip()
+        elif not self.disable_thinking:
+            # generation was cut short during reasoning
+            reasoning = completion_text
+            reasoning = reasoning.strip()
+            content = ""
+        else:
+            # thinking is disabled, so everything is content
+            reasoning = ""
+            content = completion_text
+            if content.endswith(self.eos_token):
+                content = content[: -len(self.eos_token)]
+            content = content.strip()
+
+        # TODO: handle tool calls
+
+        return {
+            "content": content,
+            "reasoning": reasoning,
+            "tool_calls": [],
+        }

--- a/rllm/trainer/config/agent_ppo_trainer.yaml
+++ b/rllm/trainer/config/agent_ppo_trainer.yaml
@@ -62,6 +62,14 @@ rllm:
   rejection_sample:
     enable: False
     multiplier: 1
+  distill:
+    enable: False
+    shared_tokenizer: False
+    teacher_rollout_args:
+      model: "default"
+      base_url: "http://localhost:8000/v1"
+      api_key: "EMPTY"
+      max_prompt_length: 32768
   sdk:
     store:
       path: ~/.rllm/traces.db

--- a/rllm/trainer/config/agent_ppo_trainer_megatron.yaml
+++ b/rllm/trainer/config/agent_ppo_trainer_megatron.yaml
@@ -59,6 +59,14 @@ rllm:
   rejection_sample:
     enable: False
     multiplier: 1
+  distill:
+    enable: False
+    shared_tokenizer: False
+    teacher_rollout_args:
+      model: "default"
+      base_url: "http://localhost:8000/v1"
+      api_key: "EMPTY"
+      max_prompt_length: 32768
 
 trainer:
   log_episodes: false

--- a/rllm/trainer/config/tinker_rl_trainer.yaml
+++ b/rllm/trainer/config/tinker_rl_trainer.yaml
@@ -31,11 +31,19 @@ sampling:
 
 # Algorithm Configuration (compatible with verl)
 algorithm:
-  adv_estimator: grpo  # REINFORCE, GRPO
+  adv_estimator: grpo  # REINFORCE, GRPO, distill
   gamma: 1.0
   lam: 0.95
   norm_adv_by_std_in_grpo: false  # math_rl doesn't normalize by std
   grouping_level: 'trajectory'  # Options: 'trajectory' or 'step'
+  remove_constant_reward_groups: false
+  shared_tokenizer: False
+  teacher_rollout_args:
+    model: "deepseek-ai/DeepSeek-Math-V2"
+    base_url: "http://localhost:8000/v1"
+    api_key: "EMPTY"
+    max_prompt_length: 32768
+    
 
 # Workflow Configuration (for workflow training mode)
 workflow:
@@ -50,6 +58,12 @@ agent:
 # Environment Configuration (for agent training mode)
 env:
   env_args: {}
+
+rollout_engine:
+  reasoning_effort: "medium"
+  accumulate_reasoning: false
+  disable_thinking: false
+  bypass_render_with_parser: false
 
 # Data Configuration
 data:

--- a/rllm/trainer/distill/__init__.py
+++ b/rllm/trainer/distill/__init__.py
@@ -1,0 +1,15 @@
+"""Shared distillation utilities for cross-tokenizer teacher-student alignment."""
+
+from rllm.trainer.distill.alignment import (
+    align_teacher_logprobs,
+    build_byte_offsets,
+    find_content_byte_ranges,
+    visualize_alignment,
+)
+
+__all__ = [
+    "align_teacher_logprobs",
+    "build_byte_offsets",
+    "find_content_byte_ranges",
+    "visualize_alignment",
+]

--- a/rllm/trainer/distill/alignment.py
+++ b/rllm/trainer/distill/alignment.py
@@ -1,0 +1,369 @@
+"""Utilities for aligning logprobs for cross-tokenizer distillation."""
+
+import logging
+from bisect import bisect_left, bisect_right
+
+from transformers import PreTrainedTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+def _bytes_to_unicode() -> dict[int, str]:
+    """GPT-2 byte-to-unicode mapping for byte-level BPE tokenizers."""
+    bs = list(range(ord("!"), ord("~") + 1)) + list(range(ord("¡"), ord("¬") + 1)) + list(range(ord("®"), ord("ÿ") + 1))
+    cs = bs[:]
+
+    n = 0
+    for b in range(256):
+        if b not in bs:
+            bs.append(b)
+            cs.append(256 + n)
+            n += 1
+
+    cs = [chr(n) for n in cs]
+    return dict(zip(bs, cs, strict=False))
+
+
+BYTE_ENCODER: dict[int, str] = _bytes_to_unicode()
+BYTE_DECODER: dict[str, int] = {v: k for k, v in BYTE_ENCODER.items()}
+
+
+def _token_str_to_bytes(token_str: str | None) -> bytes:
+    """Convert token string to raw bytes."""
+    if token_str is None:
+        return b""
+    try:
+        return bytes([BYTE_DECODER[c] for c in token_str])
+    except KeyError:
+        return token_str.encode("utf-8", errors="replace")
+
+
+def build_byte_offsets(tokenizer: PreTrainedTokenizer, token_ids: list[int]) -> list[int]:
+    """
+    Build cumulative byte offsets for token sequence.
+
+    Returns list of length n+1 where offsets[i] is byte position where token i starts,
+    and offsets[n] is total byte length.
+    """
+    if not token_ids:
+        return [0]
+
+    token_strs = tokenizer.convert_ids_to_tokens(token_ids)
+    offsets = [0]
+    cumulative = 0
+    for token_str in token_strs:
+        token_bytes = _token_str_to_bytes(token_str)
+        cumulative += len(token_bytes)
+        offsets.append(cumulative)
+
+    return offsets
+
+
+def find_content_byte_ranges(
+    text: str,
+    reasoning_str: str,
+    content_str: str,
+) -> dict[str, tuple[int, int]]:
+    """
+    Find byte ranges for reasoning and content regions.
+
+    Returns dict mapping region name to (start_byte, end_byte).
+    Only includes regions that were found.
+    """
+    text_bytes = text.encode("utf-8")
+    regions = {}
+
+    if reasoning_str:
+        reasoning_bytes = reasoning_str.encode("utf-8")
+        idx = text_bytes.find(reasoning_bytes)
+        if idx != -1:
+            regions["reasoning"] = (idx, idx + len(reasoning_bytes))
+
+    if content_str:
+        content_bytes = content_str.encode("utf-8")
+        search_start = regions.get("reasoning", (0, 0))[1]
+        idx = text_bytes.find(content_bytes, search_start)
+        if idx != -1:
+            regions["content"] = (idx, idx + len(content_bytes))
+
+    return regions
+
+
+def _find_tokens_in_range(
+    offsets: list[int],
+    range_start: int,
+    range_end: int,
+) -> tuple[int, int]:
+    """Find token indices that overlap with [range_start, range_end)."""
+    n_tokens = len(offsets) - 1
+    if n_tokens == 0:
+        return 0, 0
+
+    first = bisect_right(offsets, range_start) - 1
+    first = max(0, first)
+    last = bisect_left(offsets, range_end)
+    last = min(n_tokens, last)
+
+    return first, last
+
+
+def _compute_overlap_mapping(
+    student_offsets: list[int],
+    teacher_offsets: list[int],
+    s_region: tuple[int, int],
+    t_region: tuple[int, int],
+) -> tuple[list[list[int]], list[int]]:
+    """
+    Map student tokens to overlapping teacher tokens using two-pointer sweep.
+
+    Returns (student_to_teachers, teacher_usage_count) where student_to_teachers[i]
+    is list of teacher token indices overlapping student token i.
+    """
+    n_student = len(student_offsets) - 1
+    n_teacher = len(teacher_offsets) - 1
+
+    student_to_teachers: list[list[int]] = [[] for _ in range(n_student)]
+    teacher_usage_count = [0] * n_teacher
+
+    s_start, s_end = s_region
+    t_start, t_end = t_region
+
+    s_first, s_last = _find_tokens_in_range(student_offsets, s_start, s_end)
+    t_first, t_last = _find_tokens_in_range(teacher_offsets, t_start, t_end)
+
+    if s_first >= s_last or t_first >= t_last:
+        return student_to_teachers, teacher_usage_count
+
+    t_ptr = t_first
+
+    for s_idx in range(s_first, s_last):
+        s_tok_start = student_offsets[s_idx]
+        s_tok_end = student_offsets[s_idx + 1]
+
+        s_rel_start = max(0, s_tok_start - s_start)
+        s_rel_end = min(s_end - s_start, s_tok_end - s_start)
+
+        if s_rel_start >= s_rel_end:
+            continue
+
+        while t_ptr < t_last:
+            t_tok_end = teacher_offsets[t_ptr + 1]
+            t_rel_end = min(t_end - t_start, t_tok_end - t_start)
+            if t_rel_end > s_rel_start:
+                break
+            t_ptr += 1
+
+        for t_idx in range(t_ptr, t_last):
+            t_tok_start = teacher_offsets[t_idx]
+            t_tok_end = teacher_offsets[t_idx + 1]
+
+            t_rel_start = max(0, t_tok_start - t_start)
+            t_rel_end = min(t_end - t_start, t_tok_end - t_start)
+
+            if t_rel_start >= t_rel_end:
+                continue
+
+            if t_rel_start >= s_rel_end:
+                break
+
+            student_to_teachers[s_idx].append(t_idx)
+            teacher_usage_count[t_idx] += 1
+
+    return student_to_teachers, teacher_usage_count
+
+
+def _merge_overlap_mappings(
+    mappings: list[tuple[list[list[int]], list[int]]],
+    n_student: int,
+    n_teacher: int,
+) -> tuple[list[list[int]], list[int]]:
+    """Merge overlap mappings from multiple regions."""
+    student_to_teachers: list[list[int]] = [[] for _ in range(n_student)]
+    teacher_usage_count = [0] * n_teacher
+
+    for s2t, t_count in mappings:
+        for s_idx, t_indices in enumerate(s2t):
+            for t_idx in t_indices:
+                if t_idx not in student_to_teachers[s_idx]:
+                    student_to_teachers[s_idx].append(t_idx)
+                    teacher_usage_count[t_idx] += 1
+
+    return student_to_teachers, teacher_usage_count
+
+
+def align_teacher_logprobs(
+    student_ids: list[int],
+    student_tokenizer: PreTrainedTokenizer,
+    teacher_ids: list[int],
+    teacher_tokenizer: PreTrainedTokenizer,
+    teacher_logprobs: list[float],
+    student_logprobs: list[float],
+    reasoning_str: str,
+    content_str: str,
+) -> list[float]:
+    """
+    Align teacher logprobs to student tokens using byte-level alignment.
+
+    Maps teacher logprobs to student tokens based on byte coverage in shared content
+    regions. Returns aligned logprobs where content tokens get aggregated teacher
+    logprobs and format tokens get 0.0. On failure, returns student_logprobs.
+
+    Args:
+        student_ids: Student token IDs
+        student_tokenizer: Student tokenizer
+        teacher_ids: Teacher token IDs
+        teacher_tokenizer: Teacher tokenizer
+        teacher_logprobs: Teacher logprobs per token
+        student_logprobs: Student logprobs (fallback)
+        reasoning_str: Reasoning content (may be empty)
+        content_str: Answer content (may be empty)
+
+    Returns:
+        Aligned teacher logprobs for each student token.
+
+    Raises:
+        ValueError: If both reasoning_str and content_str are empty.
+    """
+    if not reasoning_str and not content_str:
+        raise ValueError("At least one of reasoning_str or content_str must be provided for alignment.")
+
+    n_student = len(student_ids)
+    n_teacher = len(teacher_ids)
+
+    student_offsets = build_byte_offsets(student_tokenizer, student_ids)
+    teacher_offsets = build_byte_offsets(teacher_tokenizer, teacher_ids)
+
+    student_text = student_tokenizer.decode(student_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False)
+    teacher_text = teacher_tokenizer.decode(teacher_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False)
+
+    student_regions = find_content_byte_ranges(student_text, reasoning_str, content_str)
+    teacher_regions = find_content_byte_ranges(teacher_text, reasoning_str, content_str)
+
+    if reasoning_str:
+        if "reasoning" not in student_regions or "reasoning" not in teacher_regions:
+            logger.warning(f"reasoning_str not found in decoded text. Zeroing out sample. reasoning_str[:50]={reasoning_str[:50]!r}")
+            return list(student_logprobs)
+
+    if content_str:
+        if "content" not in student_regions or "content" not in teacher_regions:
+            logger.warning(f"content_str not found in decoded text. Zeroing out sample. content_str[:50]={content_str[:50]!r}")
+            return list(student_logprobs)
+
+    mappings = []
+    for region_name in student_regions:
+        if region_name not in teacher_regions:
+            continue
+
+        s2t, t_count = _compute_overlap_mapping(
+            student_offsets,
+            teacher_offsets,
+            student_regions[region_name],
+            teacher_regions[region_name],
+        )
+        mappings.append((s2t, t_count))
+
+    student_to_teachers, teacher_usage_count = _merge_overlap_mappings(mappings, n_student, n_teacher)
+
+    aligned_logprobs = []
+    for i in range(n_student):
+        teacher_indices = student_to_teachers[i]
+
+        if not teacher_indices:
+            aligned_logprobs.append(0.0)
+        else:
+            total = 0.0
+            for j in teacher_indices:
+                usage = max(1, teacher_usage_count[j])
+                total += teacher_logprobs[j] / usage
+            aligned_logprobs.append(total)
+
+    return aligned_logprobs
+
+
+def visualize_alignment(
+    student_ids: list[int],
+    student_tokenizer: PreTrainedTokenizer,
+    teacher_ids: list[int],
+    teacher_tokenizer: PreTrainedTokenizer,
+    teacher_logprobs: list[float],
+    student_logprobs: list[float],
+    reasoning_str: str,
+    content_str: str,
+    max_tokens: int = 50,
+) -> None:
+    """
+    Visualize alignment between student and teacher tokens.
+
+    Prints student and teacher tokens with their logprobs, plus summary statistics.
+    """
+    aligned = align_teacher_logprobs(
+        student_ids,
+        student_tokenizer,
+        teacher_ids,
+        teacher_tokenizer,
+        teacher_logprobs,
+        student_logprobs,
+        reasoning_str,
+        content_str,
+    )
+
+    student_decoded = [student_tokenizer.decode([tid], clean_up_tokenization_spaces=False) for tid in student_ids[:max_tokens]]
+    teacher_decoded = [teacher_tokenizer.decode([tid], clean_up_tokenization_spaces=False) for tid in teacher_ids[:max_tokens]]
+
+    def fmt(tok: str, lp: float) -> str:
+        tok_display = repr(tok)[1:-1]
+        return f"'{tok_display}' ({lp:.5f})"
+
+    student_parts = []
+    for tok, lp in zip(student_decoded, aligned[:max_tokens], strict=False):
+        student_parts.append(fmt(tok, lp))
+
+    teacher_parts = []
+    for tok, lp in zip(teacher_decoded, teacher_logprobs[:max_tokens], strict=False):
+        teacher_parts.append(fmt(tok, lp))
+
+    print()
+    print("student -> " + " ".join(student_parts))
+    print()
+    print("teacher -> " + " ".join(teacher_parts))
+    print()
+
+    student_offsets = build_byte_offsets(student_tokenizer, student_ids)
+    teacher_offsets = build_byte_offsets(teacher_tokenizer, teacher_ids)
+    student_text = student_tokenizer.decode(student_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False)
+    teacher_text = teacher_tokenizer.decode(teacher_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False)
+    student_regions = find_content_byte_ranges(student_text, reasoning_str, content_str)
+    teacher_regions = find_content_byte_ranges(teacher_text, reasoning_str, content_str)
+
+    mappings = []
+    for region_name in student_regions:
+        if region_name not in teacher_regions:
+            continue
+        s2t, t_count = _compute_overlap_mapping(
+            student_offsets,
+            teacher_offsets,
+            student_regions[region_name],
+            teacher_regions[region_name],
+        )
+        mappings.append((s2t, t_count))
+
+    student_to_teachers, teacher_usage_count = _merge_overlap_mappings(mappings, len(student_ids), len(teacher_ids))
+
+    n_format = sum(1 for t_indices in student_to_teachers if len(t_indices) == 0)
+    n_content = len(student_to_teachers) - n_format
+
+    print(f"Summary: {len(student_ids)} student tokens, {len(teacher_ids)} teacher tokens")
+    print(f"         {n_content} content tokens, {n_format} format tokens")
+
+    aligned_sum = sum(lp for lp in aligned if lp != 0.0)
+    teacher_content_sum = sum(lp for lp, usage in zip(teacher_logprobs, teacher_usage_count, strict=False) if usage > 0)
+
+    n_perfect = 0
+    for t_indices in student_to_teachers:
+        if len(t_indices) > 0 and len(t_indices) == 1 and teacher_usage_count[t_indices[0]] == 1:
+            n_perfect += 1
+
+    perfect_pct = 100.0 * n_perfect / n_content if n_content > 0 else 0.0
+
+    print(f"\nLogprob mass: teacher content={teacher_content_sum:.4f}, aligned sum={aligned_sum:.4f}, diff={abs(teacher_content_sum - aligned_sum):.6f}")
+    print(f"Perfect 1:1 transfers: {n_perfect}/{n_content} ({perfect_pct:.1f}% of content tokens)")

--- a/rllm/trainer/tinker/tinker_data_processor.py
+++ b/rllm/trainer/tinker/tinker_data_processor.py
@@ -37,14 +37,19 @@ class TrajectoryGroup:
 
 class TinkerAdvantageComputer:
     """
-    Computes advantages using REINFORCE, GRPO, or other algorithms.
+    Computes advantages using REINFORCE, GRPO, or distillation.
     Compatible with rLLM's existing advantage computation.
     """
 
-    def __init__(self, algorithm_config):
+    def __init__(self, algorithm_config, teacher_engine=None, student_tokenizer=None, teacher_tokenizer=None):
         self.adv_estimator = algorithm_config.adv_estimator
         self.gamma = algorithm_config.gamma
         self.norm_by_std = algorithm_config.get("norm_adv_by_std_in_grpo", True)
+        self.distill_enabled = self.adv_estimator == "distill"
+        self.teacher_engine = teacher_engine
+        self.student_tokenizer = student_tokenizer
+        self.teacher_tokenizer = teacher_tokenizer
+        self.shared_tokenizer = algorithm_config.get("shared_tokenizer", False)
 
     def compute_grpo_advantages(self, group_rewards: list[float]) -> list[float]:
         """
@@ -102,6 +107,27 @@ class TinkerAdvantageComputer:
         else:
             logger.warning(f"Unknown advantage estimator {self.adv_estimator}, using GRPO")
             return self.compute_grpo_advantages(group_rewards)
+
+    def compute_distill_advantages_per_token(
+        self,
+        student_logprobs: list[float],
+        teacher_logprobs: list[float],
+    ) -> list[float]:
+        """
+        Compute per-token advantages for distillation: advantage = teacher_logprob - student_logprob.
+
+        Args:
+            student_logprobs: Student logprobs for each completion token
+            teacher_logprobs: Aligned teacher logprobs for each completion token (same length as student)
+
+        Returns:
+            List of per-token advantages
+        """
+        if len(student_logprobs) != len(teacher_logprobs):
+            raise ValueError(f"Length mismatch: student_logprobs={len(student_logprobs)}, teacher_logprobs={len(teacher_logprobs)}")
+
+        advantages = [t_lp - s_lp for t_lp, s_lp in zip(teacher_logprobs, student_logprobs, strict=False)]
+        return advantages
 
 
 class TinkerTrajectoryFilter:
@@ -261,6 +287,57 @@ class TinkerDatumBuilder:
         return datum
 
     @staticmethod
+    def build_distillation_datum(
+        prompt_ids: list[int],
+        response_ids: list[int],
+        logprobs: list[float],
+        advantages: list[float],
+    ) -> tinker.Datum:
+        """
+        Build a Datum for distillation from raw data (no trajectory needed).
+
+        Args:
+            prompt_ids: Prompt token IDs
+            response_ids: Response token IDs (completion)
+            logprobs: Student logprobs for response tokens
+            advantages: Per-token advantages (teacher_logprob - student_logprob)
+
+        Returns:
+            A single tinker.Datum
+        """
+        if len(response_ids) != len(logprobs):
+            raise ValueError(f"Length mismatch: {len(response_ids)} response_ids vs {len(logprobs)} logprobs")
+        if len(response_ids) != len(advantages):
+            raise ValueError(f"Length mismatch: {len(response_ids)} response_ids vs {len(advantages)} advantages")
+
+        # Build full sequence
+        full_sequence = list(prompt_ids) + list(response_ids)
+
+        # Logprobs/advantages: 0 for prompt tokens, actual values for response
+        full_logprobs = [0.0] * len(prompt_ids) + list(logprobs)
+        full_advantages = [0.0] * len(prompt_ids) + list(advantages)
+        full_mask = [0.0] * len(prompt_ids) + [1.0] * len(response_ids)
+
+        # Create input/target pairs (shift by 1)
+        input_tokens = full_sequence[:-1]
+        target_tokens = full_sequence[1:]
+
+        # Shift to align with targets
+        shifted_logprobs = full_logprobs[1:]
+        shifted_advantages = full_advantages[1:]
+        shifted_mask = full_mask[1:]
+
+        return tinker.types.Datum(
+            model_input=tinker.types.ModelInput.from_ints(tokens=[int(t) for t in input_tokens]),
+            loss_fn_inputs={
+                "target_tokens": TensorData.from_torch(torch.tensor(target_tokens)),
+                "logprobs": TensorData.from_torch(torch.tensor(shifted_logprobs)),
+                "advantages": TensorData.from_torch(torch.tensor(shifted_advantages)),
+                "mask": TensorData.from_torch(torch.tensor(shifted_mask)),
+            },
+        )
+
+    @staticmethod
     def build_datum_from_trajectory(trajectory: Trajectory, advantage: float) -> list[tinker.Datum]:
         """
         Build one or more Datums from a trajectory, merging steps when possible.
@@ -280,6 +357,13 @@ class TinkerDatumBuilder:
 
         # DEBUG: Check for data quality issues
         for step_idx, step in enumerate(trajectory.steps):
+            if not step.prompt_ids and step.model_output and step.model_output.prompt_ids:
+                step.prompt_ids = step.model_output.prompt_ids
+            if not step.response_ids and step.model_output and step.model_output.completion_ids:
+                step.response_ids = step.model_output.completion_ids
+            if not step.logprobs and step.model_output and step.model_output.logprobs:
+                step.logprobs = step.model_output.logprobs
+
             # Check for None values in logprobs
             if step.logprobs and None in step.logprobs:
                 logger.error(f"Step {step_idx} has None in logprobs: {step.logprobs}")
@@ -396,7 +480,7 @@ class TinkerDatumBuilder:
         return datums
 
 
-def process_episodes(
+async def process_episodes(
     episodes: list,
     advantage_computer: TinkerAdvantageComputer,
     trajectory_filter: TinkerTrajectoryFilter,
@@ -406,11 +490,16 @@ def process_episodes(
     Main pipeline to convert Episode objects to training datums.
 
     This function:
-    1. Groups trajectories based on grouping_level configuration
-    2. Computes advantages for each group
-    3. Builds Tinker Datums for training
+    1. For distillation: Flattens episodes → list of trajectories (skips grouping/filtering)
+    2. For RL (GRPO/REINFORCE): Groups trajectories based on grouping_level configuration
+    3. Computes advantages for each trajectory/group
+    4. Builds Tinker Datums for training
 
-    Grouping levels:
+    Distillation mode:
+    - Skips grouping and filtering (advantages computed per-token from teacher/student logprobs)
+    - Processes all trajectories independently
+
+    RL mode grouping levels:
     - trajectory: Group trajectories by (task_id, trajectory_name) for multi-agent workflows.
                  Advantage computed across trajectory rewards.
     - step: Group individual steps at same position for step-level advantage computation.
@@ -419,8 +508,8 @@ def process_episodes(
     Args:
         episodes: List of Episode objects
         advantage_computer: Computer for calculating advantages
-        trajectory_filter: Filter for removing constant-reward groups
-        algorithm_config: Configuration with grouping_level setting
+        trajectory_filter: Filter for removing constant-reward groups (only used in RL mode)
+        algorithm_config: Configuration with grouping_level setting (only used in RL mode)
 
     Returns:
         Tuple of (datums, metrics_dict):
@@ -431,73 +520,235 @@ def process_episodes(
 
     import numpy as np
 
-    grouping_level = algorithm_config.get("grouping_level", "episode")
-
-    # Group trajectories based on grouping_level
-    trajectory_groups_dict = defaultdict(list)
-
-    def get_task_id(episode):
-        """Extract task_id from episode.id (format: task_id:rollout_idx)"""
-        return ":".join(episode.id.split(":")[:-1]) if ":" in episode.id else episode.id
-
-    if grouping_level == "trajectory":
-        # Group by (task_id, trajectory_name) - for multi-agent workflows like solver-judge
-        for episode in episodes:
-            task_id = get_task_id(episode)
-            for trajectory in episode.trajectories:
-                group_key = (task_id, trajectory.name)
-                trajectory_groups_dict[group_key].append(trajectory)
-
-    elif grouping_level == "step":
-        # Group by (task_id, trajectory_name, step_idx) - for step-level advantages
-        for episode in episodes:
-            task_id = get_task_id(episode)
-            for trajectory in episode.trajectories:
-                for step_idx, step in enumerate(trajectory.steps):
-                    group_key = (task_id, trajectory.name, step_idx)
-                    # Create single-step trajectory
-                    from rllm.agents.agent import Trajectory
-
-                    single_step_traj = Trajectory(steps=[step], reward=step.reward, name=trajectory.name)
-                    trajectory_groups_dict[group_key].append(single_step_traj)
-
-    else:  # "episode" or default
-        # Simple grouping: all trajectories in an episode form one group
-        for episode in episodes:
-            group_key = episode.id
-            trajectory_groups_dict[group_key].extend(episode.trajectories)
-
-    # Convert dict to list of TrajectoryGroup objects for filtering
-    trajectory_groups = [TrajectoryGroup(trajectories=trajs, group_id=str(key)) for key, trajs in trajectory_groups_dict.items()]
-
-    # Apply filtering based on configuration
-    filtered_groups = trajectory_filter.filter_groups(trajectory_groups)
-
     # Track metrics
     all_advantages = []
     group_sizes = []
 
     training_datums = []
-    for group in filtered_groups:
-        # Extract rewards for the group (from all trajectories)
-        group_rewards = [traj.reward for traj in group.trajectories]
 
-        # Compute advantages
-        advantages = advantage_computer.compute(group_rewards)
+    if advantage_computer.distill_enabled:
+        import asyncio
 
-        # Track for metrics
-        all_advantages.extend(advantages)
-        group_sizes.append(len(group.trajectories))
+        teacher_chat_parser = None
+        if not advantage_computer.shared_tokenizer:
+            if not hasattr(advantage_computer.teacher_engine, "chat_parser") or advantage_computer.teacher_engine.chat_parser is None:
+                raise ValueError("Teacher engine does not have a chat_parser.")
+            teacher_chat_parser = advantage_computer.teacher_engine.chat_parser
 
-        # Create datums for all trajectories in the group
-        for trajectory, advantage in zip(group.trajectories, advantages, strict=False):
-            # Use trajectory-level building (merges steps when possible)
-            new_datums = TinkerDatumBuilder.build_datum_from_trajectory(trajectory, advantage)
-            training_datums.extend(new_datums)
+        async def process_step(global_idx: int, step: Step) -> tuple[tinker.Datum, float]:
+            """
+            Process a single step: query teacher, align, compute advantages, build datum.
+
+            Args:
+                global_idx: Global step index (for visualization on idx=0)
+                step: The step to process
+
+            Returns:
+                Tuple of (datum, avg_advantage)
+            """
+            if not step.model_output or not step.model_output.completion_ids or not step.model_output.logprobs:
+                raise ValueError("Missing model_output with completion_ids or logprobs for distillation.")
+
+            prompt_ids = step.prompt_ids or step.model_output.prompt_ids
+            if not prompt_ids:
+                raise ValueError("Missing prompt_ids in step for distillation.")
+
+            student_completion_ids = step.model_output.completion_ids
+            student_logprobs = step.model_output.logprobs
+
+            if advantage_computer.shared_tokenizer:
+                # Fast path: student and teacher use the same tokenizer
+                # Directly use student token IDs for teacher query
+                student_prompt_ids = prompt_ids
+                teacher_ids = student_prompt_ids + student_completion_ids
+                teacher_prompt_length = len(student_prompt_ids)
+
+                teacher_resp = await advantage_computer.teacher_engine.completion(
+                    teacher_ids,
+                    max_tokens=1,
+                    extra_body={"prompt_logprobs": 1},
+                )
+                if not teacher_resp.prompt_logprobs:
+                    raise ValueError("Teacher missing prompt_logprobs.")
+
+                aligned_teacher_logprobs = teacher_resp.prompt_logprobs[teacher_prompt_length:]
+
+            else:
+                # Slow path: different tokenizers, need byte-level alignment
+                from rllm.trainer.distill import align_teacher_logprobs
+
+                if not step.chat_completions:
+                    raise ValueError("Missing chat_completions in step for distillation.")
+
+                teacher_prompt_messages = step.chat_completions[:-1]
+                teacher_completion_messages = step.chat_completions[-1:]
+
+                reasoning_str = teacher_completion_messages[0].get("reasoning", "")
+                content_str = teacher_completion_messages[0].get("content", "")
+                if not reasoning_str and not content_str:
+                    raise ValueError("Missing both reasoning and content in teacher completion message.")
+
+                # Build teacher prompt and completion
+                teacher_prompt = teacher_chat_parser.parse(
+                    teacher_prompt_messages,
+                    is_first_msg=True,
+                    add_generation_prompt=True,
+                    tools=[],
+                    accumulate_reasoning=False,
+                )
+                teacher_prompt_ids = advantage_computer.teacher_tokenizer.encode(teacher_prompt, add_special_tokens=False)
+
+                teacher_completion = teacher_chat_parser.parse(
+                    teacher_completion_messages,
+                    is_first_msg=False,
+                    add_generation_prompt=False,
+                    tools=[],
+                    accumulate_reasoning=True,
+                )
+                if teacher_completion.startswith(teacher_chat_parser.generation_prompt):
+                    teacher_completion = teacher_completion[len(teacher_chat_parser.generation_prompt) :]
+
+                # Query teacher for logprobs (async)
+                teacher_full_prompt = teacher_prompt + teacher_completion
+                teacher_resp = await advantage_computer.teacher_engine.completion(
+                    teacher_full_prompt,
+                    max_tokens=1,
+                    extra_body={"prompt_logprobs": 1},
+                )
+                if not teacher_resp.prompt_logprobs:
+                    raise ValueError("Teacher missing prompt_logprobs.")
+
+                teacher_prompt_len = len(teacher_prompt_ids)
+                teacher_completion_ids = teacher_resp.prompt_ids[teacher_prompt_len:]
+                teacher_logprobs = teacher_resp.prompt_logprobs[teacher_prompt_len:]
+
+                # Align teacher logprobs to student tokens
+                aligned_teacher_logprobs = align_teacher_logprobs(
+                    student_ids=student_completion_ids,
+                    student_tokenizer=advantage_computer.student_tokenizer,
+                    teacher_ids=teacher_completion_ids,
+                    teacher_tokenizer=advantage_computer.teacher_tokenizer,
+                    teacher_logprobs=teacher_logprobs,
+                    student_logprobs=student_logprobs,
+                    reasoning_str=reasoning_str,
+                    content_str=content_str,
+                )
+
+                # Visualize first step
+                if global_idx == 0:
+                    from rllm.trainer.distill import visualize_alignment
+
+                    visualize_alignment(
+                        student_ids=student_completion_ids,
+                        student_tokenizer=advantage_computer.student_tokenizer,
+                        teacher_ids=teacher_completion_ids,
+                        teacher_tokenizer=advantage_computer.teacher_tokenizer,
+                        teacher_logprobs=teacher_logprobs,
+                        student_logprobs=student_logprobs,
+                        reasoning_str=reasoning_str,
+                        content_str=content_str,
+                        max_tokens=150,
+                    )
+
+            # Compute per-token advantages
+            advantages = advantage_computer.compute_distill_advantages_per_token(
+                student_logprobs,
+                aligned_teacher_logprobs,
+            )
+
+            datum = TinkerDatumBuilder.build_distillation_datum(
+                prompt_ids=prompt_ids,
+                response_ids=student_completion_ids,
+                logprobs=student_logprobs,
+                advantages=advantages,
+            )
+
+            avg_advantage = float(np.mean(advantages)) if advantages else 0.0
+            return datum, avg_advantage
+
+        # Collect all steps
+        all_steps: list[Step] = []
+        for episode in episodes:
+            for trajectory in episode.trajectories:
+                for step in trajectory.steps:
+                    all_steps.append(step)
+
+        import time
+
+        start_time = time.time()
+        print(f"[Distillation] Processing {len(all_steps)} steps in parallel...")
+
+        # Process all steps in parallel
+        tasks = [process_step(idx, step) for idx, step in enumerate(all_steps)]
+        results = await asyncio.gather(*tasks)
+
+        print(f"[Distillation] Processing complete in {time.time() - start_time:.2f} seconds.")
+
+        # Collect results
+        for datum, avg_advantage in results:
+            training_datums.append(datum)
+            all_advantages.append(avg_advantage)
+    else:
+        # Standard RL mode: group trajectories and compute advantages from rewards
+        grouping_level = algorithm_config.get("grouping_level", "episode")
+
+        # Group trajectories based on grouping_level
+        trajectory_groups_dict = defaultdict(list)
+
+        def get_task_id(episode):
+            """Extract task_id from episode.id (format: task_id:rollout_idx)"""
+            return ":".join(episode.id.split(":")[:-1]) if ":" in episode.id else episode.id
+
+        if grouping_level == "trajectory":
+            # Group by (task_id, trajectory_name) - for multi-agent workflows like solver-judge
+            for episode in episodes:
+                task_id = get_task_id(episode)
+                for trajectory in episode.trajectories:
+                    group_key = (task_id, trajectory.name)
+                    trajectory_groups_dict[group_key].append(trajectory)
+
+        elif grouping_level == "step":
+            # Group by (task_id, trajectory_name, step_idx) - for step-level advantages
+            for episode in episodes:
+                task_id = get_task_id(episode)
+                for trajectory in episode.trajectories:
+                    for step_idx, step in enumerate(trajectory.steps):
+                        group_key = (task_id, trajectory.name, step_idx)
+                        # Create single-step trajectory
+                        from rllm.agents.agent import Trajectory
+
+                        single_step_traj = Trajectory(steps=[step], reward=step.reward, name=trajectory.name)
+                        trajectory_groups_dict[group_key].append(single_step_traj)
+
+        else:  # "episode" or default
+            # Simple grouping: all trajectories in an episode form one group
+            for episode in episodes:
+                group_key = episode.id
+                trajectory_groups_dict[group_key].extend(episode.trajectories)
+
+        # Convert dict to list of TrajectoryGroup objects for filtering
+        trajectory_groups = [TrajectoryGroup(trajectories=trajs, group_id=str(key)) for key, trajs in trajectory_groups_dict.items()]
+
+        # Apply filtering based on configuration
+        filtered_groups = trajectory_filter.filter_groups(trajectory_groups)
+
+        for group in filtered_groups:
+            # Standard RL mode: compute scalar advantages from rewards
+            group_rewards = [traj.reward for traj in group.trajectories]
+            advantages = advantage_computer.compute(group_rewards)
+
+            # Track for metrics
+            all_advantages.extend(advantages)
+            group_sizes.append(len(group.trajectories))
+
+            # Create datums for all trajectories in the group
+            for trajectory, advantage in zip(group.trajectories, advantages, strict=False):
+                new_datums = TinkerDatumBuilder.build_datum_from_trajectory(trajectory, advantage)
+                training_datums.extend(new_datums)
 
     # Compute grouping and advantage metrics
     metrics = {}
-    if filtered_groups:
+    if not advantage_computer.distill_enabled and filtered_groups:
         metrics["grouping/num_groups"] = len(filtered_groups)
         metrics["grouping/num_groups_before_filter"] = len(trajectory_groups)
         metrics["grouping/avg_group_size"] = np.mean(group_sizes)
@@ -514,6 +765,7 @@ def process_episodes(
     return training_datums, metrics
 
 
+# TODO: is this dead code?
 def process_trajectory_groups(
     groups: list[TrajectoryGroup],
     advantage_computer: TinkerAdvantageComputer,

--- a/rllm/trainer/tinker/tinker_metrics_utils.py
+++ b/rllm/trainer/tinker/tinker_metrics_utils.py
@@ -124,6 +124,7 @@ def print_metrics_table(metrics: dict, step: int):
         print("=" * 60)
 
 
+# TODO: is this dead code?
 def print_trajectories(
     trajectories: list[list[dict]],
     advantage_computer: Any,

--- a/rllm/trainer/tinker/tinker_workflow_trainer.py
+++ b/rllm/trainer/tinker/tinker_workflow_trainer.py
@@ -67,11 +67,15 @@ class TinkerWorkflowTrainer(TinkerAgentTrainer):
             shuffle=True,
             collate_fn=lambda x: x,  # Return batches as lists
         )
-        self.val_dataloader = torch.utils.data.DataLoader(
-            val_dataset,
-            batch_size=self.config.data.val_batch_size,
-            shuffle=False,
-            collate_fn=lambda x: x,  # Return batches as lists
+        self.val_dataloader = (
+            torch.utils.data.DataLoader(
+                val_dataset,
+                batch_size=self.config.data.val_batch_size,
+                shuffle=False,
+                collate_fn=lambda x: x,  # Return batches as lists
+            )
+            if val_dataset is not None
+            else None
         )
 
         service_client = tinker.ServiceClient(base_url=self.config.tinker_base_url)
@@ -91,6 +95,7 @@ class TinkerWorkflowTrainer(TinkerAgentTrainer):
             max_prompt_length=self.config.data.max_prompt_length,
             max_response_length=self.config.data.max_response_length,
             sampling_params=sampling_params,
+            **self.config.rollout_engine,
         )
         self.agent_execution_engine = AgentWorkflowEngine(
             workflow_cls=self.workflow_class,

--- a/rllm/trainer/verl/agent_workflow_trainer.py
+++ b/rllm/trainer/verl/agent_workflow_trainer.py
@@ -57,6 +57,28 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
         self.workflow_args = workflow_args or {}
         self._validate_config()
 
+        # Initialize teacher engine if distillation is enabled
+        self.distill_enabled = self.config.rllm.get("distill", {}).get("enable", False)
+        if self.distill_enabled:
+            print("Distillation is enabled, will ignore rewards returned in episodes.")
+        self.teacher_engine = None
+        self.teacher_tokenizer = None
+        if self.distill_enabled:
+            from transformers import AutoTokenizer
+
+            from rllm.engine.rollout.openai_engine import OpenAIEngine
+
+            teacher_rollout_args = self.config.rllm.distill.get("teacher_rollout_args", {})
+            teacher_model = teacher_rollout_args.get("model", "")
+            if not teacher_model:
+                raise ValueError("model must be specified in rllm.distill.teacher_rollout_args when distillation is enabled")
+
+            self.teacher_tokenizer = AutoTokenizer.from_pretrained(teacher_model)
+            self.teacher_engine = OpenAIEngine(
+                **teacher_rollout_args,
+                tokenizer=self.teacher_tokenizer,
+            )
+
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
         self._thread.start()
@@ -286,28 +308,10 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                         batch = batch.union(old_log_prob)
 
                         if "rollout_log_probs" in batch.batch.keys():
-                            # TODO: we may want to add diff of probs too.
-                            rollout_old_log_probs = batch.batch["rollout_log_probs"]
-                            actor_old_log_probs = batch.batch["old_log_probs"]
-                            attention_mask = batch.batch["attention_mask"]
-                            responses = batch.batch["responses"]
-                            response_length = responses.size(1)
-                            response_mask = attention_mask[:, -response_length:]
+                            from verl.utils.debug.metrics import calculate_debug_metrics
 
-                            rollout_probs = torch.exp(rollout_old_log_probs)
-                            actor_probs = torch.exp(actor_old_log_probs)
-                            rollout_probs_diff = torch.abs(rollout_probs - actor_probs)
-                            rollout_probs_diff = torch.masked_select(rollout_probs_diff, response_mask.bool())
-                            rollout_probs_diff_max = torch.max(rollout_probs_diff)
-                            rollout_probs_diff_mean = torch.mean(rollout_probs_diff)
-                            rollout_probs_diff_std = torch.std(rollout_probs_diff)
-                            metrics.update(
-                                {
-                                    "training/rollout_probs_diff_max": rollout_probs_diff_max.detach().item(),
-                                    "training/rollout_probs_diff_mean": rollout_probs_diff_mean.detach().item(),
-                                    "training/rollout_probs_diff_std": rollout_probs_diff_std.detach().item(),
-                                }
-                            )
+                            debug_metrics = calculate_debug_metrics(batch)
+                            metrics.update(debug_metrics)
 
                     if self.use_reference_policy:
                         # compute reference log_prob
@@ -335,38 +339,45 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                         else:
                             batch.batch["token_level_scores"] = batch.batch["traj_rewards"]
 
-                        # compute rewards. apply_kl_penalty if available
-                        if self.config.algorithm.use_kl_in_reward:
-                            batch, kl_metrics = apply_kl_penalty(batch, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty)
-                            metrics.update(kl_metrics)
-                        else:
+                        if self.distill_enabled:
                             batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
-
-                        if self.config.rllm.stepwise_advantage.enable and self.config.rllm.stepwise_advantage.mode == "broadcast":
-                            is_last_step = batch.non_tensor_batch["is_last_step"]
-                            last_step_indices = np.where(is_last_step == True)[0]
-                            not_last_step_indices = np.where(is_last_step == False)[0]
-                            non_last_step_batch = batch.select_idxs(not_last_step_indices)
-                            batch = batch.select_idxs(last_step_indices)  # This batch only has last steps
-                            # last_step_batch contains no padded steps as it was rounded down (not padded) to a multiple of world size
+                            batch = self._remove_padding(batch)
+                            distill_advantages = asyncio.run_coroutine_threadsafe(self._compute_distill_advantages(batch), self._loop).result()
+                            batch.batch["advantages"] = distill_advantages
+                            batch.batch["returns"] = distill_advantages
                         else:
-                            batch = self._remove_padding(batch)  # compute advantages over non-padded steps only
+                            # apply_kl_penalty if available
+                            if self.config.algorithm.use_kl_in_reward:
+                                batch, kl_metrics = apply_kl_penalty(batch, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty)
+                                metrics.update(kl_metrics)
+                            else:
+                                batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
 
-                        # compute advantages, executed on the driver process
-                        batch = compute_advantage(
-                            batch,
-                            adv_estimator=self.config.algorithm.adv_estimator,
-                            gamma=self.config.algorithm.gamma,
-                            lam=self.config.algorithm.lam,
-                            num_repeat=self.config.actor_rollout_ref.rollout.n,
-                            norm_adv_by_std_in_grpo=self.config.algorithm.norm_adv_by_std_in_grpo,
-                            config=self.config.algorithm,
-                        )
+                            if self.config.rllm.stepwise_advantage.enable and self.config.rllm.stepwise_advantage.mode == "broadcast":
+                                is_last_step = batch.non_tensor_batch["is_last_step"]
+                                last_step_indices = np.where(is_last_step == True)[0]
+                                not_last_step_indices = np.where(is_last_step == False)[0]
+                                non_last_step_batch = batch.select_idxs(not_last_step_indices)
+                                batch = batch.select_idxs(last_step_indices)  # This batch only has last steps
+                                # last_step_batch contains no padded steps as it was rounded down (not padded) to a multiple of world size
+                            else:
+                                batch = self._remove_padding(batch)  # compute advantages over non-padded steps only
 
-                        if self.config.rllm.stepwise_advantage.enable and self.config.rllm.stepwise_advantage.mode == "broadcast":
-                            # Merging the separated out steps using the advantage from last steps
-                            self._stepwise_advantage_broadcast(batch, non_last_step_batch)
-                            batch = DataProto.concat([batch, non_last_step_batch])
+                            # compute advantages, executed on the driver process
+                            batch = compute_advantage(
+                                batch,
+                                adv_estimator=self.config.algorithm.adv_estimator,
+                                gamma=self.config.algorithm.gamma,
+                                lam=self.config.algorithm.lam,
+                                num_repeat=self.config.actor_rollout_ref.rollout.n,
+                                norm_adv_by_std_in_grpo=self.config.algorithm.norm_adv_by_std_in_grpo,
+                                config=self.config.algorithm,
+                            )
+
+                            if self.config.rllm.stepwise_advantage.enable and self.config.rllm.stepwise_advantage.mode == "broadcast":
+                                # Merging the separated out steps using the advantage from last steps
+                                self._stepwise_advantage_broadcast(batch, non_last_step_batch)
+                                batch = DataProto.concat([batch, non_last_step_batch])
 
                     # remove invalid items filtered out due to compact filtering
                     is_valid = batch.non_tensor_batch["is_valid"]
@@ -486,6 +497,7 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
         data_source_lst = []
         uid_lst = []
         workflow_metrics_by_source = defaultdict(lambda: defaultdict(list))
+        batches_for_distill = []
 
         for test_data in self.val_dataloader:
             test_batch = DataProto.from_single_dict(test_data)
@@ -503,6 +515,9 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
             test_batch = test_batch.sample_level_repeat(repeat_counts)
             test_output_gen_batch.meta_info.pop("repeat_counts", None)  # no longer needed after this
             test_batch = test_batch.union(test_output_gen_batch)
+
+            if self.distill_enabled:
+                batches_for_distill.append(test_batch)
 
             seen_episodes = set()
             selected_idxs = []
@@ -551,7 +566,197 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                     if values:  # Only add if we have values
                         metrics[f"val/{data_source}/{key}"] = np.mean(values)
 
+        # Compute distillation metrics if enabled
+        if self.distill_enabled and batches_for_distill:
+            try:
+                # Concatenate all validation batches
+                combined_batch = DataProto.concat(batches_for_distill)
+
+                # Compute old_log_probs for distillation
+                old_log_prob = self.actor_rollout_wg.compute_log_prob(combined_batch)
+                combined_batch = combined_batch.union(old_log_prob)
+
+                # Compute distillation advantages
+                distill_advantages = asyncio.run_coroutine_threadsafe(self._compute_distill_advantages(combined_batch), self._loop).result()
+
+                # Extract distillation metrics
+                response_mask = combined_batch.batch["response_mask"]
+                valid_advantages = distill_advantages[response_mask.bool()]
+                if len(valid_advantages) > 0:
+                    metrics["val/distill/mean_advantage"] = valid_advantages.mean().item()
+                    metrics["val/distill/std_advantage"] = valid_advantages.std().item()
+                    metrics["val/distill/min_advantage"] = valid_advantages.min().item()
+                    metrics["val/distill/max_advantage"] = valid_advantages.max().item()
+            except Exception as e:
+                print(f"Warning: Failed to compute distillation metrics during validation: {e}")
+                import traceback
+
+                traceback.print_exc()
+
         return metrics
+
+    async def _compute_distill_advantages(self, batch: DataProto) -> torch.Tensor:
+        """
+        Compute distillation advantages by querying teacher and aligning logprobs.
+
+        For each sample in the batch:
+        1. Extract student completion_ids, student logprobs, and (if needed) chat_completions
+        2. Query teacher for logprobs on the same completion
+        3. Align teacher logprobs to student tokens (byte-level alignment if different tokenizers)
+        4. Compute per-token advantages: teacher_logprob - student_logprob
+
+        Args:
+            batch: DataProto containing student responses, logprobs, and optionally chat_completions
+                  (chat_completions only needed when shared_tokenizer=False)
+
+        Returns:
+            Tensor of shape (batch_size, max_response_length) with per-token advantages.
+            Padded positions have advantages = 0.0
+        """
+        shared_tokenizer = self.config.rllm.distill.shared_tokenizer
+
+        prompts = batch.batch["prompts"]  # (batch_size, max_prompt_length)
+        responses = batch.batch["responses"]  # (batch_size, max_response_length)
+        response_mask = batch.batch["response_mask"]  # (batch_size, max_response_length)
+        attention_mask = batch.batch["attention_mask"]  # (batch_size, max_prompt_length + max_response_length)
+        rollout_log_probs = batch.batch["rollout_log_probs"]  # (batch_size, max_response_length)
+
+        batch_size, max_prompt_length = prompts.shape
+        _, max_response_length = responses.shape
+        advantages = torch.zeros((batch_size, max_response_length), dtype=torch.float32)
+
+        # Only need chat_completions and chat_parser when tokenizers differ
+        if not shared_tokenizer:
+            from rllm.trainer.distill import align_teacher_logprobs
+
+            chat_completions = batch.non_tensor_batch.get("chat_completions", None)
+            if chat_completions is None:
+                raise ValueError("chat_completions not found in batch, cannot perform distillation.")
+
+            if not hasattr(self.teacher_engine, "chat_parser") or self.teacher_engine.chat_parser is None:
+                raise ValueError("Teacher engine does not have a chat_parser.")
+            teacher_chat_parser = self.teacher_engine.chat_parser
+
+        async def get_teacher_logprobs(prompt: str | list[int], prompt_length: int, sample_idx: int) -> list[float]:
+            """Query teacher for logprobs
+            Note: We assume the teacher engine is vLLM, not SGLang.
+            This is because SGLang does not support prompt_logprobs through the completions endpoint.
+            Though we could support this through the echo and logprobs params if needed.
+            You can still use SGLang to serve the policy, but you should ensure the temperature is 1.0 and the top_p is 1.0."""
+
+            teacher_resp = await self.teacher_engine.completion(
+                prompt,
+                max_tokens=1,
+                extra_body={"prompt_logprobs": 1},
+            )
+            if not teacher_resp.prompt_logprobs:
+                raise ValueError(f"Teacher missing prompt_logprobs for sample {sample_idx}.")
+
+            return teacher_resp.prompt_logprobs[prompt_length:]
+
+        async def process_sample(sample_idx: int) -> None:
+            """Process a single sample: query teacher, align, compute advantages."""
+            try:
+                student_prompt_length = attention_mask[sample_idx, :max_prompt_length].sum().item()
+                if student_prompt_length == 0:
+                    raise ValueError(f"Sample {sample_idx} has no valid prompt tokens.")
+
+                student_response_length = attention_mask[sample_idx, -max_response_length:].sum().item()
+                if student_response_length == 0:
+                    raise ValueError(f"Sample {sample_idx} has no valid response tokens.")
+
+                student_prompt_ids = prompts[sample_idx, -student_prompt_length:].tolist()
+                student_response_ids = responses[sample_idx, :student_response_length].tolist()
+                student_logprobs = rollout_log_probs[sample_idx, :student_response_length].tolist()
+
+                if shared_tokenizer:
+                    # Fast path: student and teacher use the same tokenizer
+                    # Directly use student token IDs for teacher query
+                    teacher_ids = student_prompt_ids + student_response_ids
+                    aligned_teacher_logprobs = await get_teacher_logprobs(teacher_ids, student_prompt_length, sample_idx)
+
+                else:
+                    # Slow path: different tokenizers, need byte-level alignment
+                    sample_chat_completions = chat_completions[sample_idx]
+                    if sample_chat_completions is None or len(sample_chat_completions) == 0:
+                        raise ValueError(f"Sample {sample_idx} has no chat_completions for distillation.")
+
+                    teacher_prompt_messages = sample_chat_completions[:-1]
+                    teacher_completion_messages = sample_chat_completions[-1:]
+
+                    reasoning_str = teacher_completion_messages[0].get("reasoning", "")
+                    content_str = teacher_completion_messages[0].get("content", "")
+                    if not reasoning_str and not content_str:
+                        raise ValueError(f"Sample {sample_idx} has no reasoning or content in teacher completion message.")
+
+                    # Build teacher prompt and completion
+                    teacher_prompt = teacher_chat_parser.parse(
+                        teacher_prompt_messages,
+                        is_first_msg=True,
+                        add_generation_prompt=True,
+                        tools=[],
+                        accumulate_reasoning=False,
+                    )
+                    teacher_prompt_ids = self.teacher_tokenizer.encode(teacher_prompt, add_special_tokens=False)
+
+                    teacher_completion = teacher_chat_parser.parse(
+                        teacher_completion_messages,
+                        is_first_msg=False,
+                        add_generation_prompt=False,
+                        tools=[],
+                        accumulate_reasoning=True,
+                    )
+                    if teacher_completion.startswith(teacher_chat_parser.generation_prompt):
+                        teacher_completion = teacher_completion[len(teacher_chat_parser.generation_prompt) :]
+                    teacher_completion_ids = self.teacher_tokenizer.encode(teacher_completion, add_special_tokens=False)
+
+                    teacher_full_prompt = teacher_prompt + teacher_completion
+                    teacher_prompt_length = len(teacher_prompt_ids)
+                    teacher_logprobs = await get_teacher_logprobs(teacher_full_prompt, teacher_prompt_length, sample_idx)
+
+                    # Align teacher logprobs to student tokens using fast byte-level alignment algorithm
+                    aligned_teacher_logprobs = align_teacher_logprobs(
+                        student_ids=student_response_ids,
+                        student_tokenizer=self.tokenizer,
+                        teacher_ids=teacher_completion_ids,
+                        teacher_tokenizer=self.teacher_tokenizer,
+                        teacher_logprobs=teacher_logprobs,
+                        student_logprobs=student_logprobs,
+                        reasoning_str=reasoning_str,
+                        content_str=content_str,
+                    )
+
+                    # Visualize first sample for debugging alignment
+                    if sample_idx == 0:
+                        from rllm.trainer.distill import visualize_alignment
+
+                        visualize_alignment(
+                            student_ids=student_response_ids,
+                            student_tokenizer=self.tokenizer,
+                            teacher_ids=teacher_completion_ids,
+                            teacher_tokenizer=self.teacher_tokenizer,
+                            teacher_logprobs=teacher_logprobs,
+                            student_logprobs=student_logprobs,
+                            reasoning_str=reasoning_str,
+                            content_str=content_str,
+                            max_tokens=150,
+                        )
+
+                # reverse kl: teacher_logprob - student_logprob
+                sample_advantages = [t_lp - s_lp for t_lp, s_lp in zip(aligned_teacher_logprobs, student_logprobs, strict=False)]
+
+                advantages[sample_idx, :student_response_length] = torch.tensor(sample_advantages, dtype=torch.float32)
+
+            except Exception as e:
+                print(f"Error processing sample {sample_idx} for distillation: {e}")
+                import traceback
+
+                traceback.print_exc()
+                batch.non_tensor_batch["is_valid"][sample_idx] = False  # drop the item from the batch
+
+        await asyncio.gather(*[process_sample(i) for i in range(batch_size)])
+        advantages *= response_mask.float()
+        return advantages
 
     def generate_trajectories(self, batch, timing_raw=None, **kwargs):
         """


### PR DESCRIPTION
This pr adds support for on policy distillation for both the verl and tinker backend. We handle two cases:
1. Shared tokenizer between the student and teacher, in which case we score the students completion directly
2. Different tokenizer between the student and teacher, in which case we reformat the students input/output using the teacher's chat template and tokenizer, score the completion using this view, then align the teacher logprobs to the student. In this setting, template tokens (e.g., </think>) will receive logprob=0.0.

Included are runnable 0.6B and 8B countdown examples for verl/tinker that should converge to ~70% and ~72% acc respectively. 

We assume the teacher is served via vLLM. If the student policy uses SGLang, you should use temperate=1.0 and top_p=1.0.

Currently, tool calls are not handled in the case in which the tokenizers are different. 

Separately, this adds support for returning the rollout log probs through the workflow and logging appropriate related metrics.