### PR TITLE
overlong_filter in stepwise RL

### DIFF
--- a/rllm/engine/agent_execution_engine.py
+++ b/rllm/engine/agent_execution_engine.py
@@ -422,6 +422,7 @@ class AgentExecutionEngine:
                 "trajectory_reward": trajectory.reward,
                 "idx": env.idx,
                 "mc_returns": [step.mc_return for step in trajectory.steps][: len(episode_steps)],
+                "termination_reason": termination_reason,
             }
             return steps_result
         else:


### PR DESCRIPTION
Previous overlong_filter is only available when mode == "Token" in agent_execution_engine.py.
I implemented overlong_filter when doing stepwise RL.