### PR TITLE
fix(deps): cap transformers <5 until vLLM compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "openai",
     "tqdm",
     "requests",
+    # Core ML/AI packages
+    "torch",
+    "torchvision",
+    "transformers>=4.57.0,<5.0.0",
     # Data
     "datasets>=2.20.0",
     "pillow",


### PR DESCRIPTION
Issue #388: Transformers 5.0.0 can be auto-installed due to an open-ended lower bound, but older vLLM stacks used via verl can be incompatible (e.g. tokenizer attribute errors).

This PR adds an upper bound to prevent installing Transformers v5 until the dependency stack is confirmed compatible.

Fixes #388
