### PR TITLE
fix(ray): merge ray job submit runtime_env with rllm defaults

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,7 +89,8 @@
             "group": "Guides",
             "pages": [
               "guides/customizing-training",
-              "guides/distributed-training"
+              "guides/distributed-training",
+              "guides/ray-runtime-env"
             ]
           },
           {

--- a/docs/guides/ray-runtime-env.mdx
+++ b/docs/guides/ray-runtime-env.mdx
@@ -1,0 +1,115 @@
+---
+title: Ray runtime environment
+description: How rLLM builds the Ray runtime_env that controls environment variables on training workers, and how to override it
+---
+
+When rLLM launches verl training, it calls `ray.init()` with a `runtime_env` that controls which environment variables every Ray worker sees. This page describes what `get_ppo_ray_runtime_env()` puts in that dict, the precedence order between rLLM defaults, your shell, and `ray job submit --runtime-env-json`, and the knobs you have for overriding each layer.
+
+## Precedence
+
+`get_ppo_ray_runtime_env()` composes the runtime env from three layers. Higher layers win on key conflicts.
+
+| Priority | Source | Where it comes from |
+| -------- | ------ | ------------------- |
+| 1 (low) | rLLM defaults | `PPO_RAY_RUNTIME_ENV` in `rllm/trainer/verl/ray_runtime_env.py` |
+| 2 | Forwarded host env | Variables in your shell whose names match a `FORWARD_PREFIXES` entry |
+| 3 (high) | Job-submit runtime env | `runtime_env` field of `--runtime-env-json` passed to `ray job submit` |
+
+The first two layers are merged inside `get_ppo_ray_runtime_env()` itself: the host-forwarded vars overwrite the rLLM defaults via a plain `dict.update`. The third layer is honored by Ray's own merge inside `ray.init()`. To make that merge behave as a proper override (instead of raising on a key conflict), rLLM pops every key the job config sets from the dict it returns, so the job config's value is the one that survives.
+
+<Note>
+  This is the contract as of [PR #521](https://github.com/rllm-org/rllm/pull/521). Earlier versions did not look at the job-submit runtime env at all, so a `ray job submit --runtime-env-json=...` invocation could collide with rLLM's defaults and fail.
+</Note>
+
+## Default environment variables
+
+These are the values rLLM sets at the lowest priority. Anything you forward from your shell or specify in `--runtime-env-json` will override them.
+
+```python
+PPO_RAY_RUNTIME_ENV = {
+    "env_vars": {
+        "TOKENIZERS_PARALLELISM": "true",
+        "NCCL_DEBUG": "WARN",
+        "VLLM_LOGGING_LEVEL": "WARN",
+        "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        "VLLM_DISABLE_COMPILE_CACHE": "1",
+        "NCCL_CUMEM_ENABLE": "0",
+    },
+}
+```
+
+The last two are present to work around known issues — vLLM's compile cache corruption ([vllm-project/vllm#31199](https://github.com/vllm-project/vllm/issues/31199)) and a hang during weight sync in disaggregated mode. Override them with care.
+
+## Forwarding from your shell
+
+Any variable in your shell whose name starts with one of these prefixes is forwarded to workers automatically:
+
+| Category | Prefixes |
+| -------- | -------- |
+| Inference engines | `VLLM_`, `SGL_`, `SGLANG_` |
+| HuggingFace | `HF_`, `TOKENIZERS_`, `DATASETS_` |
+| Training frameworks | `TORCH_`, `PYTORCH_`, `DEEPSPEED_`, `MEGATRON_` |
+| CUDA / NCCL | `NCCL_`, `CUDA_`, `CUBLAS_`, `CUDNN_`, `NV_`, `NVIDIA_` |
+
+So, to bump vLLM's logging level for a single run, you can just export it before launching training:
+
+```bash
+export VLLM_LOGGING_LEVEL=DEBUG
+export NCCL_DEBUG=INFO
+python train.py ...
+```
+
+Both values will overwrite rLLM's defaults (`WARN`) on every worker.
+
+## Suppressing forwarding with `RLLM_EXCLUDE`
+
+`RLLM_EXCLUDE` is a comma-separated list that opts variables out of the host-forwarding step. Two forms are supported:
+
+<CodeGroup>
+```bash Specific variables
+export RLLM_EXCLUDE="CUDA_VISIBLE_DEVICES,HF_TOKEN"
+```
+
+```bash Whole prefixes
+export RLLM_EXCLUDE="VLLM*,CUDA*,NCCL_IB_DISABLE"
+```
+</CodeGroup>
+
+A value containing `*` removes the corresponding entry from the forward-prefix list (so `VLLM*` drops the `VLLM_` prefix entirely). Values without `*` are matched against full variable names and excluded individually. The two forms can be combined.
+
+<Tip>
+  Reach for `RLLM_EXCLUDE` when a host variable is leaking into workers and breaking them — a stray `CUDA_VISIBLE_DEVICES` from your launcher is the classic case. It only affects the host-forwarding layer; the rLLM defaults and any `--runtime-env-json` keys are untouched.
+</Tip>
+
+## Overriding with `ray job submit`
+
+If you launch training via `ray job submit`, the `runtime_env` field of `--runtime-env-json` wins over both rLLM defaults and host-forwarded vars. This is the right escape hatch when you need a different value on the cluster than on the submitting node.
+
+```bash
+ray job submit \
+  --runtime-env-json='{
+    "env_vars": {
+      "NCCL_DEBUG": "INFO",
+      "VLLM_LOGGING_LEVEL": "DEBUG"
+    },
+    "working_dir": "."
+  }' \
+  -- python train.py ...
+```
+
+`get_ppo_ray_runtime_env()` reads this dict from `RAY_JOB_CONFIG_JSON_ENV_VAR` (which the Ray job runtime sets for you), pops the listed keys from its own `env_vars` so they cannot collide, and only sets `working_dir=None` when the job config does not specify a `working_dir`. Without that handling Ray's `ray.init()` would refuse to merge and raise unless you also exported `RAY_OVERRIDE_JOB_RUNTIME_ENV=1`.
+
+## Programmatic access
+
+`AgentTrainer` calls `get_ppo_ray_runtime_env()` for you. If you need the same dict for a custom Ray actor, import it directly:
+
+```python
+import ray
+from rllm.trainer.verl.ray_runtime_env import get_ppo_ray_runtime_env
+
+runtime_env = get_ppo_ray_runtime_env()
+ray.init(runtime_env=runtime_env)
+```
+
+The returned dict always contains an `env_vars` key. It contains a `working_dir` key only when no job-submit `working_dir` is in effect.

--- a/rllm/trainer/verl/ray_runtime_env.py
+++ b/rllm/trainer/verl/ray_runtime_env.py
@@ -1,4 +1,7 @@
+import json
 import os
+
+from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
 
 PPO_RAY_RUNTIME_ENV = {
     "env_vars": {
@@ -70,6 +73,33 @@ def _get_forwarded_env_vars():
 
 
 def get_ppo_ray_runtime_env():
+    """Build the runtime_env to pass to ray.init().
+
+    Priority (low → high):
+      1. PPO_RAY_RUNTIME_ENV — rllm defaults
+      2. forwarded host env vars (VLLM_*, NCCL_*, CUDA_*, etc.)
+      3. RAY_JOB_CONFIG_JSON_ENV_VAR — runtime_env from `ray job submit --runtime-env-json=...`
+
+    Ray's ray.init() will merge the runtime_env we return here with the job config's
+    runtime_env, and raises on any key conflict unless RAY_OVERRIDE_JOB_RUNTIME_ENV=1.
+    We avoid that by popping any key the job config sets from our returned dict, so
+    the job config's value wins.
+    """
     env = PPO_RAY_RUNTIME_ENV.get("env_vars", {}).copy()
     env.update(_get_forwarded_env_vars())
-    return {"env_vars": env}
+
+    # Parse the job-submission runtime_env (if launched via `ray job submit`)
+    try:
+        job_runtime_env = json.loads(os.environ.get(RAY_JOB_CONFIG_JSON_ENV_VAR, "{}")).get("runtime_env", {}) or {}
+    except (json.JSONDecodeError, TypeError):
+        job_runtime_env = {}
+
+    # Pop keys that the job config sets — let the job config's values win during ray.init merge
+    for key in job_runtime_env.get("env_vars", {}) or {}:
+        env.pop(key, None)
+
+    runtime_env = {"env_vars": env}
+    # Only set working_dir=None when the job config doesn't specify one (avoid merge conflict)
+    if job_runtime_env.get("working_dir") is None:
+        runtime_env["working_dir"] = None
+    return runtime_env

--- a/tests/trainer/verl/test_ray_runtime_env.py
+++ b/tests/trainer/verl/test_ray_runtime_env.py
@@ -1,7 +1,10 @@
+import json
 import os
 from unittest.mock import patch
 
-from rllm.trainer.verl.ray_runtime_env import _get_forwarded_env_vars
+from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
+
+from rllm.trainer.verl.ray_runtime_env import _get_forwarded_env_vars, get_ppo_ray_runtime_env
 
 
 def test_forward_basic_env_vars():
@@ -237,3 +240,58 @@ def test_edge_case_exact_prefix():
     # Variables with suffixes should be forwarded
     assert "VLLM_WITH_SUFFIX" in forwarded
     assert "NCCL_DEBUG" in forwarded
+
+
+# ---------------------------------------------------------------------------
+# get_ppo_ray_runtime_env: job-config merge behavior
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_env_no_job_config():
+    """No `ray job submit` context → returns rllm defaults + working_dir=None."""
+    with patch.dict(os.environ, {}, clear=True):
+        runtime_env = get_ppo_ray_runtime_env()
+
+    assert "env_vars" in runtime_env
+    assert runtime_env["env_vars"]["TOKENIZERS_PARALLELISM"] == "true"
+    assert runtime_env["env_vars"]["NCCL_DEBUG"] == "WARN"
+    assert runtime_env["working_dir"] is None
+
+
+def test_runtime_env_pops_keys_from_job_config():
+    """Keys present in the job config's env_vars are popped from rllm's defaults."""
+    job_config = {
+        "runtime_env": {
+            "env_vars": {
+                "NCCL_DEBUG": "INFO",  # overrides rllm default WARN
+                "VLLM_LOGGING_LEVEL": "DEBUG",
+            }
+        }
+    }
+    with patch.dict(os.environ, {RAY_JOB_CONFIG_JSON_ENV_VAR: json.dumps(job_config)}, clear=True):
+        runtime_env = get_ppo_ray_runtime_env()
+
+    # Job-config-set keys are popped from our returned dict (so the job config wins during ray.init merge)
+    assert "NCCL_DEBUG" not in runtime_env["env_vars"]
+    assert "VLLM_LOGGING_LEVEL" not in runtime_env["env_vars"]
+    # Other rllm defaults remain
+    assert runtime_env["env_vars"]["TOKENIZERS_PARALLELISM"] == "true"
+    assert runtime_env["env_vars"]["CUDA_DEVICE_MAX_CONNECTIONS"] == "1"
+
+
+def test_runtime_env_skips_working_dir_when_job_sets_one():
+    """working_dir=None is only added when the job config doesn't specify one."""
+    job_config = {"runtime_env": {"working_dir": "/some/path"}}
+    with patch.dict(os.environ, {RAY_JOB_CONFIG_JSON_ENV_VAR: json.dumps(job_config)}, clear=True):
+        runtime_env = get_ppo_ray_runtime_env()
+
+    assert "working_dir" not in runtime_env
+
+
+def test_runtime_env_handles_invalid_job_config_json():
+    """Malformed job-config JSON is silently ignored — falls back to rllm defaults."""
+    with patch.dict(os.environ, {RAY_JOB_CONFIG_JSON_ENV_VAR: "not-json"}, clear=True):
+        runtime_env = get_ppo_ray_runtime_env()
+
+    assert runtime_env["env_vars"]["TOKENIZERS_PARALLELISM"] == "true"
+    assert runtime_env["working_dir"] is None


### PR DESCRIPTION
Update the runtime_env we hand to `ray.init()` so it composes cleanly with `ray job submit --runtime-env-json=...` instead of colliding on shared keys (`NCCL_DEBUG`, `VLLM_LOGGING_LEVEL`, `working_dir`, ...).

## Summary

`get_ppo_ray_runtime_env()` previously returned only rLLM defaults plus host-forwarded env vars. When the same training script was launched via `ray job submit --runtime-env-json=...`, Ray's own merge inside `ray.init()` would raise on any key that appeared in both dicts unless the user exported `RAY_OVERRIDE_JOB_RUNTIME_ENV=1`. This made the obvious workflow ("set `NCCL_DEBUG=INFO` for one cluster run") fail in confusing ways. This PR pins down a single precedence contract — rLLM defaults < host-forwarded < job-submit — and pre-empts the collision by popping any key the job config sets from the dict we return.

## Type of change

- [ ] Feature
- [x] Fix
- [x] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- `get_ppo_ray_runtime_env()` now reads `RAY_JOB_CONFIG_JSON_ENV_VAR` and pops every `env_vars` key the job config sets, so Ray's `ray.init()` merge sees no conflicts and the job-submit value wins.
- `working_dir=None` is only added when the job config does not set one (avoids the same merge conflict on `working_dir`).
- Malformed job-config JSON is tolerated — falls back to the previous behavior instead of raising.
- Tests cover: no job config, key-pop on overlap, `working_dir` skip, and invalid JSON.
- New docs page `docs/guides/ray-runtime-env.mdx` (added to the `Guides` group in `docs.json`) writes down the precedence contract and the override paths.

## Validation

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest tests/trainer/verl/test_ray_runtime_env.py`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Existing forwarding tests still pass; four new tests added for the job-submit merge cases.
- `mint broken-links` clean for the new docs page.

## Breaking changes / migration notes

- None for users who do not launch via `ray job submit`. For users who do, a `--runtime-env-json` `env_vars` entry now silently overrides the matching rLLM default instead of failing the job — this is the intended behavior and the previously-needed `RAY_OVERRIDE_JOB_RUNTIME_ENV=1` workaround is no longer required.

## Docs / examples

- [ ] Not needed
- [x] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

Includes new page `docs/guides/ray-runtime-env.mdx` covering the precedence contract, default env vars, forward prefixes, `RLLM_EXCLUDE`, and the `ray job submit --runtime-env-json` override path. Wired into the `Guides` group in `docs/docs.json`.

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

n/a