### PR TITLE
fix: verl transform robustness + NCCL dynamic batch sync patch

### DIFF
--- a/rllm/experimental/verl/patch.py
+++ b/rllm/experimental/verl/patch.py
@@ -11,6 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 _VERL_ACTOR_PATCHED = False
+_VERL_DYNAMIC_BATCH_PATCHED = False
 _VLLM_SDK_PATCHED = False
 
 
@@ -49,6 +50,56 @@ def patch_verl_actor_for_loss_override() -> None:
     DataParallelPPOActor.update_policy = _patched_update_policy
     _VERL_ACTOR_PATCHED = True
     logger.info("Patched DataParallelPPOActor.update_policy for per-call loss mode override")
+
+
+# ---------------------------------------------------------------------------
+# Verl dynamic batch: sync micro-batch counts across DP ranks
+# ---------------------------------------------------------------------------
+
+
+def patch_verl_dynamic_batch_sync() -> None:
+    """Patch ``prepare_dynamic_batch`` to sync micro-batch counts across DP ranks.
+
+    Fixes `verl#5750 <https://github.com/verl-project/verl/issues/5750>`_:
+    when ``use_dynamic_bsz=True``, each DP rank independently calculates
+    ``num_micro_batches`` based on its local sequence lengths.  Different
+    ranks can end up with different counts, causing NCCL collective
+    operations (AllGather/ReduceScatter in FSDP) to deadlock.
+
+    The fix defaults ``dp_group`` to ``torch.distributed.group.WORLD`` so
+    that ``prepare_dynamic_batch`` performs an ``all_reduce(MAX)`` across
+    ranks, forcing every rank to iterate through the same number of
+    micro-batches.  This is the same approach as verl PR #5591.
+    """
+    global _VERL_DYNAMIC_BATCH_PATCHED
+    if _VERL_DYNAMIC_BATCH_PATCHED:
+        return
+
+    import verl.utils.seqlen_balancing as sbl
+
+    _original_prepare = sbl.prepare_dynamic_batch
+
+    def _patched_prepare(data, max_token_len, dp_group=None, **kwargs):
+        if dp_group is None:
+            import torch.distributed
+
+            if torch.distributed.is_initialized():
+                dp_group = torch.distributed.group.WORLD
+        return _original_prepare(data, max_token_len, dp_group=dp_group, **kwargs)
+
+    sbl.prepare_dynamic_batch = _patched_prepare
+
+    # Also patch the already-imported reference in dp_actor so both
+    # compute_log_prob and update_policy use the patched version.
+    try:
+        from verl.workers.actor import dp_actor
+
+        dp_actor.prepare_dynamic_batch = _patched_prepare
+    except (ImportError, AttributeError):
+        pass  # dp_actor may not be importable outside GPU workers
+
+    _VERL_DYNAMIC_BATCH_PATCHED = True
+    logger.info("Patched prepare_dynamic_batch to sync micro-batch counts across DP ranks (verl#5750)")
 
 
 # ---------------------------------------------------------------------------

--- a/rllm/experimental/verl/transform.py
+++ b/rllm/experimental/verl/transform.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 import numpy as np
@@ -9,6 +10,8 @@ from rllm.agents.agent import Episode, Trajectory, TrajectoryGroup
 from rllm.experimental.rollout import VerlEngine
 from rllm.experimental.verl.dataclass import AccumulatedData, ProcessedStepData
 from rllm.workflows.workflow import TerminationReason
+
+logger = logging.getLogger(__name__)
 
 
 def _pad_sequence_batch(sequences: list[torch.Tensor], pad_token_id: int, max_length: int, left_pad: bool = True) -> torch.Tensor:
@@ -227,17 +230,16 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
     # This corresponds to case when we have `per_step` mode for stepwise advantage computation
     traj_reward = 0.0 if trajectory.reward is None else trajectory.reward
 
+    added_steps = 0
     for step_idx, step in enumerate(trajectory.steps):
+        if step.model_output is None or step.model_output.prompt_ids is None:
+            logger.warning(f"Step {step_idx} in trajectory {trajectory_id} has no valid model_output, skipping")
+            continue
         prompt_ids = torch.tensor(step.model_output.prompt_ids, dtype=torch.long)
         response_ids = torch.tensor(step.model_output.completion_ids, dtype=torch.long)
         mask = torch.ones_like(response_ids, dtype=torch.long)
         step_reward = step.reward
-        # Extract multimodal inputs if available
         multi_modal_inputs = step.model_output.multi_modal_inputs or {}
-        # Construct step_id from trajectory_id and step index
-        # Format: "{trajectory_id}_step{step_idx}"
-        # Example: "abc123_solver_step0", "abc123_judge_step1"
-        # Since trajectory_id doesn't contain rollout info, step_id doesn't either
         step_id = f"{trajectory_id}_step{step_idx}"
 
         step_data = ProcessedStepData(
@@ -258,8 +260,9 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
             is_last=step_idx == n_steps - 1,
             group_role=name,
         )
+        added_steps += 1
 
-    return n_steps
+    return added_steps
 
 
 def _process_episode(episode: Episode, task_id: str, accumulated: AccumulatedData) -> int:

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -134,10 +134,11 @@ class VerlBackend(BackendProtocol[Iterable, DataProto], RayPPOTrainer):
         Returns:
             VerlEngine: The initialized rollout engine.
         """
-        # Apply Verl actor patch for per-role loss mode support
-        from rllm.experimental.verl.patch import patch_verl_actor_for_loss_override
+        # Apply Verl patches
+        from rllm.experimental.verl.patch import patch_verl_actor_for_loss_override, patch_verl_dynamic_batch_sync
 
         patch_verl_actor_for_loss_override()
+        patch_verl_dynamic_batch_sync()
 
         # If SDK is enabled, instrument vLLM replicas before creating workers
         sdk_enabled = self.full_config.rllm.get("sdk", {}).get("enable", False)

--- a/rllm/trainer/verl/train_agent_ppo.py
+++ b/rllm/trainer/verl/train_agent_ppo.py
@@ -317,6 +317,11 @@ class TaskRunner:
                 agent_args=agent_args,
             )
 
+        # Apply NCCL dynamic batch sync patch (fixes verl#5750)
+        from rllm.experimental.verl.patch import patch_verl_dynamic_batch_sync
+
+        patch_verl_dynamic_batch_sync()
+
         trainer.init_workers()
         try:
             trainer.fit_agent()

--- a/rllm/trainer/verl/train_workflow_pipeline.py
+++ b/rllm/trainer/verl/train_workflow_pipeline.py
@@ -192,6 +192,11 @@ class PipelineTaskRunner:
             workflow_args=workflow_args,
         )
 
+        # Apply NCCL dynamic batch sync patch (fixes verl#5750)
+        from rllm.experimental.verl.patch import patch_verl_dynamic_batch_sync
+
+        patch_verl_dynamic_batch_sync()
+
         trainer.init_workers()
         try:
             trainer.fit_agent()


### PR DESCRIPTION
## Summary

- Guard against `None`/invalid `model_output` in the Verl transform pipeline — steps without token IDs are now skipped with a warning instead of crashing (fixes `isinstance` mismatch between two `ModelOutput` dataclasses)
- Return actual added step count from `_process_trajectory` so downstream metadata arrays match batch size (prevents `AssertionError: key episode_ids length N != batch size M`)
- Patch `prepare_dynamic_batch` to sync micro-batch counts across DP ranks via `all_reduce(MAX)`, preventing NCCL collective deadlocks when `use_dynamic_bsz=True` (fixes [verl#5750](https://github.com/verl-project/verl/issues/5750), backports the approach from [verl#5591](https://github.com/verl-project/verl/pull/5591))

The NCCL patch is applied in **all three Verl training paths**:
- Experimental `UnifiedTrainer` (`verl_backend.py`)
- Legacy `AgentWorkflowPPOTrainer` (`train_agent_ppo.py`)
- Pipeline `PipelineTaskRunner` (`train_workflow_pipeline.py`)

## Test plan

- [x] Existing tests pass (`test_store.py`, `test_verl_policy_loss.py`)
- [x] Pre-commit (ruff + ruff-format) passes
- [x] `patch_verl_dynamic_batch_sync` imports cleanly
- [x] Run a Verl training job on cluster to verify NCCL fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)