### PR TITLE
feat(engine): replace TinkerBackendServer with in-process local handler

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -77,12 +78,14 @@ class ReverseProxy:
         strip_vllm: bool = True,
         sync_traces: bool = False,
         max_retries: int = 2,
+        local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
     ) -> None:
         self.router = router
         self.store = store
         self.strip_vllm = strip_vllm
         self.sync_traces = sync_traces
         self.max_retries = max_retries
+        self.local_handler = local_handler
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
 
@@ -141,57 +144,57 @@ class ReverseProxy:
         session_id: str | None,
         originally_requested_logprobs: bool = False,
     ) -> Response:
-        worker = self.router.route(session_id)
-        url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
-        headers = self._forward_headers(request)
         t0 = time.perf_counter()
-        try:
-            resp = await self._send_with_retry(
-                method=request.method,
-                url=url,
-                content=raw_body,
-                headers=headers,
-            )
-            content = resp.content
-        finally:
-            self.router.release(worker.url)
-        latency_ms = (time.perf_counter() - t0) * 1000
 
-        # Parse response for trace extraction
-        try:
-            response_body = json.loads(content)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            response_body = {}
+        if self.local_handler is not None:
+            # In-process path: call handler directly, no HTTP
+            response_body = await self.local_handler(request_body)
+            status_code = 200
+        else:
+            # HTTP proxy path
+            worker = self.router.route(session_id)
+            url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
+            headers = self._forward_headers(request)
+            try:
+                resp = await self._send_with_retry(
+                    method=request.method,
+                    url=url,
+                    content=raw_body,
+                    headers=headers,
+                )
+                content = resp.content
+                status_code = resp.status_code
+            finally:
+                self.router.release(worker.url)
+
+            # Parse response for trace extraction
+            try:
+                response_body = json.loads(content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                response_body = {}
+
+        latency_ms = (time.perf_counter() - t0) * 1000
 
         # Persist trace
         if session_id and response_body:
             trace = build_trace_record(session_id, request_body, response_body, latency_ms)
             await self._persist(trace)
 
-        # Sanitise response — fast path when nothing needs modifying
+        # Sanitise response
         needs_strip_vllm = self.strip_vllm
         needs_strip_logprobs = not originally_requested_logprobs
-        if not needs_strip_vllm and not needs_strip_logprobs:
-            return Response(
-                content=content,
-                status_code=resp.status_code,
-                media_type=resp.headers.get("content-type", "application/json"),
-            )
 
+        sanitized = response_body
         if isinstance(response_body, dict) and response_body:
-            sanitized = strip_vllm_fields(response_body) if needs_strip_vllm else response_body
+            if needs_strip_vllm:
+                sanitized = strip_vllm_fields(response_body)
             if needs_strip_logprobs:
                 sanitized = _strip_logprobs(sanitized)
-            return Response(
-                content=json.dumps(sanitized),
-                status_code=resp.status_code,
-                media_type="application/json",
-            )
 
         return Response(
-            content=content,
-            status_code=resp.status_code,
-            media_type=resp.headers.get("content-type", "application/json"),
+            content=json.dumps(sanitized),
+            status_code=status_code,
+            media_type="application/json",
         )
 
     # ------------------------------------------------------------------
@@ -206,6 +209,9 @@ class ReverseProxy:
         session_id: str | None,
         originally_requested_logprobs: bool = False,
     ) -> StreamingResponse:
+        if self.local_handler is not None:
+            return await self._handle_streaming_local(request_body, session_id, originally_requested_logprobs)
+
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
         headers = self._forward_headers(request)
@@ -277,6 +283,107 @@ class ReverseProxy:
             media_type="text/event-stream",
             status_code=resp.status_code,
         )
+
+    async def _handle_streaming_local(
+        self,
+        request_body: dict[str, Any],
+        session_id: str | None,
+        originally_requested_logprobs: bool = False,
+    ) -> StreamingResponse:
+        """Handle streaming when using a local handler (fake-streaming)."""
+        assert self.local_handler is not None
+        t0 = time.perf_counter()
+        response_body = await self.local_handler(request_body)
+        latency_ms = (time.perf_counter() - t0) * 1000
+
+        # Persist trace from the full response
+        if session_id and response_body:
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms)
+            await self._persist(trace)
+
+        needs_strip_vllm = self.strip_vllm
+        needs_strip_logprobs = not originally_requested_logprobs
+
+        # Build SSE chunks from the complete response
+        chat_id = response_body.get("id", "chatcmpl-local")
+        created = response_body.get("created", int(time.time()))
+        model = response_body.get("model", "")
+        choices = response_body.get("choices", [])
+        first_choice = choices[0] if choices else {}
+        message = first_choice.get("message", {})
+        finish_reason = first_choice.get("finish_reason", "stop")
+
+        def _sanitize_chunk(chunk: dict[str, Any]) -> dict[str, Any]:
+            sanitized = strip_vllm_fields(chunk) if needs_strip_vllm else chunk
+            if needs_strip_logprobs:
+                sanitized = _strip_logprobs(sanitized)
+            return sanitized
+
+        async def event_generator():
+            def _sse(data: str) -> str:
+                return f"data: {data}\n\n"
+
+            # Chunk 1: role
+            yield _sse(
+                json.dumps(
+                    _sanitize_chunk(
+                        {
+                            "id": chat_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+                        }
+                    )
+                )
+            )
+
+            # Chunk 2: full content + token data
+            delta: dict[str, Any] = {}
+            if message.get("content"):
+                delta["content"] = message["content"]
+            if message.get("reasoning"):
+                delta["reasoning"] = message["reasoning"]
+            if message.get("tool_calls"):
+                delta["tool_calls"] = message["tool_calls"]
+
+            content_chunk: dict[str, Any] = {
+                "id": chat_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": delta,
+                        "finish_reason": None,
+                        "token_ids": first_choice.get("token_ids", []),
+                        "logprobs": first_choice.get("logprobs"),
+                    }
+                ],
+                "prompt_token_ids": response_body.get("prompt_token_ids", []),
+            }
+            yield _sse(json.dumps(_sanitize_chunk(content_chunk)))
+
+            # Chunk 3: finish + usage
+            yield _sse(
+                json.dumps(
+                    _sanitize_chunk(
+                        {
+                            "id": chat_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+                            "usage": response_body.get("usage", {}),
+                        }
+                    )
+                )
+            )
+
+            yield _sse("[DONE]")
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream", status_code=200)
 
     # ------------------------------------------------------------------
     # Internals

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import uuid
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -67,6 +68,7 @@ def _load_policy(dotted_path: str):
 def create_app(
     config: GatewayConfig | None = None,
     store: TraceStore | None = None,
+    local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
 ) -> FastAPI:
     """Create and return a fully configured FastAPI application."""
     if config is None:
@@ -102,6 +104,7 @@ def create_app(
         store=store,
         strip_vllm=config.strip_vllm_fields,
         sync_traces=config.sync_traces,
+        local_handler=local_handler,
     )
     sessions = SessionManager(store)
 

--- a/rllm/experimental/engine/gateway_manager.py
+++ b/rllm/experimental/engine/gateway_manager.py
@@ -4,9 +4,8 @@ Supports two execution modes:
 - 'process': subprocess via ``rllm-model-gateway`` CLI (for verl / distributed)
 - 'thread': background thread via ``create_app`` + uvicorn (for tinker / single-machine)
 
-For Tinker backends, also starts a ``TinkerBackendServer`` as the inference
-worker behind the gateway (since TinkerEngine is in-process, not a remote
-vLLM server).
+For Tinker backends, an in-process handler is injected into the gateway
+(via ``local_handler``), avoiding the need for a separate HTTP backend server.
 """
 
 from __future__ import annotations
@@ -50,7 +49,7 @@ class GatewayManager:
         self._process: subprocess.Popen | None = None
         self._thread: threading.Thread | None = None
         self._server: Any = None  # uvicorn.Server when using thread mode
-        self._backend_server: Any = None  # TinkerBackendServer for tinker
+        self._local_handler: Any = None  # in-process handler for tinker
         self._client: GatewayClient | None = None
 
     @property
@@ -69,20 +68,29 @@ class GatewayManager:
         """Start the gateway and register inference workers.
 
         For VerlEngine: registers the existing vLLM server addresses.
-        For TinkerEngine: starts a TinkerBackendServer and registers it.
+        For TinkerEngine: creates an in-process handler (no sidecar needed).
         """
-        if self.mode == "process":
-            self._start_process()
-        else:
-            self._start_thread()
+        engine_cls = type(rollout_engine).__name__
 
-        worker_urls = self._ensure_workers(rollout_engine)
-        for url in worker_urls:
-            worker_id = self.client.add_worker(url=url)
-            logger.info("Registered worker %s -> %s", worker_id, url)
+        if engine_cls == "TinkerEngine":
+            # In-process handler — no HTTP backend, no worker registration
+            from rllm.experimental.engine.tinker_adapter import create_tinker_handler
+
+            self._local_handler = create_tinker_handler(rollout_engine)
+            self._start_thread(local_handler=self._local_handler)
+        else:
+            if self.mode == "process":
+                self._start_process()
+            else:
+                self._start_thread()
+
+            worker_urls = self._ensure_workers(rollout_engine)
+            for url in worker_urls:
+                worker_id = self.client.add_worker(url=url)
+                logger.info("Registered worker %s -> %s", worker_id, url)
 
     def stop(self) -> None:
-        """Terminate the gateway (process or thread) and backend server."""
+        """Terminate the gateway (process or thread)."""
         if self._client is not None:
             self._client.close()
             self._client = None
@@ -102,9 +110,7 @@ class GatewayManager:
             self._thread = None
             self._server = None
 
-        if self._backend_server is not None:
-            self._backend_server.stop()
-            self._backend_server = None
+        self._local_handler = None
 
     # -- Session / trace API -------------------------------------------------
 
@@ -128,32 +134,8 @@ class GatewayManager:
             addresses = rollout_engine.rollout_manager.server_addresses
             return [f"http://{addr}" if not addr.startswith("http") else addr for addr in addresses]
 
-        if engine_cls == "TinkerEngine":
-            return [self._start_tinker_backend(rollout_engine)]
-
         logger.warning("Unknown engine type %s — no workers registered", engine_cls)
         return []
-
-    def _start_tinker_backend(self, rollout_engine: RolloutEngine) -> str:
-        """Start a TinkerBackendServer wrapping TinkerEngine behind OpenAI API.
-
-        The gateway proxies to this server, which calls TinkerEngine in-process.
-        """
-        from rllm.sdk.proxy.tinker_backend_server import TinkerBackendServer
-
-        # Pick a port for the backend server (gateway port + 1)
-        backend_port = self.port + 1
-        model_name = getattr(rollout_engine, "model_name", "default")
-
-        self._backend_server = TinkerBackendServer(
-            rollout_engine=rollout_engine,
-            host=self.host,
-            port=backend_port,
-            model_name=model_name,
-        )
-        self._backend_server.start()
-        logger.info("TinkerBackendServer started at %s", self._backend_server.url)
-        return self._backend_server.url
 
     # -- Internal ------------------------------------------------------------
 
@@ -190,7 +172,7 @@ class GatewayManager:
         self._process.terminate()
         raise TimeoutError(f"Gateway did not become healthy within {_HEALTH_POLL_TIMEOUT}s")
 
-    def _start_thread(self) -> None:
+    def _start_thread(self, local_handler: Any = None) -> None:
         """Start gateway in a background thread using create_app + uvicorn."""
         import uvicorn
         from rllm_model_gateway.models import GatewayConfig
@@ -202,7 +184,7 @@ class GatewayManager:
             db_path=self.db_path,
             store_worker="sqlite" if self.db_path else "memory",
         )
-        app = create_app(config=gw_config)
+        app = create_app(config=gw_config, local_handler=local_handler)
 
         uvi_config = uvicorn.Config(
             app,

--- a/rllm/experimental/engine/tinker_adapter.py
+++ b/rllm/experimental/engine/tinker_adapter.py
@@ -1,0 +1,111 @@
+"""Create a local handler from TinkerEngine for the model gateway.
+
+The handler is a plain ``async (dict) -> dict`` callable that translates
+OpenAI-format request dicts into ``TinkerEngine.get_model_response()`` calls
+and returns responses with embedded token IDs and logprobs in the format
+expected by the gateway's ``data_process.py`` extractors.
+
+This replaces the sidecar ``TinkerBackendServer`` with an in-process call,
+eliminating the extra HTTP hop and port allocation.
+"""
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from rllm.experimental.rollout.tinker_engine import TinkerEngine
+
+logger = logging.getLogger(__name__)
+
+
+def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
+    """Convert rLLM ToolCall objects to OpenAI-format tool_calls."""
+    result = []
+    for i, tc in enumerate(tool_calls):
+        name = tc.name if hasattr(tc, "name") else tc.get("name", "")
+        args = tc.arguments if hasattr(tc, "arguments") else tc.get("arguments", {})
+        if isinstance(args, dict):
+            args_str = json.dumps(args)
+        else:
+            args_str = str(args)
+        result.append(
+            {
+                "id": f"call_{i}",
+                "type": "function",
+                "function": {"name": name, "arguments": args_str},
+            }
+        )
+    return result
+
+
+def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+    """Return an async handler that calls TinkerEngine in-process.
+
+    The returned callable accepts an OpenAI chat completion request dict and
+    returns an OpenAI chat completion response dict with token extensions
+    (``prompt_token_ids``, ``token_ids``, ``logprobs``) consistent with vLLM.
+    """
+
+    async def handler(request_body: dict[str, Any]) -> dict[str, Any]:
+        messages = request_body.get("messages", [])
+        tools = request_body.get("tools", [])
+
+        kwargs: dict[str, Any] = {}
+        if tools:
+            kwargs["tools"] = tools
+        if request_body.get("temperature") is not None:
+            kwargs["temperature"] = request_body["temperature"]
+        if request_body.get("top_p") is not None:
+            kwargs["top_p"] = request_body["top_p"]
+        if request_body.get("max_tokens") is not None:
+            kwargs["max_tokens"] = request_body["max_tokens"]
+        if request_body.get("max_completion_tokens") is not None:
+            kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
+
+        model_output = await engine.get_model_response(messages, **kwargs)
+
+        response_text = model_output.content or model_output.text or ""
+        prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else []
+        completion_ids = list(model_output.completion_ids) if model_output.completion_ids else []
+        logprobs = model_output.logprobs or []
+        finish_reason = model_output.finish_reason or "stop"
+
+        response_message: dict[str, Any] = {"role": "assistant", "content": response_text}
+        if model_output.reasoning:
+            response_message["reasoning"] = model_output.reasoning
+        if model_output.tool_calls:
+            response_message["tool_calls"] = _to_openai_tool_calls(model_output.tool_calls)
+            if finish_reason == "stop":
+                finish_reason = "tool_calls"
+
+        prompt_len = model_output.prompt_length or len(prompt_ids)
+        completion_len = model_output.completion_length or len(completion_ids)
+
+        return {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": request_body.get("model", getattr(engine, "model_name", "default")),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": response_message,
+                    "finish_reason": finish_reason,
+                    "token_ids": completion_ids,
+                    "logprobs": {
+                        "content": [{"logprob": lp} for lp in logprobs],
+                    },
+                }
+            ],
+            "usage": {
+                "prompt_tokens": prompt_len,
+                "completion_tokens": completion_len,
+                "total_tokens": prompt_len + completion_len,
+            },
+            "prompt_token_ids": prompt_ids,
+        }
+
+    return handler

--- a/rllm/experimental/engine/trace_converter.py
+++ b/rllm/experimental/engine/trace_converter.py
@@ -2,10 +2,32 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 from rllm_model_gateway.models import TraceRecord
 
 from rllm.agents.agent import Step
 from rllm.experimental.rollout import ModelOutput
+from rllm.tools.tool_base import ToolCall
+
+
+def _parse_openai_tool_calls(raw_tool_calls: list[dict[str, Any]]) -> list[ToolCall]:
+    """Convert OpenAI-format tool_calls to rLLM ToolCall objects."""
+    result = []
+    for tc in raw_tool_calls:
+        func = tc.get("function", {})
+        name = func.get("name", "")
+        args_raw = func.get("arguments", "{}")
+        if isinstance(args_raw, str):
+            try:
+                arguments = json.loads(args_raw)
+            except (json.JSONDecodeError, ValueError):
+                arguments = {"raw": args_raw}
+        else:
+            arguments = args_raw
+        result.append(ToolCall(name=name, arguments=arguments))
+    return result
 
 
 def trace_record_to_step(trace: TraceRecord) -> Step:
@@ -19,9 +41,14 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
     content = trace.response_message.get("content", "") or ""
     reasoning = trace.response_message.get("reasoning", "") or ""
 
+    # Extract tool_calls from response message (OpenAI format)
+    raw_tool_calls = trace.response_message.get("tool_calls")
+    tool_calls = _parse_openai_tool_calls(raw_tool_calls) if raw_tool_calls else None
+
     model_output = ModelOutput(
         content=content,
         reasoning=reasoning,
+        tool_calls=tool_calls,
         prompt_ids=trace.prompt_token_ids,
         completion_ids=trace.completion_token_ids,
         logprobs=trace.logprobs or [],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,24 +15,32 @@ class _FakeTorch(types.ModuleType):
 
 
 # Provide a tiny torch stub so importing rllm modules doesn't require real torch.
+# Only install the stub if the real torch package is NOT available.
 if "torch" not in sys.modules:
-    sys.modules["torch"] = _FakeTorch("torch")
+    try:
+        importlib.import_module("torch")
+    except Exception:
+        sys.modules["torch"] = _FakeTorch("torch")
 
 
 # Provide a tiny PIL stub (OpenAIEngine imports PIL.Image)
+# Only install the stub if the real PIL package is NOT available.
 if "PIL" not in sys.modules:
-    pil = types.ModuleType("PIL")
-    image_mod = types.ModuleType("PIL.Image")
+    try:
+        importlib.import_module("PIL")
+    except Exception:
+        pil = types.ModuleType("PIL")
+        image_mod = types.ModuleType("PIL.Image")
 
-    class Image:  # noqa: D401
-        """Stub PIL.Image.Image."""
+        class Image:  # noqa: D401
+            """Stub PIL.Image.Image."""
 
-        pass
+            pass
 
-    image_mod.Image = Image
-    pil.Image = image_mod
-    sys.modules["PIL"] = pil
-    sys.modules["PIL.Image"] = image_mod
+        image_mod.Image = Image
+        pil.Image = image_mod
+        sys.modules["PIL"] = pil
+        sys.modules["PIL.Image"] = image_mod
 
 
 # Provide a tiny openai stub (OpenAIEngine imports openai.AsyncOpenAI)
@@ -120,7 +128,6 @@ for _name in _STUB_MODULES:
         continue
     try:
         importlib.import_module(_name)
-        continue
     except Exception:
         sys.modules[_name] = types.ModuleType(_name)
 

--- a/tests/engine/test_trace_converter.py
+++ b/tests/engine/test_trace_converter.py
@@ -1,0 +1,175 @@
+"""Tests for trace_converter: trace_record_to_step with tool_calls support."""
+
+from rllm_model_gateway.models import TraceRecord
+
+from rllm.experimental.engine.trace_converter import (
+    _parse_openai_tool_calls,
+    trace_record_to_step,
+)
+
+# ------------------------------------------------------------------
+# _parse_openai_tool_calls
+# ------------------------------------------------------------------
+
+
+class TestParseOpenaiToolCalls:
+    def test_basic_conversion(self):
+        raw = [
+            {
+                "id": "call_0",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "London"}',
+                },
+            }
+        ]
+        result = _parse_openai_tool_calls(raw)
+        assert len(result) == 1
+        assert result[0].name == "get_weather"
+        assert result[0].arguments == {"city": "London"}
+
+    def test_multiple_tool_calls(self):
+        raw = [
+            {
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "search", "arguments": '{"q": "test"}'},
+            },
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "calc", "arguments": '{"expr": "1+1"}'},
+            },
+        ]
+        result = _parse_openai_tool_calls(raw)
+        assert len(result) == 2
+        assert result[0].name == "search"
+        assert result[1].name == "calc"
+        assert result[1].arguments == {"expr": "1+1"}
+
+    def test_invalid_json_arguments(self):
+        raw = [
+            {
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "foo", "arguments": "not-json"},
+            }
+        ]
+        result = _parse_openai_tool_calls(raw)
+        assert result[0].name == "foo"
+        assert result[0].arguments == {"raw": "not-json"}
+
+    def test_dict_arguments(self):
+        """Arguments already parsed as dict (e.g. from in-process handler)."""
+        raw = [
+            {
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "bar", "arguments": {"x": 1}},
+            }
+        ]
+        result = _parse_openai_tool_calls(raw)
+        assert result[0].arguments == {"x": 1}
+
+    def test_empty_list(self):
+        assert _parse_openai_tool_calls([]) == []
+
+
+# ------------------------------------------------------------------
+# trace_record_to_step with tool_calls
+# ------------------------------------------------------------------
+
+
+class TestTraceRecordToStep:
+    def _make_trace(self, **overrides) -> TraceRecord:
+        defaults = {
+            "trace_id": "t-001",
+            "session_id": "s-001",
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "prompt_token_ids": [1, 2, 3],
+            "response_message": {
+                "role": "assistant",
+                "content": "Hi there!",
+            },
+            "completion_token_ids": [10, 11],
+            "logprobs": [-0.5, -0.3],
+            "finish_reason": "stop",
+        }
+        defaults.update(overrides)
+        return TraceRecord(**defaults)
+
+    def test_basic_step(self):
+        trace = self._make_trace()
+        step = trace_record_to_step(trace)
+
+        assert step.id == "t-001"
+        assert step.model_response == "Hi there!"
+        assert step.model_output.content == "Hi there!"
+        assert step.model_output.prompt_ids == [1, 2, 3]
+        assert step.model_output.completion_ids == [10, 11]
+        assert step.model_output.logprobs == [-0.5, -0.3]
+        assert step.model_output.tool_calls is None
+
+    def test_step_with_tool_calls(self):
+        trace = self._make_trace(
+            response_message={
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "London"}',
+                        },
+                    },
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "calculate",
+                            "arguments": '{"expr": "2+2"}',
+                        },
+                    },
+                ],
+            },
+            finish_reason="tool_calls",
+        )
+        step = trace_record_to_step(trace)
+
+        assert step.model_output.tool_calls is not None
+        assert len(step.model_output.tool_calls) == 2
+        assert step.model_output.tool_calls[0].name == "get_weather"
+        assert step.model_output.tool_calls[0].arguments == {"city": "London"}
+        assert step.model_output.tool_calls[1].name == "calculate"
+        assert step.model_output.tool_calls[1].arguments == {"expr": "2+2"}
+        assert step.model_output.finish_reason == "tool_calls"
+
+    def test_step_with_reasoning(self):
+        trace = self._make_trace(
+            response_message={
+                "role": "assistant",
+                "content": "42",
+                "reasoning": "Let me think...",
+            },
+        )
+        step = trace_record_to_step(trace)
+        assert step.thought == "Let me think..."
+        assert step.model_output.reasoning == "Let me think..."
+
+    def test_chat_completions_includes_response(self):
+        trace = self._make_trace()
+        step = trace_record_to_step(trace)
+        assert len(step.chat_completions) == 2  # user msg + assistant msg
+        assert step.chat_completions[-1]["role"] == "assistant"
+
+    def test_no_tool_calls_key_means_none(self):
+        """If response_message has no tool_calls key, model_output.tool_calls should be None."""
+        trace = self._make_trace(
+            response_message={"role": "assistant", "content": "just text"},
+        )
+        step = trace_record_to_step(trace)
+        assert step.model_output.tool_calls is None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,11 @@
+import os
+
+import pytest
+
+TINKER_API_KEY = os.environ.get("TINKER_API_KEY")
+TINKER_MODEL_NAME = "Qwen/Qwen3-8B"
+
+requires_tinker = pytest.mark.skipif(
+    not TINKER_API_KEY,
+    reason="TINKER_API_KEY env var required",
+)

--- a/tests/integration/test_tinker_gateway_integration.py
+++ b/tests/integration/test_tinker_gateway_integration.py
@@ -1,0 +1,361 @@
+"""Integration test: real TinkerEngine → create_tinker_handler → gateway → trace → trace_record_to_step.
+
+Requires TINKER_API_KEY env var (auto-skipped otherwise).
+Uses a small model (Qwen/Qwen3-8B) with short max_tokens to keep costs low.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+import uvicorn
+
+from .conftest import TINKER_MODEL_NAME, requires_tinker
+
+
+def create_tinker_engine():
+    """Bootstrap a real TinkerEngine with a sampling client."""
+    import tinker
+    from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+    from rllm.experimental.rollout.tinker_engine import TinkerEngine
+
+    tokenizer = get_tokenizer(TINKER_MODEL_NAME)
+    service_client = tinker.ServiceClient()
+    sampling_client = service_client.create_sampling_client(base_model=TINKER_MODEL_NAME)
+
+    engine = TinkerEngine(
+        base_url="",
+        model_name=TINKER_MODEL_NAME,
+        tokenizer=tokenizer,
+        service_client=service_client,
+        max_prompt_length=1024,
+        max_response_length=128,
+        max_model_length=2048,
+        sampling_params={"train": {"temperature": 0.0}, "val": {"temperature": 0.0}},
+        bypass_render_with_parser=True,
+        disable_thinking=True,
+    )
+    engine.set_sampling_client(sampling_client)
+    return engine
+
+
+class GatewayServer:
+    def __init__(self, app, port=0):
+        self.host = "127.0.0.1"
+        self.port = port
+        self.app = app
+        self.server = None
+        self.thread = None
+
+    @property
+    def url(self):
+        return f"http://{self.host}:{self.port}"
+
+    def start(self):
+        config = uvicorn.Config(self.app, host=self.host, port=self.port, log_level="error")
+        self.server = uvicorn.Server(config)
+        self.thread = threading.Thread(target=self.server.run, daemon=True)
+        self.thread.start()
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if self.server.started:
+                for sock in self.server.servers:
+                    self.port = sock.sockets[0].getsockname()[1]
+                return
+            time.sleep(0.05)
+        raise RuntimeError("Server failed to start")
+
+    def stop(self):
+        if self.server:
+            self.server.should_exit = True
+        if self.thread:
+            self.thread.join(timeout=5.0)
+
+
+@pytest.fixture(scope="module")
+def tinker_gateway():
+    """Start a gateway with a real TinkerEngine behind create_tinker_handler."""
+    from rllm_model_gateway import GatewayConfig, create_app
+
+    from rllm.experimental.engine.tinker_adapter import create_tinker_handler
+
+    engine = create_tinker_engine()
+    handler = create_tinker_handler(engine)
+    config = GatewayConfig(
+        store_worker="memory",
+        workers=[],
+        health_check_interval=999,
+        sync_traces=True,
+    )
+    app = create_app(config, local_handler=handler)
+    server = GatewayServer(app)
+    server.start()
+    yield server
+    server.stop()
+
+
+@requires_tinker
+class TestTinkerAdapterE2E:
+    def test_basic_completion(self, tinker_gateway):
+        """Real tinker inference through gateway, verify clean response."""
+        import openai
+        from rllm_model_gateway import GatewayClient
+
+        gw = GatewayClient(tinker_gateway.url)
+        sid = gw.create_session(session_id="tinker-basic")
+        url = gw.get_session_url(sid)
+
+        oai = openai.OpenAI(base_url=url, api_key="dummy")
+        resp = oai.chat.completions.create(
+            model=TINKER_MODEL_NAME,
+            messages=[{"role": "user", "content": "What is 2+2? Answer with just the number."}],
+            max_tokens=32,
+        )
+
+        assert resp.choices[0].message.content is not None
+        assert len(resp.choices[0].message.content) > 0
+        assert resp.choices[0].finish_reason in ("stop", "length")
+        assert resp.usage.prompt_tokens > 0
+        assert resp.usage.completion_tokens > 0
+        gw.close()
+
+    def test_vllm_fields_stripped(self, tinker_gateway):
+        """Raw response must not leak token_ids or prompt_token_ids."""
+        import httpx
+        from rllm_model_gateway import GatewayClient
+
+        gw = GatewayClient(tinker_gateway.url)
+        sid = gw.create_session(session_id="tinker-strip")
+        url = gw.get_session_url(sid)
+
+        raw = httpx.post(
+            f"{url}/chat/completions",
+            json={
+                "model": TINKER_MODEL_NAME,
+                "messages": [{"role": "user", "content": "Say hi."}],
+                "max_tokens": 16,
+            },
+        )
+        data = raw.json()
+        assert "prompt_token_ids" not in data
+        for choice in data.get("choices", []):
+            assert "token_ids" not in choice
+        gw.close()
+
+    def test_trace_has_token_data(self, tinker_gateway):
+        """Trace should contain real prompt_token_ids, completion_token_ids, logprobs."""
+        import openai
+        from rllm_model_gateway import GatewayClient
+
+        gw = GatewayClient(tinker_gateway.url)
+        sid = gw.create_session(session_id="tinker-trace")
+        url = gw.get_session_url(sid)
+
+        oai = openai.OpenAI(base_url=url, api_key="dummy")
+        oai.chat.completions.create(
+            model=TINKER_MODEL_NAME,
+            messages=[{"role": "user", "content": "What is 1+1?"}],
+            max_tokens=32,
+        )
+
+        traces = gw.get_session_traces(sid)
+        assert len(traces) == 1
+        t = traces[0]
+
+        assert len(t.prompt_token_ids) > 0, "trace should have real prompt token IDs"
+        assert len(t.completion_token_ids) > 0, "trace should have real completion token IDs"
+        assert t.logprobs is not None and len(t.logprobs) > 0, "trace should have logprobs"
+        assert len(t.logprobs) == len(t.completion_token_ids), "logprobs count should match completion tokens"
+        assert t.response_message["role"] == "assistant"
+        assert len(t.response_message.get("content", "")) > 0
+        assert t.finish_reason in ("stop", "length")
+        assert t.latency_ms > 0
+        gw.close()
+
+    def test_trace_round_trips_to_step(self, tinker_gateway):
+        """trace_record_to_step should reconstruct a valid ModelOutput from real trace."""
+        import openai
+        from rllm_model_gateway import GatewayClient
+
+        from rllm.experimental.engine.trace_converter import trace_record_to_step
+
+        gw = GatewayClient(tinker_gateway.url)
+        sid = gw.create_session(session_id="tinker-step")
+        url = gw.get_session_url(sid)
+
+        oai = openai.OpenAI(base_url=url, api_key="dummy")
+        oai.chat.completions.create(
+            model=TINKER_MODEL_NAME,
+            messages=[{"role": "user", "content": "What is 3+4?"}],
+            max_tokens=32,
+        )
+
+        traces = gw.get_session_traces(sid)
+        step = trace_record_to_step(traces[0])
+
+        assert step.model_output.prompt_ids is not None
+        assert len(step.model_output.prompt_ids) > 0
+        assert step.model_output.completion_ids is not None
+        assert len(step.model_output.completion_ids) > 0
+        assert step.model_output.logprobs is not None
+        assert len(step.model_output.logprobs) > 0
+        assert step.model_output.content is not None
+        assert len(step.model_output.content) > 0
+        assert step.model_output.finish_reason in ("stop", "length")
+        assert step.model_output.prompt_ids == traces[0].prompt_token_ids
+        assert step.model_output.completion_ids == traces[0].completion_token_ids
+        gw.close()
+
+    def test_streaming_delivers_content_and_trace(self, tinker_gateway):
+        """Streaming through the gateway should deliver real content and capture trace."""
+        import openai
+        from rllm_model_gateway import GatewayClient
+
+        gw = GatewayClient(tinker_gateway.url)
+        sid = gw.create_session(session_id="tinker-stream")
+        url = gw.get_session_url(sid)
+
+        oai = openai.OpenAI(base_url=url, api_key="dummy")
+        stream = oai.chat.completions.create(
+            model=TINKER_MODEL_NAME,
+            messages=[{"role": "user", "content": "Say hello."}],
+            max_tokens=16,
+            stream=True,
+        )
+
+        parts = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                parts.append(chunk.choices[0].delta.content)
+        full = "".join(parts)
+        assert len(full) > 0
+
+        traces = gw.get_session_traces(sid)
+        assert len(traces) == 1
+        assert len(traces[0].prompt_token_ids) > 0
+        assert len(traces[0].completion_token_ids) > 0
+        gw.close()
+
+    def test_multi_turn(self, tinker_gateway):
+        """Multiple calls under one session should produce separate traces."""
+        import openai
+        from rllm_model_gateway import GatewayClient
+
+        gw = GatewayClient(tinker_gateway.url)
+        sid = gw.create_session(session_id="tinker-multi")
+        url = gw.get_session_url(sid)
+
+        oai = openai.OpenAI(base_url=url, api_key="dummy")
+        for q in ["What is 1+1?", "What is 2+2?"]:
+            oai.chat.completions.create(
+                model=TINKER_MODEL_NAME,
+                messages=[{"role": "user", "content": q}],
+                max_tokens=16,
+            )
+
+        traces = gw.get_session_traces(sid)
+        assert len(traces) == 2
+        for t in traces:
+            assert len(t.prompt_token_ids) > 0
+            assert len(t.completion_token_ids) > 0
+        gw.close()
+
+    def test_tool_calling_multi_turn(self, tinker_gateway):
+        """Send tools, get tool_calls back, send tool result, get final answer.
+
+        Simulates what an agent with tool does:
+        1. Request with tools defined → model responds with tool_calls
+        2. Send tool result back → model responds with final answer
+        Verifies tools flow through the prompt and tool_calls appear in traces.
+        """
+        import openai
+        from rllm_model_gateway import GatewayClient
+
+        from rllm.experimental.engine.trace_converter import trace_record_to_step
+
+        gw = GatewayClient(tinker_gateway.url)
+        sid = gw.create_session(session_id="tinker-tools")
+        url = gw.get_session_url(sid)
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "Evaluate a math expression and return the result.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "expression": {
+                                "type": "string",
+                                "description": "The math expression to evaluate",
+                            }
+                        },
+                        "required": ["expression"],
+                    },
+                },
+            }
+        ]
+
+        oai = openai.OpenAI(base_url=url, api_key="dummy")
+
+        # Turn 1: request with tools
+        resp = oai.chat.completions.create(
+            model=TINKER_MODEL_NAME,
+            messages=[{"role": "user", "content": "What is 17 * 23? Use the calculator tool."}],
+            tools=tools,
+            max_tokens=256,
+        )
+
+        msg = resp.choices[0].message
+        traces = gw.get_session_traces(sid)
+        assert len(traces) >= 1
+
+        t0 = traces[0]
+        assert len(t0.prompt_token_ids) > 0
+        assert len(t0.completion_token_ids) > 0
+        assert t0.logprobs is not None and len(t0.logprobs) > 0
+
+        # Model chose to use tools — verify the full round-trip
+        assert resp.choices[0].finish_reason == "tool_calls"
+        tc = msg.tool_calls[0]
+        assert tc.function.name == "calculator"
+        args = json.loads(tc.function.arguments)
+        assert "expression" in args
+
+        # Verify tool_calls in trace
+        assert "tool_calls" in t0.response_message
+        assert t0.response_message["tool_calls"][0]["function"]["name"] == "calculator"
+
+        # Verify trace_record_to_step reconstructs tool_calls
+        step = trace_record_to_step(t0)
+        assert step.model_output.tool_calls is not None
+        assert step.model_output.tool_calls[0].name == "calculator"
+
+        # Turn 2: send tool result back
+        result = str(eval(args["expression"]))
+        resp2 = oai.chat.completions.create(
+            model=TINKER_MODEL_NAME,
+            messages=[
+                {"role": "user", "content": "What is 17 * 23? Use the calculator tool."},
+                {
+                    "role": "assistant",
+                    "content": msg.content or "",
+                    "tool_calls": [{"id": tc.id, "type": "function", "function": {"name": tc.function.name, "arguments": tc.function.arguments}} for tc in msg.tool_calls],
+                },
+                {"role": "tool", "tool_call_id": tc.id, "content": result},
+            ],
+            tools=tools,
+            max_tokens=128,
+        )
+        assert resp2.choices[0].message.content is not None
+
+        traces_after = gw.get_session_traces(sid)
+        assert len(traces_after) == 2
+        t1 = traces_after[1]
+        assert len(t1.prompt_token_ids) > 0
+        assert len(t1.completion_token_ids) > 0
+
+        gw.close()


### PR DESCRIPTION
## Summary

This PR simplifies the integration or Tinker with rllm-model-gateway by replacing the TinkerBackendServer (a standalone http server) with a simple local handler; also adds tool call support.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Docs
- [x] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- Inject an async handler directly into the gateway's ReverseProxy instead of running a sidecar HTTP server for TinkerEngine. 
- Add tool_calls parsing to trace_converter and integration tests for the full tinker → gateway → trace → step pipeline.
- Updated `tests/conftest.py` to try importing first so that integration can run when the dependencies are available.

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- unit test: `pytest tests/engine/test_trace_converter.py`
- integration test: `pytest tests/integration/test_tinker_gateway_integration.py` (`TINKER_API_KEY` env var required). 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [x] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
