### PR TITLE
Reset workflow with task and uid before workflow execution

### DIFF
--- a/rllm/experimental/engine/unified_workflow_engine.py
+++ b/rllm/experimental/engine/unified_workflow_engine.py
@@ -123,6 +123,7 @@ class UnifiedWorkflowEngine:
         try:
             for retry_attempt in range(1, self.retry_limit + 1):
                 uid = f"{task_id}:{rollout_idx}"
+                workflow.reset(task=task, uid=uid)
                 episode = await workflow.run_with_termination_handling(task=task, uid=uid, **kwargs)
 
                 # We will make sure that the episode has the correct `uid` and `task` fields.


### PR DESCRIPTION
Set `self.uid` and `self.task` before `run_with_termination_handling()` to ensure these attributes are available for `postprocess_episode()` to populate `episode.id` and `episode.task`.