### PR TITLE
feat(tinker): add tool-use support for renderer path and fix checkpoint auto-resume

### DIFF
--- a/.github/workflows/test-tinker.yml
+++ b/.github/workflows/test-tinker.yml
@@ -1,0 +1,38 @@
+name: Test Tinker engine
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rllm/experimental/rollout/**"
+      - "rllm/trainer/tinker/**"
+      - "tests/engine/test_tinker_engine.py"
+      - ".github/workflows/test-tinker.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "rllm/experimental/rollout/**"
+      - "rllm/trainer/tinker/**"
+      - "tests/engine/test_tinker_engine.py"
+      - ".github/workflows/test-tinker.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra tinker
+
+      - name: Run Tinker engine tests
+        run: uv run pytest tests/engine/test_tinker_engine.py -v

--- a/rllm/experimental/rollout/tinker_engine.py
+++ b/rllm/experimental/rollout/tinker_engine.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, cast
 
 import tinker
@@ -9,6 +10,7 @@ from typing_extensions import override  # need to use typing_extensions for pyth
 from rllm.experimental.rollout.rollout_engine import ModelOutput, RolloutEngine
 from rllm.experimental.rollout.types import ImageProcessor, Processor, TinkerTokenInput, TinkerTokenOutput, TokenInput, Tokenizer, TokenOutput
 from rllm.parser import ChatTemplateParser
+from rllm.tools.tool_base import ToolCall
 from rllm.workflows import TerminationEvent, TerminationReason
 
 """
@@ -52,6 +54,63 @@ def _flat_token_input_length(token_input: TokenInput) -> int:
     return length
 
 
+def _convert_openai_messages(messages: list[dict[str, Any]]) -> list[Message]:
+    """Convert OpenAI message dicts to tinker-cookbook Messages.
+
+    Follows the same pattern as tinker_cookbook.third_party.litellm.provider._convert_openai_messages.
+    TODO: once these helpers are refactored out of the litellm provider into a shared module
+    (e.g. tinker_cookbook.renderers.openai_compat), import directly instead of duplicating.
+    """
+    from tinker_cookbook.renderers.base import ToolCall as TinkerToolCall
+
+    out: list[Message] = []
+    for msg in messages:
+        tinker_msg: Message = {
+            "role": msg["role"],
+            "content": msg.get("content") or "",
+        }
+        if "name" in msg:
+            tinker_msg["name"] = msg["name"]
+        if "tool_call_id" in msg:
+            tinker_msg["tool_call_id"] = msg["tool_call_id"]
+        if "tool_calls" in msg:
+            tinker_msg["tool_calls"] = [TinkerToolCall.model_validate(tc) for tc in msg["tool_calls"]]
+        out.append(tinker_msg)
+    return out
+
+
+def _prepare_messages_with_tools(
+    renderer: renderers.Renderer,
+    messages: list[Message],
+    tools: list[dict[str, Any]],
+) -> list[Message]:
+    """Inject tool declarations into the message list via the renderer.
+
+    Follows the same pattern as tinker_cookbook.third_party.litellm.provider._prepare_messages_with_tools.
+    TODO: once these helpers are refactored out of the litellm provider into a shared module
+    (e.g. tinker_cookbook.renderers.openai_compat), import directly instead of duplicating.
+    """
+    from tinker_cookbook.renderers.base import ToolSpec
+
+    tool_specs: list[ToolSpec] = []
+    for tool in tools:
+        if tool.get("type") != "function":
+            continue
+        func = tool["function"]
+        tool_specs.append(ToolSpec(name=func["name"], description=func.get("description", ""), parameters=func.get("parameters", {})))
+
+    system_prompt = ""
+    if messages and messages[0]["role"] == "system":
+        content = messages[0].get("content") or ""
+        system_prompt = content if isinstance(content, str) else ""
+        remaining = list(messages[1:])
+    else:
+        remaining = list(messages)
+
+    prefix = renderer.create_conversation_prefix_with_tools(tool_specs, system_prompt)
+    return prefix + remaining
+
+
 def _parse_tinker_message(message: Message) -> tuple[str, str, list[Any]]:
     tinker_content = message["content"]
     if isinstance(tinker_content, list):
@@ -66,8 +125,20 @@ def _parse_tinker_message(message: Message) -> tuple[str, str, list[Any]]:
     else:  # no reasoning parsed
         content = tinker_content
         reasoning = ""
-    # TODO(listar2000): the Tinker tool_calls is not fully compatible with the rLLM one
-    tool_calls = message.get("tool_calls", [])
+    # Convert tinker-cookbook ToolCall (function.name/function.arguments) to rllm ToolCall (name/arguments)
+    raw_tool_calls = message.get("tool_calls", [])
+    tool_calls = []
+    for tc in raw_tool_calls:
+        if hasattr(tc, "function"):
+            # tinker-cookbook ToolCall: ToolCall(function=FunctionBody(name, arguments), id)
+            args = tc.function.arguments
+            tool_calls.append(ToolCall(name=tc.function.name, arguments=json.loads(args) if isinstance(args, str) else args))
+        elif isinstance(tc, ToolCall):
+            tool_calls.append(tc)
+        elif isinstance(tc, dict):
+            tool_calls.append(ToolCall(name=tc.get("name", ""), arguments=tc.get("arguments", {})))
+        else:
+            raise TypeError(f"Unrecognized tool_call type: {type(tc)}")
     return content, reasoning, tool_calls
 
 
@@ -157,29 +228,20 @@ class TinkerEngine(RolloutEngine):
         """
         self.sampling_client = sampling_client
 
-    def _convert_images_to_content_list(self, messages: list[dict]) -> list[dict]:
-        """
-        Convert messages from standard format to Tinker renderer format.
+    @staticmethod
+    def _convert_images_to_content_list(messages: list[dict]) -> list[dict]:
+        """Convert rllm image format to renderer content list format.
 
-        Standard format: {"role": "user", "content": "text", "images": [PIL.Image]}
-        Tinker format:   {"role": "user", "content": [{"type": "image", "image": img}, {"type": "text", "text": "..."}]}
-
-        Args:
-            messages: List of messages in standard format
-
-        Returns:
-            List of messages in Tinker renderer format
+        {"content": "text", "images": [PIL.Image]} -> {"content": [ImagePart, TextPart]}
         """
         converted = []
         for msg in messages:
             if "images" in msg and msg["images"]:
-                # Convert to content list format
                 content_list = []
                 for img in msg["images"]:
                     content_list.append({"type": "image", "image": img})
                 content_list.append({"type": "text", "text": msg.get("content", "")})
                 converted.append({**msg, "content": content_list})
-                # Remove the images key since it's now in content
                 del converted[-1]["images"]
             else:
                 converted.append(msg)
@@ -337,10 +399,14 @@ class TinkerEngine(RolloutEngine):
             token_input = self.tokenizer.encode(prompt, add_special_tokens=False)  # type: ignore
         else:
             # Use Tinker renderer
-            # Convert standard image format to Tinker renderer format
+            # Convert images, then convert OpenAI messages to renderer format
             converted_messages = self._convert_images_to_content_list(messages)
+            tinker_messages = _convert_openai_messages(converted_messages)
+            # Inject tool definitions via renderer if tools are provided
+            if tools:
+                tinker_messages = _prepare_messages_with_tools(self.renderer, tinker_messages, tools)
             # Build prompt using renderer
-            token_input: TinkerTokenInput = self.renderer.build_generation_prompt(converted_messages).chunks  # type: ignore
+            token_input: TinkerTokenInput = self.renderer.build_generation_prompt(tinker_messages).chunks  # type: ignore
 
         sampled_sequence = await self.get_token_output_from_token_input(token_input=token_input, **kwargs)
         return self.assemble_model_output(token_input=token_input, token_output=sampled_sequence)

--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -381,7 +381,12 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
         os.makedirs(self.full_config.training.default_local_dir, exist_ok=True)
 
         # Initialize training client and load checkpoint
-        start_batch, self.sampling_client = await self.policy_trainer.initialize_async(resume_from_checkpoint=True)
+        # Auto-resume from local checkpoints is disabled: the checkpoint dir is shared across
+        # all experiments, so it can load wrong model weights. To resume, use
+        # training.resume_from_tinker_id=tinker://... to target a specific checkpoint.
+        # TODO: enable auto-resume once checkpoint dir is scoped per-experiment.
+        resume = bool(self.full_config.training.resume_from_tinker_id)
+        start_batch, self.sampling_client = await self.policy_trainer.initialize_async(resume_from_checkpoint=resume)
 
         # Update trainer state with the start batch from checkpoint
         trainer_state.global_step = start_batch

--- a/rllm/trainer/tinker/tinker_policy_trainer.py
+++ b/rllm/trainer/tinker/tinker_policy_trainer.py
@@ -141,11 +141,7 @@ class TinkerPolicyTrainer:
         if resume_info:
             # Resume from checkpoint
             logger.info(f"Resuming from checkpoint: {resume_info}")
-            try:
-                self.training_client = await self.service_client.create_training_client_from_state_async(resume_info["state_path"])
-            except Exception as e:
-                logger.error(f"Failed to resume from checkpoint: {e}")
-                raise
+            self.training_client = await self.service_client.create_training_client_from_state_async(resume_info["state_path"])
 
             if "sampler_path" in resume_info:
                 logger.info(f"Using sampler checkpoint: {resume_info['sampler_path']}")
@@ -388,6 +384,9 @@ class TinkerPolicyTrainer:
         Returns:
             Resume info dictionary or None if no checkpoint exists
         """
+        # TODO: default_local_dir is shared across all experiments (e.g. /tmp/rllm-tinker-checkpoints),
+        # so this can load checkpoints from a different model/experiment. Should scope by experiment
+        # name like tinker-cookbook does with its per-experiment log_path.
         return checkpoint_utils.get_last_checkpoint(self.config.training.default_local_dir)
 
     @require_training_client

--- a/tests/engine/test_tinker_engine.py
+++ b/tests/engine/test_tinker_engine.py
@@ -1,0 +1,203 @@
+"""Tests for tinker_engine OpenAI-to-renderer conversion helpers."""
+
+import json
+
+import pytest
+from tinker_cookbook.renderers import get_renderer
+from tinker_cookbook.renderers.base import ToolCall as TinkerToolCall
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+from rllm.experimental.rollout.tinker_engine import (
+    _convert_openai_messages,
+    _parse_tinker_message,
+    _prepare_messages_with_tools,
+)
+from rllm.tools.tool_base import ToolCall as RllmToolCall
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+CALCULATOR_TOOL_OPENAI = {
+    "type": "function",
+    "function": {
+        "name": "calculator",
+        "description": "Compute math expressions",
+        "parameters": {
+            "type": "object",
+            "properties": {"expression": {"type": "string"}},
+            "required": ["expression"],
+        },
+    },
+}
+
+TOOL_CALL_OPENAI = {
+    "id": "call_0",
+    "type": "function",
+    "function": {"name": "calculator", "arguments": '{"expression": "2+2"}'},
+}
+
+
+def _make_tinker_tool_call(name: str = "calculator", arguments: str = '{"expression": "2+2"}', id: str = "call_0"):
+    return TinkerToolCall(
+        function=TinkerToolCall.FunctionBody(name=name, arguments=arguments),
+        id=id,
+    )
+
+
+# ------------------------------------------------------------------
+# _convert_openai_messages
+# ------------------------------------------------------------------
+
+
+class TestConvertOpenaiMessages:
+    def test_tool_calls_become_pydantic_objects(self):
+        """OpenAI tool_calls dicts should be converted to TinkerToolCall objects."""
+        messages = [
+            {"role": "assistant", "content": "Let me calculate.", "tool_calls": [TOOL_CALL_OPENAI]},
+        ]
+        result = _convert_openai_messages(messages)
+        tc = result[0]["tool_calls"][0]
+        assert isinstance(tc, TinkerToolCall)
+        assert tc.function.name == "calculator"
+        assert json.loads(tc.function.arguments) == {"expression": "2+2"}
+
+    def test_tool_response_preserves_fields(self):
+        """Tool response messages should preserve tool_call_id and name."""
+        messages = [
+            {"role": "tool", "content": "4", "tool_call_id": "call_0", "name": "calculator"},
+        ]
+        result = _convert_openai_messages(messages)
+        assert result[0]["tool_call_id"] == "call_0"
+        assert result[0]["name"] == "calculator"
+
+    def test_array_content_passed_through(self):
+        """Strands sends content as [{"type": "text", "text": "..."}] — list is truthy so it passes through."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What is 2+2?"}]},
+        ]
+        result = _convert_openai_messages(messages)
+        assert result[0]["content"] == [{"type": "text", "text": "What is 2+2?"}]
+
+    def test_none_content_becomes_empty_string(self):
+        messages = [{"role": "assistant", "content": None}]
+        result = _convert_openai_messages(messages)
+        assert result[0]["content"] == ""
+
+
+# ------------------------------------------------------------------
+# _prepare_messages_with_tools
+# ------------------------------------------------------------------
+
+
+class TestPrepareMessagesWithTools:
+    @pytest.fixture()
+    def qwen3_renderer(self):
+        tok = get_tokenizer("Qwen/Qwen3-8B")
+        return get_renderer("qwen3", tok, model_name="Qwen/Qwen3-8B")
+
+    def test_tools_injected_into_system_message(self, qwen3_renderer):
+        """Tool definitions should appear in the system message content."""
+        messages = _convert_openai_messages(
+            [
+                {"role": "system", "content": "Solve math problems."},
+                {"role": "user", "content": "What is 2+2?"},
+            ]
+        )
+        result = _prepare_messages_with_tools(qwen3_renderer, messages, [CALCULATOR_TOOL_OPENAI])
+
+        system_content = result[0]["content"]
+        assert "calculator" in system_content
+        assert "<tools>" in system_content
+        assert "Solve math problems." in system_content
+
+    def test_system_prompt_not_duplicated(self, qwen3_renderer):
+        """Original system message should be replaced, not duplicated."""
+        messages = _convert_openai_messages(
+            [
+                {"role": "system", "content": "Be helpful."},
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+        result = _prepare_messages_with_tools(qwen3_renderer, messages, [CALCULATOR_TOOL_OPENAI])
+
+        system_messages = [m for m in result if m["role"] == "system"]
+        assert len(system_messages) == 1
+
+    def test_no_system_message_creates_one(self, qwen3_renderer):
+        """If no system message exists, one should be created with tool definitions."""
+        messages = _convert_openai_messages(
+            [
+                {"role": "user", "content": "What is 2+2?"},
+            ]
+        )
+        result = _prepare_messages_with_tools(qwen3_renderer, messages, [CALCULATOR_TOOL_OPENAI])
+
+        assert result[0]["role"] == "system"
+        assert "calculator" in result[0]["content"]
+        assert result[-1]["role"] == "user"
+
+    def test_non_function_tools_ignored(self, qwen3_renderer):
+        """Tools without type='function' should be silently skipped."""
+        messages = _convert_openai_messages(
+            [
+                {"role": "system", "content": "Hi"},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+        bad_tool = {"type": "retrieval", "name": "search"}
+        result = _prepare_messages_with_tools(qwen3_renderer, messages, [bad_tool])
+
+        # No tools injected, but system message still present
+        assert "<tools>" not in result[0]["content"]
+
+
+# ------------------------------------------------------------------
+# _parse_tinker_message
+# ------------------------------------------------------------------
+
+
+class TestParseTinkerMessage:
+    def test_tinker_tool_calls_converted_to_rllm(self):
+        """Tinker ToolCall(function=FunctionBody(...)) should become rllm ToolCall(name, arguments)."""
+        tc = _make_tinker_tool_call()
+        message = {"role": "assistant", "content": "result", "tool_calls": [tc]}
+
+        content, reasoning, tool_calls = _parse_tinker_message(message)
+        assert len(tool_calls) == 1
+        assert isinstance(tool_calls[0], RllmToolCall)
+        assert tool_calls[0].name == "calculator"
+        assert tool_calls[0].arguments == {"expression": "2+2"}
+
+    def test_structured_content_with_thinking(self):
+        """List content with thinking and text parts should be separated."""
+        message = {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "Let me reason..."},
+                {"type": "text", "text": "The answer is 4."},
+            ],
+        }
+        content, reasoning, tool_calls = _parse_tinker_message(message)
+        assert "answer is 4" in content
+        assert "reason" in reasoning
+        assert tool_calls == []
+
+    def test_string_content_no_reasoning(self):
+        """Plain string content should have empty reasoning."""
+        message = {"role": "assistant", "content": "Hello world"}
+        content, reasoning, tool_calls = _parse_tinker_message(message)
+        assert content == "Hello world"
+        assert reasoning == ""
+
+    def test_multiple_tool_calls(self):
+        """Multiple tool calls should all be converted."""
+        tcs = [
+            _make_tinker_tool_call("calculator", '{"expression": "2+2"}', "call_0"),
+            _make_tinker_tool_call("calculator", '{"expression": "3*3"}', "call_1"),
+        ]
+        message = {"role": "assistant", "content": "Computing...", "tool_calls": tcs}
+        _, _, tool_calls = _parse_tinker_message(message)
+        assert len(tool_calls) == 2
+        assert tool_calls[0].arguments == {"expression": "2+2"}
+        assert tool_calls[1].arguments == {"expression": "3*3"}


### PR DESCRIPTION
## Summary

- Add tool-use support for Tinker renderer path and fix checkpoint auto-resume. 
- Add related unit tests and CI workflow.

## Type of change

- [x] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [x] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- Convert OpenAI messages and tool specs to tinker-cookbook format so the renderer path (bypass_render_with_parser=False) supports tool-calling
- Properly convert tinker-cookbook ToolCall to rllm ToolCall in _parse_tinker_message, raising TypeError on unrecognized types
- Disable auto-resume from shared checkpoint dir to prevent cross-experiment weight contamination. Experiment id based scoping similar to tinker-cookbook will be added in a follow-up PR. 
- Add unit tests for message conversion, tool injection, and response parsing
- Add CI workflow for tinker engine tests
## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `uv run pytest tests/engine/test_tinker_engine.py -v` passed.

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
