### PR TITLE
fix(config): various config fixes for unified trainer

### DIFF
--- a/rllm/experimental/common/config.py
+++ b/rllm/experimental/common/config.py
@@ -39,6 +39,10 @@ class AsyncTrainingConfig:
             assert self.fwd_bwd_group_size >= 1
             assert self.mini_batch_size % self.fwd_bwd_group_size == 0, f"mini_batch_size ({self.mini_batch_size}) must be divisible by fwd_bwd_group_size ({self.fwd_bwd_group_size})"
 
+    @classmethod
+    def from_config(cls, config: DictConfig) -> "AsyncTrainingConfig":
+        return cls(**OmegaConf.to_container(config))  # type: ignore
+
 
 @dataclass
 class CompactFilteringConfig:
@@ -146,7 +150,7 @@ class RolloutCorrectionConfig:
     """
 
     tis_mode: str | None = None
-    bypass_mode: bool = True
+    bypass_mode: bool | None = None
     tis_cap: float = 5.0
 
 
@@ -219,8 +223,8 @@ class AlgorithmConfig:
         rc_section = config.rllm.algorithm.get("rollout_correction", {})
         rollout_correction = RolloutCorrectionConfig(
             tis_mode=rc_section.get("tis_mode", None),
-            bypass_mode=rc_section.get("bypass_mode", True),
-            tis_cap=rc_section.get("tis_cap", 5.0),
+            bypass_mode=rc_section.get("bypass_mode", None),
+            tis_cap=rc_section.get("tis_cap", 2.0),
         )
         return cls(
             estimator=rLLMAdvantageEstimator(config.algorithm.adv_estimator),

--- a/rllm/experimental/config/rllm/backend/tinker.yaml
+++ b/rllm/experimental/config/rllm/backend/tinker.yaml
@@ -88,3 +88,6 @@ rllm:
   rollout:
     n: ${oc.select:training.group_size, 8}
     n_val: ${oc.select:validation.group_size, 1}
+  algorithm:
+    rollout_correction:
+      bypass_mode: True

--- a/rllm/experimental/config/rllm/backend/verl.yaml
+++ b/rllm/experimental/config/rllm/backend/verl.yaml
@@ -48,6 +48,8 @@ rllm:
     gamma: ${oc.select:algorithm.gamma, 1.0}
     lam: ${oc.select:algorithm.lam, 0.95}
     norm_adv_by_std_in_grpo: ${oc.select:algorithm.norm_adv_by_std_in_grpo, true}
+    rollout_correction:
+      bypass_mode: False
 
   rollout:
     n: ${oc.select:actor_rollout_ref.rollout.n, 8}

--- a/rllm/experimental/config/rllm/base.yaml
+++ b/rllm/experimental/config/rllm/base.yaml
@@ -63,9 +63,9 @@ algorithm:
   eps_clip_high: null     # Asymmetric upper clip bound (null = symmetric)
   router_replay: false    # Router Replay (R3): replay MoE expert routing from inference during training
   rollout_correction:
-    bypass_mode: true     # true = use rollout logprobs as pi_old (2-policy), false = proximal forward (3-policy)
+    bypass_mode: null     # true = pi_old = pi_rollout, false = pi_old is computed (null = backend default)
     tis_mode: null        # null = disabled, "token" or "sequence" = TIS importance sampling level
-    tis_cap: 5.0          # Upper clamp on TIS importance weight
+    tis_cap: 2.0          # Upper clamp on TIS importance weight
 
 # Stepwise advantage
 # TODO(listar2000): deprecate the `per_step` mode and refactor this config.
@@ -176,11 +176,11 @@ gateway:
 # Async Training Configuration
 async_training:
   enable: false
-  mini_batch_size: 1
+  mini_batch_size: 64
   fwd_bwd_group_size: null  # task batches per forward-backward pass (default: mini_batch_size)
   staleness_threshold: 0.0
   trigger_parameter_sync_step: 1
-  partial_rollout: true
+  partial_rollout: false
   episode_offload_dir: null       # NVMe offload dir for pending episodes (null = disabled)
   trajectory_group_offload_dir: null  # NVMe offload dir for queued task batches (null = disabled)
 

--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -149,16 +149,7 @@ class UnifiedTrainer:
         self._validate_and_setup_configs()
         self._setup_logging()
 
-        # Async training config
-        async_cfg = self.rllm_config.get("async_training", {})
-        self.async_config = AsyncTrainingConfig(
-            enable=async_cfg.get("enable", False),
-            mini_batch_size=async_cfg.get("mini_batch_size", 1),
-            fwd_bwd_group_size=async_cfg.get("fwd_bwd_group_size", 1),
-            staleness_threshold=async_cfg.get("staleness_threshold", 0.0),
-            trigger_parameter_sync_step=async_cfg.get("trigger_parameter_sync_step", 1),
-            partial_rollout=async_cfg.get("partial_rollout", True),
-        )
+        self.async_config = AsyncTrainingConfig.from_config(self.rllm_config.get("async_training", {}))
 
         rollout_engine: RolloutEngine = self.backend.init_rollout_engine(
             cf_config=self.cf_config,


### PR DESCRIPTION
## Summary
Fixes various config related items for unified trainer.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Move bypass_mode default into backend yamls (tinker=True, verl=False); base.yaml becomes null = "use backend default"
- Lower tis_cap default 5.0 → 2.0
- Async training defaults: mini_batch_size 1 → 64, partial_rollout true → false
- Add AsyncTrainingConfig.from_config() factory and use it from UnifiedTrainer

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
