### PR TITLE
【Fix】All content in examples/search were empty

### DIFF
--- a/examples/search/README.md
+++ b/examples/search/README.md
@@ -8,6 +8,9 @@ Train search agents using dense retrieval on Wikipedia with pre-built E5 embeddi
 ```bash
 cd examples/search
 python download_search_data.py --data_dir ./search_data
+
+cd examples/search/search_data/prebuilt_indices
+cat part_aa part_ab > e5_Flat.index
 ```
 
 Downloads:

--- a/examples/search/local_retrieval_tool.py
+++ b/examples/search/local_retrieval_tool.py
@@ -92,8 +92,8 @@ class LocalRetrievalTool(Tool):
         formatted_results = []
         for i, result in enumerate(results[: self.max_results], 1):
             # Extract key information
-            doc_id = result.get("id", f"doc_{i}")
-            content = result.get("content", "")  # Fixed: use "content" not "contents"
+            doc_id = result.get("document", {}).get("id", f"doc_{i}")
+            content = result.get("document", {}).get("contents", "")
             score = result.get("score", 0.0)
 
             # Truncate content if too long (keep first 300 characters)


### PR DESCRIPTION
When reproducing the search case (**examples/search**), we found that the reward curve still showed no upward trend after 100 training iterations. **By checking the trajectory records, we discovered that all query results were empty.** We then located the issue to local_retrieval_tool.py and identified that the original command in this file failed to retrieve the content field. Although we cannot upload images, verification has confirmed that **the fixed cases can now achieve a steady increase in the reward curve.**

Therefore, we propose the following fix strategy:
- fix the issue #392 that training does not converge due to failure to retrieve content in local_retrieval_tool.py

In addition, we have added the index file merging operation to enable users to reproduce this case more easily:
- Add index merging operation in README.md

**This is the tool return content before modification:**
{"role": "tool", "content": "[Document 1] (ID: doc_1, Score: 0.836)\n\n\n[Document 2] (ID: doc_2, Score: 0.833)\n\n\n[Document 3] (ID: doc_3, Score: 0.833)\n\n\n[Document 4] (ID: doc_4, Score: 0.833)\n\n\n[Document 5] (ID: doc_5, Score: 0.830)\n\n", "tool_call_id": "ff0d4c6f-c92b-4a58-a2d1-3e373dfabb36"}

**This is the tool return content after modification:**
{"role": "tool", "content": "[Document 1] (ID: 17162596, Score: 0.869)\n\"Gary Cornish\"\nto boxing, the sport where he had shown most ability, at age of 19. His amateur career was short, due to the difficulty in finding suitable opponents, and he turned professional with an amateur record of 9-0. His break out fight came in 2015, when he challenged Hungarian Zoltan Csala ...\n\n[Document 2] (ID: 20372469, Score: 0.860)\n\"Anthony Joshua\"\nTyson Fury and Dereck Chisora the 12-round distance. A day after the fight, Johnson announced his retirement, although he made a comeback in March 2017. On 16 July 2015, it was announced that Joshua would fight undefeated Scottish boxer Gary Cornish (21-0, 12 KOs) for the vacant Com...\n\n[Document 3] (ID: 19529919, Score: 0.849)\n\"Gary Cornish\"\nGary Cornish Gary Cornish (born April 10, 1987) is a Scottish professional boxer. Cornish has had 27 fights, winning 25 with 2 losses. As a youngster he played football for Brora Rangers. He decided to go to the local boxing gym only to improve his fitness for football. He fell in lov...\n\n[Document 4] (ID: 19529921, Score: 0.833)\n\"Gary Cornish\"\nthe Vacant Commonwealth Belt, losing the fight in the first round. Cornish remained largely absent from the public eye following the Joshua fight, but has since regrouped in 2016 with two points victories in bouts fought in Scotland. Cornish is proud of his Scottish heritage. He has a...\n\n[Document 5] (ID: 20372470, Score: 0.825)\n\"Anthony Joshua\"\nsaid, \"\"Gary had a solid jab so I had to make sure I didn't take any of those shots. He was throwing a large jab and I tried to slip it. I managed to land the right hand and it was a perfect connection and he went down.\"\" Immediately after Joshua stopped Cornish, Hearn confirmed Dil...\n\n[Document 6] (ID: 20372465, Score: 0.825)\n\"Anthony Joshua\"\nto 4-0. The following month, on the undercard of Ricky Burns against Terence Crawford, Joshua defeated Hector Alfredo Avila with a 1st-round KO, in Glasgow, Scotland. In May that year Joshua knocked out Matt Legg in one round on the undercard of Carl Froch vs. George Groves II at We...\n\n[Document 7] (ID: 20372455, Score: 0.824)\n\"Anthony Joshua\"\nAnthony Joshua Joshua represented England at the 2011 World Championships as an amateur in the super-heavyweight division, winning a silver medal; he also represented Great Britain at the 2012 Olympics, winning gold. In 2014, a year after turning professional, he was named Prospect ...\n\n[Document 8] (ID: 20372464, Score: 0.823)\n\"Anthony Joshua\"\nin the first round. Joshua's second professional fight was against English heavyweight Paul Butlin at the Motorpoint Arena in Sheffield on 26 October 2013. The bout was stopped in the 2nd round when the referee decided Butlin was taking too much punishment and declared Joshua the wi...\n\n[Document 9] (ID: 5848030, Score: 0.823)\n\"Gary Turner (fighter)\"\nin Croatia. Gary is a 10-time world champion (x2 kickboxing, x8 Ju-Jitsu) who has also won countless European and domestic titles across a wide range of martial arts styles. Pro Kickboxing Amateur Kickboxing Ju-Jitsu Judo Shootfighting Gary Turner (fighter) Gary Turner (born ...\n\n[Document 10] (ID: 20372515, Score: 0.821)\n\"Anthony Joshua\"\nand the same team from CHHP London in Harley Street are available at BXR including a number of sports therapists, physiotherapists, doctors and osteopaths alongside BXR's boxers, boxing coaches and MMA fighters. The gym opened in January 2017 on Chiltern Street in Marylebone, London...\n", "tool_call_id": "7afba693-f76a-409b-afe6-dfe4ff062f63"}
