### PR TITLE
Fix: Misc fixes for verl 0.7.1

### DIFF
--- a/examples/countdown/unified_trainer/train_countdown_unified_verl.py
+++ b/examples/countdown/unified_trainer/train_countdown_unified_verl.py
@@ -1,0 +1,28 @@
+import hydra
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.experimental.unified_trainer import AgentTrainer
+from rllm.rewards.countdown_reward import countdown_reward_fn
+from rllm.workflows.simple_workflow import SimpleWorkflow
+
+
+@hydra.main(config_path="pkg://rllm.experimental.config", config_name="unified", version_base=None)
+def main(config):
+    train_dataset = DatasetRegistry.load_dataset("countdown", "train")
+    test_dataset = DatasetRegistry.load_dataset("countdown", "test")
+
+    trainer = AgentTrainer(
+        workflow_class=SimpleWorkflow,
+        workflow_args={
+            "reward_function": countdown_reward_fn,
+        },
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=test_dataset,
+        backend="verl",
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/countdown/unified_trainer/train_countdown_unified_verl.sh
+++ b/examples/countdown/unified_trainer/train_countdown_unified_verl.sh
@@ -1,0 +1,59 @@
+set -x
+
+python -m examples.countdown.unified_trainer.train_countdown_unified_verl \
+    rllm/backend=verl \
+    data.train_batch_size=64 \
+    data.max_prompt_length=2048 \
+    data.max_response_length=1024 \
+    actor_rollout_ref.model.path=Qwen/Qwen3-0.6B \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=32768 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0.0 \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode="async" \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.6 \
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.95 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.adv_estimator=grpo \
+    rllm.compact_filtering.enable=False \
+    rllm.compact_filtering.mask_max_prompt_length_exceeded=True \
+    rllm.compact_filtering.mask_max_response_length_exceeded=True \
+    rllm.compact_filtering.mask_max_turns_exceeded=False \
+    rllm.compact_filtering.mask_timeout=True \
+    rllm.rejection_sample.enable=False \
+    rllm.rejection_sample.multiplier=1.0 \
+    rllm.stepwise_advantage.enable=False \
+    rllm.stepwise_advantage.mode=per_step \
+    trainer.critic_warmup=0 \
+    trainer.use_legacy_worker_impl=disable \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name='rllm-countdown' \
+    trainer.experiment_name='countdown-unified-verl' \
+    trainer.val_before_train=True \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=1000 \
+    trainer.test_freq=10 \
+    trainer.default_hdfs_dir=null \
+    trainer.total_epochs=100
+
+pkill -9 -f 'ray::WorkerDict'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,15 +84,14 @@ dev = [
 ]
 
 verl = [
-    "torch",
     "transformers>=4.55.0,<5.0.0",
     "numpy",
     "verl==0.7.1",
     "ray",
-    "torch>=2.8.0",
+    "torch>=2.10.0",
     "torchvision>=0.23.0",
-    "vllm>=0.10.2,<=0.12.0",
-    "flash-attn>=2.8.1",
+    "vllm==0.17.0",
+    "flash-attn==2.8.1",
     "qwen-vl-utils",
 ]
 
@@ -156,6 +155,7 @@ rllm-model-gateway = { path = "./rllm-model-gateway", editable = true }
 [tool.uv]
 override-dependencies = [
     "litellm[proxy]>=1.80.0,<1.82.7",
+    "numpy>=1.26.0",
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/rllm/experimental/rollout/verl_engine.py
+++ b/rllm/experimental/rollout/verl_engine.py
@@ -13,6 +13,7 @@ from rllm.workflows import TerminationEvent, TerminationReason
 
 class VerlEngine(RolloutEngine):
     def __init__(self, config: DictConfig, rollout_manager: AgentLoopManager, tokenizer: Tokenizer, processor=None, **kwargs):
+        super().__init__()
         self.config = config
 
         if config.actor_rollout_ref.rollout.name not in ["vllm", "sglang"]:

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -258,7 +258,7 @@ class VerlBackend(BackendProtocol[Iterable, DataProto], RayPPOTrainer):
             repeat_times = self.full_config.rllm.rollout.n
         batch = batch.repeat(repeat_times=repeat_times)
         # Step 2: execute tasks using the agent workflow engine (async)
-        episodes = await self._execute_tasks_async(batch, agent_workflow_engine, **kwargs)
+        episodes = await self._execute_tasks_async(batch, agent_workflow_engine, is_validation=is_validation, **kwargs)
         # Step 3: sleep the replicas to free kv_cache before weight sync (if free_cache_engine is enabled)
         # Only sleep during training — validation doesn't update weights, so there's no wake_up call after it.
         # Sleeping after validation would leave replicas asleep, causing CUDA illegal memory access on the next generation.

--- a/rllm/trainer/verl/agent_workflow_trainer.py
+++ b/rllm/trainer/verl/agent_workflow_trainer.py
@@ -331,23 +331,23 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                     batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
 
                     # recompute old_log_probs
-                    # Follow verl's _compute_old_log_prob pattern for new worker path:
-                    # convert to TensorDict + no-padding, send, convert output back.
+                    # Mirror verl's RayPPOTrainer._compute_old_log_prob: the new EngineWorker
+                    # path (use_legacy_worker_impl == "disable") takes a TensorDict in no-padding
+                    # format; the legacy AsyncActorRolloutRefWorker takes a DataProto directly.
                     with marked_timer("old_log_prob", timing_raw, color="blue"):
-                        batch_td = batch.to_tensordict()
-                        batch_td = left_right_2_no_padding(batch_td)
-                        tu.assign_non_tensor(batch_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
-                        old_log_prob_output = self.actor_rollout_wg.compute_log_prob(batch_td)
-                        # New worker returns TensorDict in no-padding format
-                        if isinstance(old_log_prob_output, TensorDict):
+                        if self.use_legacy_worker_impl == "disable":
+                            batch_td = batch.to_tensordict()
+                            batch_td = left_right_2_no_padding(batch_td)
+                            tu.assign_non_tensor(batch_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
+                            old_log_prob_output = self.actor_rollout_wg.compute_log_prob(batch_td)
+                            # New worker returns TensorDict in no-padding format
                             entropy = tu.get(old_log_prob_output, "entropy")
                             log_probs = tu.get(old_log_prob_output, "log_probs")
-                            # Convert from no-padding back to padding format
                             entropy = no_padding_2_padding(entropy, batch_td)
                             log_probs = no_padding_2_padding(log_probs, batch_td)
                             old_log_prob = DataProto.from_tensordict(tu.get_tensordict({"old_log_probs": log_probs.float(), "entropys": entropy.float()}))
                         else:
-                            old_log_prob = old_log_prob_output
+                            old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = batch.batch["response_mask"]
                         loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
@@ -364,18 +364,29 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                             metrics.update(debug_metrics)
 
                     if self.use_reference_policy:
-                        # compute reference log_prob (reuse batch_td from old_log_prob)
+                        # compute reference log_prob
                         with marked_timer("ref", timing_raw, color="olive"):
-                            if not self.ref_in_actor:
-                                ref_log_prob_output = self.ref_policy_wg.compute_ref_log_prob(batch_td)
-                            else:
-                                ref_log_prob_output = self.actor_rollout_wg.compute_ref_log_prob(batch_td)
-                            if isinstance(ref_log_prob_output, TensorDict):
+                            if self.use_legacy_worker_impl == "disable":
+                                # Reuse batch_td from old_log_prob, but override the metadata for
+                                # the ref step (verl's RayPPOTrainer._compute_ref_log_prob pattern).
+                                # When ref_in_actor (LoRA), we use the actor worker's compute_log_prob
+                                # with no_lora_adapter=True so the base model is used for ref.
+                                ref_metadata = {"calculate_entropy": False, "compute_loss": False}
+                                if self.ref_in_actor:
+                                    ref_metadata["no_lora_adapter"] = True
+                                tu.assign_non_tensor(batch_td, **ref_metadata)
+                                if self.ref_in_actor:
+                                    ref_log_prob_output = self.actor_rollout_wg.compute_log_prob(batch_td)
+                                else:
+                                    ref_log_prob_output = self.ref_policy_wg.compute_ref_log_prob(batch_td)
                                 ref_lp = tu.get(ref_log_prob_output, "log_probs")
                                 ref_lp = no_padding_2_padding(ref_lp, batch_td)
                                 ref_log_prob = DataProto.from_tensordict(tu.get_tensordict({"ref_log_prob": ref_lp.float()}))
                             else:
-                                ref_log_prob = ref_log_prob_output
+                                if not self.ref_in_actor:
+                                    ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
+                                else:
+                                    ref_log_prob = self.actor_rollout_wg.compute_ref_log_prob(batch)
                             batch = batch.union(ref_log_prob)
 
                     # compute values
@@ -457,26 +468,31 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
 
                     # implement critic warmup
                     if self.config.trainer.critic_warmup <= self.global_steps:
-                        # verl 0.7.1 new worker path: update_actor needs training metadata
-                        ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+                        # Mirror verl's RayPPOTrainer._update_actor: meta_info goes onto the
+                        # DataProto for the legacy worker; the new EngineWorker path needs a
+                        # TensorDict in no-padding format with training metadata set via
+                        # tu.assign_non_tensor.
+                        batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
                         batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
-                        batch.meta_info["mini_batch_size"] = ppo_mini_batch_size
-                        batch.meta_info["epochs"] = self.config.actor_rollout_ref.actor.ppo_epochs
-                        batch.meta_info["seed"] = self.config.actor_rollout_ref.actor.data_loader_seed
-                        batch.meta_info["dataloader_kwargs"] = {
-                            "shuffle": self.config.actor_rollout_ref.actor.shuffle,
-                        }
-                        batch.meta_info["compute_loss"] = True
-                        tu.assign_non_tensor(
-                            batch.batch,
-                            temperature=self.config.actor_rollout_ref.rollout.temperature,
-                            global_batch_size=ppo_mini_batch_size,
-                            calculate_entropy=(self.config.actor_rollout_ref.actor.entropy_coeff != 0.0),
-                        )
+                        if self.use_legacy_worker_impl == "disable":
+                            ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+                            update_batch = batch.to_tensordict()
+                            update_batch = left_right_2_no_padding(update_batch)
+                            tu.assign_non_tensor(
+                                update_batch,
+                                calculate_entropy=(self.config.actor_rollout_ref.actor.entropy_coeff != 0.0),
+                                global_batch_size=ppo_mini_batch_size,
+                                mini_batch_size=ppo_mini_batch_size,
+                                epochs=self.config.actor_rollout_ref.actor.ppo_epochs,
+                                seed=self.config.actor_rollout_ref.actor.data_loader_seed,
+                                dataloader_kwargs={"shuffle": self.config.actor_rollout_ref.actor.shuffle},
+                            )
+                        else:
+                            update_batch = batch
 
                         # update actor
                         with marked_timer("update_actor", timing_raw, color="red"):
-                            actor_output = self.actor_rollout_wg.update_actor(batch)
+                            actor_output = self.actor_rollout_wg.update_actor(update_batch)
 
                         # save checkpoint
                         if self.config.trainer.save_freq > 0 and self.global_steps % self.config.trainer.save_freq == 0:
@@ -669,18 +685,17 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                 combined_batch = DataProto.concat(batches_for_distill)
                 combined_batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
 
-                # Follow verl's no-padding pattern for compute_log_prob
-                cb_td = combined_batch.to_tensordict()
-                cb_td = left_right_2_no_padding(cb_td)
-                tu.assign_non_tensor(cb_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
-
-                old_log_prob_output = self.actor_rollout_wg.compute_log_prob(cb_td)
-                if isinstance(old_log_prob_output, TensorDict):
+                if self.use_legacy_worker_impl == "disable":
+                    # New worker path: convert to TensorDict + no-padding, then convert back.
+                    cb_td = combined_batch.to_tensordict()
+                    cb_td = left_right_2_no_padding(cb_td)
+                    tu.assign_non_tensor(cb_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
+                    old_log_prob_output = self.actor_rollout_wg.compute_log_prob(cb_td)
                     log_probs = tu.get(old_log_prob_output, "log_probs")
                     log_probs = no_padding_2_padding(log_probs, cb_td)
                     old_log_prob = DataProto.from_tensordict(tu.get_tensordict({"old_log_probs": log_probs.float()}))
                 else:
-                    old_log_prob = old_log_prob_output
+                    old_log_prob = self.actor_rollout_wg.compute_log_prob(combined_batch)
                 combined_batch = combined_batch.union(old_log_prob)
 
                 # Compute distillation advantages


### PR DESCRIPTION
## Summary

Misc bug fixes for verl 0.7.1 integration

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

1. support both old and new worker implementations in agent workflow engine
2. add super().__init__() to experimental verl engine
3. fix verl backend (unified trainer) to pass validation vlag to engine
4. adopt verl deps from branch verl_071_deps
5. add countdown example for sync verl with unified trainer

## Validation
https://wandb.ai/agentica/rllm-countdown
Three runs all track the same val performance:
1. agent workflow train + legacy verl worker
2. agent workflow train + new verl worker
3. unified trainer sync verl (only support new verl worker)

- [x] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- passes pre-commit tests

## Breaking changes / migration notes

None

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [x] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
