### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+      placeholder: Describe the bug clearly...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `python -m rllm.trainer.verl.train_agent_ppo ...`
+        2. Wait for step N
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output / Traceback
+      description: Paste the full error output or traceback.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: rllm-version
+    attributes:
+      label: rLLM Version
+      description: Output of `pip show rllm` or the commit hash you're using.
+      placeholder: e.g., 0.2.1 or commit abc1234
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Training Backend
+      options:
+        - verl
+        - tinker
+        - N/A
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      placeholder: e.g., 3.11.5
+    validations:
+      required: true
+
+  - type: input
+    id: gpu-cuda
+    attributes:
+      label: GPU / CUDA Version
+      placeholder: e.g., A100 80GB / CUDA 12.1
+    validations:
+      required: false
+
+  - type: input
+    id: vllm-version
+    attributes:
+      label: vLLM Version (if applicable)
+      placeholder: e.g., 0.8.5
+    validations:
+      required: false
+
+  - type: textarea
+    id: training-config
+    attributes:
+      label: Training Script / Config
+      description: Paste relevant parts of your training script or Hydra config.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information (screenshots, training curves, related issues, etc.).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your feature suggestion! Please describe the problem and your proposed solution.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this feature solve? Why is it needed?
+      placeholder: I'm trying to do X but currently there's no way to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've tried.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information (code examples, links, references, etc.).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,41 @@
+name: Question
+description: Ask a question about using rLLM
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question? Fill out the sections below. For general discussion, consider joining our [Discord](https://discord.gg/BDH46HT9en).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What do you want to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to accomplish? What have you already tried?
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant-code
+    attributes:
+      label: Relevant Code / Config
+      description: Paste any relevant code, config, or script.
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: rLLM version, backend (verl/tinker), Python version, GPU info — if relevant to your question.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+## Summary
+
+<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->
+
+## Type of change
+
+- [ ] Feature
+- [ ] Fix
+- [ ] Docs
+- [ ] Refactor
+- [ ] Example / Project
+- [ ] Infra / CI
+
+## What changed
+
+<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->
+
+- 
+- 
+- 
+
+## Validation
+
+<!-- Replace with the checks you actually ran. If nothing was run, say why. -->
+
+- [ ] `pre-commit run --all-files`
+- [ ] Targeted tests: `pytest ...`
+- [ ] Manual validation performed
+- [ ] Not run (reason below)
+
+Validation details:
+- 
+
+## Breaking changes / migration notes
+
+<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->
+
+- None
+
+## Docs / examples
+
+- [ ] Not needed
+- [ ] Updated docs
+- [ ] Updated examples
+- [ ] Follow-up docs needed
+
+## Related issues / PRs
+
+- Fixes #
+- Related to #
+- Stacked on / depends on #
+
+## Screenshots / logs
+
+<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->


### PR DESCRIPTION
## Summary

Add GitHub issue templates (bug report, feature request, question) and a PR template to improve the quality and consistency of community contributions. Currently, most issues lack environment info, reproduction steps, or structured formatting — these templates address that.

## Type of change

- [x] Infra / CI

## What changed

- Added 3 YAML-based issue form templates (`.github/ISSUE_TEMPLATE/`) with auto-labeling (`bug`, `enhancement`, `question`)
- Bug report template requires rLLM version, training backend, Python version, and reproduction steps
- Added PR template (`.github/pull_request_template.md`) with summary, type-of-change checklist, validation, and breaking-changes sections

## Validation

- [x] Manual validation performed

Validation details:
- YAML syntax validated with `yaml.safe_load` for all 3 issue templates
- Confirmed templates follow [GitHub issue form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema)

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed

## Related issues / PRs

- None