### PR TITLE
add steps[i].chat_completions; token_warning_threshold from agent_args

### DIFF
--- a/rllm/agents/swe_agent.py
+++ b/rllm/agents/swe_agent.py
@@ -12,7 +12,6 @@ from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
 from rllm.agents.system_prompts import SWE_SYSTEM_PROMPT, SWE_SYSTEM_PROMPT_FN_CALL, SWE_USER_PROMPT, SWE_USER_PROMPT_FN_CALL, SWEAGENT_SYSTEM_PROMPT, SWEAGENT_USER_PROMPT
 
 
-
 def parse_oai_response(response):
     thought = response.choices[0].message.content
     if not thought:


### PR DESCRIPTION
1. 修复了SWEAgent里没有保存self._trajectory.steps[i].chat_completions的内容的bug：和tool_agent逻辑一致，steps[i].chat_completions是包含历史的快照。
2. 现在可以通过设置rllm.agent.agent_args.token_warning_threshold来设置token_warning_threshold