### PR TITLE
Add deprecation notices in docs

### DIFF
--- a/docs/core-concepts/agent-run-format.md
+++ b/docs/core-concepts/agent-run-format.md
@@ -101,6 +101,9 @@ For solver-judge, default grouping typically yields:
 
 ## 6. Overriding Default Grouping
 
+!!! warning "As for rLLM v0.3, this remains an experimental feature shipped with the [Unified Trainer](../experimental/unified-trainer.md)"
+    If you are still using the legacy trainers (`agent_workflow_trainer` for `Verl` or `tinker_workflow_trainer` for `Tinker`), the grouping rules are not explicit, and the stepwise advantage computation pattern follows the [Stepwise GRPO guide](./rl-algos.md).
+
 You can override grouping by passing `traj_grouping_hook` to `AgentTrainer` / `UnifiedTrainer`.
 
 ```python

--- a/docs/core-concepts/rl-algos.md
+++ b/docs/core-concepts/rl-algos.md
@@ -1,5 +1,8 @@
 In rLLM, we categorize agents into two types based on how they accumulate context over time:
 
+!!! warning "Deprecation warning"
+    The stepwise mode `per_step` will be soon deprecated, together with the legacy trainers (`agent_workflow_trainer` for `Verl` or `tinker_workflow_trainer` for `Tinker`). For the new [`UnifiedTrainer`](../experimental/unified-trainer.md)-based workflow trainer, the advantage calculation (via grouping) and broadcasting pattern is explicitly codified in the [run format guide](./agent-run-format.md), and will allow user-customization.
+
 1. **Cumulative Agents**
     
     These agents accumulate their full interaction history across turns. At each step, the environment observation and the model’s response are appended to the existing prompt, forming a single long trajectory containing all previous interactions. This setting is suitable when the entire context fits within the model’s window.

--- a/docs/core-concepts/training.md
+++ b/docs/core-concepts/training.md
@@ -1,5 +1,8 @@
 # RL Training with AgentTrainer
 
+!!! warning "Deprecation warning"
+    The current `AgentTrainer` will be soon replaced with a newer, [`UnifiedTrainer`](../experimental/unified-trainer.md)-based agent trainer. If you are working with `Tinker`, we highly recommend you to migrate to the new [`UnifiedTrainer`](../experimental/unified-trainer.md)-based workflow trainer. See [RL Training with Tinker (with Unified Trainer)](../examples/tinker_rl.md) for an upgraded solver-judge workflow example.
+
 Training in rLLM uses reinforcement learning algorithms to update agent policies based on rewards. This page explains the training architecture, available algorithms, and how to configure and run training jobs.
 
 ## Overview

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -7,7 +7,7 @@ This section contains examples demonstrating how to use rLLM to train agents for
 ### 🧩 [rLLM SDK](../core-concepts/sdk.md)
 Train agents using the rLLM SDK, including tutorials for a math agent, solver-judge workflow, and LangGraph RAG agent.
 
-### 🚀 [RL Training with Tinker](tinker_rl.md)
+### 🚀 [RL Training with Tinker (with Unified Trainer)](tinker_rl.md)
 Train a solver‑judge RL workflow using Tinker's hosted GPU service.
 
 ### 🧪 [Verifiers (Prime Intellect Hub)](verifiers.md)

--- a/docs/examples/tinker_rl.md
+++ b/docs/examples/tinker_rl.md
@@ -1,13 +1,13 @@
-# RL Training with Tinker
+# RL Training with Tinker (using Unified Trainer)
 
-This example shows how to train a **solver‑judge RL workflow** with the **Tinker** backend in rLLM, using Tinker's hosted GPU service.
+This example shows how to train a **solver‑judge RL workflow** with the **Tinker** backend in rLLM, using Tinker's hosted GPU service and the **Unified Trainer**.
 
 ## Overview
 
 With this example you will:
 
 1. Train a **solver‑judge workflow** for the Countdown task using the Tinker backend
-2. Reuse the unified Tinker RL config (`tinker_rl_trainer.yaml`) for workflow training
+2. Use the **Unified Trainer** (`rllm.experimental.unified_trainer.AgentTrainer`) with the unified Hydra config system
 
 Under the hood, rLLM integrates with Tinker as:
 
@@ -25,41 +25,46 @@ Under the hood, rLLM integrates with Tinker as:
 uv pip install -e .[tinker] --torch-backend=cpu
 ```
 
-### Configure Tinker authentication
+### Configure authentication
 
-Set your Tinker API key:
+Set your API keys:
 
 ```bash
 export TINKER_API_KEY=your_api_key_here
+export WANDB_API_KEY=your_wandb_key_here  # optional, for W&B logging
 ```
 
-You can obtain an API key from the Tinker console.
+You can obtain a Tinker API key from the Tinker console.
 
-### Shared Tinker RL config
+### Unified configuration system
 
-This example uses the unified RL config in rLLM:
+This example uses the **unified Hydra config** introduced with the experimental unified trainer. Configuration is organized into:
 
-```python title="rllm/trainer/config/tinker_rl_trainer.yaml"
---8<-- "rllm/trainer/config/tinker_rl_trainer.yaml"
-```
+- **Backend-agnostic rLLM configs** (`rllm/experimental/config/rllm/base.yaml`): core training settings shared across all backends
+- **Tinker-specific configs** (`rllm/experimental/config/rllm/backend/tinker.yaml`): Tinker service, model, sampling, and data settings
+- **Unified entry point** (`rllm/experimental/config/unified.yaml`): combines all configs
 
 Key options you may want to tune:
 
-- `model.name`: base model to fine‑tune (e.g. `Qwen/Qwen3-8B`, `Qwen/Qwen3-30B-A3B`)
-- `model.lora_rank`: LoRA rank
-- `training.group_size`: number of trajectories per prompt (GRPO group size)
-- `data.max_prompt_length` / `data.max_response_length`: context and generation lengths
-- `trainer.total_epochs`, `trainer.logger`, `trainer.project_name`, `trainer.experiment_name`
+| Config path | Description |
+|---|---|
+| `model.name` | Base model to fine‑tune (e.g. `Qwen/Qwen3-8B`) |
+| `model.lora_rank` | LoRA rank |
+| `training.group_size` | Number of trajectories per prompt (GRPO group size) |
+| `data.max_prompt_length` / `data.max_response_length` | Context and generation lengths |
+| `rllm.trainer.total_epochs` / `rllm.trainer.total_batches` | Training budget |
+| `rllm.trainer.logger` | Logging backends (`console`, `wandb`, `tensorboard`) |
+| `rllm.algorithm.adv_estimator` | Advantage estimator (`grpo`, `reinforce`, `rloo`, etc.) |
 
-You can override any of these from the command line using Hydra syntax (see below).
+Backend-specific keys (under `model.*`, `training.*`, `sampling.*`, `data.*`) are forwarded into the common `rllm.*` namespace automatically. See the [rLLM and Backend Config](../experimental/rllm-and-backend-config.md) docs for details.
 
 ---
 
 ## Solver‑Judge RL Training with Tinker
 
-This example trains a **multi‑agent solver‑judge workflow** on the Countdown task using the same Tinker RL backend.
+This example trains a **multi‑agent solver‑judge workflow** on the Countdown task using the Tinker backend and the Unified Trainer.
 
-### 2.1 Prepare Countdown dataset
+### 1. Prepare Countdown dataset
 
 First download and register the Countdown dataset:
 
@@ -80,58 +85,93 @@ Dataset preparation:
 --8<-- "examples/countdown/prepare_countdown_data.py"
 ```
 
-### 2.2 Solver‑Judge workflow with Tinker backend
+### 2. Training entrypoint
 
-The Tinker RL training entrypoint for the solver‑judge workflow is:
+The training entrypoint uses `AgentTrainer` from the experimental unified trainer:
 
-```python title="examples/solver_judge_tinker/train_solver_judge_flow_tinker.py"
---8<-- "examples/solver_judge_tinker/train_solver_judge_flow_tinker.py"
+```python title="rllm/experimental/test_examples/test_tinker_solver_judge.py"
+--8<-- "rllm/experimental/test_examples/test_tinker_solver_judge.py"
 ```
 
-It uses:
+Key differences from the legacy trainer:
 
-- `SolverJudgeWorkflow` from `examples.solver_judge.solver_judge_flow`
-- `countdown_reward_fn` as the reward function
-- `AgentTrainer` with `backend="tinker"` and `workflow_class=SolverJudgeWorkflow`
+- Uses `rllm.experimental.unified_trainer.AgentTrainer` instead of `rllm.trainer.AgentTrainer`
+- Config is loaded from `rllm.experimental.config` with `config_name="unified"`
+- Supports per‑role advantage estimator mapping via `traj_group_adv_estimator_map` (e.g. GRPO for solver, REINFORCE for judge)
 
-### 2.3 Train solver‑judge workflow with Tinker
+### 3. Train solver‑judge workflow with Tinker
 
-Run the provided shell script:
+Run training with the following script:
 
 ```bash
-cd examples/solver_judge_tinker
-bash train_solver_judge_flow_tinker.sh
+export TINKER_API_KEY=YOUR-TINKER-KEY
+export WANDB_API_KEY=YOUR-WANDB-KEY # optional
+
+MODEL_PATH=Qwen/Qwen3-4B-Instruct-2507
+MODEL_LORA_RANK=32
+
+# structure runname as <model_path>_<lora_rank>_<date>_<time>
+date_str=$(date +%Y-%m-%d)
+time_str=$(date +%H-%M-%S)
+run_name=TINKER_${MODEL_PATH}_${MODEL_LORA_RANK}_${date_str}_${time_str}
+local_dir=/path/to/your/local/dir
+
+python3 -m rllm.experimental.test_examples.test_tinker_solver_judge \
+    rllm/backend=tinker \
+    rllm.compact_filtering.enable=False \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.use_rllm=true \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.trainer.total_batches=100 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger=['wandb'] \
+    rllm.trainer.project_name='tinker-solver-judge' \
+    rllm.trainer.experiment_name=$run_name \
+    rllm.trainer.val_before_train=true \
+    rllm.trainer.test_freq=20 \
+    rllm.trainer.save_freq=20 \
+    model.name=$MODEL_PATH \
+    model.lora_rank=$MODEL_LORA_RANK \
+    training.group_size=5 \
+    training.learning_rate=4e-5 \
+    training.default_local_dir=$local_dir \
+    sampling.train.temperature=1.0 \
+    sampling.train.top_p=1.0 \
+    data.max_prompt_length=2048 \
+    data.max_response_length=1024 \
+    data.train_batch_size=32 \
+    data.val_batch_size=512
 ```
 
 This will:
 
 - Fine‑tune `Qwen/Qwen3-4B-Instruct-2507` with LoRA (rank 32)
-- Train with GRPO using **trajectory‑level grouping** (`algorithm.grouping_level=trajectory`)
-- Use normalized advantages for stability (`algorithm.norm_adv_by_std_in_grpo=true`)
+- Use rLLM‑native advantage computation with per‑role estimators (GRPO for solver, REINFORCE for judge)
+- Normalize advantages by standard deviation for stability
+- Run validation before training and every 20 batches
 - Log training metrics to Weights & Biases
 
-Shell configuration:
+You can customize training via Hydra CLI overrides. Note that:
 
-```bash title="examples/solver_judge_tinker/train_solver_judge_flow_tinker.sh"
---8<-- "examples/solver_judge_tinker/train_solver_judge_flow_tinker.sh"
-```
+- **rLLM-level settings** use the `rllm.*` prefix (e.g. `rllm.algorithm.adv_estimator`, `rllm.trainer.total_batches`)
+- **Tinker backend settings** use their native keys (e.g. `model.name`, `training.group_size`, `sampling.train.temperature`)
 
-You can customize training via CLI overrides, e.g.:
+For example, to switch to a larger model with a smaller LoRA rank:
 
 ```bash
-cd examples/solver_judge_tinker
-python -m examples.solver_judge_tinker.train_solver_judge_flow_tinker \
+python3 -m rllm.experimental.test_examples.test_tinker_solver_judge \
+    rllm/backend=tinker \
     model.name=Qwen/Qwen3-8B \
     model.lora_rank=16 \
     training.group_size=8 \
     data.train_batch_size=32 \
-    trainer.total_epochs=20 \
-    trainer.logger=['console','wandb'] \
-    trainer.project_name='solver-judge-tinker' \
-    trainer.experiment_name='countdown-grpo-qwen3-8b'
+    rllm.trainer.total_batches=200 \
+    rllm.trainer.logger=['console','wandb'] \
+    rllm.trainer.project_name='solver-judge-tinker' \
+    rllm.trainer.experiment_name='countdown-grpo-qwen3-8b'
 ```
 
-### 2.4 Run the workflow with Tinker rollout engine (optional)
+### 4. Run the workflow with Tinker rollout engine (optional)
 
 For interactive evaluation (no training step), you can run the Countdown solver‑judge workflow directly using Tinker for sampling:
 
@@ -149,15 +189,11 @@ This script:
 
 ## Monitoring and Checkpoints
 
-For the solver‑judge example:
-
 - **Logging**:
-  - Set `trainer.logger=['console','wandb']` to enable Weights & Biases
-  - Use `trainer.project_name` / `trainer.experiment_name` to organize runs
+    - Set `rllm.trainer.logger=['console','wandb']` to enable Weights & Biases
+    - Use `rllm.trainer.project_name` / `rllm.trainer.experiment_name` to organize runs
 - **Checkpoints**:
-  - Local paths are controlled by `trainer.default_local_dir`
-  - You can resume from a Tinker checkpoint via `trainer.resume_from_tinker_id='tinker://<uuid>/weights/<checkpoint_name>'`
+    - Local paths are controlled by `training.default_local_dir`
+    - You can resume from a Tinker checkpoint via `training.resume_from_tinker_id='tinker://<uuid>/weights/<checkpoint_name>'`
 
-This gives you an end‑to‑end RL training pipeline where **rollouts, gradients, and checkpoints all run on Tinker's managed GPU service**, while rLLM handles datasets, workflows, and trainer orchestration.
-
-
+This gives you an end‑to‑end RL training pipeline where **rollouts, gradients, and checkpoints all run on Tinker's managed GPU service**, while rLLM's unified trainer handles datasets, workflows, advantage computation, and training orchestration.

--- a/docs/experimental/unified-trainer.md
+++ b/docs/experimental/unified-trainer.md
@@ -7,6 +7,8 @@ It manages the full training loop -- episode generation, data transformation, ad
 computation, policy updates, validation, and logging -- while delegating all
 backend-specific operations to a pluggable `BackendProtocol` implementation.
 
+This page contains the technical details of the Unified Trainer training loop. For anyone simply wanting to use the Unified Trainer, please refer to [RL Training with Tinker (with Unified Trainer)](../examples/tinker_rl.md) for a complete example with the solver-judge workflow.
+
 ---
 
 ## Architecture Overview


### PR DESCRIPTION
### What does this PR do?

- Upgrade the Tinker solver-judge example in doc to one that uses the new UnifiedTrainer
- Add deprecation notice to a few "Core Concepts" docs.