### PR TITLE
fix(metrics): include dropped workflow episodes in denominators

### DIFF
--- a/rllm/engine/agent_workflow_engine.py
+++ b/rllm/engine/agent_workflow_engine.py
@@ -254,19 +254,35 @@ class AgentWorkflowEngine:
         chat_completions_list = []
         rollout_log_probs_list = []
 
+        dropped_episodes: list[dict] = []
+
         for i, episode in enumerate(episodes):
             total_steps = 0
 
             if episode is None:
                 print(f"Episode {i} is None (failed task), dropping it from the batch")
+                dropped_episodes.append(
+                    {
+                        "task_id": task_ids[i],
+                        "episode_id": None,
+                        "termination_reason": "unknown",
+                    }
+                )
                 repeat_counts.append(0)
                 continue
 
             if all(len(trajectory.steps) == 0 for trajectory in episode.trajectories):
-                # termination hits before an agent finishes it's first step
+                # Termination hits before an agent finishes its first step.
                 # (e.g., the initial prompt exceeds max_prompt_length or a timeout occurs)
-                # we delete the episode from the batch by setting repeat_counts to 0
+                # We delete the episode from the batch by setting repeat_counts to 0.
                 print(f"Episode {episode.id} has no valid trajectories, dropping it from the batch")
+                dropped_episodes.append(
+                    {
+                        "task_id": task_ids[i],
+                        "episode_id": episode.id,
+                        "termination_reason": episode.termination_reason.value if episode.termination_reason is not None else "unknown",
+                    }
+                )
                 repeat_counts.append(0)
                 continue
 
@@ -366,6 +382,18 @@ class AgentWorkflowEngine:
             termination_reasons.extend([episode.termination_reason if episode.termination_reason is not None else TerminationReason.UNKNOWN] * total_steps)
             metrics.extend([episode.metrics] * total_steps)
             repeat_counts.append(total_steps)
+
+        # If all episodes were dropped (e.g. all hit max_prompt_length_exceeded), return an empty DataProto.
+        # This avoids downstream crashes and allows trainers to account for dropped episodes via meta_info.
+        if len(prompts) == 0:
+            return DataProto.from_dict(
+                tensors={},
+                non_tensors={},
+                meta_info={
+                    "repeat_counts": repeat_counts,
+                    "dropped_episodes": dropped_episodes,
+                },
+            )
 
         prompts_batch = torch.nn.utils.rnn.pad_sequence(
             [torch.flip(i, dims=[0]) for i in prompts],
@@ -477,6 +505,7 @@ class AgentWorkflowEngine:
             non_tensors=non_tensors,
             meta_info={
                 "repeat_counts": repeat_counts,
+                "dropped_episodes": dropped_episodes,
             },
         )
 

--- a/rllm/trainer/verl/agent_workflow_trainer.py
+++ b/rllm/trainer/verl/agent_workflow_trainer.py
@@ -226,6 +226,12 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                             episode_unique_idxs.append(i)
                     episode_unique_batch = new_batch.select_idxs(episode_unique_idxs)
 
+                    # Include termination reasons from episodes that were dropped before producing any steps.
+                    # These are reported via meta_info from AgentWorkflowEngine.transform_results_for_verl.
+                    dropped_episodes = final_gen_batch_output.meta_info.get("dropped_episodes", [])
+                    for ep in dropped_episodes:
+                        termination_counts.update([ep.get("termination_reason", "unknown")])
+
                     # log metrics returned by workflows
                     for metric_dict in episode_unique_batch.non_tensor_batch["metrics"]:
                         for key, value in metric_dict.items():
@@ -463,8 +469,10 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                 for key, value in workflow_metrics.items():
                     metrics[f"batch/{key}"] = np.mean(value)
 
+                # Denominator should be the number of attempted tasks (including those dropped before 1st step),
+                # otherwise metrics are biased/inflated.
                 for r in TerminationReason:
-                    metrics[f"batch/{r.value}"] = termination_counts[r.value] / len(set(new_batch.non_tensor_batch["episode_ids"]))
+                    metrics[f"batch/{r.value}"] = termination_counts[r.value] / max(1, num_tasks)
 
                 metrics["batch/num_tasks"] = num_tasks
 
@@ -515,7 +523,24 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
             test_batch.pop(batch_keys=["input_ids", "attention_mask", "position_ids"], non_tensor_batch_keys=["raw_prompt_ids"])  # these are not needed for environment based interaction
             test_batch.meta_info = {"validate": True}
 
+            # Keep a mapping from task_id -> data_source so we can account for dropped episodes.
+            base_data_sources = test_batch.non_tensor_batch.get("data_source", None)
+            if base_data_sources is None:
+                base_data_sources = ["unknown"] * len(test_batch)
+            task_to_source = dict(zip(test_batch.non_tensor_batch["task_ids"].tolist(), base_data_sources, strict=False))
+
             test_output_gen_batch = self.generate_trajectories(batch=test_batch)
+
+            # Account for dropped episodes in validation metrics to avoid inflated pass@k.
+            dropped_episodes = test_output_gen_batch.meta_info.get("dropped_episodes", [])
+            for ep in dropped_episodes:
+                uid = ep.get("task_id")
+                if uid is None:
+                    continue
+                is_correct_lst.append(False)
+                uid_lst.append(uid)
+                data_source_lst.append(task_to_source.get(uid, "unknown"))
+
             repeat_counts = test_output_gen_batch.meta_info["repeat_counts"]
             # need to repeat to make shape match
             test_batch = test_batch.sample_level_repeat(repeat_counts)

--- a/tests/engine/test_dropped_episodes_metrics.py
+++ b/tests/engine/test_dropped_episodes_metrics.py
@@ -1,0 +1,79 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_workflow_engine_module(monkeypatch):
+    # Stub verl + torch bits imported inside the function.
+    verl = types.ModuleType("verl")
+
+    class FakeDataProto:
+        def __init__(self, meta_info):
+            self.meta_info = meta_info
+
+        @classmethod
+        def from_dict(cls, tensors=None, non_tensors=None, meta_info=None):  # noqa: ARG002
+            return cls(meta_info=meta_info)
+
+    verl.DataProto = FakeDataProto
+
+    verl_utils = types.ModuleType("verl.utils")
+    verl_tf = types.ModuleType("verl.utils.torch_functional")
+    verl_tf.pad_sequence_to_length = lambda x, *a, **k: x
+
+    sys.modules["verl"] = verl
+    sys.modules["verl.utils"] = verl_utils
+    sys.modules["verl.utils.torch_functional"] = verl_tf
+
+    # Stub torch so type annotations don't crash import in minimal env.
+    torch = types.ModuleType("torch")
+    torch.Tensor = object
+    torch.long = "long"
+    torch.float32 = "float32"
+    torch.nn = types.SimpleNamespace(utils=types.SimpleNamespace(rnn=types.SimpleNamespace(pad_sequence=lambda *a, **k: [])))
+    torch.zeros_like = lambda *a, **k: []
+    torch.as_tensor = lambda *a, **k: []
+    torch.arange = lambda *a, **k: []
+    torch.cumsum = lambda *a, **k: []
+    torch.concat = lambda *a, **k: []
+    sys.modules["torch"] = torch
+
+    module_path = Path(__file__).resolve().parents[2] / "rllm" / "engine" / "agent_workflow_engine.py"
+    spec = importlib.util.spec_from_file_location("rllm_agent_workflow_engine_test", module_path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_transform_results_includes_dropped_episodes_meta(monkeypatch):
+    mod = _load_workflow_engine_module(monkeypatch)
+
+    # Minimal episode stubs
+    class Ep:
+        def __init__(self, id, termination_reason=None, trajectories=None):
+            self.id = id
+            self.termination_reason = termination_reason
+            self.trajectories = trajectories or []
+            self.metrics = {}
+            self.is_correct = False
+
+    class Term:
+        def __init__(self, value):
+            self.value = value
+
+    episodes = [
+        None,
+        Ep("t1:0", termination_reason=Term("max_prompt_length_exceeded"), trajectories=[type("T", (), {"steps": []})()]),
+    ]
+
+    # Instantiate engine without running __init__
+    engine = object.__new__(mod.AgentWorkflowEngine)
+    engine.config = type("Cfg", (), {"rllm": type("R", (), {"stepwise_advantage": type("S", (), {"enable": False})()})()})()
+    engine.rollout_engine = type("RE", (), {"chat_parser": type("CP", (), {})()})()
+
+    out = mod.AgentWorkflowEngine.transform_results_for_verl(engine, episodes, ["t0", "t1"])
+
+    assert "dropped_episodes" in out.meta_info
+    assert len(out.meta_info["dropped_episodes"]) == 2


### PR DESCRIPTION
Issue #382 reports that workflow episodes that terminate before producing any steps (e.g. max_prompt_length_exceeded) are silently dropped (repeat_counts=0) and not counted in metrics, inflating pass@k and hiding termination reasons.

This PR:
- Tracks dropped episodes in `AgentWorkflowEngine.transform_results_for_verl` and returns them in `meta_info.dropped_episodes`.
- Updates `AgentWorkflowTrainer` to:
  - include dropped termination reasons in `termination_counts`
  - use `num_tasks` as denominator for termination metrics
  - account for dropped episodes in validation pass@k by treating them as incorrect.
- Adds a regression test to ensure dropped episodes are surfaced in meta_info.

Fixes #382
