### PR TITLE
fix(verl): build transform attention masks from sequence lengths

### DIFF
--- a/rllm/experimental/verl/transform.py
+++ b/rllm/experimental/verl/transform.py
@@ -37,17 +37,25 @@ def _pad_sequence_batch(sequences: list[torch.Tensor], pad_token_id: int, max_le
     return batch
 
 
-def _retrieve_batch_attention_masks(batch: torch.Tensor, pad_token_id: int, max_length: int) -> torch.Tensor:
-    """Retrieves the attention masks for a batch of prompts/responses.
+def _build_attention_masks_from_lengths(sequences: list[torch.Tensor], max_length: int, left_pad: bool) -> torch.Tensor:
+    """Builds attention masks from sequence lengths, not token values.
 
-    Note that in original implementation, this operation is padding-aware, i.e. it has DIFFERENT behavior for left-pad (prompts)
-    and right-pad (responses) sequences. This is to ensure compatibility with the `input_ids` constructed with results from function `_pad_sequence_batch`.
-
-    The current version simply uses the constructed `promits_batch` (`responses_batch`) instead of the original `prompts` (`responses`) lengths.
+    Args:
+        sequences: List of unpadded sequences.
+        max_length: The maximum length to pad to.
+        left_pad: Whether the corresponding padded batch is left-padded.
+    Returns:
+        torch.Tensor: The attention masks matching the padded sequences.
     """
-    assert len(batch.shape) == 2, f"batch must be a 2D tensor, but got {batch.shape}"
-    assert batch.shape[1] == max_length, f"input batch must have been padded to {max_length}, but got {batch.shape[1]}"
-    return batch != pad_token_id
+    device = sequences[0].device if sequences else torch.device("cpu")
+    mask = torch.zeros((len(sequences), max_length), dtype=torch.bool, device=device)
+    for i, sequence in enumerate(sequences):
+        seq_len = min(len(sequence), max_length)
+        if left_pad:
+            mask[i, max_length - seq_len :] = True
+        else:
+            mask[i, :seq_len] = True
+    return mask
 
 
 def _build_step_and_trajectory_rewards(step_rewards: list[float], trajectory_rewards: list[float], responses_batch: torch.Tensor, responses: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
@@ -147,8 +155,8 @@ def _batch_tensors_and_build_data_proto(accumulated: AccumulatedData, pad_token_
     responses_batch = _pad_sequence_batch(accumulated.responses, pad_token_id, max_response_length, left_pad=False)  # shape: [bs, max_response_length]
     input_ids = torch.concat([prompts_batch, responses_batch], dim=1)  # shape: [bs, max_prompt_length + max_response_length]
 
-    prompts_mask = _retrieve_batch_attention_masks(prompts_batch, pad_token_id, max_prompt_length)
-    responses_mask = _retrieve_batch_attention_masks(responses_batch, pad_token_id, max_response_length)
+    prompts_mask = _build_attention_masks_from_lengths(accumulated.prompts, max_prompt_length, left_pad=True)
+    responses_mask = _build_attention_masks_from_lengths(accumulated.responses, max_response_length, left_pad=False)
     attention_mask = torch.concat([prompts_mask, responses_mask], dim=1)  # shape: [bs, max_prompt_length + max_response_length]
 
     # Handle position_ids: use multimodal handler if processor is available

--- a/tests/unified_trainer/test_verl_transform.py
+++ b/tests/unified_trainer/test_verl_transform.py
@@ -187,3 +187,20 @@ class TestRolloutLogProbsPropagation:
         # All standard fields should still be present
         for key in ["input_ids", "attention_mask", "position_ids", "prompts", "responses", "response_mask", "traj_rewards", "step_rewards"]:
             assert key in batch.batch, f"Standard field '{key}' should be present"
+
+
+class TestAttentionMaskConstruction:
+    def test_attention_mask_uses_lengths_not_pad_token_values(self):
+        """Real pad_token_id tokens inside a sequence should remain attended."""
+        episodes = [
+            _make_episode(
+                prompt_ids=[11, 0, 12],
+                completion_ids=[0, 13],
+            )
+        ]
+        engine = _make_mock_rollout_engine(pad_token_id=0)
+
+        batch = transform_episodes_to_dataproto(episodes, engine, max_prompt_length=5, max_response_length=4)
+
+        assert batch.batch["input_ids"][0].tolist() == [0, 0, 11, 0, 12, 0, 13, 0, 0]
+        assert batch.batch["attention_mask"][0].tolist() == [False, False, True, True, True, True, True, False, False]


### PR DESCRIPTION
## Summary

This PR makes verl transform attention-mask construction derive from sequence lengths rather than token values. `_pad_sequence_batch` already determines where padding is inserted: prompts are left-padded and responses are right-padded. The attention mask should mirror that padding layout directly. The previous `batch != pad_token_id` shortcut is equivalent in the common case, but it relies on the tokenizer-specific invariant that `pad_token_id` only appears in padded positions; length-based masking removes that unnecessary assumption.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Replaced value-based attention-mask construction in `rllm/experimental/verl/transform.py` with length-based mask construction.
- Preserved existing prompt left-padding and response right-padding behavior.
- Added a synthetic regression test showing mask construction follows sequence length rather than token value.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `uv run --no-project --with pytest python -m pytest tests/unified_trainer/test_verl_transform.py -q` passed: `7 passed, 1 warning`.
- `uv run --no-project --with pre-commit pre-commit run ruff-format --files rllm/experimental/verl/transform.py tests/unified_trainer/test_verl_transform.py` passed.
- `uv run --no-project --with pre-commit pre-commit run ruff --files rllm/experimental/verl/transform.py tests/unified_trainer/test_verl_transform.py` passed.
- `git diff --check` passed.

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs
