### PR TITLE
[Bugfix] Make sure the tracking logger is now explicitly finished by trainers

### DIFF
--- a/rllm/trainer/tinker/tinker_agent_trainer.py
+++ b/rllm/trainer/tinker/tinker_agent_trainer.py
@@ -299,7 +299,11 @@ class TinkerAgentTrainer:
         if batch_idx % self.config.trainer.save_freq != 0:
             logger.info(f"Saving final checkpoint at batch {batch_idx}")
             await self.trainer.save_checkpoint_async(batch_idx, kind="state")
-        del tracking_logger
+
+        try:
+            tracking_logger.finish()
+        except Exception:
+            pass  # skip errors during cleanup
 
     def init_envs_and_agents(self, batch):
         """

--- a/rllm/trainer/tinker/tinker_sft_trainer.py
+++ b/rllm/trainer/tinker/tinker_sft_trainer.py
@@ -317,7 +317,10 @@ class TinkerSFTTrainer:
             logger.info("Training was already complete; nothing to do")
 
         self.tracking_logger.log(data={"status": "completed"}, step=total_steps)
-        del self.tracking_logger
+        try:
+            self.tracking_logger.finish()
+        except Exception:
+            pass  # skip errors during cleanup
         logger.info("Training completed successfully")
 
     async def validate(self, val_dataset) -> dict[str, float]:

--- a/rllm/trainer/verl/agent_workflow_trainer.py
+++ b/rllm/trainer/verl/agent_workflow_trainer.py
@@ -129,7 +129,7 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
         """
         The training loop of PPO. Adapted to train the underlying model of agent.
         """
-        from verl.utils.tracking import Tracking
+        from rllm.utils.tracking import Tracking
 
         logger = Tracking(
             project_name=self.config.trainer.project_name,
@@ -490,6 +490,12 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                         val_metrics = self._validate_agent()
                         pprint(f"Final validation metrics: {val_metrics}")
                         logger.log(data=val_metrics, step=self.global_steps)
+
+                    try:
+                        logger.finish()
+                    except Exception:
+                        pass  # skip errors during cleanup
+
                     return
 
     def _validate_agent(self):


### PR DESCRIPTION
### What does this PR do?

In short, this PR adds a function `.finish()` for the `rllm.utils.tracking.Tracking` logger (and redirect `__del__` to use this function) and makes sure that all trainers using this tracking logger will clean it up by explicitly calling `.finish()`.

The previous approach used `del logger` -- which relies on the **garbage collector** scheduling to run the content of the `__del__` function and is known to be [unreliable](https://stackoverflow.com/questions/1481488/what-is-the-del-method-and-how-do-i-call-it), especially that we should avoid putting "must-run" clean up logic within the `__del__` method.

**An actual bug caused by this** is that the `wandb` logger sometimes (depending on GC, so this is not reproducible every time) keep hanging even after the `tinker` training has finished, which is because the current `wandb` logger finishing logic is nested under `__del__`. 

**The solution is pretty simple:** just make sure to call the `.finish()` function, which explicitly and always clean up all the logger backends. This solution should also not introduce any backward compatibility issue, since (1) I have manually checked all usages and refactored accordingly, and (2) the `__del__` function still exists and rely on `finish` under the hood.