### PR TITLE
Fix ChatTemplateParser import in SFT trainer

### DIFF
--- a/rllm/trainer/verl/sft_dataset.py
+++ b/rllm/trainer/verl/sft_dataset.py
@@ -2,7 +2,8 @@ import logging
 
 import torch
 from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset
-from verl.utils.parser.chat_template_parser import ChatTemplateParser
+
+from rllm.parser import ChatTemplateParser
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Fix `ModuleNotFoundError: No module named 'verl.utils.parser'` when using the SFT trainer (#426). The import pointed to a non-existent verl module instead of rllm's own `ChatTemplateParser`.

## Type of change

- [x] Fix

## What changed

- Changed `sft_dataset.py` to import `ChatTemplateParser` from `rllm.parser` instead of `verl.utils.parser.chat_template_parser`
- This aligns with every other file in the codebase (18 files all import from `rllm.parser`)
- The rllm implementation has the same API (`get_parser()`, `parse()` with `is_first_msg` and `add_generation_prompt` params)

## Validation

- [x] `pre-commit run --all-files`
- [x] Manual validation performed

Validation details:
- Verified rllm's `ChatTemplateParser` has identical API surface: `get_parser(tokenizer)` factory method and `parse(messages, add_generation_prompt, is_first_msg)` signature
- Pre-commit hooks (ruff lint + format) pass

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed

## Related issues / PRs

- Fixes #426

## Screenshots / logs

N/A