### PR TITLE
chore(scripts): simplify and pin megatron dependencies

### DIFF
--- a/scripts/install_megatron.sh
+++ b/scripts/install_megatron.sh
@@ -15,16 +15,17 @@ echo "=== Megatron dependency installer for rLLM ==="
 echo "TORCH_BACKEND=${TORCH_BACKEND}"
 
 echo "[1/5] Installing nvidia-modelopt..."
-uv pip install 'nvidia-modelopt[torch]>=0.37.0'
+uv pip install 'nvidia-modelopt>=0.37.0'
 
 echo "[2/5] Installing transformer-engine (this may take a while)..."
 MAX_JOBS=128 uv pip install --no-cache --no-build-isolation "transformer_engine[pytorch]==2.10" --torch-backend="${TORCH_BACKEND}"
 
+# megatron-core > 0.15.0 required for numpy>=2.0.0 compatibility
 echo "[3/5] Installing megatron-core..."
-uv pip install --no-deps "git+https://github.com/NVIDIA/Megatron-LM.git@core_v0.15.0"
+uv pip install --no-deps megatron-core==0.16.1 
 
 echo "[4/5] Installing megatron-bridge..."
-uv pip install --no-deps -U "git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@550924c04368a175ef261a72230204410f455260"
+uv pip install --no-deps megatron-bridge==0.3.1
 
 echo "[5/5] Installing NVIDIA Apex (required for gradient accumulation fusion)..."
 APEX_PARALLEL_BUILD=8 APEX_CPP_EXT=1 APEX_CUDA_EXT=1 \


### PR DESCRIPTION
## Summary

1. Remove the `torch` extra from 'nvidia-modelopt>=0.37.0', which no longer exists.
2. Bump `megatron-core` to 0.16.1, as 0.15.0 relies on legacy numpy (< 2.0.0, np.product) that results in errors when saving model checkpoints. 0.16.1 has moved to `np.prod`.
3. Switch megatron-core and megatron-bridge from git-based installs to versioned PyPI packages.

## Validation

Intallation

```bash
uv pip install -e ".[verl]" --torch-backend=cu129
bash scripts/install_megatron.sh cu129
```

e2e

```bash
bash examples/agentcore_math/train_agentcore_math_verl.sh
```

was able to run and save model checkpoints without errors (pending some separate PRs to fix the verl engine code path). 
