### PR TITLE
fix(verl): preserve multi-turn tool-call prefix extension for math tool agent for Qwen 3 models

### DIFF
--- a/cookbooks/math_tool_agent/train_verl.sh
+++ b/cookbooks/math_tool_agent/train_verl.sh
@@ -11,12 +11,20 @@ set -euo pipefail
 unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
 
 MODEL_PATH=Qwen/Qwen3-4B-Instruct-2507
+MULTI_TURN_EXTENSION=${MULTI_TURN_EXTENSION:-true}
+VLLM_TOOL_ARGS=()
+if [[ "$MULTI_TURN_EXTENSION" != "true" ]]; then
+    VLLM_TOOL_ARGS+=(+actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true)
+    VLLM_TOOL_ARGS+=(+actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes)
+fi
 
 python -u train.py \
     rllm/backend=verl \
     algorithm.adv_estimator=grpo \
     algorithm.norm_adv_by_std_in_grpo=true \
     rllm.algorithm.use_rllm=true \
+    rllm.multi_turn_extension=$MULTI_TURN_EXTENSION \
+    rllm.accumulate_reasoning=true \
     data.train_batch_size=32 \
     data.val_batch_size=256 \
     data.max_prompt_length=2048 \
@@ -41,8 +49,7 @@ python -u train.py \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.mode=async \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes \
+    "${VLLM_TOOL_ARGS[@]}" \
     actor_rollout_ref.rollout.enforce_eager=False \
     +actor_rollout_ref.rollout.max_model_len=32768 \
     actor_rollout_ref.rollout.temperature=1.0 \

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -121,3 +121,7 @@ class GatewayConfig(BaseModel):
     sync_traces: bool = False
     sampling_params_priority: str = "client"
     model: str | None = None  # When set, overrides ``body.model``
+    tokenizer_name: str | None = None
+    disable_thinking: bool = False
+    accumulate_reasoning: bool = False
+    multi_turn_extension: bool = False

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -20,7 +20,7 @@ from rllm_model_gateway.data_process import (
     build_trace_record_from_chunks,
     strip_vllm_fields,
 )
-from rllm_model_gateway.models import TraceRecord
+from rllm_model_gateway.models import GatewayConfig, TraceRecord
 from rllm_model_gateway.session_router import SessionRouter
 from rllm_model_gateway.store.base import TraceStore
 
@@ -40,6 +40,202 @@ _HOP_BY_HOP = frozenset(
         "host",
     }
 )
+
+
+class _RllmParserTransport:
+    """Convert chat-completions requests to raw-text completions requests.
+
+    Rendering and completion parsing stay delegated to ``rllm.parser``; this
+    class only adapts the HTTP transport shape.
+    """
+
+    def __init__(self, config: GatewayConfig, parser: Any | None = None) -> None:
+        self.config = config
+        self.accumulate_reasoning = config.accumulate_reasoning
+
+        if parser is not None:
+            self.parser = parser
+            return
+
+        if not config.tokenizer_name:
+            raise ValueError("tokenizer_name is required for rLLM parser transport")
+
+        from transformers import AutoTokenizer
+
+        from rllm.parser import ChatTemplateParser
+
+        tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_name, trust_remote_code=True)
+        self.parser = ChatTemplateParser.get_parser(
+            tokenizer,
+            disable_thinking=config.disable_thinking,
+            multi_turn_extension=config.multi_turn_extension,
+        )
+
+        if type(self.parser).parse_completion_text is ChatTemplateParser.parse_completion_text:
+            raise ValueError(f"Parser {type(self.parser).__name__} does not implement parse_completion_text")
+
+    def chat_to_completion(self, body: dict[str, Any], *, originally_requested_logprobs: bool) -> dict[str, Any]:
+        messages = body.get("messages")
+        if not isinstance(messages, list):
+            raise ValueError("parser transport requires a chat messages list")
+        if body.get("stream"):
+            raise ValueError("parser transport does not support stream=true in v1")
+        if body.get("n", 1) != 1:
+            raise ValueError("parser transport supports only n=1 in v1")
+        if body.get("top_logprobs") is not None and not originally_requested_logprobs:
+            raise ValueError("top_logprobs requires logprobs=true")
+
+        self._reject_multimodal(messages)
+
+        tools = body.get("tools") or []
+        tool_choice = body.get("tool_choice")
+        if tool_choice in (None, "auto"):
+            tools_for_prompt = tools
+        elif tool_choice == "none":
+            tools_for_prompt = []
+        else:
+            raise ValueError("parser transport supports only omitted, auto, or none tool_choice in v1")
+
+        prompt_text = self.parser.parse(
+            messages,
+            add_generation_prompt=True,
+            is_first_msg=True,
+            tools=tools_for_prompt,
+            accumulate_reasoning=self.accumulate_reasoning,
+        )
+
+        stop_token_ids = sorted(set(body.get("stop_token_ids") or []) | set(getattr(self.parser, "stop_sequences", []) or []))
+        completion_logprobs = body["top_logprobs"] if body.get("top_logprobs") is not None else 1
+
+        converted: dict[str, Any] = {
+            "model": body.get("model"),
+            "prompt": prompt_text,
+            "max_tokens": body.get("max_tokens") or body.get("max_completion_tokens"),
+            "temperature": body.get("temperature"),
+            "top_p": body.get("top_p"),
+            "top_k": body.get("top_k"),
+            "stop": body.get("stop"),
+            "stop_token_ids": stop_token_ids,
+            "logprobs": completion_logprobs,
+            "return_token_ids": True,
+            "add_special_tokens": False,
+        }
+
+        for key in (
+            "min_tokens",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+            "ignore_eos",
+            "include_stop_str_in_output",
+            "skip_special_tokens",
+        ):
+            if key in body:
+                converted[key] = body[key]
+
+        return {k: v for k, v in converted.items() if v is not None}
+
+    def completion_to_chat(self, response: dict[str, Any]) -> dict[str, Any]:
+        choices = response.get("choices") or []
+        if len(choices) != 1:
+            raise ValueError("parser transport expected exactly one completion choice")
+
+        choice = choices[0]
+        completion_text = choice.get("text")
+        if completion_text is None:
+            raise ValueError("vLLM completion response missing choices[0].text")
+
+        token_ids = choice.get("token_ids")
+        if token_ids is None:
+            raise ValueError("vLLM completion response missing choices[0].token_ids")
+        token_ids = list(token_ids)
+
+        parsed = self.parser.parse_completion_text(completion_text)
+        logprobs = self._normalize_logprobs(choice, token_ids)
+        tool_calls = self._tool_calls_to_openai(parsed.get("tool_calls") or [], choice.get("index", 0))
+
+        message: dict[str, Any] = {
+            "role": "assistant",
+            "content": parsed.get("content", "") or "",
+        }
+        if parsed.get("reasoning"):
+            message["reasoning"] = parsed["reasoning"]
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+
+        prompt_token_ids = choice.get("prompt_token_ids")
+        if prompt_token_ids is None:
+            prompt_token_ids = response.get("prompt_token_ids", [])
+
+        return {
+            "id": response.get("id"),
+            "object": "chat.completion",
+            "created": response.get("created"),
+            "model": response.get("model"),
+            "prompt_token_ids": list(prompt_token_ids or []),
+            "choices": [
+                {
+                    "index": choice.get("index", 0),
+                    "message": message,
+                    "finish_reason": "tool_calls" if tool_calls else choice.get("finish_reason"),
+                    "token_ids": token_ids,
+                    "logprobs": logprobs,
+                }
+            ],
+            "usage": response.get("usage", {}),
+        }
+
+    @staticmethod
+    def _reject_multimodal(messages: list[dict[str, Any]]) -> None:
+        for message in messages:
+            if message.get("images") is not None:
+                raise ValueError("parser transport does not support image inputs in v1")
+            content = message.get("content")
+            if isinstance(content, list | dict):
+                raise ValueError("parser transport does not support multimodal message content in v1")
+
+    @staticmethod
+    def _normalize_logprobs(choice: dict[str, Any], token_ids: list[int]) -> dict[str, Any]:
+        lp_obj = choice.get("logprobs")
+        if not lp_obj:
+            raise ValueError("vLLM completion response missing logprobs")
+
+        tokens = lp_obj.get("tokens")
+        token_logprobs = lp_obj.get("token_logprobs")
+        top_logprobs = lp_obj.get("top_logprobs")
+        if tokens is None or token_logprobs is None:
+            raise ValueError("vLLM completion response missing sampled-token logprobs")
+        if len(tokens) != len(token_ids) or len(token_logprobs) != len(token_ids):
+            raise ValueError("vLLM completion logprobs are not aligned with token_ids")
+        if any(logprob is None for logprob in token_logprobs):
+            raise ValueError("vLLM completion logprobs contain None")
+
+        content: list[dict[str, Any]] = []
+        for i, (token, logprob) in enumerate(zip(tokens, token_logprobs, strict=True)):
+            entry: dict[str, Any] = {"token": token, "logprob": logprob}
+            if top_logprobs is not None and i < len(top_logprobs) and top_logprobs[i] is not None:
+                entry["top_logprobs"] = [{"token": top_token, "logprob": top_logprob} for top_token, top_logprob in top_logprobs[i].items()]
+            content.append(entry)
+        return {"content": content}
+
+    @staticmethod
+    def _tool_calls_to_openai(tool_calls: list[Any], choice_index: int) -> list[dict[str, Any]]:
+        result = []
+        for tool_index, tool_call in enumerate(tool_calls):
+            name = getattr(tool_call, "name", None)
+            arguments = getattr(tool_call, "arguments", None)
+            if name is None and isinstance(tool_call, dict):
+                name = tool_call.get("name")
+                arguments = tool_call.get("arguments")
+            result.append(
+                {
+                    "id": f"call_{choice_index}_{tool_index}",
+                    "type": "function",
+                    "function": {"name": name or "", "arguments": json.dumps(arguments or {})},
+                }
+            )
+        return result
 
 
 def _strip_logprobs(response: dict[str, Any]) -> dict[str, Any]:
@@ -79,6 +275,8 @@ class ReverseProxy:
         sync_traces: bool = False,
         max_retries: int = 2,
         local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+        parser_config: GatewayConfig | None = None,
+        parser_transport: _RllmParserTransport | None = None,
     ) -> None:
         self.router = router
         self.store = store
@@ -86,6 +284,7 @@ class ReverseProxy:
         self.sync_traces = sync_traces
         self.max_retries = max_retries
         self.local_handler = local_handler
+        self.parser_transport = parser_transport or (_RllmParserTransport(parser_config) if parser_config is not None else None)
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
 
@@ -129,6 +328,8 @@ class ReverseProxy:
         is_stream = request_body.get("stream", False)
 
         if is_stream:
+            if self.parser_transport is not None and request.method.upper() == "POST" and request.url.path.endswith("/chat/completions"):
+                raise ValueError("parser transport does not support stream=true in v1")
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)
         return await self._handle_non_streaming(request, body, request_body, session_id, originally_requested_logprobs)
 
@@ -152,14 +353,26 @@ class ReverseProxy:
             status_code = 200
         else:
             # HTTP proxy path
+            parser_mode = self.parser_transport is not None and request.method.upper() == "POST" and request.url.path.endswith("/chat/completions")
+            if parser_mode:
+                upstream_body = self.parser_transport.chat_to_completion(
+                    request_body,
+                    originally_requested_logprobs=originally_requested_logprobs,
+                )
+                upstream_path = "/v1/completions"
+                upstream_content = json.dumps(upstream_body).encode("utf-8")
+            else:
+                upstream_path = request.url.path
+                upstream_content = raw_body
+
             worker = self.router.route(session_id)
-            url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
+            url = self._build_url(worker.api_url, upstream_path, str(request.url.query))
             headers = self._forward_headers(request)
             try:
                 resp = await self._send_with_retry(
                     method=request.method,
                     url=url,
-                    content=raw_body,
+                    content=upstream_content,
                     headers=headers,
                 )
                 content = resp.content
@@ -172,6 +385,9 @@ class ReverseProxy:
                 response_body = json.loads(content)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 response_body = {}
+
+            if parser_mode and status_code < 400 and response_body:
+                response_body = self.parser_transport.completion_to_chat(response_body)
 
         latency_ms = (time.perf_counter() - t0) * 1000
 

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -123,8 +123,7 @@ def create_app(
 
     if config.multi_turn_extension and local_handler is not None:
         logger.warning(
-            "rllm.multi_turn_extension=true was set, but gateway parser transport is disabled because local_handler is in use. "
-            "The local handler must preserve multi-turn prefix extension itself."
+            "rllm.multi_turn_extension=true was set, but gateway parser transport is disabled because local_handler is in use. The local handler must preserve multi-turn prefix extension itself."
         )
     elif config.multi_turn_extension:
         _validate_parser_transport_config(config)

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -121,6 +121,14 @@ def create_app(
     if config is None:
         config = GatewayConfig()
 
+    if config.multi_turn_extension and local_handler is not None:
+        logger.warning(
+            "rllm.multi_turn_extension=true was set, but gateway parser transport is disabled because local_handler is in use. "
+            "The local handler must preserve multi-turn prefix extension itself."
+        )
+    elif config.multi_turn_extension:
+        _validate_parser_transport_config(config)
+
     _install_access_log_filter()
 
     if store is None:
@@ -154,6 +162,7 @@ def create_app(
         strip_vllm=config.strip_vllm_fields,
         sync_traces=config.sync_traces,
         local_handler=local_handler,
+        parser_config=config if config.multi_turn_extension and local_handler is None else None,
     )
     sessions = SessionManager(store)
 
@@ -395,6 +404,7 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         "RLLM_GATEWAY_DB_PATH": "db_path",
         "RLLM_GATEWAY_LOG_LEVEL": "log_level",
         "RLLM_GATEWAY_STORE": "store_worker",
+        "RLLM_GATEWAY_TOKENIZER_NAME": "tokenizer_name",
     }
     for env_key, config_key in env_map.items():
         val = os.environ.get(env_key)
@@ -403,6 +413,16 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
                 data[config_key] = int(val)
             else:
                 data[config_key] = val
+
+    bool_env_map = {
+        "RLLM_GATEWAY_MULTI_TURN_EXTENSION": "multi_turn_extension",
+        "RLLM_GATEWAY_DISABLE_THINKING": "disable_thinking",
+        "RLLM_GATEWAY_ACCUMULATE_REASONING": "accumulate_reasoning",
+    }
+    for env_key, config_key in bool_env_map.items():
+        val = os.environ.get(env_key)
+        if val is not None:
+            data[config_key] = val.lower() in ("1", "true", "yes", "on")
 
     # 3. CLI args (highest priority)
     if getattr(args, "host", None) is not None:
@@ -419,6 +439,14 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["sampling_params_priority"] = args.sampling_params_priority
     if getattr(args, "model", None) is not None:
         data["model"] = args.model
+    if getattr(args, "tokenizer_name", None) is not None:
+        data["tokenizer_name"] = args.tokenizer_name
+    if getattr(args, "multi_turn_extension", None) is not None:
+        data["multi_turn_extension"] = args.multi_turn_extension
+    if getattr(args, "disable_thinking", None) is not None:
+        data["disable_thinking"] = args.disable_thinking
+    if getattr(args, "accumulate_reasoning", None) is not None:
+        data["accumulate_reasoning"] = args.accumulate_reasoning
 
     # Workers from CLI --worker flags (WorkerConfig validator auto-splits URLs)
     worker_urls = getattr(args, "worker", None) or []
@@ -426,6 +454,16 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["workers"] = [{"url": raw_url, "worker_id": str(i)} for i, raw_url in enumerate(worker_urls)]
 
     return GatewayConfig(**data)
+
+
+def _validate_parser_transport_config(config: GatewayConfig) -> None:
+    if not config.tokenizer_name:
+        raise ValueError("multi_turn_extension=true requires tokenizer_name for gateway parser transport")
+    if not config.disable_thinking and not config.accumulate_reasoning:
+        raise ValueError(
+            "multi_turn_extension=true requires either disable_thinking=true or accumulate_reasoning=true. "
+            "Otherwise reasoning emitted by the model may be omitted from future rendered prompts and break prefix extension."
+        )
 
 
 # ------------------------------------------------------------------
@@ -460,6 +498,15 @@ def main() -> None:
         default=None,
         help="If set, the gateway rewrites every request body's 'model' field to this value before forwarding.",
     )
+    parser.add_argument(
+        "--tokenizer-name",
+        type=str,
+        default=None,
+        help="Tokenizer/model path used by parser transport when multi-turn extension is enabled.",
+    )
+    parser.add_argument("--multi-turn-extension", action="store_true", default=None)
+    parser.add_argument("--disable-thinking", action="store_true", default=None)
+    parser.add_argument("--accumulate-reasoning", action="store_true", default=None)
 
     args = parser.parse_args()
     config = _load_config(args)

--- a/rllm-model-gateway/tests/helpers/mock_vllm.py
+++ b/rllm-model-gateway/tests/helpers/mock_vllm.py
@@ -45,6 +45,29 @@ MOCK_RESPONSE = {
     "kv_transfer_params": None,
 }
 
+MOCK_COMPLETION_RESPONSE = {
+    "id": "cmpl-mock",
+    "object": "text_completion",
+    "model": "mock-model",
+    "choices": [
+        {
+            "index": 0,
+            "text": "Hello from mock!",
+            "finish_reason": "stop",
+            "stop_reason": None,
+            "token_ids": [10, 11, 12],
+            "prompt_token_ids": [1, 2, 3, 4, 5],
+            "logprobs": {
+                "tokens": ["Hello", " from", " mock!"],
+                "token_logprobs": [-0.5, -0.3, -0.1],
+                "top_logprobs": [{"Hello": -0.5}, {" from": -0.3}, {" mock!": -0.1}],
+                "text_offset": [0, 5, 10],
+            },
+        }
+    ],
+    "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+}
+
 
 def stream_chunks():
     """Yield SSE chunks that mirror vLLM 0.11+ streaming format."""
@@ -131,7 +154,7 @@ def build_mock_vllm_app() -> FastAPI:
     async def chat_completions(request: Request):
         body = await request.json()
         with app.state._log_lock:
-            app.state.request_log.append(body)
+            app.state.request_log.append({"_path": "/v1/chat/completions", **body})
 
         if body.get("stream"):
             return StreamingResponse(stream_chunks(), media_type="text/event-stream")
@@ -141,8 +164,8 @@ def build_mock_vllm_app() -> FastAPI:
     async def completions(request: Request):
         body = await request.json()
         with app.state._log_lock:
-            app.state.request_log.append(body)
-        return JSONResponse(content=MOCK_RESPONSE)
+            app.state.request_log.append({"_path": "/v1/completions", **body})
+        return JSONResponse(content=MOCK_COMPLETION_RESPONSE)
 
     return app
 
@@ -187,7 +210,7 @@ def build_controllable_mock_vllm_app(response_delay: float = 0.0) -> FastAPI:
     async def chat_completions(request: Request):
         body = await request.json()
         with app.state._log_lock:
-            app.state.request_log.append(body)
+            app.state.request_log.append({"_path": "/v1/chat/completions", **body})
 
         if app.state.response_delay > 0:
             import asyncio

--- a/rllm-model-gateway/tests/unit/test_parser_transport.py
+++ b/rllm-model-gateway/tests/unit/test_parser_transport.py
@@ -1,0 +1,193 @@
+"""Unit tests for the rLLM parser-backed transport adapter."""
+
+from types import SimpleNamespace
+
+import pytest
+from rllm_model_gateway.models import GatewayConfig
+from rllm_model_gateway.proxy import _RllmParserTransport
+
+
+class FakeParser:
+    stop_sequences = [999]
+
+    def __init__(self):
+        self.parse_calls = []
+        self.parsed_completion = {
+            "content": "Hello from mock!",
+            "reasoning": "",
+            "tool_calls": [],
+        }
+
+    def parse(self, messages, **kwargs):
+        self.parse_calls.append({"messages": messages, **kwargs})
+        return "RAW_PROMPT"
+
+    def parse_completion_text(self, text):
+        self.last_completion_text = text
+        return self.parsed_completion
+
+
+def _transport(parser=None, **config_kwargs):
+    config = GatewayConfig(
+        model="Qwen/Qwen3-4B-Instruct-2507",
+        tokenizer_name="Qwen/Qwen3-4B-Instruct-2507",
+        multi_turn_extension=True,
+        accumulate_reasoning=True,
+        **config_kwargs,
+    )
+    return _RllmParserTransport(config, parser=parser or FakeParser())
+
+
+def _chat_body(**overrides):
+    body = {
+        "model": "mock-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "calc"}}],
+        "temperature": 0.7,
+        "max_completion_tokens": 16,
+        "logprobs": True,
+        "stop_token_ids": [123],
+        "add_special_tokens": True,
+    }
+    body.update(overrides)
+    return body
+
+
+def _completion_response(**choice_overrides):
+    choice = {
+        "index": 0,
+        "text": "Hello from mock!",
+        "finish_reason": "stop",
+        "token_ids": [10, 11, 12],
+        "prompt_token_ids": [1, 2, 3],
+        "logprobs": {
+            "tokens": ["Hello", " from", " mock!"],
+            "token_logprobs": [-0.5, -0.3, -0.1],
+            "top_logprobs": [{"Hello": -0.5}, {" from": -0.3}, {" mock!": -0.1}],
+        },
+    }
+    choice.update(choice_overrides)
+    return {
+        "id": "cmpl-test",
+        "created": 123,
+        "model": "mock-model",
+        "choices": [choice],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 3},
+    }
+
+
+def test_chat_to_completion_uses_raw_prompt_and_allowlist():
+    parser = FakeParser()
+    converted = _transport(parser).chat_to_completion(_chat_body(), originally_requested_logprobs=False)
+
+    assert converted["prompt"] == "RAW_PROMPT"
+    assert converted["max_tokens"] == 16
+    assert converted["logprobs"] == 1
+    assert converted["return_token_ids"] is True
+    assert converted["add_special_tokens"] is False
+    assert converted["stop_token_ids"] == [123, 999]
+    assert "messages" not in converted
+    assert parser.parse_calls[0]["tools"] == _chat_body()["tools"]
+
+
+def test_chat_to_completion_preserves_top_logprobs_zero():
+    converted = _transport().chat_to_completion(
+        _chat_body(top_logprobs=0),
+        originally_requested_logprobs=True,
+    )
+    assert converted["logprobs"] == 0
+
+
+def test_chat_to_completion_always_requests_sampled_logprobs_for_trace():
+    converted = _transport().chat_to_completion(
+        _chat_body(logprobs=False),
+        originally_requested_logprobs=False,
+    )
+    assert converted["logprobs"] == 1
+
+
+def test_chat_to_completion_rejects_top_logprobs_without_original_logprobs():
+    with pytest.raises(ValueError, match="top_logprobs requires logprobs=true"):
+        _transport().chat_to_completion(
+            _chat_body(top_logprobs=5),
+            originally_requested_logprobs=False,
+        )
+
+
+def test_chat_to_completion_tool_choice_none_omits_tools():
+    parser = FakeParser()
+    _transport(parser).chat_to_completion(
+        _chat_body(tool_choice="none"),
+        originally_requested_logprobs=False,
+    )
+    assert parser.parse_calls[0]["tools"] == []
+
+
+def test_chat_to_completion_rejects_required_tool_choice():
+    with pytest.raises(ValueError, match="tool_choice"):
+        _transport().chat_to_completion(
+            _chat_body(tool_choice="required"),
+            originally_requested_logprobs=False,
+        )
+
+
+def test_completion_to_chat_normalizes_logprobs_and_prompt_ids():
+    parser = FakeParser()
+    chat = _transport(parser).completion_to_chat(_completion_response())
+
+    assert chat["object"] == "chat.completion"
+    assert chat["prompt_token_ids"] == [1, 2, 3]
+    choice = chat["choices"][0]
+    assert choice["message"] == {"role": "assistant", "content": "Hello from mock!"}
+    assert choice["token_ids"] == [10, 11, 12]
+    assert choice["logprobs"]["content"][0]["logprob"] == -0.5
+    assert choice["logprobs"]["content"][0]["top_logprobs"] == [{"token": "Hello", "logprob": -0.5}]
+    assert parser.last_completion_text == "Hello from mock!"
+
+
+def test_completion_to_chat_converts_tool_calls_and_finish_reason():
+    parser = FakeParser()
+    parser.parsed_completion = {
+        "content": "",
+        "reasoning": "",
+        "tool_calls": [SimpleNamespace(name="calculator", arguments={"expression": "1+1"})],
+    }
+
+    chat = _transport(parser).completion_to_chat(_completion_response())
+    choice = chat["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["tool_calls"] == [
+        {
+            "id": "call_0_0",
+            "type": "function",
+            "function": {"name": "calculator", "arguments": '{"expression": "1+1"}'},
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "logprobs",
+    [
+        None,
+        {"tokens": ["Hello"], "token_logprobs": [-0.5]},
+        {"tokens": ["Hello", " from", " mock!"], "token_logprobs": [-0.5, None, -0.1]},
+    ],
+)
+def test_completion_to_chat_requires_dense_logprobs(logprobs):
+    with pytest.raises(ValueError, match="logprobs|None|aligned"):
+        _transport().completion_to_chat(_completion_response(logprobs=logprobs))
+
+
+def test_completion_to_chat_preserves_truncated_mid_tool_as_text():
+    parser = FakeParser()
+    parser.parsed_completion = {
+        "content": '<tool_call>{"name": "calculator"',
+        "reasoning": "",
+        "tool_calls": [],
+    }
+
+    chat = _transport(parser).completion_to_chat(_completion_response(finish_reason="length"))
+    choice = chat["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["content"].startswith("<tool_call>")
+    assert "tool_calls" not in choice["message"]

--- a/rllm-model-gateway/tests/unit/test_server.py
+++ b/rllm-model-gateway/tests/unit/test_server.py
@@ -5,13 +5,15 @@ mock vLLM backend server for proxy tests.
 """
 
 import json
+import logging
 
 import httpx
 import pytest
 import pytest_asyncio
+import rllm_model_gateway.proxy as proxy_mod
 from rllm_model_gateway import GatewayConfig, create_app
 from rllm_model_gateway.models import WorkerConfig, WorkerInfo, _split_worker_url
-from rllm_model_gateway.proxy import ReverseProxy
+from rllm_model_gateway.proxy import ReverseProxy, _RllmParserTransport
 
 from tests.helpers.mock_vllm import MockVLLMServer
 
@@ -245,6 +247,108 @@ class TestProxy:
         choice = data["choices"][0]
         assert "logprobs" in choice, "logprobs should be present when client requested them"
         assert choice["logprobs"]["content"] is not None
+
+
+class _FakeParser:
+    stop_sequences = [999]
+
+    def parse(self, messages, **kwargs):
+        self.parse_kwargs = kwargs
+        return "RAW_PROMPT"
+
+    def parse_completion_text(self, text):
+        return {"content": "Hello from parser!", "reasoning": "", "tool_calls": []}
+
+
+class TestParserTransportProxy:
+    @pytest.fixture
+    def parser_app(self, mock_vllm: MockVLLMServer, monkeypatch):
+        fake_parser = _FakeParser()
+
+        def _make_transport(config):
+            return _RllmParserTransport(config, parser=fake_parser)
+
+        monkeypatch.setattr(proxy_mod, "_RllmParserTransport", _make_transport)
+        config = GatewayConfig(
+            store_worker="memory",
+            workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
+            health_check_interval=999,
+            sync_traces=True,
+            model="Qwen/Qwen3-4B-Instruct-2507",
+            tokenizer_name="Qwen/Qwen3-4B-Instruct-2507",
+            multi_turn_extension=True,
+            accumulate_reasoning=True,
+        )
+        app = create_app(config)
+        app.state.fake_parser = fake_parser
+        return app
+
+    @pytest_asyncio.fixture
+    async def parser_client(self, parser_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=parser_app),
+            base_url="http://testserver",
+        ) as c:
+            yield c
+
+    @pytest.mark.asyncio
+    async def test_parser_transport_forwards_to_completions_and_traces(
+        self,
+        parser_client: httpx.AsyncClient,
+        mock_vllm: MockVLLMServer,
+    ):
+        resp = await parser_client.post(
+            "/sessions/parser-sess/v1/chat/completions",
+            json={
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "tools": [{"type": "function", "function": {"name": "calculator"}}],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["choices"][0]["message"]["content"] == "Hello from parser!"
+
+        upstream = mock_vllm.request_log[-1]
+        assert upstream["_path"] == "/v1/completions"
+        assert upstream["prompt"] == "RAW_PROMPT"
+        assert upstream["add_special_tokens"] is False
+        assert upstream["return_token_ids"] is True
+        assert upstream["logprobs"] == 1
+        assert "messages" not in upstream
+
+        traces_resp = await parser_client.get("/sessions/parser-sess/traces")
+        traces = traces_resp.json()
+        assert len(traces) == 1
+        assert traces[0]["messages"] == [{"role": "user", "content": "hello"}]
+        assert traces[0]["prompt_token_ids"] == [1, 2, 3, 4, 5]
+        assert traces[0]["completion_token_ids"] == [10, 11, 12]
+        assert traces[0]["logprobs"] == [-0.5, -0.3, -0.1]
+
+    def test_local_handler_logs_parser_transport_skip(self, caplog):
+        async def local_handler(body):
+            return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+        caplog.set_level(logging.WARNING)
+        create_app(
+            GatewayConfig(
+                store_worker="memory",
+                multi_turn_extension=True,
+            ),
+            local_handler=local_handler,
+        )
+        assert "gateway parser transport is disabled because local_handler is in use" in caplog.text
+
+    def test_parser_transport_config_requires_reasoning_mode(self, mock_vllm: MockVLLMServer):
+        with pytest.raises(ValueError, match="disable_thinking=true or accumulate_reasoning=true"):
+            create_app(
+                GatewayConfig(
+                    store_worker="memory",
+                    workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
+                    model="Qwen/Qwen3-4B-Instruct-2507",
+                    tokenizer_name="Qwen/Qwen3-4B-Instruct-2507",
+                    multi_turn_extension=True,
+                )
+            )
 
 
 # ------------------------------------------------------------------

--- a/rllm/engine/agent_execution_engine.py
+++ b/rllm/engine/agent_execution_engine.py
@@ -74,6 +74,7 @@ class AgentExecutionEngine:
         self.max_prompt_length = max_prompt_length
         self.enforce_max_prompt_length = enforce_max_prompt_length
         self.disable_thinking = self.config.get("rllm", {}).get("disable_thinking", False) if self.config is not None else False
+        self.multi_turn_extension = self.config.get("rllm", {}).get("multi_turn_extension", False) if self.config is not None else False
 
         self.agent_class = agent_class
         self.agent_args = agent_args
@@ -91,7 +92,7 @@ class AgentExecutionEngine:
             assert env_class.is_multithread_safe(), "Environment must be multithread safe for async engine"
 
         if chat_parser is None:
-            self.chat_parser = ChatTemplateParser.get_parser(self.tokenizer, disable_thinking=self.disable_thinking)
+            self.chat_parser = ChatTemplateParser.get_parser(self.tokenizer, disable_thinking=self.disable_thinking, multi_turn_extension=self.multi_turn_extension)
         else:
             self.chat_parser = chat_parser
 

--- a/rllm/engine/rollout/verl_engine.py
+++ b/rllm/engine/rollout/verl_engine.py
@@ -22,7 +22,13 @@ class VerlEngine(RolloutEngine):
 
         self.tokenizer = tokenizer
         self.processor = processor
-        self.chat_parser = ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=config.get("rllm", {}).get("disable_thinking", False))
+        rllm_config = config.get("rllm", {})
+        self.chat_parser = ChatTemplateParser.get_parser(
+            tokenizer,
+            processor=processor,
+            disable_thinking=rllm_config.get("disable_thinking", False),
+            multi_turn_extension=rllm_config.get("multi_turn_extension", False),
+        )
 
         self.max_prompt_length = config.data.max_prompt_length
         self.max_response_length = config.data.max_response_length

--- a/rllm/experimental/config/rllm/base.yaml
+++ b/rllm/experimental/config/rllm/base.yaml
@@ -80,6 +80,9 @@ disable_thinking: False
 # Accumulate reasoning
 accumulate_reasoning: False
 
+# Preserve raw assistant whitespace when re-rendering multi-turn tool calls
+multi_turn_extension: False
+
 # Mask truncated samples
 mask_truncated_samples: False
 filter_token_mismatch: True

--- a/rllm/experimental/engine/gateway_manager.py
+++ b/rllm/experimental/engine/gateway_manager.py
@@ -78,6 +78,7 @@ class GatewayManager:
     """
 
     def __init__(self, config: DictConfig, mode: str = "thread") -> None:
+        self.config = config
         gw_cfg = config.rllm.get("gateway", {})
         configured_host = gw_cfg.get("host", None)
         self.host: str = configured_host if configured_host else _get_routable_ip()
@@ -87,6 +88,10 @@ class GatewayManager:
         self.sampling_params_priority: str = gw_cfg.get("sampling_params_priority", "client")
         # The gateway always pins ``body.model`` to whatever the trainer is serving
         self.model: str | None = config.get("model", {}).get("name", None)
+        self.tokenizer_name: str | None = gw_cfg.get("tokenizer_name", None)
+        self.multi_turn_extension: bool = bool(config.rllm.get("multi_turn_extension", False))
+        self.disable_thinking: bool = bool(config.rllm.get("disable_thinking", False))
+        self.accumulate_reasoning: bool = bool(config.rllm.get("accumulate_reasoning", False))
         self.mode = mode
 
         self._process: subprocess.Popen | None = None
@@ -127,6 +132,7 @@ class GatewayManager:
         For TinkerEngine: creates an in-process handler (no sidecar needed).
         """
         engine_cls = type(rollout_engine).__name__
+        self._populate_parser_config(rollout_engine)
 
         if engine_cls == "TinkerEngine":
             # In-process handler — no HTTP backend, no worker registration
@@ -135,6 +141,7 @@ class GatewayManager:
             self._local_handler = create_tinker_handler(rollout_engine)
             self._start_thread(local_handler=self._local_handler)
         else:
+            self._validate_parser_config_for_proxy()
             if self.mode == "process":
                 self._start_process()
             else:
@@ -218,6 +225,32 @@ class GatewayManager:
 
     # -- Internal ------------------------------------------------------------
 
+    def _populate_parser_config(self, rollout_engine: RolloutEngine) -> None:
+        if not self.model:
+            actor_rollout_ref = self.config.get("actor_rollout_ref", {})
+            model_cfg = actor_rollout_ref.get("model", {}) if actor_rollout_ref else {}
+            self.model = model_cfg.get("path") or self.config.get("model", {}).get("name", None)
+
+        if self.tokenizer_name:
+            return
+
+        tokenizer = getattr(rollout_engine, "tokenizer", None)
+        self.tokenizer_name = getattr(tokenizer, "name_or_path", None)
+        if self.tokenizer_name:
+            return
+
+        actor_rollout_ref = self.config.get("actor_rollout_ref", {})
+        model_cfg = actor_rollout_ref.get("model", {}) if actor_rollout_ref else {}
+        self.tokenizer_name = model_cfg.get("path") or self.config.get("model", {}).get("name", None)
+
+    def _validate_parser_config_for_proxy(self) -> None:
+        if not self.multi_turn_extension:
+            return
+        if not self.tokenizer_name:
+            raise ValueError("rllm.multi_turn_extension=true requires a tokenizer/model path for gateway parser transport")
+        if not self.disable_thinking and not self.accumulate_reasoning:
+            raise ValueError("rllm.multi_turn_extension=true requires either rllm.disable_thinking=true or rllm.accumulate_reasoning=true")
+
     def _start_process(self) -> None:
         """Launch gateway as a subprocess and poll until healthy."""
         cmd = [
@@ -235,6 +268,14 @@ class GatewayManager:
             cmd.extend(["--sampling-params-priority", self.sampling_params_priority])
         if self.model:
             cmd.extend(["--model", self.model])
+        if self.tokenizer_name:
+            cmd.extend(["--tokenizer-name", self.tokenizer_name])
+        if self.multi_turn_extension:
+            cmd.append("--multi-turn-extension")
+        if self.disable_thinking:
+            cmd.append("--disable-thinking")
+        if self.accumulate_reasoning:
+            cmd.append("--accumulate-reasoning")
 
         logger.info("Starting gateway subprocess: %s", " ".join(cmd))
         # Inherit parent's stdout/stderr so gateway logs are visible for debugging.
@@ -271,6 +312,10 @@ class GatewayManager:
             store_worker="sqlite" if self.db_path else "memory",
             sampling_params_priority=self.sampling_params_priority,
             model=self.model,
+            tokenizer_name=self.tokenizer_name,
+            disable_thinking=self.disable_thinking,
+            accumulate_reasoning=self.accumulate_reasoning,
+            multi_turn_extension=self.multi_turn_extension,
         )
         app = create_app(config=gw_config, local_handler=local_handler)
 

--- a/rllm/experimental/rollout/verl_engine.py
+++ b/rllm/experimental/rollout/verl_engine.py
@@ -28,11 +28,21 @@ class VerlEngine(RolloutEngine):
 
         self.tokenizer = tokenizer
         self.processor = processor
-        self.chat_parser = ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=config.get("rllm", {}).get("disable_thinking", False))
+        rllm_config = config.get("rllm", {})
+        self.disable_thinking = rllm_config.get("disable_thinking", False)
+        self.accumulate_reasoning = rllm_config.get("accumulate_reasoning", False)
+        self.multi_turn_extension = rllm_config.get("multi_turn_extension", False)
+        if self.multi_turn_extension and not self.disable_thinking and not self.accumulate_reasoning:
+            raise ValueError("rllm.multi_turn_extension=true requires either rllm.disable_thinking=true or rllm.accumulate_reasoning=true")
+        self.chat_parser = ChatTemplateParser.get_parser(
+            tokenizer,
+            processor=processor,
+            disable_thinking=self.disable_thinking,
+            multi_turn_extension=self.multi_turn_extension,
+        )
 
         self.max_prompt_length = config.data.max_prompt_length
         self.max_response_length = config.data.max_response_length
-        self.accumulate_reasoning = config.get("rllm", {}).get("accumulate_reasoning", False)
 
         self.train_sampling_params = dict(
             temperature=0.0 if config.actor_rollout_ref.rollout.do_sample is False else config.actor_rollout_ref.rollout.temperature,

--- a/rllm/parser/chat_template_parser.py
+++ b/rllm/parser/chat_template_parser.py
@@ -47,6 +47,9 @@ class ChatTemplateParser:
     def parse_completion(self, completion_ids: list[int]):
         raise NotImplementedError("ChatTemplateParser does not support parse_completion")
 
+    def parse_completion_text(self, completion_text: str):
+        raise NotImplementedError("ChatTemplateParser does not support parse_completion_text")
+
     def verify_equivalence(self, messages, verbose=True):
         """Verify that parsing messages together is equivalent to parsing them individually.
 
@@ -84,13 +87,16 @@ class ChatTemplateParser:
         return is_equivalent
 
     @classmethod
-    def get_parser(cls, tokenizer, processor=None, disable_thinking=False) -> "ChatTemplateParser":
+    def get_parser(cls, tokenizer, processor=None, disable_thinking=False, multi_turn_extension=False) -> "ChatTemplateParser":
         """Factory method to get the appropriate parser based on a string identifier.
 
         Args:
             parser_type (str): String identifier for the parser type
             tokenizer: The tokenizer to use with the parser
             disable_thinking: Whether generation prompt will disable thinking.
+            multi_turn_extension: Whether Qwen-style parsers should preserve
+                assistant content whitespace around tool calls so multi-turn
+                prompts re-render as a byte-identical extension of prior turns.
 
         Returns:
             ChatTemplateParser: An instance of the requested parser
@@ -109,10 +115,10 @@ class ChatTemplateParser:
                     return DeepSeekV32ExpChatTemplateParser(tokenizer, disable_thinking=disable_thinking)
                 else:
                     logger.info(f"Using DeepseekQwenChatTemplateParser for {tokenizer.name_or_path}")
-                    return DeepseekQwenChatTemplateParser(tokenizer, disable_thinking=disable_thinking)
+                    return DeepseekQwenChatTemplateParser(tokenizer, disable_thinking=disable_thinking, multi_turn_extension=multi_turn_extension)
             elif "qwen" in model_name or "r2e" in model_name or "deepswe" in model_name or "qwen" in tokenizer_cls:
                 logger.info(f"Using QwenChatTemplateParser for {tokenizer.name_or_path}")
-                return QwenChatTemplateParser(tokenizer, processor=processor, disable_thinking=disable_thinking)
+                return QwenChatTemplateParser(tokenizer, processor=processor, disable_thinking=disable_thinking, multi_turn_extension=multi_turn_extension)
             elif "llama" in model_name:
                 logger.info(f"Using LlamaChatTemplateParser for {tokenizer.name_or_path}")
                 return LlamaChatTemplateParser(tokenizer)
@@ -185,10 +191,11 @@ class ChatTemplateParser:
 
 
 class DeepseekQwenChatTemplateParser(ChatTemplateParser):
-    def __init__(self, tokenizer, disable_thinking=False):
+    def __init__(self, tokenizer, disable_thinking=False, multi_turn_extension=False):
         super().__init__(tokenizer)
 
         self.disable_thinking = disable_thinking
+        self.multi_turn_extension = multi_turn_extension
         self.bos_token = tokenizer.bos_token
         self.eos_token = tokenizer.eos_token
         self.system_token = ""
@@ -261,7 +268,8 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
         return self.user_token + message["content"]
 
     def parse_assistant(self, message, accumulate_reasoning=False):
-        content = (message.get("content", None) or "").strip()
+        raw_content = message.get("content", None) or ""
+        content = raw_content if self.multi_turn_extension else raw_content.strip()
         reasoning = (message.get("reasoning", None) or "").strip()
         tool_calls = message.get("tool_calls", None) or []
 
@@ -279,7 +287,7 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
 
             if content:
                 result += content
-                if tool_calls:
+                if tool_calls and not self.multi_turn_extension:
                     result += "\n"
 
             if tool_calls:
@@ -337,15 +345,14 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
 
             return self.user_token + tool_outputs_str
 
-    def parse_completion(self, completion_ids):
-        completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=False)
-
+    def parse_completion_text(self, completion_text: str):
         if completion_text.count("</think>") == 1:
             reasoning, _, content = completion_text.partition("</think>")
             if content.endswith(self.eos_token):
                 content = content[: -len(self.eos_token)]
             reasoning = reasoning.strip()
-            content = content.strip()
+            if not self.multi_turn_extension:
+                content = content.strip()
         else:
             # DeepSeekQwen should always have reasoning
             reasoning = completion_text.strip()
@@ -360,7 +367,8 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
             wrapper_end_pattern = re.escape(self.tool_parser.tool_calls_end)
             content = re.sub(f"{begin_pattern}.*?{end_pattern}", "", content, flags=re.DOTALL)
             content = re.sub(f"{wrapper_begin_pattern}.*?{wrapper_end_pattern}", "", content, flags=re.DOTALL)
-            content = content.strip()
+            if not self.multi_turn_extension:
+                content = content.strip()
         else:
             tool_calls = []
 
@@ -370,11 +378,16 @@ class DeepseekQwenChatTemplateParser(ChatTemplateParser):
             "tool_calls": tool_calls,
         }
 
+    def parse_completion(self, completion_ids):
+        completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=False)
+        return self.parse_completion_text(completion_text)
+
 
 class QwenChatTemplateParser(ChatTemplateParser):
-    def __init__(self, tokenizer, processor=None, disable_thinking=False):
+    def __init__(self, tokenizer, processor=None, disable_thinking=False, multi_turn_extension=False):
         super().__init__(tokenizer, processor=processor)
         self.disable_thinking = disable_thinking
+        self.multi_turn_extension = multi_turn_extension
         self.bos_token = tokenizer.bos_token
         self.eos_token = tokenizer.eos_token
         self.eot_token = "<|im_end|>\n"
@@ -455,7 +468,8 @@ class QwenChatTemplateParser(ChatTemplateParser):
         return self.user_token + message["content"] + self.eot_token
 
     def parse_assistant(self, message, accumulate_reasoning=False):
-        content = (message.get("content", None) or "").strip()
+        raw_content = message.get("content", None) or ""
+        content = raw_content if self.multi_turn_extension else raw_content.strip()
         reasoning = (message.get("reasoning", None) or "").strip()
         tool_calls = message.get("tool_calls", None) or []
 
@@ -471,7 +485,7 @@ class QwenChatTemplateParser(ChatTemplateParser):
 
             if content:
                 result += content
-                if tool_calls:
+                if tool_calls and not self.multi_turn_extension:
                     result += "\n"
 
             if tool_calls:
@@ -531,10 +545,9 @@ class QwenChatTemplateParser(ChatTemplateParser):
             text = text[: -len(self.eos_token)]
         if text.endswith(self.eot_token):
             text = text[: -len(self.eot_token)]
-        return text.strip()
+        return text if self.multi_turn_extension else text.strip()
 
-    def parse_completion(self, completion_ids):
-        completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=False)
+    def parse_completion_text(self, completion_text: str):
         if completion_text.count("</think>") == 1:
             reasoning, _, content = completion_text.partition("</think>")
             if reasoning.startswith("<think>"):
@@ -565,7 +578,8 @@ class QwenChatTemplateParser(ChatTemplateParser):
             begin_pattern = re.escape(self.tool_parser.tool_call_begin)
             end_pattern = re.escape(self.tool_parser.tool_call_end)
             content = re.sub(f"{begin_pattern}.*?{end_pattern}", "", content, flags=re.DOTALL)
-            content = content.strip()
+            if not self.multi_turn_extension:
+                content = content.strip()
         else:
             tool_calls = []
 
@@ -574,6 +588,10 @@ class QwenChatTemplateParser(ChatTemplateParser):
             "reasoning": reasoning,
             "tool_calls": tool_calls,
         }
+
+    def parse_completion(self, completion_ids):
+        completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=False)
+        return self.parse_completion_text(completion_text)
 
     def process_image_data(self, messages):
         from qwen_vl_utils import fetch_image

--- a/tests/parser/test_multi_turn_extension.py
+++ b/tests/parser/test_multi_turn_extension.py
@@ -1,0 +1,90 @@
+import json
+
+from rllm.parser import DeepseekQwenChatTemplateParser, QwenChatTemplateParser
+
+
+class DummyQwenTokenizer:
+    name_or_path = "Qwen/Qwen3-4B-Instruct-2507"
+    bos_token = "<|endoftext|>"
+    eos_token = "<|endoftext|>"
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=False):
+        rendered = ""
+        for message in messages:
+            rendered += f"<|im_start|>{message['role']}\n{message.get('content', '')}<|im_end|>\n"
+        if add_generation_prompt:
+            rendered += "<|im_start|>assistant\n"
+        return rendered
+
+
+class DummyDeepseekQwenTokenizer:
+    name_or_path = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+    bos_token = "<｜begin▁of▁sentence｜>"
+    eos_token = "<｜end▁of▁sentence｜>"
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=False):
+        rendered = ""
+        for message in messages:
+            rendered += f"{message.get('content', '')}"
+        if add_generation_prompt:
+            rendered += "<｜Assistant｜>"
+        return rendered
+
+
+def _completion_text(content: str = "Use the calculator."):
+    tool_call = {"name": "calculate", "arguments": {"expression": "1+1"}}
+    return f"{content}<tool_call>\n{json.dumps(tool_call)}\n</tool_call><|im_end|>\n"
+
+
+def test_qwen_multi_turn_extension_preserves_tool_call_prefix():
+    parser = QwenChatTemplateParser(DummyQwenTokenizer(), multi_turn_extension=True)
+    completion = _completion_text()
+    parsed = parser.parse_completion_text(completion)
+
+    rerendered = parser.parse_assistant(parsed, accumulate_reasoning=True)
+
+    assert rerendered == parser.assistant_token + completion
+
+
+def test_qwen_default_render_canonicalizes_tool_call_separator():
+    parser = QwenChatTemplateParser(DummyQwenTokenizer(), multi_turn_extension=False)
+    completion = _completion_text()
+    parsed = parser.parse_completion_text(completion)
+
+    rerendered = parser.parse_assistant(parsed, accumulate_reasoning=True)
+
+    assert rerendered != parser.assistant_token + completion
+    assert "Use the calculator.\n<tool_call>" in rerendered
+
+
+def _deepseek_completion_text(content: str = "Use the calculator."):
+    return (
+        "<think>\nreasoning\n</think>"
+        f"{content}"
+        "<｜tool▁calls▁begin｜>"
+        "\n<｜tool▁call▁begin｜>function<｜tool▁sep｜>calculate\n"
+        "```json\n"
+        '{"expression": "1+1"}\n'
+        "```\n"
+        "<｜tool▁call▁end｜>\n"
+        "<｜tool▁calls▁end｜>"
+        "<｜end▁of▁sentence｜>"
+    )
+
+
+def test_deepseek_qwen_multi_turn_extension_preserves_tool_call_separator():
+    parser = DeepseekQwenChatTemplateParser(DummyDeepseekQwenTokenizer(), multi_turn_extension=True)
+    parsed = parser.parse_completion_text(_deepseek_completion_text())
+
+    rerendered = parser.parse_assistant(parsed, accumulate_reasoning=True)
+
+    assert "Use the calculator.<｜tool▁calls▁begin｜>" in rerendered
+
+
+def test_deepseek_qwen_default_render_canonicalizes_tool_call_separator():
+    parser = DeepseekQwenChatTemplateParser(DummyDeepseekQwenTokenizer(), multi_turn_extension=False)
+    parsed = parser.parse_completion_text(_deepseek_completion_text())
+
+    rerendered = parser.parse_assistant(parsed, accumulate_reasoning=True)
+
+    assert "Use the calculator.\n<｜tool▁calls▁begin｜>" in rerendered


### PR DESCRIPTION
## Summary

This PR adds `rllm.multi_turn_extension` support for Qwen 3 multi-turn tool-calling rollouts through the verl gateway path. When enabled, the gateway renders chat prompts with rLLM's chat template parser and forwards raw text to vLLM's `/v1/completions`, avoiding vLLM chat-template canonicalization that breaks prefix-extension checks. Qwen 3 and Deepseek-Qwen parsers now preserve model-emitted assistant whitespace around tool calls so replayed turns remain byte-identical. This is not an issue for Qwen 3.5 and Qwen 3 coder models, which use `qwen3_coder` and `qwen3_xml` parsers. This is an issue with the `hermes` parser.

## Type of change

- [x] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [x] Example / Project
- [ ] Infra / CI

## What changed

- Added parser-backed gateway transport for `multi_turn_extension=true`, converting chat-completions requests to raw-text completions while preserving trace token ids and logprobs.
- Threaded `multi_turn_extension`, tokenizer name, thinking mode, and accumulated reasoning config through the gateway and verl rollout setup.
- Updated Qwen and Deepseek-Qwen parser rendering/parsing so tool-call turns can preserve model-emitted whitespace.
- Made `cookbooks/math_tool_agent/train_verl.sh` default to `MULTI_TURN_EXTENSION=true` with legacy vLLM tool parsing only when disabled.
- Added focused parser and gateway tests for raw-text transport, logprob normalization, tool-call finish reasons, and Qwen/Deepseek-Qwen whitespace behavior.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `PYTHONPATH=. uv run --no-project --with pytest python -m pytest tests/parser/test_multi_turn_extension.py -q` passed: `4 passed`.
- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-asyncio --with fastapi --with uvicorn --with httpx --with 'pydantic>=2' --with aiosqlite --with PyYAML python -m pytest tests/unit/test_parser_transport.py tests/unit/test_server.py -q` passed: `60 passed, 2 warnings`.
- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-asyncio --with fastapi --with uvicorn --with httpx --with 'pydantic>=2' --with aiosqlite --with PyYAML python -m pytest tests/unit/ -q` passed: `186 passed, 2 warnings`.
- `uv run --no-project --with ruff ruff check ...` passed on changed Python files.
- `python -m compileall -q ...`, `bash -n cookbooks/math_tool_agent/train_verl.sh`, and `git diff --check` passed.

## Breaking changes / migration notes

- Adds `rllm.multi_turn_extension`, defaulting to `False` in base config.
- For `multi_turn_extension=true`, gateway parser transport requires a tokenizer/model path and either `rllm.disable_thinking=true` or `rllm.accumulate_reasoning=true`.
- Streaming, `n>1`, multimodal chat content, and required tool-choice enforcement are not supported by the v1 parser transport path.

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [x] Updated examples
- [x] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

N/A