### PR TITLE
fix: unified async trainer with verl backend

### DIFF
--- a/rllm/experimental/rollout/verl_engine.py
+++ b/rllm/experimental/rollout/verl_engine.py
@@ -13,6 +13,7 @@ from rllm.workflows import TerminationEvent, TerminationReason
 
 class VerlEngine(RolloutEngine):
     def __init__(self, config: DictConfig, rollout_manager: AgentLoopManager, tokenizer: Tokenizer, processor=None, **kwargs):
+        super().__init__()
         self.config = config
 
         if config.actor_rollout_ref.rollout.name not in ["vllm", "sglang"]:

--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -543,7 +543,15 @@ class UnifiedTrainer:
                 self.agent_workflow_engine.set_training_step(trainer_state.global_step, mode="train", epoch=epoch)
 
                 for batch in train_dataloader:
-                    task = batch[0]
+                    # Extract single task from batch (train_batch_size=1).
+                    # verl dataloader yields dicts (with extra_info, raw_prompt keys),
+                    # not indexable lists.
+                    if isinstance(batch, dict):
+                        task = batch.get("extra_info", [{}])[0]
+                    elif hasattr(batch, 'non_tensor_batch'):
+                        task = batch.non_tensor_batch.get("extra_info", [{}])[0]
+                    else:
+                        task = batch[0]
 
                     await coordinator.wait_for_generation_allowed()
                     if not coordinator.has_quota():
@@ -622,12 +630,14 @@ class UnifiedTrainer:
 
                 # Forward-backward on this chunk
                 trainer_state.trajectory_groups = chunk_groups
+                trainer_state.episodes = all_episodes
 
                 if trainer_state.has_trajectory_groups:
                     logger.info(f"[TrainingLoop] Step {trainer_state.global_step}: fwd-bwd pass {pass_idx + 1}/{num_fwd_bwd_passes} ({len(chunk_groups)} groups)")
                     await self.backend.on_batch_start(trainer_state)
                     trainer_state.backend_batch = self.backend.transform_to_backend_batch(trainer_state)
                     await self.backend.process_backend_batch(trainer_state)
+                    await self.backend.compute_advantages(trainer_state, self.algorithm_config)
 
                     # Drain per-chunk backend metrics into aggregator
                     aggregator.record_dict(trainer_state.metrics)
@@ -686,7 +696,10 @@ class UnifiedTrainer:
             step_time = trainer_state.metrics.get("time/step", 1.0)
             trainer_state.metrics["async/trainer_idle_ratio"] = buffer_wait_time / max(step_time, 1e-9)
 
-            # 7. on_batch_end writes backend metrics (progress, optim, timing)
+            # 7. on_batch_end writes backend metrics (progress, optim, timing).
+            # Populate timing_dict["step"] so verl's compute_throughout_metrics can compute throughput.
+            # The sync path uses `with simple_timer("step", timing_dict)` but async doesn't.
+            trainer_state.timing_dict["step"] = time.perf_counter() - step_start
             await self.backend.on_batch_end(trainer_state)
 
             # 7. Print and log


### PR DESCRIPTION
## Summary

Fixes 5 bugs that prevent the async training path (`_fit_fully_async` from PR #481) from working with the verl backend. The sync path is unaffected.

## Bugs fixed

### 1. `_generation_loop` batch type mismatch (`unified_trainer.py`)
`batch[0]` crashes because verl's dataloader yields dicts (with `extra_info`/`raw_prompt` keys), not indexable lists. Fix: handle `dict` and `DataProto` batch types before falling back to `batch[0]`.

### 2. `VerlEngine.__init__` missing `super().__init__()` (`verl_engine.py`)
The experimental `VerlEngine` doesn't call `super().__init__()`, so the base class `weight_version = 0` attribute is never set. The async trainer reads `rollout_engine.weight_version` for staleness tracking → `AttributeError`.

### 3. `trainer_state.episodes` not set before fwd-bwd pass (`unified_trainer.py`)
`_training_loop` never sets `trainer_state.episodes` before calling `transform_to_backend_batch`, which asserts that episodes are present. The existing assignment after the optimizer step is for visualization/logging — too late for the fwd-bwd pass.

### 4. `compute_advantages` skipped in async path (`unified_trainer.py`)
`_training_loop` calls `process_backend_batch` → `update_policy` but skips `compute_advantages`. The sync path (`_fit_sync`) has all three steps. Without advantages, `update_policy` fails with `KeyError: 'advantages'`.

### 5. `timing_dict["step"]` not populated (`unified_trainer.py`)
verl's `compute_throughout_metrics` (called by `on_batch_end`) requires `timing_raw["step"]`. The sync path uses `with simple_timer("step", timing_dict)` but the async path doesn't go through that code path.

## Test plan

- [x] Qwen3.5-0.8B, verl backend, async GRPO: 3 training steps completed successfully