### PR TITLE
fix(verl): zero response_mask on padded rows to keep loss magnitude stable

### DIFF
--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -344,8 +344,13 @@ class VerlBackend(BackendProtocol[Iterable, DataProto], RayPPOTrainer):
         original_batch_size = batch.batch["prompts"].shape[0]
         batch, pad_size = pad_dataproto_to_divisor(batch, divisor)
 
-        # for the padded dataproto, make the traj mask to 0. is_last_step also False
+        # Neutralise the padded rows. `advantages=0` (set by
+        # update_dataproto_with_advantages via is_pad_step) zeros the loss
+        # numerator; zeroing `response_mask` keeps pad tokens out of
+        # `batch_num_tokens` so the loss denominator equals the real-token
+        # count and loss magnitude is invariant to pad_size.
         pad_start, pad_end = original_batch_size, original_batch_size + pad_size
+        batch.batch["response_mask"][pad_start:pad_end] = 0
         batch.non_tensor_batch["is_last_step"][pad_start:pad_end] = False
         batch.non_tensor_batch["is_pad_step"][pad_start:pad_end] = True
         batch.non_tensor_batch["is_valid"][pad_start:pad_end] = False


### PR DESCRIPTION
### Summary

Pad rows already had advantages=0 (numerator=0) via is_pad_step, but their response_mask was left at 1, so pad tokens inflated the batch_num_tokens denominator. This shrank the effective learning rate by pad_fraction, which is material when turn counts are variable -- e.g. ~40% at 1.2 avg turns with train_batch_size=64, rollout.n=4, dp=8, ppo_mini_batch_size=64.

Zero response_mask for pad rows so they contribute nothing to the denominator either. Loss magnitude now matches the un-padded batch.

### Test

Unfortunately training collapse still happens for `bash examples/agentcore_math/train_agentcore_math_verl.sh`, but this PR should still be a valid fix as explained above.