### PR TITLE
feat: Let AgentFlow use is_validation and preserve TerminationReason in metrics

### DIFF
--- a/rllm/experimental/engine/agent_flow_engine.py
+++ b/rllm/experimental/engine/agent_flow_engine.py
@@ -231,6 +231,7 @@ class AgentFlowEngine:
             base_url=session_url,
             model=self.model,
             session_uid=uid,
+            is_validation=is_validation,
         )
 
         # 3. Run agent flow (prefers arun if available, else run in executor)
@@ -276,7 +277,8 @@ class AgentFlowEngine:
         for signal in eval_output.signals:
             enriched.metrics[signal.name] = signal.value
 
-        enriched.termination_reason = TerminationReason.ENV_DONE
+        if enriched.termination_reason is None:
+            enriched.termination_reason = TerminationReason.ENV_DONE
         return enriched
 
     def _enrich_episode(

--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -808,7 +808,8 @@ class UnifiedTrainer:
     # =========================================================================
     # Helper functions
     # =========================================================================
-    def _collect_workflow_metrics_from_episodes(self, episodes: list[Episode]) -> tuple[dict, Counter]:
+    @staticmethod
+    def _collect_workflow_metrics_from_episodes(episodes: list[Episode]) -> tuple[dict, Counter]:
         workflow_metrics = defaultdict(list)
         termination_counts = Counter()
         for episode in episodes:

--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -418,6 +418,12 @@ class UnifiedTrainer:
             return
 
         workflow_metrics, termination_counts = self._collect_workflow_metrics_from_episodes(trainer_state.episodes)
+        for key, value in workflow_metrics.items():
+            trainer_state.metrics[f"batch/{key}"] = np.mean(value)
+
+        total_counts = max(sum(termination_counts.values()), 1)
+        for r in TerminationReason:
+            trainer_state.metrics[f"batch/termination_reason/{r.value}"] = termination_counts[r.value] / total_counts
 
         # stage 2: transform episodes to trajectory groups (sync)
         trajectory_groups, transform_metrics = transform_episodes_to_trajectory_groups(trainer_state.episodes, self.transform_config, self.cf_config, traj_grouping_hook=self.traj_grouping_hook)
@@ -460,13 +466,6 @@ class UnifiedTrainer:
                 max_steps_to_visualize=2,
                 show_workflow_metadata=True,
             )
-
-        for key, value in workflow_metrics.items():
-            trainer_state.metrics[f"batch/{key}"] = np.mean(value)
-
-        total_counts = max(sum(termination_counts.values()), 1)
-        for r in TerminationReason:
-            trainer_state.metrics[f"batch/termination_reason/{r.value}"] = termination_counts[r.value] / total_counts
 
     # =========================================================================
     # Fully-asynchronous training pipeline
@@ -815,8 +814,8 @@ class UnifiedTrainer:
         for episode in episodes:
             for k, v in episode.metrics.items():
                 workflow_metrics[k].append(v)
-            if episode.termination_reason is not None:
-                termination_counts[episode.termination_reason.value] += 1
+            reason = episode.termination_reason or TerminationReason.UNKNOWN
+            termination_counts[getattr(reason, "value", reason)] += 1
         # reduce the metrics to a scalar value, with error handling
         reduced_workflow_metrics = {}
         for k, v in workflow_metrics.items():

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -144,6 +144,7 @@ class AgentConfig:
     model: str
     session_uid: str
     metadata: dict = field(default_factory=dict)
+    is_validation: bool = False
 
 
 @runtime_checkable

--- a/tests/engine/test_agent_flow_engine.py
+++ b/tests/engine/test_agent_flow_engine.py
@@ -1,0 +1,65 @@
+import asyncio
+
+from rllm.agents.agent import Episode, Trajectory
+from rllm.eval.types import EvalOutput
+from rllm.experimental.engine.agent_flow_engine import AgentFlowEngine
+from rllm.workflows.workflow import TerminationReason
+
+
+class _Agent:
+    def __init__(self):
+        self.config = None
+
+    async def arun(self, task, config):
+        self.config = config
+        return Episode(
+            id=task.id,
+            termination_reason=TerminationReason.ERROR,
+            trajectories=[Trajectory(name="solver")],
+        )
+
+
+class _Evaluator:
+    def evaluate(self, task, episode):
+        return EvalOutput(reward=0.0, is_correct=False)
+
+
+class _Gateway:
+    def __init__(self):
+        self.created = None
+        self.deleted = None
+
+    async def acreate_session(self, session_id, is_validation=False):
+        self.created = (session_id, is_validation)
+
+    def get_session_url(self, session_id):
+        return f"http://gateway/{session_id}"
+
+    async def aget_traces(self, session_id):
+        return []
+
+    async def adelete_session(self, session_id):
+        self.deleted = session_id
+
+
+def test_run_single_passes_validation_flag_and_preserves_termination_reason():
+    agent = _Agent()
+    gateway = _Gateway()
+    engine = AgentFlowEngine(
+        agent_flow=agent,
+        evaluator=_Evaluator(),
+        gateway=gateway,
+        model="test-model",
+        n_parallel_tasks=1,
+    )
+
+    try:
+        episode = asyncio.run(engine._run_single({"question": "q"}, "task:0", is_validation=True))
+    finally:
+        engine.shutdown()
+
+    assert gateway.created == ("task:0", True)
+    assert gateway.deleted == "task:0"
+    assert agent.config.is_validation is True
+    assert agent.config.session_uid == "task:0"
+    assert episode.termination_reason == TerminationReason.ERROR

--- a/tests/eval/test_eval_types.py
+++ b/tests/eval/test_eval_types.py
@@ -188,6 +188,7 @@ class TestF1Evaluator:
 def test_agent_config_defaults():
     config = AgentConfig(base_url="http://localhost:8000", model="test-model", session_uid="s1")
     assert config.metadata == {}
+    assert config.is_validation is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unified_trainer/test_termination_metrics.py
+++ b/tests/unified_trainer/test_termination_metrics.py
@@ -1,48 +1,16 @@
-import asyncio
-
-import rllm.experimental.unified_trainer as unified_trainer
 from rllm.agents.agent import Episode
-from rllm.experimental.unified_trainer import TrainerState, UnifiedTrainer
+from rllm.experimental.unified_trainer import UnifiedTrainer
 from rllm.workflows.workflow import TerminationReason
 
 
-class _WorkflowEngine:
-    def set_training_step(self, step, mode="train", epoch=0):
-        pass
+def test_collect_workflow_metrics_counts_unknown_termination_reason():
+    episodes = [
+        Episode(id="task:0", termination_reason=None, metrics={"custom": 1.0}),
+        Episode(id="task:1", termination_reason=TerminationReason.ERROR, metrics={"custom": 3.0}),
+    ]
 
+    workflow_metrics, termination_counts = UnifiedTrainer._collect_workflow_metrics_from_episodes(episodes)
 
-class _Backend:
-    async def generate_episodes(self, batch, agent_workflow_engine, is_validation=False):
-        return [
-            Episode(id="task:0", termination_reason=None, metrics={"custom": 1.0}),
-            Episode(id="task:1", termination_reason=TerminationReason.ERROR, metrics={"custom": 3.0}),
-        ]
-
-
-def test_train_batch_populates_termination_metrics_before_early_return(monkeypatch):
-    monkeypatch.setattr(
-        unified_trainer,
-        "transform_episodes_to_trajectory_groups",
-        lambda episodes, transform_config, compact_filtering_config, traj_grouping_hook=None: ([], {}),
-    )
-    monkeypatch.setattr(
-        unified_trainer,
-        "apply_rejection_sampling_and_filtering",
-        lambda episodes, groups, config, state: ([], episodes, {}),
-    )
-
-    trainer = object.__new__(UnifiedTrainer)
-    trainer.agent_workflow_engine = _WorkflowEngine()
-    trainer.backend = _Backend()
-    trainer.transform_config = None
-    trainer.cf_config = None
-    trainer.traj_grouping_hook = None
-    trainer.rs_config = None
-
-    state = TrainerState()
-    asyncio.run(trainer._train_batch_async(batch={}, trainer_state=state))
-
-    assert state.metrics["batch/custom"] == 2.0
-    assert state.metrics["batch/termination_reason/unknown"] == 0.5
-    assert state.metrics["batch/termination_reason/error"] == 0.5
-    assert state.metrics["batch/termination_reason/env_done"] == 0.0
+    assert workflow_metrics["custom"] == 2.0
+    assert termination_counts[TerminationReason.UNKNOWN.value] == 1
+    assert termination_counts[TerminationReason.ERROR.value] == 1

--- a/tests/unified_trainer/test_termination_metrics.py
+++ b/tests/unified_trainer/test_termination_metrics.py
@@ -1,0 +1,48 @@
+import asyncio
+
+import rllm.experimental.unified_trainer as unified_trainer
+from rllm.agents.agent import Episode
+from rllm.experimental.unified_trainer import TrainerState, UnifiedTrainer
+from rllm.workflows.workflow import TerminationReason
+
+
+class _WorkflowEngine:
+    def set_training_step(self, step, mode="train", epoch=0):
+        pass
+
+
+class _Backend:
+    async def generate_episodes(self, batch, agent_workflow_engine, is_validation=False):
+        return [
+            Episode(id="task:0", termination_reason=None, metrics={"custom": 1.0}),
+            Episode(id="task:1", termination_reason=TerminationReason.ERROR, metrics={"custom": 3.0}),
+        ]
+
+
+def test_train_batch_populates_termination_metrics_before_early_return(monkeypatch):
+    monkeypatch.setattr(
+        unified_trainer,
+        "transform_episodes_to_trajectory_groups",
+        lambda episodes, transform_config, compact_filtering_config, traj_grouping_hook=None: ([], {}),
+    )
+    monkeypatch.setattr(
+        unified_trainer,
+        "apply_rejection_sampling_and_filtering",
+        lambda episodes, groups, config, state: ([], episodes, {}),
+    )
+
+    trainer = object.__new__(UnifiedTrainer)
+    trainer.agent_workflow_engine = _WorkflowEngine()
+    trainer.backend = _Backend()
+    trainer.transform_config = None
+    trainer.cf_config = None
+    trainer.traj_grouping_hook = None
+    trainer.rs_config = None
+
+    state = TrainerState()
+    asyncio.run(trainer._train_batch_async(batch={}, trainer_state=state))
+
+    assert state.metrics["batch/custom"] == 2.0
+    assert state.metrics["batch/termination_reason/unknown"] == 0.5
+    assert state.metrics["batch/termination_reason/error"] == 0.5
+    assert state.metrics["batch/termination_reason/env_done"] == 0.0


### PR DESCRIPTION
## Summary

This PR makes validation mode visible to AgentFlow implementations through `AgentConfig.is_validation`. It also preserves AgentFlow-provided `TerminationReason` values instead of overwriting them with `ENV_DONE`, and ensures termination reason metrics are populated immediately after episode generation so they are still logged when a batch exits early.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Added `AgentConfig.is_validation` with a default of `False`, and passed it from `AgentFlowEngine`.
- Preserved existing episode `termination_reason` values during AgentFlow enrichment.
- Populated `batch/termination_reason/*` metrics before transform/rejection/backend stages can return early.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Targeted unit tests cover the `AgentConfig.is_validation` default, `AgentFlowEngine` validation/termination behavior, and termination metric aggregation.
- Passed: `/mlx_devbox/users/jason.wei/playground/verl_vllm018_env/.venv/bin/python -m pytest tests/eval/test_eval_types.py::test_agent_config_defaults tests/engine/test_agent_flow_engine.py tests/unified_trainer/test_termination_metrics.py -q`
- Passed: `/mlx_devbox/users/jason.wei/playground/verl_vllm018_env/.venv/bin/ruff check rllm/types.py rllm/experimental/engine/agent_flow_engine.py rllm/experimental/unified_trainer.py tests/eval/test_eval_types.py tests/engine/test_agent_flow_engine.py tests/unified_trainer/test_termination_metrics.py`

## Breaking changes / migration notes

- Adds an optional `AgentConfig.is_validation` field defaulting to `False`; existing construction remains compatible.
