### PR TITLE
fix(verl): move legacy worker override to launcher before worker class selection

### DIFF
--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -208,14 +208,6 @@ class VerlBackend(BackendProtocol[Iterable, DataProto], RayPPOTrainer):
         """Validate verl-specific configuration settings."""
         assert self.config.actor_rollout_ref.rollout.mode == "async", "Only async rollout mode is supported for VerlBackend"
         assert self.use_rm is False, "Reward models are not supported. Rewards should be assigned using a reward function in the workflow or environment."
-        # Enforce new EngineWorker path (TensorDict + no-padding)
-        legacy_mode = self.config.trainer.get("use_legacy_worker_impl", "auto")
-        if legacy_mode != "disable":  # force to disable legacy worker impl
-            logger.warning(
-                "VerlBackend forces use_legacy_worker_impl='disable' (new EngineWorker path), got '{legacy_mode}'."
-                "If you insist on using the legacy worker implementation, consider using the older agent workflow trainer."
-            )
-            self.config.trainer.use_legacy_worker_impl = "disable"
         if self.config.rllm.stepwise_advantage.mode != "broadcast":
             # automatically set the stepwise_advantage_mode to "broadcast", the warning is already shown in AlgorithmConfig.from_config
             self.config.rllm.stepwise_advantage.mode = "broadcast"

--- a/rllm/experimental/verl/verl_launcher.py
+++ b/rllm/experimental/verl/verl_launcher.py
@@ -1,3 +1,5 @@
+import logging
+
 import ray
 from omegaconf import DictConfig
 
@@ -7,6 +9,8 @@ from rllm.experimental.verl.verl_backend import VerlBackend
 from rllm.trainer.verl.ray_runtime_env import get_ppo_ray_runtime_env
 from rllm.trainer.verl.train_agent_ppo import TaskRunner
 from rllm.workflows.workflow import Workflow
+
+logger = logging.getLogger(__name__)
 
 
 # TODO(listar2000): when later deprecating `train_agent_ppo`, need to migrate all the logic here to `WorkflowTaskRunner`
@@ -41,6 +45,14 @@ class WorkflowTaskRunner(TaskRunner):
         pprint(OmegaConf.to_container(config))
         OmegaConf.register_new_resolver("mul", lambda x, y: int(x) * int(y))
         OmegaConf.resolve(config)
+
+        # Force the new EngineWorker path before worker classes are selected.
+        # VerlBackend (UnifiedTrainer) requires use_legacy_worker_impl='disable';
+        # this must happen before add_actor_rollout_worker() reads the value.
+        legacy_mode = config.trainer.get("use_legacy_worker_impl", "auto")
+        if legacy_mode != "disable":
+            logger.warning(f"VerlBackend requires use_legacy_worker_impl='disable' (new EngineWorker path), got '{legacy_mode}'. Overriding to 'disable'.")
+            config.trainer.use_legacy_worker_impl = "disable"
 
         actor_rollout_cls, ray_worker_group_cls = self.add_actor_rollout_worker(config)
         self.add_critic_worker(config)


### PR DESCRIPTION
### Issue
Legacy worker override happens too late. Code path:

1. add_actor_rollout_worker(config) reads config.trainer.use_legacy_worker_impl to decide which worker class to use — "disable" picks the new ActorRolloutRefWorker (from engine_workers.py), anything else picks the legacy AsyncActorRolloutRefWorker (e.g., from megatron_workers.py).
2. VerlBackend.validate_config() forces the value to "disable" — but it runs later, inside UnifiedTrainer.__init__ at line 262, after add_actor_rollout_worker has already selected the wrong worker class                                                                                                        
3. The new EngineWorker's ActorRolloutRefWorker has set_loss_fn (via `@register` decorator that gets bound to the RayWorkerGroup). The legacy AsyncActorRolloutRefWorker does not. So when init_rollout_engine called self.actor_rollout_wg.set_loss_fn(...), it crashed with AttributeError: 'RayWorkerGroup' object has no       
attribute 'set_loss_fn'

### Fix
- Forces "disable" in the launcher before add_actor_rollout_worker reads it, so the right worker class is selected from the start.
- Fixes two minor bugs in the original `logger.warning(...)` (not a f-string, no space between concatenation). 

### Test
- `examples/agentcore_math/train_agentcore_math_verl.sh` runs without the `AttributeError`. 