### PR TITLE
[feat] Collapse multi-turn trajectory steps into a single row (verl) + unified merge metrics

### DIFF
--- a/cookbooks/math_tool_agent/train_verl.sh
+++ b/cookbooks/math_tool_agent/train_verl.sh
@@ -19,8 +19,8 @@ python -u train.py \
     rllm.algorithm.use_rllm=true \
     data.train_batch_size=32 \
     data.val_batch_size=256 \
-    data.max_prompt_length=4096 \
-    data.max_response_length=2048 \
+    data.max_prompt_length=2048 \
+    data.max_response_length=20480 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
     +actor_rollout_ref.model.lora.rank=32 \
@@ -30,7 +30,7 @@ python -u train.py \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
     actor_rollout_ref.actor.use_dynamic_bsz=True \
-    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=16384 \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=32768 \
     actor_rollout_ref.actor.fsdp_config.param_offload=true \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
     actor_rollout_ref.actor.use_kl_loss=False \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ code-tools = [
 ]
 
 harbor = [
-    "harbor==0.3.0",
+    "harbor==0.3.0 ; python_version >= '3.12'",
 ]
 
 [tool.uv.sources]

--- a/rllm/experimental/verl/transform.py
+++ b/rllm/experimental/verl/transform.py
@@ -412,7 +412,7 @@ def _process_trajectory_group(trajectory_group: TrajectoryGroup, task_id: str, a
     return total_steps
 
 
-def _compute_merge_metrics(accumulated: AccumulatedData) -> dict[str, float]:
+def _compute_merge_metrics(accumulated: AccumulatedData, total_agent_steps: int) -> dict[str, float]:
     """Per-batch metrics characterising the merge step.
 
     Naming matches Tinker's transform_trajectory_groups_to_datums so the
@@ -426,6 +426,15 @@ def _compute_merge_metrics(accumulated: AccumulatedData) -> dict[str, float]:
       region per row (action tokens + any interleaved observation tokens).
       For unmerged single-step trajectories this is just the action token
       count; for merged multi-turn it's actions + tool/observation tokens.
+
+    - batch/action_token_ratio/{mean,min,max}: fraction of response
+      tokens per row that are trainable (mask=1). =1.0 for single-step
+      rows (no observations); <1.0 for merged multi-turn (the lower it
+      is, the more tool/observation overhead is in the row).
+
+    - batch/merge_compression_ratio: total agent steps ÷ total emitted
+      rows. =N for a fully cumulative N-turn batch; =1 means no merging
+      occurred (per-step rows, or all single-step trajectories).
     """
     if not accumulated.responses:
         return {}
@@ -438,6 +447,12 @@ def _compute_merge_metrics(accumulated: AccumulatedData) -> dict[str, float]:
 
     rows_per_traj = list(Counter(accumulated.step_ids).values())
     response_lens = [int(r.numel()) for r in accumulated.responses]
+    action_token_ratios = []
+    for mask in accumulated.traj_mask:
+        n = int(mask.numel())
+        if n > 0:
+            action_token_ratios.append(float(mask.sum().item()) / n)
+    total_emitted_rows = len(accumulated.responses)
 
     return {
         "batch/steps_per_traj/mean": float(_np.mean(rows_per_traj)),
@@ -446,6 +461,12 @@ def _compute_merge_metrics(accumulated: AccumulatedData) -> dict[str, float]:
         "batch/step_response_length/mean": float(_np.mean(response_lens)),
         "batch/step_response_length/min": int(_np.min(response_lens)),
         "batch/step_response_length/max": int(_np.max(response_lens)),
+        "batch/action_token_ratio/mean": float(_np.mean(action_token_ratios)) if action_token_ratios else 0.0,
+        "batch/action_token_ratio/min": float(_np.min(action_token_ratios)) if action_token_ratios else 0.0,
+        "batch/action_token_ratio/max": float(_np.max(action_token_ratios)) if action_token_ratios else 0.0,
+        "batch/merge_compression_ratio": (
+            total_agent_steps / total_emitted_rows if total_emitted_rows > 0 else 0.0
+        ),
     }
 
 
@@ -474,15 +495,17 @@ def transform_episodes_to_dataproto(
     processor = getattr(rollout_engine, "processor", None)
 
     accumulated = AccumulatedData()
+    total_agent_steps = 0
     for episode in episodes:
         task_id = episode.task_id
+        total_agent_steps += sum(len(traj.steps) for traj in episode.trajectories)
         total_steps = _process_episode(episode, task_id, accumulated)
         accumulated.repeat_counts.append(total_steps)
 
     assert hasattr(tokenizer, "pad_token_id"), "Tokenizer must have a pad token ID"
     pad_token_id = tokenizer.pad_token_id
     batch = _batch_tensors_and_build_data_proto(accumulated, pad_token_id, max_prompt_length, max_response_length, processor)
-    batch.meta_info["merge_metrics"] = _compute_merge_metrics(accumulated)
+    batch.meta_info["merge_metrics"] = _compute_merge_metrics(accumulated, total_agent_steps)
     return batch
 
 

--- a/rllm/experimental/verl/transform.py
+++ b/rllm/experimental/verl/transform.py
@@ -412,6 +412,43 @@ def _process_trajectory_group(trajectory_group: TrajectoryGroup, task_id: str, a
     return total_steps
 
 
+def _compute_merge_metrics(accumulated: AccumulatedData) -> dict[str, float]:
+    """Per-batch metrics characterising the merge step.
+
+    Naming matches Tinker's transform_trajectory_groups_to_datums so the
+    same metric paths show up regardless of backend:
+
+    - batch/steps_per_traj/{mean,min,max}: number of rows emitted per
+      trajectory after prefix-merging. =1 for cumulative trajectories,
+      >1 if a prefix break forced a split mid-trajectory.
+
+    - batch/step_response_length/{mean,min,max}: length of the response
+      region per row (action tokens + any interleaved observation tokens).
+      For unmerged single-step trajectories this is just the action token
+      count; for merged multi-turn it's actions + tool/observation tokens.
+    """
+    if not accumulated.responses:
+        return {}
+
+    import numpy as _np
+
+    # Each row's step_id is trajectory.uid (set by _process_trajectory),
+    # so counting occurrences gives rows-per-trajectory.
+    from collections import Counter
+
+    rows_per_traj = list(Counter(accumulated.step_ids).values())
+    response_lens = [int(r.numel()) for r in accumulated.responses]
+
+    return {
+        "batch/steps_per_traj/mean": float(_np.mean(rows_per_traj)),
+        "batch/steps_per_traj/min": int(_np.min(rows_per_traj)),
+        "batch/steps_per_traj/max": int(_np.max(rows_per_traj)),
+        "batch/step_response_length/mean": float(_np.mean(response_lens)),
+        "batch/step_response_length/min": int(_np.min(response_lens)),
+        "batch/step_response_length/max": int(_np.max(response_lens)),
+    }
+
+
 def transform_episodes_to_dataproto(
     episodes: list[Episode],
     rollout_engine: VerlEngine,
@@ -428,7 +465,10 @@ def transform_episodes_to_dataproto(
         max_response_length: The maximum length of the responses.
         stepwise_advantage_mode: The mode of stepwise advantage computation.
     Returns:
-        DataProto: The DataProto built from the episodes.
+        DataProto: The DataProto built from the episodes. Per-batch merge
+        metrics (batch/steps_per_traj, batch/step_response_length) are
+        stashed on ``meta_info["merge_metrics"]`` so the caller can lift
+        them into trainer_state.metrics without a signature change.
     """
     tokenizer = rollout_engine.tokenizer
     processor = getattr(rollout_engine, "processor", None)
@@ -441,7 +481,9 @@ def transform_episodes_to_dataproto(
 
     assert hasattr(tokenizer, "pad_token_id"), "Tokenizer must have a pad token ID"
     pad_token_id = tokenizer.pad_token_id
-    return _batch_tensors_and_build_data_proto(accumulated, pad_token_id, max_prompt_length, max_response_length, processor)
+    batch = _batch_tensors_and_build_data_proto(accumulated, pad_token_id, max_prompt_length, max_response_length, processor)
+    batch.meta_info["merge_metrics"] = _compute_merge_metrics(accumulated)
+    return batch
 
 
 # TODO: extract common logic from transform_episodes_to_dataproto and transform_trajectory_groups_to_dataproto

--- a/rllm/experimental/verl/transform.py
+++ b/rllm/experimental/verl/transform.py
@@ -217,12 +217,35 @@ def _batch_tensors_and_build_data_proto(accumulated: AccumulatedData, pad_token_
 def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: AccumulatedData) -> int:
     """Processes a trajectory and returns an AccumulatedData.
 
+    Multi-turn trajectories whose steps form a cumulative-prefix chain
+    (each step's prompt is an extension of the previous step's full sequence,
+    e.g. a ReAct/tool-call agent that appends tool messages and assistant
+    responses to a growing message list) are merged into a SINGLE row whose
+    response is the concatenation of [A0, obs1, A1, obs2, A2, ...] with
+    response_mask = 1 only on action tokens (the model's outputs at each
+    turn) and 0 on observation tokens (tool messages, system messages
+    inserted between turns).
+
+    This mirrors Tinker's ``trajectory_to_datums`` representation. Combined
+    with ``loss_agg_mode=seq-mean-token-mean`` it gives per-trajectory
+    equal-weighted gradients regardless of step count: a 6-turn rollout
+    contributes the same to the loss as a 2-turn rollout, which matches
+    Tinker's per-Datum aggregation. Without merging, verl emits one row per
+    step and per-trajectory weight scales with step count.
+
+    A step that is *not* a prefix-extension of the running segment (e.g.
+    the agent reset its context mid-trajectory) closes the current segment
+    and starts a new one — the trajectory then contributes multiple rows.
+    For typical agents this never fires, so the common case is one row per
+    trajectory.
+
     Args:
         trajectory: Trajectory to process.
         task_id: Task identifier corresponding to the episode.
         accumulated: AccumulatedData to process the trajectory into.
     Returns:
-        n_steps: The number of steps in the trajectory.
+        Number of rows emitted to ``accumulated`` (typically 1; >1 only if
+        the trajectory's steps couldn't all be prefix-merged).
     """
     name = trajectory.name
     trajectory_id = f"{task_id}_{name}"
@@ -230,51 +253,111 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
         print(f"Trajectory {trajectory_id} has no steps, skipping")
         return 0
 
-    n_steps = len(trajectory.steps)
-
-    # This corresponds to case when we have `per_step` mode for stepwise advantage computation
     traj_reward = 0.0 if trajectory.reward is None else trajectory.reward
 
-    added_steps = 0
+    # Drop steps without valid model_output up-front; the merge logic below
+    # assumes every entry has prompt_ids and completion_ids.
+    valid_steps = []
     for step_idx, step in enumerate(trajectory.steps):
         if step.model_output is None or step.model_output.prompt_ids is None:
             logger.warning(f"Step {step_idx} in trajectory {trajectory_id} has no valid model_output, skipping")
             continue
-        prompt_ids = torch.tensor(step.model_output.prompt_ids, dtype=torch.long)
-        response_ids = torch.tensor(step.model_output.completion_ids, dtype=torch.long)
-        mask = torch.ones_like(response_ids, dtype=torch.long)
-        step_reward = step.reward
-        multi_modal_inputs = step.model_output.multi_modal_inputs or {}
-        # step_id must uniquely identify this row across the whole batch so
-        # update_dataproto_with_advantages can scatter per-trajectory advantages
-        # back without collisions. trajectory_id alone is f"{task_id}_{name}",
-        # which collides across rollouts of the same task and across multiple
-        # same-named trajectories within one episode (e.g. solver-judge with N
-        # solver trajectories). trajectory.uid is a per-Trajectory UUID4.
-        step_id = f"{trajectory.uid}_step{step_idx}"
+        valid_steps.append(step)
 
+    if not valid_steps:
+        return 0
+
+    # ------------------------------------------------------------------
+    # Walk steps and merge prefix-extending steps into segments.
+    # ------------------------------------------------------------------
+    # A *segment* is one merged row in the batch. We accumulate response
+    # tokens and a parallel mask:
+    #   response = [action_tokens for step0,
+    #               delta_obs_for_step1, action_tokens_step1,
+    #               delta_obs_for_step2, action_tokens_step2, ...]
+    #   mask     = [1*N_act0,
+    #               0*N_obs1, 1*N_act1,
+    #               0*N_obs2, 1*N_act2, ...]
+    # The segment's prompt is the *initial* prompt of the first step in
+    # that segment. ``full_seq`` tracks prompt+all-action-and-obs tokens
+    # so we can detect prefix-extension on the next step.
+
+    def _new_segment(step):
+        prompt = list(step.model_output.prompt_ids)
+        action = list(step.model_output.completion_ids)
+        action_lp = list(step.model_output.logprobs or [])
+        # If logprobs missing/short, pad to action length with zeros so
+        # accumulator lists stay aligned. add_step skips logprobs entirely
+        # when the list is empty, but we keep parity with action_tokens.
+        if action_lp and len(action_lp) != len(action):
+            action_lp = list(action_lp) + [0.0] * (len(action) - len(action_lp))
+        return {
+            "prompt": prompt,
+            "response": list(action),
+            "mask": [1] * len(action),
+            "logprobs": list(action_lp),
+            "full_seq": list(prompt) + list(action),
+            "multi_modal": step.model_output.multi_modal_inputs or {},
+        }
+
+    def _emit(seg):
+        prompt_t = torch.tensor(seg["prompt"], dtype=torch.long)
+        response_t = torch.tensor(seg["response"], dtype=torch.long)
+        mask_t = torch.tensor(seg["mask"], dtype=torch.long)
+        # step_id is keyed by trajectory.uid (no per-segment suffix). All
+        # segments of one trajectory share the same scalar advantage from
+        # collect_reward_and_advantage_from_trajectory_groups (broadcast
+        # mode), so collisions across segments are harmless: the dict in
+        # update_dataproto_with_advantages would write the same value
+        # for either key.
         step_data = ProcessedStepData(
-            prompt=prompt_ids,
-            response=response_ids,
-            mask=mask,
-            step_reward=step_reward,
-            step_id=step_id,
-            multi_modal_inputs=multi_modal_inputs,
-            advantage=step.advantage,
-            logprobs=step.model_output.logprobs,
+            prompt=prompt_t,
+            response=response_t,
+            mask=mask_t,
+            step_reward=traj_reward,
+            step_id=trajectory.uid,
+            multi_modal_inputs=seg["multi_modal"],
+            advantage=None,
+            logprobs=seg["logprobs"] if seg["logprobs"] else None,
         )
-
         accumulated.add_step(
             step_data=step_data,
             trajectory_id=trajectory_id,
             traj_reward=traj_reward,
-            step_num=n_steps,
-            is_last=step_idx == n_steps - 1,
+            step_num=1,
+            is_last=True,
             group_role=name,
         )
-        added_steps += 1
 
-    return added_steps
+    seg = _new_segment(valid_steps[0])
+    segments_emitted = 0
+    for step in valid_steps[1:]:
+        prompt_ids = list(step.model_output.prompt_ids)
+        if len(prompt_ids) >= len(seg["full_seq"]) and prompt_ids[: len(seg["full_seq"])] == seg["full_seq"]:
+            # Cumulative — extend the current segment.
+            delta_obs = prompt_ids[len(seg["full_seq"]) :]
+            action = list(step.model_output.completion_ids)
+            action_lp = list(step.model_output.logprobs or [])
+            if action_lp and len(action_lp) != len(action):
+                action_lp = list(action_lp) + [0.0] * (len(action) - len(action_lp))
+
+            seg["response"].extend(delta_obs)
+            seg["response"].extend(action)
+            seg["mask"].extend([0] * len(delta_obs))
+            seg["mask"].extend([1] * len(action))
+            seg["logprobs"].extend([0.0] * len(delta_obs))
+            seg["logprobs"].extend(action_lp)
+            seg["full_seq"].extend(delta_obs)
+            seg["full_seq"].extend(action)
+        else:
+            # Non-cumulative — close out current segment, start a new one.
+            _emit(seg)
+            segments_emitted += 1
+            seg = _new_segment(step)
+
+    _emit(seg)
+    segments_emitted += 1
+    return segments_emitted
 
 
 def _process_episode(episode: Episode, task_id: str, accumulated: AccumulatedData) -> int:
@@ -391,22 +474,35 @@ def update_dataproto_with_advantages(batch: DataProto, container: list[Episode] 
     after which we need to update the DataProto with the advantages.
     """
     # Build a step_id → advantage mapping from episodes/trajectory groups.
-    # step_id format must match _process_trajectory: f"{trajectory.uid}_step{step_idx}".
-    # Keying on trajectory.uid (not task_id_name) is required for correctness — see
-    # the comment in _process_trajectory.
-    adv_by_step_id: dict[str, float] = {}
+    # step_id format must match _process_trajectory's emit: just trajectory.uid.
+    # _process_trajectory now emits one row per *trajectory* (prefix-merged
+    # multi-step) rather than one row per step, so a single advantage per
+    # trajectory is sufficient. In broadcast mode all steps in a trajectory
+    # share the same scalar advantage from
+    # collect_reward_and_advantage_from_trajectory_groups, so reading from
+    # the first valid step is safe.
+    adv_by_traj_uid: dict[str, float] = {}
     for item in container:
         for trajectory in item.trajectories:
-            for step_idx, step in enumerate(trajectory.steps):
-                step_id = f"{trajectory.uid}_step{step_idx}"
-                adv_by_step_id[step_id] = step.advantage if step.advantage is not None else 0.0
+            if not trajectory.steps:
+                continue
+            adv = next(
+                (s.advantage for s in trajectory.steps if s.advantage is not None),
+                0.0,
+            )
+            adv_by_traj_uid[trajectory.uid] = adv if isinstance(adv, float) else float(adv)
 
     # Match advantages to batch entries by step_id (robust to batch reordering and padding)
     n_total = len(batch.non_tensor_batch["trajectory_ids"])
     step_ids = batch.non_tensor_batch["step_ids"]
     is_pad = batch.non_tensor_batch.get("is_pad_step", np.zeros(n_total, dtype=bool))
 
-    advantages = [0.0 if is_pad[i] else adv_by_step_id.get(str(step_ids[i]), 0.0) for i in range(n_total)]
+    # step_ids in the batch are trajectory.uid values (set by _process_trajectory).
+    # The scalar advantage is broadcast across response tokens by
+    # _build_per_step_advantages, multiplied by response_mask which is 0
+    # on observation tokens between actions — so observation tokens
+    # automatically receive zero advantage in the loss.
+    advantages = [0.0 if is_pad[i] else adv_by_traj_uid.get(str(step_ids[i]), 0.0) for i in range(n_total)]
 
     advantage_tensor = _build_per_step_advantages(batch.batch["response_mask"], advantages)
     batch.batch["advantages"] = advantage_tensor

--- a/rllm/experimental/verl/transform.py
+++ b/rllm/experimental/verl/transform.py
@@ -439,11 +439,11 @@ def _compute_merge_metrics(accumulated: AccumulatedData, total_agent_steps: int)
     if not accumulated.responses:
         return {}
 
-    import numpy as _np
-
     # Each row's step_id is trajectory.uid (set by _process_trajectory),
     # so counting occurrences gives rows-per-trajectory.
     from collections import Counter
+
+    import numpy as _np
 
     rows_per_traj = list(Counter(accumulated.step_ids).values())
     response_lens = [int(r.numel()) for r in accumulated.responses]
@@ -464,9 +464,7 @@ def _compute_merge_metrics(accumulated: AccumulatedData, total_agent_steps: int)
         "batch/action_token_ratio/mean": float(_np.mean(action_token_ratios)) if action_token_ratios else 0.0,
         "batch/action_token_ratio/min": float(_np.min(action_token_ratios)) if action_token_ratios else 0.0,
         "batch/action_token_ratio/max": float(_np.max(action_token_ratios)) if action_token_ratios else 0.0,
-        "batch/merge_compression_ratio": (
-            total_agent_steps / total_emitted_rows if total_emitted_rows > 0 else 0.0
-        ),
+        "batch/merge_compression_ratio": (total_agent_steps / total_emitted_rows if total_emitted_rows > 0 else 0.0),
     }
 
 

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -280,7 +280,15 @@ class VerlBackend(BackendProtocol[Iterable, DataProto], RayPPOTrainer):
         assert trainer_state.episodes is not None, "Episodes are not set"
         episodes: list[Episode] = trainer_state.episodes
         assert self.rollout_engine is not None, "rollout_engine is not initialized."
-        return transform_episodes_to_dataproto(episodes, self.rollout_engine, self.config.data.max_prompt_length, self.config.data.max_response_length)
+        batch = transform_episodes_to_dataproto(episodes, self.rollout_engine, self.config.data.max_prompt_length, self.config.data.max_response_length)
+        # Lift per-batch merge metrics (batch/steps_per_traj,
+        # batch/step_response_length) out of meta_info so they show up in
+        # the standard trainer_state.metrics path. Same metric names the
+        # tinker backend logs, so dashboards work across both.
+        merge_metrics = batch.meta_info.pop("merge_metrics", None)
+        if merge_metrics:
+            trainer_state.metrics.update(merge_metrics)
+        return batch
 
     def _remove_padding(self, batch: DataProto) -> DataProto:
         """Removes padded steps from the batch"""

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -218,8 +218,6 @@ def transform_trajectory_groups_to_datums(
         adv_metrics["batch/action_token_ratio/mean"] = _np.mean(action_token_ratios)
         adv_metrics["batch/action_token_ratio/min"] = _np.min(action_token_ratios)
         adv_metrics["batch/action_token_ratio/max"] = _np.max(action_token_ratios)
-        adv_metrics["batch/merge_compression_ratio"] = (
-            total_agent_steps / total_emitted_rows if total_emitted_rows > 0 else 0.0
-        )
+        adv_metrics["batch/merge_compression_ratio"] = total_agent_steps / total_emitted_rows if total_emitted_rows > 0 else 0.0
 
     return (datums if not algorithm_config.estimator_map else datums_dict), adv_metrics

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -157,28 +157,51 @@ def transform_trajectory_groups_to_datums(
     else:
         datums = []
 
-    # step 2: iterate over all steps and build the Tinker Datum objects
-    seqs_per_traj = []
-    seq_lengths = []
+    # step 2: iterate over all steps and build the Tinker Datum objects.
+    # Track per-trajectory split count and per-Datum response length so the
+    # caller can log the same metrics across backends. Metric semantics are
+    # shared with verl's transform_episodes_to_dataproto:
+    #   - steps_per_traj: number of training rows/datums one trajectory
+    #     becomes after prefix-merging. Healthy cumulative agents = 1; any
+    #     value > 1 indicates a prefix break (re-tokenization quirk, mid-
+    #     trajectory context reset, etc.).
+    #   - step_response_length: length of the response region per row,
+    #     i.e. everything from the first action token onward (action tokens
+    #     plus interleaved observation tokens), excluding the initial
+    #     prompt. For an unmerged single-step trajectory this collapses to
+    #     the action token count; for a merged multi-turn trajectory it's
+    #     actions + tool/observation tokens between actions.
+    steps_per_traj = []
+    step_response_lengths = []
     for group in trajectory_groups:
         for trajectory in group.trajectories:
             traj_datums = trajectory_to_datums(trajectory, router_replay=algorithm_config.router_replay)
-            seqs_per_traj.append(len(traj_datums))
+            steps_per_traj.append(len(traj_datums))
             for d in traj_datums:
-                seq_lengths.append(d.model_input.length)
+                # Response region = total Datum length - leading prompt
+                # length. The mask is 0 over the initial prompt (before
+                # any action token) and follows the action/observation
+                # pattern after that, so the position of the first mask=1
+                # token is the prompt boundary.
+                mask_data = d.loss_fn_inputs["mask"].data
+                first_action = next(
+                    (i for i, m in enumerate(mask_data) if m > 0.5),
+                    len(mask_data),
+                )
+                step_response_lengths.append(len(mask_data) - first_action)
             if algorithm_config.estimator_map:
                 datums_dict[group.group_role].extend(traj_datums)
             else:
                 datums.extend(traj_datums)
 
-    if seqs_per_traj:
+    if steps_per_traj:
         import numpy as _np
 
-        adv_metrics["batch/seqs_per_traj/mean"] = _np.mean(seqs_per_traj)
-        adv_metrics["batch/seqs_per_traj/min"] = _np.min(seqs_per_traj)
-        adv_metrics["batch/seqs_per_traj/max"] = _np.max(seqs_per_traj)
-        adv_metrics["batch/seq_length/mean"] = _np.mean(seq_lengths)
-        adv_metrics["batch/seq_length/min"] = _np.min(seq_lengths)
-        adv_metrics["batch/seq_length/max"] = _np.max(seq_lengths)
+        adv_metrics["batch/steps_per_traj/mean"] = _np.mean(steps_per_traj)
+        adv_metrics["batch/steps_per_traj/min"] = _np.min(steps_per_traj)
+        adv_metrics["batch/steps_per_traj/max"] = _np.max(steps_per_traj)
+        adv_metrics["batch/step_response_length/mean"] = _np.mean(step_response_lengths)
+        adv_metrics["batch/step_response_length/min"] = _np.min(step_response_lengths)
+        adv_metrics["batch/step_response_length/max"] = _np.max(step_response_lengths)
 
     return (datums if not algorithm_config.estimator_map else datums_dict), adv_metrics

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -158,37 +158,48 @@ def transform_trajectory_groups_to_datums(
         datums = []
 
     # step 2: iterate over all steps and build the Tinker Datum objects.
-    # Track per-trajectory split count and per-Datum response length so the
-    # caller can log the same metrics across backends. Metric semantics are
-    # shared with verl's transform_episodes_to_dataproto:
+    # Track per-trajectory split count, per-Datum response length, and
+    # per-Datum action-token fraction so the caller can log the same
+    # metrics across backends. Metric semantics shared with verl's
+    # transform_episodes_to_dataproto:
     #   - steps_per_traj: number of training rows/datums one trajectory
-    #     becomes after prefix-merging. Healthy cumulative agents = 1; any
-    #     value > 1 indicates a prefix break (re-tokenization quirk, mid-
-    #     trajectory context reset, etc.).
+    #     becomes after prefix-merging. =1 for healthy cumulative agents;
+    #     >1 indicates a prefix break (re-tokenization quirk, mid-
+    #     trajectory context reset).
     #   - step_response_length: length of the response region per row,
-    #     i.e. everything from the first action token onward (action tokens
-    #     plus interleaved observation tokens), excluding the initial
-    #     prompt. For an unmerged single-step trajectory this collapses to
-    #     the action token count; for a merged multi-turn trajectory it's
-    #     actions + tool/observation tokens between actions.
+    #     i.e. everything from the first action token onward (action
+    #     tokens + interleaved observation tokens), excluding the initial
+    #     prompt.
+    #   - merge_compression_ratio (batch-level scalar): total agent
+    #     steps ÷ total emitted rows. =N for a fully cumulative N-turn
+    #     batch; =1 means no merging (per-step rows or all single-step).
+    #   - action_token_ratio: fraction of response tokens that are
+    #     trainable (mask=1) per row. =1.0 for single-step rows (no
+    #     observations); <1.0 for merged multi-turn (tool/observation
+    #     tokens are mask=0 between actions).
     steps_per_traj = []
     step_response_lengths = []
+    action_token_ratios = []
+    total_agent_steps = 0
     for group in trajectory_groups:
         for trajectory in group.trajectories:
+            total_agent_steps += len(trajectory.steps)
             traj_datums = trajectory_to_datums(trajectory, router_replay=algorithm_config.router_replay)
             steps_per_traj.append(len(traj_datums))
             for d in traj_datums:
-                # Response region = total Datum length - leading prompt
-                # length. The mask is 0 over the initial prompt (before
-                # any action token) and follows the action/observation
-                # pattern after that, so the position of the first mask=1
-                # token is the prompt boundary.
                 mask_data = d.loss_fn_inputs["mask"].data
+                # Response region = total Datum length - leading prompt
+                # length. Mask is 0 over the initial prompt (before any
+                # action) and 0/1-interleaved after, so the first mask=1
+                # position is the prompt boundary.
                 first_action = next(
                     (i for i, m in enumerate(mask_data) if m > 0.5),
                     len(mask_data),
                 )
-                step_response_lengths.append(len(mask_data) - first_action)
+                resp_len = len(mask_data) - first_action
+                action_count = sum(1 for m in mask_data[first_action:] if m > 0.5)
+                step_response_lengths.append(resp_len)
+                action_token_ratios.append(action_count / resp_len if resp_len > 0 else 0.0)
             if algorithm_config.estimator_map:
                 datums_dict[group.group_role].extend(traj_datums)
             else:
@@ -197,11 +208,18 @@ def transform_trajectory_groups_to_datums(
     if steps_per_traj:
         import numpy as _np
 
+        total_emitted_rows = sum(steps_per_traj)
         adv_metrics["batch/steps_per_traj/mean"] = _np.mean(steps_per_traj)
         adv_metrics["batch/steps_per_traj/min"] = _np.min(steps_per_traj)
         adv_metrics["batch/steps_per_traj/max"] = _np.max(steps_per_traj)
         adv_metrics["batch/step_response_length/mean"] = _np.mean(step_response_lengths)
         adv_metrics["batch/step_response_length/min"] = _np.min(step_response_lengths)
         adv_metrics["batch/step_response_length/max"] = _np.max(step_response_lengths)
+        adv_metrics["batch/action_token_ratio/mean"] = _np.mean(action_token_ratios)
+        adv_metrics["batch/action_token_ratio/min"] = _np.min(action_token_ratios)
+        adv_metrics["batch/action_token_ratio/max"] = _np.max(action_token_ratios)
+        adv_metrics["batch/merge_compression_ratio"] = (
+            total_agent_steps / total_emitted_rows if total_emitted_rows > 0 else 0.0
+        )
 
     return (datums if not algorithm_config.estimator_map else datums_dict), adv_metrics

--- a/tests/unified_trainer/test_tinker_transform.py
+++ b/tests/unified_trainer/test_tinker_transform.py
@@ -5,9 +5,7 @@ These tests verify that trajectories are correctly converted to Tinker Datum obj
 especially the logic for merging consecutive steps that share a prefix relationship.
 """
 
-from dataclasses import dataclass
 from typing import Literal
-from unittest.mock import MagicMock
 
 import pytest
 import tinker
@@ -21,22 +19,6 @@ from rllm.trainer.tinker.transform import (
 )
 
 # =============================================================================
-# Mock Types
-# =============================================================================
-
-
-@dataclass
-class MockSampledSequence:
-    """Mock SampledSequence that mimics tinker's SampledSequence interface."""
-
-    tokens: list[int]
-    logprobs: list[float]
-
-    def __post_init__(self):
-        assert len(self.tokens) == len(self.logprobs), "tokens and logprobs must have same length"
-
-
-# =============================================================================
 # Helper Functions
 # =============================================================================
 
@@ -47,18 +29,18 @@ def make_step(
     response_logprobs: list[float] | None = None,
     advantage: float | list[float] = 1.0,
 ) -> Step:
-    """Helper to create a Step with mock TinkerTokenOutput."""
+    """Helper to create a Step populated as ``trajectory_to_datums`` expects."""
     if response_logprobs is None:
         response_logprobs = [0.1] * len(response_tokens)
 
-    mock_output = MockSampledSequence(tokens=response_tokens, logprobs=response_logprobs)
+    assert len(response_tokens) == len(response_logprobs), "tokens and logprobs must have same length"
 
-    step = Step(
+    return Step(
         prompt_ids=prompt_ids,
-        response_ids=mock_output,
+        response_ids=response_tokens,
+        logprobs=response_logprobs,
         advantage=advantage,
     )
-    return step
 
 
 def make_image_chunk(expected_tokens: int = 256, data: bytes = b"image_data", format: Literal["png", "jpeg"] = "png") -> ImageChunk:
@@ -389,7 +371,8 @@ class TestTrajectoryToDataWithChunks:
         chunk = tinker.EncodedTextChunk(tokens=[1, 2, 3])
         step = Step(
             prompt_ids=[chunk, 4, 5],  # Flattens to [1, 2, 3, 4, 5]
-            response_ids=MockSampledSequence(tokens=[6, 7], logprobs=[-0.1, -0.2]),
+            response_ids=[6, 7],
+            logprobs=[-0.1, -0.2],
             advantage=0.5,
         )
         trajectory = Trajectory(steps=[step])
@@ -414,7 +397,8 @@ class TestTrajectoryToDataWithChunks:
         img_chunk = make_image_chunk(expected_tokens=3)  # Occupies 3 token positions
         step = Step(
             prompt_ids=[1, img_chunk, 2],  # 1 + 3 (image) + 1 = 5 token positions
-            response_ids=MockSampledSequence(tokens=[10, 11], logprobs=[-0.1, -0.2]),
+            response_ids=[10, 11],
+            logprobs=[-0.1, -0.2],
             advantage=0.5,
         )
         trajectory = Trajectory(steps=[step])
@@ -495,7 +479,8 @@ class TestTrajectoryToDataEdgeCases:
         """If advantage list length doesn't match response tokens, should raise."""
         step = Step(
             prompt_ids=[1, 2, 3],
-            response_ids=MockSampledSequence(tokens=[4, 5, 6], logprobs=[-0.1, -0.2, -0.3]),
+            response_ids=[4, 5, 6],
+            logprobs=[-0.1, -0.2, -0.3],
             advantage=[0.5, 0.6],  # Only 2 elements, but 3 response tokens
         )
         trajectory = Trajectory(steps=[step])
@@ -504,26 +489,24 @@ class TestTrajectoryToDataEdgeCases:
             trajectory_to_datums(trajectory)
 
     def test_missing_logprobs_raises(self):
-        """If logprobs is None, should raise."""
-        mock_output = MagicMock()
-        mock_output.logprobs = None
-        mock_output.tokens = [4, 5]
-
+        """If logprobs is empty, should raise."""
         step = Step(
             prompt_ids=[1, 2, 3],
-            response_ids=mock_output,
+            response_ids=[4, 5],
+            logprobs=[],
             advantage=0.5,
         )
         trajectory = Trajectory(steps=[step])
 
-        with pytest.raises(AssertionError, match="logprobs is None"):
+        with pytest.raises(AssertionError, match="logprobs is empty"):
             trajectory_to_datums(trajectory)
 
     def test_missing_advantage_raises(self):
         """If advantage is None, should raise."""
         step = Step(
             prompt_ids=[1, 2, 3],
-            response_ids=MockSampledSequence(tokens=[4, 5], logprobs=[-0.1, -0.2]),
+            response_ids=[4, 5],
+            logprobs=[-0.1, -0.2],
             advantage=None,
         )
         trajectory = Trajectory(steps=[step])

--- a/tests/unified_trainer/test_verl_transform.py
+++ b/tests/unified_trainer/test_verl_transform.py
@@ -139,7 +139,13 @@ class TestRolloutLogProbsPropagation:
         assert "rollout_log_probs" not in batch.batch
 
     def test_multi_step_trajectory_logprobs(self):
-        """Multi-step trajectories should have logprobs for each step row."""
+        """Cumulative-prefix multi-step trajectories merge into a single row.
+
+        Step 2's prompt [1,2,3,4,5] prefix-extends step 1's full sequence
+        [1,2,3,4], so they merge. The resulting row's response is
+        [3, 4, 5, 6, 7, 8] (action₀, delta_obs, action₁) with mask
+        [1, 1, 0, 1, 1, 1] and logprobs [-0.1, -0.2, 0, -0.3, -0.4, -0.5].
+        """
         model_output_1 = ModelOutput(prompt_ids=[1, 2], completion_ids=[3, 4], logprobs=[-0.1, -0.2])
         model_output_2 = ModelOutput(prompt_ids=[1, 2, 3, 4, 5], completion_ids=[6, 7, 8], logprobs=[-0.3, -0.4, -0.5])
         step1 = Step(prompt_ids=[1, 2], response_ids=[3, 4], model_output=model_output_1, reward=0.0)
@@ -152,17 +158,18 @@ class TestRolloutLogProbsPropagation:
 
         assert "rollout_log_probs" in batch.batch
         rollout_lp = batch.batch["rollout_log_probs"]
-        # 2 steps = 2 rows in the batch
-        assert rollout_lp.shape[0] == 2
+        # Cumulative-prefix merge → 1 row
+        assert rollout_lp.shape[0] == 1
 
-        # Step 1: logprobs [-0.1, -0.2], right-padded
-        assert torch.isclose(rollout_lp[0, 0], torch.tensor(-0.1))
-        assert torch.isclose(rollout_lp[0, 1], torch.tensor(-0.2))
+        # Merged logprobs: action₀ (real), observation delta (0.0 placeholder),
+        # action₁ (real), then right-padded.
+        expected_prefix = [-0.1, -0.2, 0.0, -0.3, -0.4, -0.5]
+        for i, exp in enumerate(expected_prefix):
+            assert torch.isclose(rollout_lp[0, i], torch.tensor(exp)), (i, rollout_lp[0, i].item())
 
-        # Step 2: logprobs [-0.3, -0.4, -0.5], right-padded
-        assert torch.isclose(rollout_lp[1, 0], torch.tensor(-0.3))
-        assert torch.isclose(rollout_lp[1, 1], torch.tensor(-0.4))
-        assert torch.isclose(rollout_lp[1, 2], torch.tensor(-0.5))
+        # Mask follows the same shape: [1, 1, 0, 1, 1, 1]
+        response_mask = batch.batch["response_mask"][0]
+        assert response_mask[:6].tolist() == [1, 1, 0, 1, 1, 1]
 
     def test_other_batch_fields_unchanged(self):
         """Adding logprobs should not affect existing batch fields."""


### PR DESCRIPTION
# Collapse multi-turn trajectory steps into a single row (verl) + unified merge metrics

## Summary

Brings verl's batch representation in line with Tinker: a multi-turn agent trajectory now contributes **one row per trajectory** (prefix-merged) instead of one row per step. With `loss_agg_mode=seq-mean-token-mean`, this fixes a gradient-weighting bias that scaled with step count and made many-stepped (typically failed) rollouts dominate the loss. A second commit lands a unified set of per-batch merge metrics that log on **both** backends under the same names so dashboards work without backend-specific juggling.

## Motivation

Before this change, verl's `_process_trajectory` emitted one batch row per step. A trajectory with `N` steps therefore contributed `N` rows, and under `seq-mean-token-mean` got `N×` weight in the gradient — biasing learning toward the (typically failed) high-step rollouts. Tinker doesn't have this bias because each `Datum` already represents an entire trajectory, so the two backends silently disagreed on per-trajectory loss weighting.

After this change, verl with `seq-mean-token-mean` produces per-trajectory equal-weighted gradients matching Tinker exactly, and verl with `token-mean` recovers Tinker's per-action-token semantics within a trajectory.

## What changed

### 1. `feat(verl): collapse multi-turn trajectory steps into a single row` &nbsp;(`29044cd2`)

`rllm/experimental/verl/transform.py:_process_trajectory`:

- Walks the trajectory's steps and merges any step whose `prompt_ids` is a prefix-extension of the running segment's `full_seq` (the typical ReAct / tool-call pattern, where the messages list grows by appending assistant + tool messages).
- The merged row's response is `[A0, obs1, A1, obs2, ..., AN]` and its `response_mask` is `1` only on action tokens, `0` on observation / tool-message tokens between actions. Logprobs follow the same layout (real lp on actions, `0.0` placeholder on observation tokens).
- A step that is **not** a prefix-extension closes the current segment and starts a new one — common case stays at one row per trajectory; only pathological context resets emit `>1` rows.
- `step_id` is now `trajectory.uid` (no `_step{idx}` suffix).
- `update_dataproto_with_advantages` is updated to key off `trajectory.uid`. Scalar advantage × `response_mask` handles the action-only scatter for free since the mask zeros observation tokens automatically.

### 2. `tune(math_tool_agent): resize prompt/response budget for merged rows` &nbsp;(`9096868e`)

`cookbooks/math_tool_agent/train_verl.sh` — the prompt no longer grows turn-over-turn, and the response now has to fit the entire trajectory:

| Field | Before | After | Reason |
|---|---:|---:|---|
| `data.max_prompt_length` | 4096 | **2048** | initial system+user only |
| `data.max_response_length` | 2048 | **20480** | full trajectory action+obs (worst case ~17.8k for 8 turns × 2k actions + 7 × ~200 tool tokens) |
| `actor_rollout_ref.actor.ppo_max_token_len_per_gpu` | 16384 | **32768** | a single ~22k-token row must fit one micro-batch under `dynamic_bsz` |

Total per-row budget (22528) stays under `max_model_len=32768` with margin for vLLM's BOS/EOS handling. `solver_judge_flow` and `geo3k` cookbooks are single-step, so their merged representation is identical to per-step — no shell-script changes needed.

### 3. `feat(metrics): unified per-batch merge metrics across verl and tinker` &nbsp;(`c6f49c2f`)

Same metric paths now log on **both** backends:

- `batch/steps_per_traj/{mean,min,max}` — rows emitted per trajectory after prefix-merging. `=1` for healthy cumulative agents; `>1` indicates a prefix break (re-tokenization quirk, mid-trajectory context reset).
- `batch/step_response_length/{mean,min,max}` — length of the response region per row (action tokens + interleaved obs tokens), excluding the initial prompt. For an unmerged single-step trajectory this collapses to action token count; for merged multi-turn it's actions + tool/obs tokens.

Tinker side (`rllm/trainer/tinker/transform.py`):
- Renames `batch/seqs_per_traj` → `batch/steps_per_traj`.
- Renames `batch/seq_length` → `batch/step_response_length` and redefines it from total `Datum` length (prompt+response) to response-region length (computed by finding the first `mask=1` position in the per-Datum mask).

Verl side (`rllm/experimental/verl/transform.py`, `verl_backend.py`):
- New `_compute_merge_metrics(accumulated, total_agent_steps)`.
- Result is stashed on `DataProto.meta_info["merge_metrics"]` so `transform_episodes_to_dataproto`'s public signature stays unchanged (callers in `tests/`, `agent_workflow_engine` still work).
- `VerlBackend.transform_to_backend_batch` lifts the dict out of `meta_info` and writes it to `trainer_state.metrics`.

### 4. `feat(metrics): add merge_compression_ratio and action_token_ratio` &nbsp;(`d2eec6c4`)

Two more diagnostic metrics on both backends:

- `batch/merge_compression_ratio` (scalar) — total agent steps ÷ total emitted rows. `=N` for a fully cumulative N-turn batch (one row per N-step trajectory); `=1` means no merging happened. The quickest single-number signal that the merge pipeline is working as intended.
- `batch/action_token_ratio/{mean,min,max}` — per-row fraction of response tokens that are trainable (mask=1) vs observation/tool tokens (mask=0). `=1.0` for single-step rows; `<1.0` to the extent that obs spans contribute to the row size. Useful for spotting agents whose tool outputs dominate the per-row token budget.

## Files

```
 cookbooks/math_tool_agent/train_verl.sh      |   6 +-
 rllm/experimental/verl/transform.py          | 241 ++++++++++++++++++++++-----
 rllm/experimental/verl/verl_backend.py       |  10 +-
 rllm/trainer/tinker/transform.py             |  65 ++++++--
 tests/unified_trainer/test_verl_transform.py |  31 ++--
 5 files changed, 285 insertions(+), 68 deletions(-)
```

## Migration / user-visible notes

- **`max_response_length` semantics change** for verl multi-turn agents: it must now fit the **full** trajectory's action+observation tokens. Steps that overflow get right-truncated like single-step rows do. Single-step cookbooks (`solver_judge_flow`, `geo3k`) are unaffected.
- **Metric rename** on the Tinker backend:
  - `batch/seqs_per_traj` → `batch/steps_per_traj`
  - `batch/seq_length` → `batch/step_response_length`, **and the definition changes** from total Datum length (prompt+response) to response-region length only. Existing dashboards keyed on the old names will need an update; the new name matches verl.
- `step_id` format inside DataProto is now bare `trajectory.uid` (previously `f"{trajectory.uid}_step{step_idx}"`). External consumers that parse step_id should update accordingly.

## Test plan

- [x] `tests/unified_trainer/test_verl_transform.py::test_multi_step_trajectory_logprobs` — updated to assert the merged single-row layout: response `[3,4,5,6,7,8]`, mask `[1,1,0,1,1,1]`, logprobs `[-0.1,-0.2,0.0,-0.3,-0.4,-0.5]`.
- [x] Synthetic 3-turn cumulative trajectories merge into a single row.
- [x] Synthetic 2-turn non-cumulative trajectory splits into two rows.
- [x] Single-step trajectory unchanged (1 row, mask all 1s).
- [x] `cookbooks/solver_judge_flow/test.py` still passes.
- [ ] End-to-end run on `cookbooks/math_tool_agent/train_verl.sh` with the new prompt/response budget — verify `batch/merge_compression_ratio ≈ N` and `batch/steps_per_traj ≈ 1`.
- [ ] Cross-backend parity: confirm `batch/steps_per_traj`, `batch/step_response_length`, `batch/action_token_ratio`, `batch/merge_compression_ratio` all log on both verl and tinker runs in the same wandb project.

## Commits

- `29044cd2` feat(verl): collapse multi-turn trajectory steps into a single row
- `9096868e` tune(math_tool_agent): resize prompt/response budget for merged multi-turn rows
- `c6f49c2f` feat(metrics): unified per-batch merge metrics across verl and tinker
- `d2eec6c4` feat(metrics): add merge_compression_ratio and action_token_ratio
