### PR TITLE
fix(verl): disable vllm compile cache to work around corruption bug

### DIFF
--- a/rllm/trainer/verl/ray_runtime_env.py
+++ b/rllm/trainer/verl/ray_runtime_env.py
@@ -7,7 +7,9 @@ PPO_RAY_RUNTIME_ENV = {
         "VLLM_LOGGING_LEVEL": "WARN",
         "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true",
         "CUDA_DEVICE_MAX_CONNECTIONS": "1",
-        "VLLM_USE_V1": "1",
+        # TODO: disable compile cache due to cache corruption issue
+        # https://github.com/vllm-project/vllm/issues/31199
+        "VLLM_DISABLE_COMPILE_CACHE": "1",
         # To prevent hanging or crash during synchronization of weights between actor and rollout
         # in disaggregated mode. See:
         # https://docs.vllm.ai/en/latest/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues


### PR DESCRIPTION
## Summary

- Currently, vLLM's torch compile results in corrupted cache when there are multiple instances on the same machine. We disable caching similar to [verl](https://github.com/verl-project/verl/blob/main/verl/trainer/constants_ppo.py)
- Cleaned up the legacy `VLLM_USE_V1` var as the v0 engine has been deprecated for vLLM v0.12.0.


## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI


## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [x] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- [`examples/agentcore_math/train_agentcore_math_verl.sh`](https://github.com/rllm-org/rllm/blob/main/examples/agentcore_math/train_agentcore_math_verl.sh) was able to finish vLLM engine start without compilation cache errors.