### PR TITLE
added modal deploy script and training code

### DIFF
--- a/examples/solver_judge_modal/modal_deploy.py
+++ b/examples/solver_judge_modal/modal_deploy.py
@@ -1,0 +1,60 @@
+import os
+import subprocess
+
+import modal
+
+app = modal.App("skyrl-tx")
+
+# Persistent volumes
+hf_cache = modal.Volume.from_name("hf-cache", create_if_missing=True)
+checkpoints = modal.Volume.from_name("skyrl-checkpoints", create_if_missing=True)
+
+# Change this to the model you want to serve
+BASE_MODEL = "Qwen/Qwen3-0.6B"
+
+image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:12.8.0-devel-ubuntu22.04",
+        add_python="3.12",
+    )
+    .apt_install("git", "build-essential", "libnuma-dev")
+    .pip_install("uv")
+    .run_commands("git clone --recurse-submodules https://github.com/NovaSky-AI/SkyRL.git /opt/skyrl")
+    .run_commands("cd /opt/skyrl && uv sync --python $(which python3) --extra tinker --extra fsdp --no-dev")
+    .env({"HF_HOME": "/root/.cache/huggingface"})
+    .workdir("/opt/skyrl")
+)
+
+
+@app.function(
+    image=image,
+    gpu="A100:2",
+    volumes={
+        "/root/.cache/huggingface": hf_cache,
+        "/checkpoints": checkpoints,
+    },
+    timeout=86400,  # 24h max container lifetime
+    scaledown_window=1800,  # 30min idle before shutdown
+    max_containers=1,  # Single container to keep session state consistent
+)
+@modal.web_server(port=8000, startup_timeout=600)
+def serve():
+    # Remove stale database from previous runs to avoid "Deleting models not yet implemented" crash
+    db_path = "/opt/skyrl/skyrl/tinker/tinker.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    subprocess.Popen(
+        [
+            "/opt/skyrl/.venv/bin/python",
+            "-m",
+            "skyrl.tinker.api",
+            "--base-model",
+            BASE_MODEL,
+            "--backend",
+            "fsdp",
+            "--port",
+            "8000",
+        ],
+        cwd="/opt/skyrl",
+    )

--- a/examples/solver_judge_modal/train_solver_judge_flow_tinker_unified.py
+++ b/examples/solver_judge_modal/train_solver_judge_flow_tinker_unified.py
@@ -1,0 +1,36 @@
+import hydra
+
+from examples.solver_judge.solver_judge_flow import SolverJudgeWorkflow
+from rllm.data.dataset import DatasetRegistry
+from rllm.experimental.common.config import rLLMAdvantageEstimator
+from rllm.experimental.unified_trainer import AgentTrainer
+from rllm.rewards.countdown_reward import countdown_reward_fn
+
+
+@hydra.main(config_path="pkg://rllm.experimental.config", config_name="unified", version_base=None)
+def main(config):
+    train_dataset = DatasetRegistry.load_dataset("countdown", "train")
+    test_dataset = DatasetRegistry.load_dataset("countdown", "test")
+
+    traj_group_adv_estimator_map = {
+        "solver": rLLMAdvantageEstimator.OTHER,
+        "judge": rLLMAdvantageEstimator.OTHER,
+    }
+
+    trainer = AgentTrainer(
+        workflow_class=SolverJudgeWorkflow,
+        workflow_args={
+            "n_solutions": 2,
+            "reward_function": countdown_reward_fn,
+        },
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=test_dataset,
+        backend="tinker",
+        traj_group_adv_estimator_map=traj_group_adv_estimator_map,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Solver-Judge Workflow on Modal (SkyRL-TX Tinker Backend)

## Summary

- Add solver-judge workflow example using a **Modal-deployed SkyRL-TX (Tinker)** backend
- Deploys Tinker API server on Modal with A100x2 GPUs; training runs locally via the rllm unified trainer

## How to Run

### Prerequisites

- [Modal](https://modal.com/) account and CLI set up:
  ```bash
  pip install modal
  modal setup
  ```
- rllm installed:
  ```bash
  pip install -e ./verl
  pip install -e .
  ```

### Step 1: Deploy the Tinker server on Modal

```bash
cd examples/solver_judge_modal
modal deploy modal_deploy.py
```

This spins up a SkyRL-TX Tinker API server on **2x A100 GPUs**. Once deployed, note the serving URL (e.g. `https://<your-workspace>--skyrl-tx-serve.modal.run`).

### Step 2: Update the training script

Edit `train_solver_judge_flow_tinker_unified.sh` and set:

| Variable | Description |
|---|---|
| `tinker_base_url` | Modal serving URL from Step 1 |
| `TINKER_API_KEY` | Fake API key starts with "tml-"|
| `RLLM_API_KEY` | *(Optional)* rllm-ui API key |
| `RLLM_UI_URL` | *(Optional)* rllm-ui URL for logging |

### Step 3: Run training locally
Create bash script to run training. For example,
```bash
cd <rllm repo root>
bash examples/solver_judge_modal/train_solver_judge_flow_tinker_unified.sh
```

Training runs **locally** and sends forward/backward calls to the Modal-hosted Tinker server. Logs go to **wandb** and optionally **rllm-ui**.
<img width="2922" height="1442" alt="image" src="https://github.com/user-attachments/assets/ee75e668-b384-47aa-9a70-f680b71f10e0" />
