### PR TITLE
Use user-assistant probe for default chat template parser. Add suppor…

### DIFF
--- a/rllm/parser/chat_template_parser.py
+++ b/rllm/parser/chat_template_parser.py
@@ -26,7 +26,7 @@ class ChatTemplateParser:
         self.generation_prompt = self._get_generation_prompt(tokenizer)
 
     def _get_generation_prompt(self, tokenizer):
-        messages = [{"role": "assistant", "content": ""}]
+        messages = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": ""}]
 
         with_prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
         without_prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=False, tokenize=False)

--- a/tests/parser/test_chat_parser.py
+++ b/tests/parser/test_chat_parser.py
@@ -9,6 +9,24 @@ from rllm.parser import (
 from rllm.parser.utils import PARSER_TEST_MESSAGES
 
 
+class _ProbeSensitiveTokenizer:
+    def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=False):
+        if messages == [{"role": "assistant", "content": ""}]:
+            raise ValueError("assistant-only probe is invalid for this tokenizer")
+
+        rendered = "|".join(f"{msg['role']}:{msg['content']}" for msg in messages)
+        if add_generation_prompt:
+            rendered += "<GEN>"
+        return rendered
+
+
+def test_default_chat_template_parser_generation_prompt_probe():
+    tokenizer = _ProbeSensitiveTokenizer()
+    parser = ChatTemplateParser(tokenizer)
+
+    assert parser.generation_prompt == "<GEN>"
+
+
 def test_qwen_chat_template_parser():
     # Test with Qwen tokenizer
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B")


### PR DESCRIPTION
## Summary

This PR fixes the default chat-template generation-prompt probe in `ChatTemplateParser`. The old probe used a lone assistant message, which works for some tokenizers but fails for stricter templates such as Qwen 3.5 models, which raises `TemplateError: No user query found in messages.` The new probe uses a minimal `user -> assistant` exchange instead, which preserves the `with_prompt - without_prompt` diff used to extract the generation prompt while matching the conversation structure expected by those tokenizers. A targeted regression test covers the failure mode we hit.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Changed `ChatTemplateParser._get_generation_prompt()` to probe chat templates with `[{role: "user", "content": "hi"}, {"role": "assistant", "content": ""}]` instead of a lone assistant message.
- Kept the same diff-based extraction logic: compute `apply_chat_template(..., add_generation_prompt=True)` minus `apply_chat_template(..., add_generation_prompt=False)` on the same message list.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `python -m pytest tests/parser/test_chat_parser.py -k generation_prompt_probe -q`
- Result: `1 passed, 5 deselected`
- `python -m py_compile rllm/parser/chat_template_parser.py tests/parser/test_chat_parser.py`
- Manual tokenizer probe: `Qwen/Qwen3.5-4B` with old probe `[{role: "assistant", content: ""}]` gives `TemplateError: No user query found in messages.` New probe `[{role: "user", content: "hi"}, {role: "assistant", content: ""}]` gives succeeded and extracted `'<|im_start|>assistant\n<think>\n'`
- For earlier Qwen tokenizers and Llama tokenizers, both old and new probes succeeded and produced the same generation-prompt diff

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed
