### PR TITLE
fix(examples): use seq-mean-token-sum loss aggregation for agentcore math verl example

### DIFF
--- a/examples/agentcore_math/train_agentcore_math_verl.sh
+++ b/examples/agentcore_math/train_agentcore_math_verl.sh
@@ -42,7 +42,7 @@ python -m examples.agentcore_math.train_agentcore_math_verl \
     actor_rollout_ref.actor.megatron.use_mbridge=True \
     actor_rollout_ref.actor.megatron.vanilla_mbridge=False \
     actor_rollout_ref.actor.megatron.param_offload=True \
-    actor_rollout_ref.actor.loss_agg_mode=token-mean \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-sum \
     actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \


### PR DESCRIPTION
## Summary

Switch `loss_agg_mode` from `token-mean` to `seq-mean-token-sum` in the AgentCore + verl math example to match the aggregation semantics of the tinker `ppo` loss that the sibling tinker recipe uses. With`token-mean` the run suffered occasional training collapse; with `seq-mean-token-sum` training is stable and comparable to the tinker run which has never collapsed. The slower convergence compared to Tinker might be due to missing rollout correction in rLLM, which could be fixed by https://github.com/rllm-org/rllm/pull/507. 

  ## Why this matches tinker

The tinker recipe uses the `ppo` loss, which per the [tinker docs](https://tinker-docs.thinkingmachines.ai/tinker/losses/ppo) computes `loss = -ppo_objective.sum()` per datum — i.e. **token-sum within each sequence**, then mean across datums at the batch level.

Verl's `seq-mean-token-sum` (`verl/trainer/ppo/core_algos.py:agg_loss`) mirrors this:

seq_losses[i] = Σ_tokens (loss_mat * loss_mask)          # token-sum
loss          = Σ_i seq_losses[i] / global_batch_size    # seq-mean

In rLLM's verl backend, `global_batch_size = ppo_mini_batch_size * rollout.n` (set in `ray_trainer.py` / `verl_backend.py`). Each step in a multi-turn trajectory is emitted as its own DataProto row (`rllm/experimental/verl/transform.py:_process_trajectory`), but because token-sum is additive across partitions, summing per-step losses and dividing by the trajectory count is algebraically identical to tinker's "sum action-token losses over the whole trajectory, mean across trajectories."

In contrast, `token-mean` divides by the total token count in the batch, so long responses dominate the update (a few long-response rollouts can steer the gradient far more than many short ones).

## Test

- [x] Launched `examples/agentcore_math/train_agentcore_math_verl.sh` with `seq-mean-token-sum`; training
progressed without collapse. (wandb: `gsm8k-verl-megatron-4b-token-sum-seq-mean`). The plot below shows the results from both settings (each with three runs). 

<img width="1141" height="790" alt="Screenshot 2026-04-27 at 8 42 32 AM" src="https://github.com/user-attachments/assets/1737c7b5-8c31-42b1-8035-08f2d71e7405" />
