### PR TITLE
Pydantic Error

### DIFF
--- a/examples/geo3k/geo3k_workflow.py
+++ b/examples/geo3k/geo3k_workflow.py
@@ -38,7 +38,7 @@ class Geo3KWorkflow(Workflow):
             messages = [{"role": "user", "content": question}]
 
         output: ModelOutput = await self.rollout_engine.get_model_response(messages, application_id=uid, **kwargs)
-        action = Action(output.content)
+        action = Action(action=output.content)
         reward_result = self.reward_fn(task, action)
 
         trajectory: Trajectory = self.agent.trajectory


### PR DESCRIPTION
## Summary

<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->
Fixes a runtime error caused by incorrect initialization of the `Action` model. Previously, `Action` was instantiated with a positional argument (`Action(output.content)`), which is incompatible with `BaseModel`-based initialization. The update ensures proper keyword-based initialization, resolving the `TypeError`.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed
- Updated `Action` initialization from positional to keyword argument:
  - `Action(output.content)` → `Action(action=output.content)`
- Fixed compatibility with `BaseModel` (likely Pydantic-based) initialization requirements
- Eliminated runtime `TypeError: BaseModel.__init__() takes 1 positional argument but 2 were given`


## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Verified that the task runner executes without raising `TypeError`
- Confirmed correct object creation and downstream usage of `Action`

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs
action = Action(output.content) to action = Action(action=output.content)
(TaskRunner pid=1407691)     action = Action(output.content)
(TaskRunner pid=1407691)              ^^^^^^^^^^^^^^^^^^^^^^
(TaskRunner pid=1407691) TypeError: BaseModel.__init__() takes 1 positional argument but 2 were given

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
Before:
TypeError: BaseModel.init() takes 1 positional argument but 2 were given

After:
No error; Action initialized correctly