### PR TITLE
fix: replace bare except with except Exception in taco.py

### DIFF
--- a/rllm/rewards/code_utils/taco.py
+++ b/rllm/rewards/code_utils/taco.py
@@ -148,19 +148,19 @@ def process_input_output(inputs, outputs):
     try:
         if isinstance(inputs[0], dict):
             inputs = [{int(k): v for k, v in inputs[0].items()}]
-    except:
+    except Exception:
         True
 
     try:
         if isinstance(outputs, dict):
             outputs = [{int(k): v for k, v in outputs.items()}]
-    except:
+    except Exception:
         True
 
     try:
         if isinstance(outputs[0], dict):
             outputs = [{int(k): v for k, v in outputs[0].items()}]
-    except:
+    except Exception:
         True
 
     return inputs, outputs
@@ -190,7 +190,7 @@ def compile_and_get_func(program, which_type, method_name, timeout, debug):
         signal.alarm(timeout)
         method = getattr(tmp, method_name)  # get_attr second arg must be str
         signal.alarm(0)
-    except:
+    except Exception:
         signal.alarm(0)
         e = sys.exc_info()
         if debug:
@@ -325,7 +325,7 @@ def execute_cb_code(method, inputs_list, outputs_list, timeout, early_stop=True,
                 if isinstance(exec_outputs[0], tuple):
                     exec_outputs = [list(x) for x in exec_outputs]
                     tmp_result = tmp_result or (exec_outputs == outputs[0])
-            except:
+            except Exception:
                 True
             if tmp_result:
                 results.append((True, EXECUTION_RESULTS[1]))


### PR DESCRIPTION
## Summary

Replace 5 bare `except:` clauses with `except Exception:` in `rllm/rewards/code_utils/taco.py`.

Bare `except:` catches **all** exceptions including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`, which is almost never intended. Since none of these blocks re-raise the original exception, `except Exception:` is the correct replacement — it catches all regular errors while allowing system-level signals to propagate normally.

**Change (5 occurrences):**
```python
# Before
except:
    True  # or other no-op / error handling

# After
except Exception:
    True  # or other no-op / error handling
```

## Testing
No behavior change for normal exception paths — style/correctness fix only. Ensures `KeyboardInterrupt` / `SystemExit` can propagate correctly.