### PR TITLE
refactor(types): unify trajectory data types under `rllm.types`

### DIFF
--- a/rllm/__init__.py
+++ b/rllm/__init__.py
@@ -33,7 +33,8 @@ def __getattr__(name: str):
 
     _agent_exports = {"BaseAgent", "Action", "Step", "Trajectory", "Episode"}
     if name in _agent_exports:
-        from rllm.agents.agent import Action, BaseAgent, Episode, Step, Trajectory
+        from rllm.agents.agent import BaseAgent
+        from rllm.types import Action, Episode, Step, Trajectory
 
         _exports = {
             "BaseAgent": BaseAgent,

--- a/rllm/agents/__init__.py
+++ b/rllm/agents/__init__.py
@@ -1,4 +1,5 @@
-from rllm.agents.agent import Action, BaseAgent, Episode, Step, Trajectory
+from rllm.agents.agent import BaseAgent
+from rllm.types import Action, Episode, Step, Trajectory
 
 # Concrete agent implementations load on first access (see __getattr__) so optional /
 # heavy dependencies are not pulled in by `import rllm.agents`.

--- a/rllm/agents/agent.py
+++ b/rllm/agents/agent.py
@@ -1,302 +1,41 @@
+"""Backward-compat re-export shim for the trajectory data types.
+
+The canonical home for :class:`Step`, :class:`Trajectory`, :class:`Episode`,
+:class:`Action`, :class:`TrajectoryGroup` is :mod:`rllm.types`. This module
+re-exports them so existing imports keep working::
+
+    from rllm.agents.agent import Episode, Step, Trajectory  # still works
+
+The :class:`BaseAgent` ABC stays here because it is part of the legacy
+``Agent + Environment`` execution path (driven by
+:class:`rllm.engine.agent_execution_engine.AgentExecutionEngine`) which is
+slated for deprecation. New agents should implement
+:class:`rllm.types.AgentFlow` instead.
+"""
+
 from __future__ import annotations
 
-import uuid
 from abc import ABC, abstractmethod
-from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from rllm.types import (
+    _DEFAULT_TRAJ_NAME,
+    Action,
+    Episode,
+    Step,
+    Trajectory,
+    TrajectoryGroup,
+)
 
-from rllm.types import Episode as _EpisodeBase
-from rllm.types import Step as _StepBase
-from rllm.types import Trajectory as _TrajectoryBase
-
-if TYPE_CHECKING:
-    from rllm.engine.rollout import ModelOutput
-
-
-class Step(_StepBase):
-    """Training step with token IDs, logprobs, advantage."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
-
-    # Training-specific fields
-    prompt_ids: list[int] | list[Any] = Field(default_factory=list)
-    response_ids: list[int] = Field(default_factory=list)
-    logprobs: list[float] = Field(default_factory=list)
-    routing_matrices: list[str] | None = None  # per-token routing matrices (R3, transient)
-
-    chat_completions: list[dict[str, Any]] = Field(default_factory=list)
-
-    observation: Any = None
-    thought: str = ""
-    # action: inherited from _StepBase
-    model_response: str = ""
-    model_output: Any = None  # Runtime type is ModelOutput | None; uses Any to avoid circular import
-
-    # reward, done: inherited from _StepBase
-    mc_return: float = 0.0
-
-    # Per-token or scalar advantages
-    advantage: list[float] | float | None = None
-
-    # weight version at time of generation (for async training staleness tracking)
-    weight_version: int | None = None
-
-    @property
-    def info(self) -> dict:
-        """Alias for metadata. Auto-initializes to {} if None so mutation works."""
-        if self.metadata is None:
-            self.metadata = {}
-        return self.metadata
-
-    @info.setter
-    def info(self, value: dict) -> None:
-        self.metadata = value
-
-    def model_post_init(self, __context: Any) -> None:
-        self.chat_completions = deepcopy(self.chat_completions)
-        if self.model_output is None:
-            return
-        # backfill fields like prompt_ids, response_ids, logprobs, etc.
-        if len(self.prompt_ids) == 0 and self.model_output.prompt_ids is not None:
-            self.prompt_ids = self.model_output.prompt_ids
-        if len(self.response_ids) == 0 and self.model_output.completion_ids is not None:
-            self.response_ids = self.model_output.completion_ids
-        if len(self.logprobs) == 0 and self.model_output.logprobs is not None:
-            self.logprobs = self.model_output.logprobs
-        if self.routing_matrices is None and getattr(self.model_output, "routing_matrices", None) is not None:
-            self.routing_matrices = self.model_output.routing_matrices
-        if self.weight_version is None and hasattr(self.model_output, "weight_version"):
-            self.weight_version = self.model_output.weight_version
-
-        # check that the lengths would match up
-        if len(self.logprobs) > 0:
-            assert len(self.response_ids) == len(self.logprobs), f"length mismatch between response_ids and logprobs, got {len(self.response_ids)}, {len(self.logprobs)}"
-
-    def to_dict(self) -> dict:
-        from rllm.tools.tool_base import ToolCall, ToolOutput
-
-        # Helper function to recursively convert ToolCall and ToolOutput objects to dicts
-        def _serialize_value(value):
-            if isinstance(value, ToolCall | ToolOutput):
-                return value.to_dict()
-            elif isinstance(value, list):
-                return [_serialize_value(item) for item in value]
-            elif isinstance(value, dict):
-                return {k: _serialize_value(v) for k, v in value.items()}
-            else:
-                return value
-
-        return {
-            "prompt_ids": self.prompt_ids,
-            "response_ids": self.response_ids,
-            "logprobs": self.logprobs,
-            "routing_matrices": self.routing_matrices,
-            "chat_completions": _serialize_value(self.chat_completions),
-            "observation": self.observation,
-            "thought": self.thought,
-            "action": self.action.action if isinstance(self.action, Action) else self.action,
-            "model_response": self.model_response,
-            "model_output": self.model_output.to_dict() if self.model_output is not None else None,
-            "info": self.info,
-            "reward": self.reward,
-            "done": self.done,
-            "mc_return": self.mc_return,
-            "advantage": self.advantage,
-            "weight_version": self.weight_version,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> Step:
-        from rllm.engine.rollout import ModelOutput
-
-        return cls(
-            prompt_ids=data["prompt_ids"],
-            response_ids=data["response_ids"],
-            logprobs=data["logprobs"],
-            routing_matrices=data.get("routing_matrices"),
-            chat_completions=data["chat_completions"],
-            observation=data["observation"],
-            thought=data["thought"],
-            action=data["action"],
-            model_response=data["model_response"],
-            model_output=ModelOutput.from_dict(data["model_output"]) if data.get("model_output", None) is not None else None,
-            metadata=data.get("info", data.get("metadata", {})),
-            reward=data["reward"],
-            done=data["done"],
-            mc_return=data["mc_return"],
-            advantage=data.get("advantage", 0.0),
-            weight_version=data.get("weight_version"),
-        )
-
-    @classmethod
-    def from_model_output(cls, model_output: ModelOutput, messages: list[dict] | None = None, action: Any | None = None) -> Step:
-        return cls(
-            prompt_ids=model_output.prompt_ids or [],
-            response_ids=model_output.completion_ids or [],
-            logprobs=model_output.logprobs or [],
-            routing_matrices=getattr(model_output, "routing_matrices", None),
-            chat_completions=(messages or []) + [{"role": "assistant", "content": model_output.content, "reasoning": model_output.reasoning}],
-            thought=model_output.reasoning or "",
-            action=action,
-            model_response=model_output.content or "",
-            model_output=model_output,
-            weight_version=model_output.weight_version,
-        )
-
-
-class Action(BaseModel):
-    action: Any = None
-
-
-_DEFAULT_TRAJ_NAME = "default_traj_name"
-
-
-class Trajectory(_TrajectoryBase):
-    """Training trajectory extending the canonical Trajectory with core defaults."""
-
-    name: str = _DEFAULT_TRAJ_NAME  # Override canonical default for core compat
-    steps: list[Step] = Field(default_factory=list)  # Narrow type to training Step
-
-    @property
-    def info(self) -> dict:
-        """Alias for metadata. Auto-initializes to {} if None so mutation works."""
-        if self.metadata is None:
-            self.metadata = {}
-        return self.metadata
-
-    @info.setter
-    def info(self, value: dict) -> None:
-        self.metadata = value
-
-    def to_dict(self):
-        # Remove large/non-serializable payloads (e.g., images) from task
-        def _sanitize_task(task_obj):
-            if isinstance(task_obj, dict):
-                cleaned = {k: v for k, v in task_obj.items() if k not in ("image", "images")}
-                return cleaned
-            return task_obj
-
-        return {
-            "uid": self.uid,
-            "name": self.name,
-            "task": _sanitize_task(self.task),
-            "steps": [step.to_dict() for step in self.steps],
-            "reward": float(self.reward) if self.reward is not None else None,
-            "info": self.info,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> Trajectory:
-        """Create Trajectory from dictionary, properly deserializing Step objects."""
-        return cls(
-            uid=data.get("uid", str(uuid.uuid4())),
-            name=data["name"],
-            task=data["task"],
-            steps=[Step.from_dict(step_data) for step_data in data.get("steps", [])],
-            reward=data["reward"],
-            metadata=data.get("info", data.get("metadata", {})),
-        )
-
-    def is_cumulative(self) -> bool:
-        """
-        Returns True if for every step after the first, its chat_completions is an exact superset
-        of the previous step's chat_completions (i.e., the previous chat_completions is a prefix).
-        """
-        prev = None
-        for step in self.steps:
-            if prev is not None:
-                prev_cc = prev.chat_completions
-                curr_cc = step.chat_completions
-                if not (len(curr_cc) >= len(prev_cc) and curr_cc[: len(prev_cc)] == prev_cc):
-                    return False
-            prev = step
-        return True
-
-
-class Episode(_EpisodeBase):
-    """Training episode extending the canonical Episode."""
-
-    trajectories: list[Trajectory] = Field(default_factory=list)  # Narrow type
-
-    @property
-    def info(self) -> dict:
-        """Alias for metadata. Auto-initializes to {} if None."""
-        return self.metadata
-
-    @info.setter
-    def info(self, value: dict) -> None:
-        self.metadata = value
-
-    def to_dict(self):
-        # Remove large/non-serializable payloads (e.g., images) from task
-        def _sanitize_task(task_obj):
-            if isinstance(task_obj, dict):
-                cleaned = {k: v for k, v in task_obj.items() if k not in ("image", "images")}
-                return cleaned
-            return task_obj
-
-        return {
-            "id": self.id,
-            "task": _sanitize_task(self.task),
-            "termination_reason": self.termination_reason.value if self.termination_reason is not None else None,
-            "is_correct": bool(self.is_correct),
-            "trajectories": [trajectory.to_dict() for trajectory in self.trajectories],
-            "metrics": self.metrics,
-            "info": self.info,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> Episode:
-        """Create Episode from dictionary, properly deserializing Trajectory objects."""
-        from rllm.workflows.workflow import TerminationReason
-
-        return cls(
-            id=data["id"],
-            task=data["task"],
-            termination_reason=TerminationReason(data.get("termination_reason", TerminationReason.UNKNOWN)),
-            is_correct=data["is_correct"],
-            trajectories=[Trajectory.from_dict(trajectory_data) for trajectory_data in data["trajectories"]],
-            metrics=data.get("metrics", {}),
-            metadata=data.get("info", data.get("metadata", {})),
-        )
-
-    @property
-    def task_id(self) -> str:
-        return self.id.split(":")[0]
-
-    @property
-    def rollout_idx(self) -> str:
-        return self.id.split(":")[1]
-
-
-class TrajectoryGroup(BaseModel):
-    """
-    A group of trajectories for advantage computation.
-
-    Unlike Episode (which represents raw rollout data), TrajectoryGroup is specifically
-    structured for advantage computation. All trajectories in a group will have their
-    rewards compared to compute advantages (e.g., via GRPO).
-
-    Attributes:
-        trajectories: List of trajectories to compare for advantage computation
-        group_id: Optional identifier for the group (e.g., "task1:agent_0")
-        metadata: List of metadata for each trajectory in the group
-    """
-
-    trajectories: list[Trajectory]
-    group_id: str = ""
-    metadata: list[dict] = Field(default_factory=list)
-    weight_version: int = 0
-
-    @property
-    def group_role(self) -> str:
-        return self.group_id.split(":")[1] if ":" in self.group_id[:-1] else "all_groups"
-
-    @property
-    def task_id(self) -> str:
-        return self.group_id.split(":")[0]
+__all__ = [
+    "Action",
+    "BaseAgent",
+    "Episode",
+    "Step",
+    "Trajectory",
+    "TrajectoryGroup",
+    "_DEFAULT_TRAJ_NAME",
+]
 
 
 class BaseAgent(ABC):

--- a/rllm/agents/appworld_react_agents.py
+++ b/rllm/agents/appworld_react_agents.py
@@ -3,7 +3,8 @@ from typing import Any
 
 from jinja2 import Template
 
-from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
+from rllm.types import Action, Step, Trajectory
 
 
 class AppWorldReactAgent(BaseAgent):

--- a/rllm/agents/code_agent.py
+++ b/rllm/agents/code_agent.py
@@ -2,7 +2,8 @@ import copy
 import logging
 from typing import Any
 
-from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
+from rllm.types import Action, Step, Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/agents/frozenlake_agent.py
+++ b/rllm/agents/frozenlake_agent.py
@@ -3,9 +3,10 @@ import logging
 import re
 from typing import Any
 
-from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.agents.system_prompts import *
 from rllm.environments.frozenlake.frozenlake import FrozenLakeEnv
+from rllm.types import Action, Step, Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/agents/math_agent.py
+++ b/rllm/agents/math_agent.py
@@ -1,7 +1,8 @@
 import copy
 from typing import Any
 
-from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
+from rllm.types import Action, Step, Trajectory
 
 
 class MathAgent(BaseAgent):

--- a/rllm/agents/miniwob_agent.py
+++ b/rllm/agents/miniwob_agent.py
@@ -16,8 +16,9 @@ from browsergym.core.action.highlevel import HighLevelActionSet  # type: ignore[
 from browsergym.utils.obs import flatten_axtree_to_str, flatten_dom_to_str, prune_html  # type: ignore[import-untyped]
 from PIL import Image
 
-from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.agents.system_prompts import *
+from rllm.types import Action, Step, Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/agents/swe_agent.py
+++ b/rllm/agents/swe_agent.py
@@ -8,8 +8,9 @@ try:
 except ImportError:
     SWEAction = None
 
-from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.agents.system_prompts import SWE_SYSTEM_PROMPT, SWE_SYSTEM_PROMPT_FN_CALL, SWE_USER_PROMPT, SWE_USER_PROMPT_FN_CALL, SWEAGENT_SYSTEM_PROMPT, SWEAGENT_USER_PROMPT
+from rllm.types import Action, Step, Trajectory
 
 
 def parse_oai_response(response):

--- a/rllm/agents/tool_agent.py
+++ b/rllm/agents/tool_agent.py
@@ -4,12 +4,13 @@ import logging
 import uuid
 from typing import Any
 
-from rllm.agents.agent import Action, BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.agents.system_prompts import TOOL_SYSTEM_PROMPT
 from rllm.parser import ToolParser, get_tool_parser
 from rllm.tools.mcp_tool import MCPTool
 from rllm.tools.multi_tool import MultiTool
 from rllm.tools.tool_base import Tool
+from rllm.types import Action, Step, Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/agents/webarena_agent.py
+++ b/rllm/agents/webarena_agent.py
@@ -11,8 +11,9 @@ import numpy as np
 from browsergym.utils.obs import _process_bid
 from PIL import Image
 
-from rllm.agents.agent import BaseAgent, Step, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.agents.system_prompts import *
+from rllm.types import Step, Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/engine/agent_execution_engine.py
+++ b/rllm/engine/agent_execution_engine.py
@@ -10,7 +10,7 @@ try:
 except ImportError as err:
     raise ImportError("AgentExecutionEngine requires extra dependencies. Install with: pip install rllm[train]") from err
 
-from rllm.agents.agent import Action, BaseAgent, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.agents.utils import (
     convert_messages_to_tokens_and_masks,
     get_recent_assistant_user_messages,
@@ -21,6 +21,7 @@ from rllm.environments.env_utils import (
     compute_trajectory_reward,
 )
 from rllm.parser import ChatTemplateParser
+from rllm.types import Action, Trajectory
 from rllm.utils import colorful_print
 
 logger = logging.getLogger(__name__)

--- a/rllm/engine/agent_sdk_engine.py
+++ b/rllm/engine/agent_sdk_engine.py
@@ -17,7 +17,6 @@ try:
 except ImportError as err:
     raise ImportError("AgentSdkEngine requires extra dependencies. Install with: pip install rllm[train]") from err
 
-from rllm.agents.agent import Episode, Trajectory
 from rllm.engine.rollout import ModelOutput, RolloutEngine
 from rllm.engine.rollout.verl_engine import VerlEngine
 from rllm.sdk.data_process import group_steps, trace_to_step
@@ -26,6 +25,7 @@ from rllm.sdk.proxy.proxy_manager import VerlProxyManager
 from rllm.sdk.session import SESSION_BACKEND
 from rllm.sdk.session.base import wrap_with_session_context
 from rllm.sdk.store.sqlite_store import SqliteTraceStore
+from rllm.types import Episode, Trajectory
 from rllm.types import Trajectory as BaseTrajectory
 from rllm.utils import colorful_print
 from rllm.workflows.workflow import TerminationReason

--- a/rllm/engine/agent_workflow_engine.py
+++ b/rllm/engine/agent_workflow_engine.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from tqdm import tqdm
 
-from rllm.agents.agent import Episode
 from rllm.engine.rollout import RolloutEngine
+from rllm.types import Episode
 from rllm.utils import colorful_print
 from rllm.workflows.workflow import TerminationReason, Workflow
 

--- a/rllm/environments/env_utils.py
+++ b/rllm/environments/env_utils.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import numpy as np
 
-from rllm.agents.agent import Trajectory
+from rllm.types import Trajectory
 
 
 def compute_trajectory_reward(trajectory: "Trajectory") -> "Trajectory":

--- a/rllm/environments/frozenlake/frozenlake.py
+++ b/rllm/environments/frozenlake/frozenlake.py
@@ -12,8 +12,8 @@ import numpy as np
 from gymnasium.envs.toy_text.frozen_lake import FrozenLakeEnv as GymFrozenLakeEnv
 from gymnasium.utils import seeding
 
-from rllm.agents.agent import Action
 from rllm.environments.base.base_env import BaseEnv
+from rllm.types import Action
 
 MAX_STEPS: int = 5
 

--- a/rllm/experimental/buffer.py
+++ b/rllm/experimental/buffer.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from tqdm import tqdm
 
-from rllm.agents.agent import Episode, TrajectoryGroup
 from rllm.experimental.common import (
     AlgorithmConfig,
     CompactFilteringConfig,
@@ -28,6 +27,7 @@ from rllm.experimental.common import (
 from rllm.experimental.common.transform import transform_episodes_to_trajectory_groups
 from rllm.experimental.metrics import MetricsAggregator
 from rllm.experimental.sync_coordinator import SyncCoordinator
+from rllm.types import Episode, TrajectoryGroup
 from rllm.workflows.workflow import TerminationReason
 
 logger = logging.getLogger(__name__)

--- a/rllm/experimental/common/advantage.py
+++ b/rllm/experimental/common/advantage.py
@@ -10,9 +10,9 @@ from collections.abc import Callable
 
 import numpy as np
 
-from rllm.agents.agent import TrajectoryGroup
 from rllm.experimental.common.config import AlgorithmConfig, rLLMAdvantageEstimator
 from rllm.experimental.common.rl_algo import calculate_grpo_advantages_per_group, calculate_rloo_advantages_per_group
+from rllm.types import TrajectoryGroup
 from rllm.utils.logging import DuplicateLoggingFilter
 
 logger = logging.getLogger(__name__)

--- a/rllm/experimental/common/config.py
+++ b/rllm/experimental/common/config.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from omegaconf import DictConfig, OmegaConf
 
-from rllm.agents.agent import _DEFAULT_TRAJ_NAME
+from rllm.types import _DEFAULT_TRAJ_NAME
 from rllm.workflows.workflow import TerminationReason
 
 

--- a/rllm/experimental/common/metrics.py
+++ b/rllm/experimental/common/metrics.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 
 import numpy as np
 
-from rllm.agents.agent import TrajectoryGroup
+from rllm.types import TrajectoryGroup
 
 
 def reduce_metrics_by_trajectory_name(trajectory_groups: list[TrajectoryGroup], prefix: str = "reward", include_fraction_zero: bool = False) -> dict:

--- a/rllm/experimental/common/rejection_sampling.py
+++ b/rllm/experimental/common/rejection_sampling.py
@@ -7,8 +7,8 @@ tracking episode-level correctness metrics while filtering based on reward varia
 
 from dataclasses import dataclass, field
 
-from rllm.agents.agent import Episode, TrajectoryGroup
 from rllm.experimental.common.config import RejectionSamplingConfig
+from rllm.types import Episode, TrajectoryGroup
 
 
 @dataclass

--- a/rllm/experimental/common/transform.py
+++ b/rllm/experimental/common/transform.py
@@ -16,8 +16,8 @@ from collections.abc import Callable
 
 import numpy as np
 
-from rllm.agents.agent import Episode, Trajectory, TrajectoryGroup
 from rllm.experimental.common.config import CompactFilteringConfig, TransformConfig
+from rllm.types import Episode, Trajectory, TrajectoryGroup
 from rllm.workflows.workflow import TerminationReason
 
 logger = logging.getLogger(__name__)

--- a/rllm/experimental/common/visualization.py
+++ b/rllm/experimental/common/visualization.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import click
 
-from rllm.agents.agent import Trajectory, TrajectoryGroup
+from rllm.types import Trajectory, TrajectoryGroup
 
 
 @dataclass

--- a/rllm/experimental/engine/agent_flow_engine.py
+++ b/rllm/experimental/engine/agent_flow_engine.py
@@ -17,10 +17,9 @@ from typing import TYPE_CHECKING
 
 from tqdm import tqdm
 
-from rllm.agents.agent import Episode, Step, Trajectory
 from rllm.eval.types import EvalOutput
 from rllm.experimental.engine.trace_converter import compute_step_metrics, trace_record_to_step
-from rllm.types import AgentConfig, Task, run_agent_flow
+from rllm.types import AgentConfig, Episode, Step, Task, Trajectory, run_agent_flow
 from rllm.utils import colorful_print
 from rllm.workflows.workflow import TerminationReason
 

--- a/rllm/experimental/engine/remote_agent_flow_engine.py
+++ b/rllm/experimental/engine/remote_agent_flow_engine.py
@@ -10,7 +10,6 @@ import logging
 import uuid
 from collections import defaultdict
 
-from rllm.agents.agent import Episode, Step, Trajectory
 from rllm.experimental.engine.gateway_manager import GatewayManager
 from rllm.experimental.engine.remote_runtime.protocol import (
     RemoteAgentRuntime,
@@ -18,6 +17,7 @@ from rllm.experimental.engine.remote_runtime.protocol import (
     TaskSubmission,
 )
 from rllm.experimental.engine.trace_converter import compute_step_metrics, trace_record_to_step
+from rllm.types import Episode, Step, Trajectory
 from rllm.utils.episode_logger import EpisodeLogger
 from rllm.workflows.workflow import TerminationReason
 

--- a/rllm/experimental/engine/sdk_workflow.py
+++ b/rllm/experimental/engine/sdk_workflow.py
@@ -25,11 +25,11 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
-from rllm.agents.agent import Episode, Trajectory
 from rllm.sdk.data_process import group_steps, trace_to_step
 from rllm.sdk.protocol import Trace
 from rllm.sdk.session.base import wrap_with_session_context
 from rllm.sdk.store.sqlite_store import SqliteTraceStore
+from rllm.types import Episode, Trajectory
 from rllm.types import Trajectory as BaseTrajectory
 from rllm.workflows.workflow import TerminationReason, Workflow
 

--- a/rllm/experimental/engine/trace_converter.py
+++ b/rllm/experimental/engine/trace_converter.py
@@ -5,9 +5,9 @@ from typing import Any
 
 from rllm_model_gateway.models import TraceRecord
 
-from rllm.agents.agent import Step, Trajectory
 from rllm.experimental.rollout import ModelOutput
 from rllm.tools.tool_base import ToolCall
+from rllm.types import Step, Trajectory
 
 
 def _parse_openai_tool_calls(raw_tool_calls: list[dict[str, Any]]) -> list[ToolCall]:

--- a/rllm/experimental/engine/unified_workflow_engine.py
+++ b/rllm/experimental/engine/unified_workflow_engine.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 from tqdm import tqdm
 
-from rllm.agents.agent import Episode
 from rllm.experimental.rollout import RolloutEngine
+from rllm.types import Episode
 from rllm.workflows.store import Store
 from rllm.workflows.workflow import TerminationReason, Workflow
 

--- a/rllm/experimental/opsd/advantage.py
+++ b/rllm/experimental/opsd/advantage.py
@@ -2,8 +2,8 @@ import numpy as np
 from tinker import ModelInput, SamplingClient
 from tinker_cookbook.rl.metrics import discounted_future_sum_vectorized
 
-from rllm.agents.agent import Step
 from rllm.parser.chat_template_parser import ChatTemplateParser
+from rllm.types import Step
 
 
 async def calculate_reverse_kl_advantage(

--- a/rllm/experimental/opsd/workflow_utils.py
+++ b/rllm/experimental/opsd/workflow_utils.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 from rllm.experimental.opsd.advantage import calculate_reverse_kl_advantage
 
 if TYPE_CHECKING:
-    from rllm.agents.agent import Episode
+    from rllm.types import Episode
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/experimental/protocol.py
+++ b/rllm/experimental/protocol.py
@@ -14,10 +14,10 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from omegaconf import DictConfig
 
-from rllm.agents.agent import Episode
 from rllm.data import Dataset
 from rllm.experimental.common.advantage import AlgorithmConfig, collect_reward_and_advantage_from_trajectory_groups
 from rllm.experimental.rollout import RolloutEngine
+from rllm.types import Episode
 
 if TYPE_CHECKING:
     from rllm.experimental.engine.unified_workflow_engine import UnifiedWorkflowEngine

--- a/rllm/experimental/rollout/completer.py
+++ b/rllm/experimental/rollout/completer.py
@@ -13,9 +13,9 @@ from collections.abc import Callable
 from dataclasses import field
 from typing import TYPE_CHECKING, Any
 
-from rllm.agents.agent import Step
 from rllm.experimental.rollout.rollout_engine import ModelOutput, RolloutEngine
 from rllm.experimental.rollout.types import TokenInput, Tokenizer, TokenOutput
+from rllm.types import Step
 
 if TYPE_CHECKING:
     from rllm.parser import ChatTemplateParser

--- a/rllm/experimental/test_examples/opsd/math_opsd_workflow.py
+++ b/rllm/experimental/test_examples/opsd/math_opsd_workflow.py
@@ -1,8 +1,8 @@
-from rllm.agents.agent import Episode, Trajectory
 from rllm.experimental.opsd.workflow_utils import OPSDConfig, opsd_postprocess
 from rllm.experimental.rollout.completer import Completer
 from rllm.experimental.rollout.rollout_engine import RolloutEngine
 from rllm.rewards.reward_fn import math_reward_fn
+from rllm.types import Episode, Trajectory
 from rllm.workflows.workflow import Workflow
 
 

--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -13,7 +13,6 @@ import numpy as np
 from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
-from rllm.agents.agent import Episode, TrajectoryGroup
 from rllm.data import Dataset
 from rllm.experimental.buffer import TrajectoryGroupBuffer
 from rllm.experimental.common.advantage import (
@@ -42,6 +41,7 @@ from rllm.experimental.metrics import MetricsAggregator
 from rllm.experimental.protocol import BackendProtocol
 from rllm.experimental.rollout import RolloutEngine
 from rllm.experimental.sync_coordinator import SyncCoordinator, SyncCoordinatorConfig
+from rllm.types import Episode, TrajectoryGroup
 from rllm.utils import EpisodeLogger, Tracking, extract_source_metadata
 from rllm.workflows.store import Store
 from rllm.workflows.workflow import TerminationReason, Workflow

--- a/rllm/experimental/verl/transform.py
+++ b/rllm/experimental/verl/transform.py
@@ -6,9 +6,9 @@ import torch
 from verl.protocol import DataProto
 from verl.utils.torch_functional import pad_sequence_to_length
 
-from rllm.agents.agent import Episode, Trajectory, TrajectoryGroup
 from rllm.experimental.rollout import VerlEngine
 from rllm.experimental.verl.dataclass import AccumulatedData, ProcessedStepData
+from rllm.types import Episode, Trajectory, TrajectoryGroup
 from rllm.workflows.workflow import TerminationReason
 
 logger = logging.getLogger(__name__)

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -31,7 +31,6 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.metric import reduce_metrics
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
 
-from rllm.agents.agent import Episode
 from rllm.data import Dataset
 from rllm.experimental.common import (
     AlgorithmConfig,
@@ -42,6 +41,7 @@ from rllm.experimental.protocol import BackendProtocol
 from rllm.experimental.rollout import RolloutEngine, VerlEngine
 from rllm.experimental.verl import compute_advantage_verl, transform_episodes_to_dataproto, update_dataproto_with_advantages
 from rllm.experimental.verl.metrics import calculate_debug_metrics_compat
+from rllm.types import Episode
 
 if TYPE_CHECKING:
     from rllm.experimental.engine.unified_workflow_engine import UnifiedWorkflowEngine

--- a/rllm/integrations/harbor/atif_trajectory_bridge.py
+++ b/rllm/integrations/harbor/atif_trajectory_bridge.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from rllm.agents.agent import Step
+from rllm.types import Step
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/integrations/harbor/trial_helper.py
+++ b/rllm/integrations/harbor/trial_helper.py
@@ -419,8 +419,8 @@ def outcome_to_episode(outcome: HarborTaskOutcome, uid: str, task: dict):
     Returns:
         An ``rllm.types.Episode`` populated with reward and metadata.
     """
-    from rllm.agents.agent import Episode, Trajectory
     from rllm.integrations.harbor.atif_trajectory_bridge import load_atif_steps
+    from rllm.types import Episode, Trajectory
 
     reward = outcome.reward
     is_correct = outcome.is_correct

--- a/rllm/integrations/verifiers.py
+++ b/rllm/integrations/verifiers.py
@@ -33,10 +33,10 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
-from rllm.agents.agent import Episode, Step, Trajectory
 from rllm.engine.rollout import ModelOutput
 from rllm.sdk.proxy.proxy_manager import VerlProxyManager
 from rllm.sdk.store.sqlite_store import SqliteTraceStore
+from rllm.types import Episode, Step, Trajectory
 
 if TYPE_CHECKING:
     from verifiers import Environment

--- a/rllm/rewards/reward_fn.py
+++ b/rllm/rewards/reward_fn.py
@@ -3,11 +3,11 @@ import string
 from collections import Counter
 from typing import Protocol, runtime_checkable
 
-from rllm.agents.agent import Action
 from rllm.rewards.code_reward import RewardCodeFn
 from rllm.rewards.math_reward import RewardMathFn
 from rllm.rewards.reward_types import RewardConfig, RewardInput, RewardOutput
 from rllm.rewards.search_reward import RewardSearchFn
+from rllm.types import Action
 
 
 @runtime_checkable

--- a/rllm/sdk/data_process.py
+++ b/rllm/sdk/data_process.py
@@ -3,9 +3,9 @@ import logging
 import uuid
 from collections import defaultdict
 
-from rllm.agents.agent import Step, Trajectory
 from rllm.engine.rollout import ModelOutput
 from rllm.sdk.protocol import LLMInput, LLMOutput, Trace
+from rllm.types import Step, Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/trainer/agent_sft_trainer.py
+++ b/rllm/trainer/agent_sft_trainer.py
@@ -2,7 +2,7 @@ import logging
 
 from torch.distributed.device_mesh import init_device_mesh
 
-from rllm.agents.agent import Trajectory
+from rllm.types import Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/trainer/deprecated/tinker_agent_trainer.py
+++ b/rllm/trainer/deprecated/tinker_agent_trainer.py
@@ -21,7 +21,6 @@ import torch
 from omegaconf import OmegaConf
 from transformers import AutoTokenizer
 
-from rllm.agents.agent import Episode, Step, Trajectory
 from rllm.engine.agent_execution_engine import AsyncAgentExecutionEngine
 from rllm.trainer.deprecated.tinker_metrics_utils import (
     compute_training_metrics,
@@ -29,6 +28,7 @@ from rllm.trainer.deprecated.tinker_metrics_utils import (
     print_metrics_table,
 )
 from rllm.trainer.deprecated.tinker_policy_trainer import TinkerPolicyTrainer
+from rllm.types import Episode, Step, Trajectory
 
 if TYPE_CHECKING:
     pass

--- a/rllm/trainer/deprecated/tinker_data_processor.py
+++ b/rllm/trainer/deprecated/tinker_data_processor.py
@@ -11,7 +11,7 @@ import tinker
 import torch
 from tinker.types.tensor_data import TensorData
 
-from rllm.agents.agent import Step, Trajectory, TrajectoryGroup
+from rllm.types import Step, Trajectory, TrajectoryGroup
 
 logger = logging.getLogger(__name__)
 
@@ -717,7 +717,7 @@ async def process_episodes(
                     for step_idx, step in enumerate(trajectory.steps):
                         group_key = (task_id, trajectory.name, step_idx)
                         # Create single-step trajectory
-                        from rllm.agents.agent import Trajectory
+                        from rllm.types import Trajectory
 
                         single_step_traj = Trajectory(steps=[step], reward=step.reward, name=trajectory.name)
                         trajectory_groups_dict[group_key].append(single_step_traj)

--- a/rllm/trainer/deprecated/tinker_metrics_utils.py
+++ b/rllm/trainer/deprecated/tinker_metrics_utils.py
@@ -9,7 +9,7 @@ import tinker
 import torch
 from tinker_cookbook.display import colorize_example
 
-from rllm.agents.agent import Episode
+from rllm.types import Episode
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/trainer/deprecated/tinker_workflow_trainer.py
+++ b/rllm/trainer/deprecated/tinker_workflow_trainer.py
@@ -16,11 +16,11 @@ import tinker
 import torch
 from transformers import AutoTokenizer
 
-from rllm.agents.agent import Episode
 from rllm.engine.agent_workflow_engine import AgentWorkflowEngine
 from rllm.engine.rollout.tinker_engine import TinkerEngine
 from rllm.trainer.deprecated.tinker_agent_trainer import TinkerAgentTrainer
 from rllm.trainer.deprecated.tinker_policy_trainer import TinkerPolicyTrainer
+from rllm.types import Episode
 
 if TYPE_CHECKING:
     pass

--- a/rllm/trainer/distill/advantage.py
+++ b/rllm/trainer/distill/advantage.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Callable
 
-from rllm.agents.agent import Step
+from rllm.types import Step
 
 logger = logging.getLogger(__name__)
 

--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -21,7 +21,6 @@ import torch
 from omegaconf import DictConfig
 from transformers import AutoTokenizer
 
-from rllm.agents.agent import Episode
 from rllm.data import Dataset
 from rllm.experimental.common import AlgorithmConfig, simple_timer
 from rllm.experimental.protocol import BackendProtocol
@@ -30,6 +29,7 @@ from rllm.trainer.tinker.tinker_metrics_utils import (
     update_training_metrics,
 )
 from rllm.trainer.tinker.tinker_policy_trainer import TinkerPolicyTrainer
+from rllm.types import Episode
 
 if TYPE_CHECKING:
     from transformers.tokenization_utils import PreTrainedTokenizer

--- a/rllm/trainer/tinker/tinker_policy_trainer.py
+++ b/rllm/trainer/tinker/tinker_policy_trainer.py
@@ -18,7 +18,6 @@ from tinker.types import AdamParams
 from tinker_cookbook import checkpoint_utils
 from tinker_cookbook.tokenizer_utils import Tokenizer
 
-from rllm.agents.agent import TrajectoryGroup
 from rllm.experimental.common import (
     AlgorithmConfig,
     CompactFilteringConfig,
@@ -26,6 +25,7 @@ from rllm.experimental.common import (
     rLLMAdvantageEstimator,
 )
 from rllm.trainer.tinker.transform import transform_trajectory_groups_to_datums
+from rllm.types import TrajectoryGroup
 
 if TYPE_CHECKING:
     import torch

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -10,10 +10,10 @@ import tinker
 from tinker.types.tensor_data import TensorData
 from tinker_cookbook.supervised.common import create_rightshifted_model_input_and_leftshifted_targets
 
-from rllm.agents.agent import Trajectory, TrajectoryGroup
 from rllm.experimental.common import AlgorithmConfig, collect_reward_and_advantage_from_trajectory_groups
 from rllm.experimental.rollout.tinker_engine import _flat_token_input_length, _flat_token_input_to_model_input
 from rllm.experimental.rollout.types import TinkerTokenInput
+from rllm.types import Trajectory, TrajectoryGroup
 
 
 def _is_prefix(seq1: TinkerTokenInput, seq2: TinkerTokenInput) -> bool:

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -1,12 +1,18 @@
 """Canonical lightweight types for rLLM.
 
 Single source of truth for the core data shapes (:class:`Task`,
-:class:`Step`, :class:`Trajectory`, :class:`Episode`) and the
-producer/consumer protocols around them (:class:`AgentFlow`,
-:class:`Evaluator`, :class:`AgentConfig`, :func:`run_agent_flow`).
+:class:`Step`, :class:`Trajectory`, :class:`Episode`, :class:`Action`,
+:class:`TrajectoryGroup`) and the producer/consumer protocols around
+them (:class:`AgentFlow`, :class:`Evaluator`, :class:`AgentConfig`,
+:func:`run_agent_flow`).
 
 Eval-specific result shapes (:class:`~rllm.eval.types.EvalOutput`,
 :class:`~rllm.eval.types.Signal`) live in :mod:`rllm.eval.types`.
+
+Historically the training-side (token IDs, logprobs, advantages, ...)
+fields lived on subclasses in ``rllm.agents.agent``. They have been
+folded into the canonical classes here; ``rllm.agents.agent`` remains
+as a backward-compat re-export shim.
 """
 
 from __future__ import annotations
@@ -14,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import uuid
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -21,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
+    from rllm.engine.rollout import ModelOutput
     from rllm.eval.types import EvalOutput
 
 
@@ -73,11 +81,35 @@ class Task:
         return self.dataset_dir / self.sub_dir if self.sub_dir else self.dataset_dir
 
 
+# ---------------------------------------------------------------------------
+# Trajectory data types (formerly defined in rllm.agents.agent)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TRAJ_NAME = "default_traj_name"
+
+
+class Action(BaseModel):
+    """Wraps an arbitrary action emitted by an agent."""
+
+    action: Any = None
+
+
 class Step(BaseModel):
-    """A single interaction step (one LLM call with optional reward)."""
+    """A single interaction step (one LLM call with optional reward).
+
+    Fields are split into two groups:
+
+    - **Core / eval**: ``id``, ``input``, ``output``, ``action``,
+      ``reward``, ``done``, ``metadata`` — populated by every code path
+      (harness, eval, training).
+    - **Training payloads**: ``prompt_ids``, ``response_ids``, ``logprobs``,
+      ``chat_completions``, ``model_output``, ``advantage`` etc. —
+      populated by training rollouts; default-empty in eval-only paths.
+    """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
 
+    # Core / eval fields
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     input: Any | None = None
     output: Any | None = None
@@ -86,6 +118,122 @@ class Step(BaseModel):
     done: bool = False
     metadata: dict | None = None
 
+    # Training-side payloads
+    prompt_ids: list[int] | list[Any] = Field(default_factory=list)
+    response_ids: list[int] = Field(default_factory=list)
+    logprobs: list[float] = Field(default_factory=list)
+    routing_matrices: list[str] | None = None  # per-token routing matrices (R3, transient)
+    chat_completions: list[dict[str, Any]] = Field(default_factory=list)
+    observation: Any = None
+    thought: str = ""
+    model_response: str = ""
+    model_output: Any = None  # Runtime type is ModelOutput | None; uses Any to avoid circular import
+    mc_return: float = 0.0
+    advantage: list[float] | float | None = None
+    weight_version: int | None = None  # weight version at time of generation (async staleness)
+
+    @property
+    def info(self) -> dict:
+        """Alias for metadata. Auto-initializes to {} if None so mutation works."""
+        if self.metadata is None:
+            self.metadata = {}
+        return self.metadata
+
+    @info.setter
+    def info(self, value: dict) -> None:
+        self.metadata = value
+
+    def model_post_init(self, __context: Any) -> None:
+        self.chat_completions = deepcopy(self.chat_completions)
+        if self.model_output is None:
+            return
+        # backfill fields like prompt_ids, response_ids, logprobs, etc.
+        if len(self.prompt_ids) == 0 and self.model_output.prompt_ids is not None:
+            self.prompt_ids = self.model_output.prompt_ids
+        if len(self.response_ids) == 0 and self.model_output.completion_ids is not None:
+            self.response_ids = self.model_output.completion_ids
+        if len(self.logprobs) == 0 and self.model_output.logprobs is not None:
+            self.logprobs = self.model_output.logprobs
+        if self.routing_matrices is None and getattr(self.model_output, "routing_matrices", None) is not None:
+            self.routing_matrices = self.model_output.routing_matrices
+        if self.weight_version is None and hasattr(self.model_output, "weight_version"):
+            self.weight_version = self.model_output.weight_version
+
+        # check that the lengths would match up
+        if len(self.logprobs) > 0:
+            assert len(self.response_ids) == len(self.logprobs), f"length mismatch between response_ids and logprobs, got {len(self.response_ids)}, {len(self.logprobs)}"
+
+    def to_dict(self) -> dict:
+        from rllm.tools.tool_base import ToolCall, ToolOutput
+
+        # Helper function to recursively convert ToolCall and ToolOutput objects to dicts
+        def _serialize_value(value):
+            if isinstance(value, ToolCall | ToolOutput):
+                return value.to_dict()
+            elif isinstance(value, list):
+                return [_serialize_value(item) for item in value]
+            elif isinstance(value, dict):
+                return {k: _serialize_value(v) for k, v in value.items()}
+            else:
+                return value
+
+        return {
+            "prompt_ids": self.prompt_ids,
+            "response_ids": self.response_ids,
+            "logprobs": self.logprobs,
+            "routing_matrices": self.routing_matrices,
+            "chat_completions": _serialize_value(self.chat_completions),
+            "observation": self.observation,
+            "thought": self.thought,
+            "action": self.action.action if isinstance(self.action, Action) else self.action,
+            "model_response": self.model_response,
+            "model_output": self.model_output.to_dict() if self.model_output is not None else None,
+            "info": self.info,
+            "reward": self.reward,
+            "done": self.done,
+            "mc_return": self.mc_return,
+            "advantage": self.advantage,
+            "weight_version": self.weight_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Step:
+        from rllm.engine.rollout import ModelOutput
+
+        return cls(
+            prompt_ids=data["prompt_ids"],
+            response_ids=data["response_ids"],
+            logprobs=data["logprobs"],
+            routing_matrices=data.get("routing_matrices"),
+            chat_completions=data["chat_completions"],
+            observation=data["observation"],
+            thought=data["thought"],
+            action=data["action"],
+            model_response=data["model_response"],
+            model_output=ModelOutput.from_dict(data["model_output"]) if data.get("model_output", None) is not None else None,
+            metadata=data.get("info", data.get("metadata", {})),
+            reward=data["reward"],
+            done=data["done"],
+            mc_return=data["mc_return"],
+            advantage=data.get("advantage", 0.0),
+            weight_version=data.get("weight_version"),
+        )
+
+    @classmethod
+    def from_model_output(cls, model_output: ModelOutput, messages: list[dict] | None = None, action: Any | None = None) -> Step:
+        return cls(
+            prompt_ids=model_output.prompt_ids or [],
+            response_ids=model_output.completion_ids or [],
+            logprobs=model_output.logprobs or [],
+            routing_matrices=getattr(model_output, "routing_matrices", None),
+            chat_completions=(messages or []) + [{"role": "assistant", "content": model_output.content, "reasoning": model_output.reasoning}],
+            thought=model_output.reasoning or "",
+            action=action,
+            model_response=model_output.content or "",
+            model_output=model_output,
+            weight_version=model_output.weight_version,
+        )
+
 
 class Trajectory(BaseModel):
     """A sequence of Steps forming one agent trajectory."""
@@ -93,7 +241,7 @@ class Trajectory(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
 
     uid: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str = "agent"
+    name: str = _DEFAULT_TRAJ_NAME
     task: Any = None
     steps: list[Step] = Field(default_factory=list)
     reward: float | None = None
@@ -106,6 +254,61 @@ class Trajectory(BaseModel):
     def result(self):
         """Get the output from the trajectory (backward compatibility)."""
         return self.output
+
+    @property
+    def info(self) -> dict:
+        """Alias for metadata. Auto-initializes to {} if None so mutation works."""
+        if self.metadata is None:
+            self.metadata = {}
+        return self.metadata
+
+    @info.setter
+    def info(self, value: dict) -> None:
+        self.metadata = value
+
+    def to_dict(self):
+        # Remove large/non-serializable payloads (e.g., images) from task
+        def _sanitize_task(task_obj):
+            if isinstance(task_obj, dict):
+                cleaned = {k: v for k, v in task_obj.items() if k not in ("image", "images")}
+                return cleaned
+            return task_obj
+
+        return {
+            "uid": self.uid,
+            "name": self.name,
+            "task": _sanitize_task(self.task),
+            "steps": [step.to_dict() for step in self.steps],
+            "reward": float(self.reward) if self.reward is not None else None,
+            "info": self.info,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Trajectory:
+        """Create Trajectory from dictionary, properly deserializing Step objects."""
+        return cls(
+            uid=data.get("uid", str(uuid.uuid4())),
+            name=data["name"],
+            task=data["task"],
+            steps=[Step.from_dict(step_data) for step_data in data.get("steps", [])],
+            reward=data["reward"],
+            metadata=data.get("info", data.get("metadata", {})),
+        )
+
+    def is_cumulative(self) -> bool:
+        """
+        Returns True if for every step after the first, its chat_completions is an exact superset
+        of the previous step's chat_completions (i.e., the previous chat_completions is a prefix).
+        """
+        prev = None
+        for step in self.steps:
+            if prev is not None:
+                prev_cc = prev.chat_completions
+                curr_cc = step.chat_completions
+                if not (len(curr_cc) >= len(prev_cc) and curr_cc[: len(prev_cc)] == prev_cc):
+                    return False
+            prev = step
+        return True
 
 
 class Episode(BaseModel):
@@ -129,6 +332,76 @@ class Episode(BaseModel):
     @property
     def rollout_idx(self) -> str:
         return self.id.split(":")[1]
+
+    @property
+    def info(self) -> dict:
+        """Alias for metadata. Auto-initializes to {} if None."""
+        return self.metadata
+
+    @info.setter
+    def info(self, value: dict) -> None:
+        self.metadata = value
+
+    def to_dict(self):
+        # Remove large/non-serializable payloads (e.g., images) from task
+        def _sanitize_task(task_obj):
+            if isinstance(task_obj, dict):
+                cleaned = {k: v for k, v in task_obj.items() if k not in ("image", "images")}
+                return cleaned
+            return task_obj
+
+        return {
+            "id": self.id,
+            "task": _sanitize_task(self.task),
+            "termination_reason": self.termination_reason.value if self.termination_reason is not None else None,
+            "is_correct": bool(self.is_correct),
+            "trajectories": [trajectory.to_dict() for trajectory in self.trajectories],
+            "metrics": self.metrics,
+            "info": self.info,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Episode:
+        """Create Episode from dictionary, properly deserializing Trajectory objects."""
+        from rllm.workflows.workflow import TerminationReason
+
+        return cls(
+            id=data["id"],
+            task=data["task"],
+            termination_reason=TerminationReason(data.get("termination_reason", TerminationReason.UNKNOWN)),
+            is_correct=data["is_correct"],
+            trajectories=[Trajectory.from_dict(trajectory_data) for trajectory_data in data["trajectories"]],
+            metrics=data.get("metrics", {}),
+            metadata=data.get("info", data.get("metadata", {})),
+        )
+
+
+class TrajectoryGroup(BaseModel):
+    """
+    A group of trajectories for advantage computation.
+
+    Unlike Episode (which represents raw rollout data), TrajectoryGroup is specifically
+    structured for advantage computation. All trajectories in a group will have their
+    rewards compared to compute advantages (e.g., via GRPO).
+
+    Attributes:
+        trajectories: List of trajectories to compare for advantage computation
+        group_id: Optional identifier for the group (e.g., "task1:agent_0")
+        metadata: List of metadata for each trajectory in the group
+    """
+
+    trajectories: list[Trajectory]
+    group_id: str = ""
+    metadata: list[dict] = Field(default_factory=list)
+    weight_version: int = 0
+
+    @property
+    def group_role(self) -> str:
+        return self.group_id.split(":")[1] if ":" in self.group_id[:-1] else "all_groups"
+
+    @property
+    def task_id(self) -> str:
+        return self.group_id.split(":")[0]
 
 
 # ---------------------------------------------------------------------------

--- a/rllm/utils/episode_logger.py
+++ b/rllm/utils/episode_logger.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from rllm.agents.agent import Episode
+from rllm.types import Episode
 
 
 class EpisodeLogger:

--- a/rllm/workflows/cumulative_workflow.py
+++ b/rllm/workflows/cumulative_workflow.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from rllm.agents.agent import Episode
 from rllm.engine.rollout.rollout_engine import ModelOutput
+from rllm.types import Episode
 from rllm.workflows.timing_mixin import TimingTrackingMixin
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 

--- a/rllm/workflows/distillation_workflow.py
+++ b/rllm/workflows/distillation_workflow.py
@@ -1,7 +1,7 @@
-from rllm.agents.agent import Episode, Step, Trajectory
 from rllm.engine import ModelOutput, RolloutEngine
 from rllm.rewards.reward_fn import RewardFunction
 from rllm.trainer.distill import compute_step_distill_advantage
+from rllm.types import Episode, Step, Trajectory
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 
 

--- a/rllm/workflows/eval_protocol_workflow.py
+++ b/rllm/workflows/eval_protocol_workflow.py
@@ -13,8 +13,8 @@ try:
 except ImportError as err:
     raise ImportError("EvalProtocolWorkflow requires extra dependencies. Install with: pip install rllm[eval-protocol]") from err
 
-from rllm.agents.agent import Episode, Step, Trajectory
 from rllm.engine.rollout.openai_engine import OpenAIEngine
+from rllm.types import Episode, Step, Trajectory
 from rllm.workflows.workflow import Workflow
 
 

--- a/rllm/workflows/multi_turn_workflow.py
+++ b/rllm/workflows/multi_turn_workflow.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from rllm.agents.agent import Episode
 from rllm.engine.rollout.rollout_engine import ModelOutput
+from rllm.types import Episode
 from rllm.workflows.timing_mixin import TimingTrackingMixin
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 

--- a/rllm/workflows/simple_workflow.py
+++ b/rllm/workflows/simple_workflow.py
@@ -1,6 +1,7 @@
-from rllm.agents.agent import Action, BaseAgent, Episode, Step, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.engine import ModelOutput, RolloutEngine
 from rllm.rewards.reward_fn import RewardFunction
+from rllm.types import Action, Episode, Step, Trajectory
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 
 

--- a/rllm/workflows/single_turn_workflow.py
+++ b/rllm/workflows/single_turn_workflow.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from rllm.agents.agent import Episode
 from rllm.engine.rollout.rollout_engine import ModelOutput
+from rllm.types import Episode
 from rllm.workflows.timing_mixin import TimingTrackingMixin
 from rllm.workflows.workflow import TerminationEvent, TerminationReason, Workflow
 

--- a/rllm/workflows/workflow.py
+++ b/rllm/workflows/workflow.py
@@ -8,9 +8,10 @@ from functools import partial
 
 import numpy as np
 
-from rllm.agents.agent import BaseAgent, Episode, Trajectory
+from rllm.agents.agent import BaseAgent
 from rllm.engine.rollout.rollout_engine import RolloutEngine
 from rllm.environments.base.base_env import BaseEnv
+from rllm.types import Episode, Trajectory
 from rllm.workflows.store import Store
 
 


### PR DESCRIPTION
# refactor(types): unify trajectory data types under `rllm.types`

## Summary

This branch (`dev-cleanup`) consolidates the canonical trajectory data types under `rllm.types` and migrates package-internal imports to point at the new location. It is a pure refactor — no behavior changes — and is the first step toward deprecating the legacy `AgentExecutionEngine + BaseAgent + Environment` stack in favor of `AgentFlow`.

Three commits, all import-swap / relocation:

| Commit | Subject |
| --- | --- |
| `f657fe05` | refactor(types): promote trajectory data types to `rllm.types` |
| `dfdeb169` | refactor(types): swap in-package imports to `rllm.types` |
| `50c51cd5` | refactor(types): swap legacy-path imports to `rllm.types` |

Diff vs `main`: **59 files changed, +382 / −358**, of which the only non-trivial logic move is `rllm/types.py` (+283) and `rllm/agents/agent.py` (−289, now a shim).

## Motivation

Before this branch, the trajectory data types were split across two modules:

- `rllm/types.py` held lightweight `Step`, `Trajectory`, `Episode` (eval-only fields).
- `rllm/agents/agent.py` held subclasses of those types with the training-side fields (`prompt_ids`, `response_ids`, `logprobs`, `chat_completions`, `model_output`, `advantage`, `mc_return`, `weight_version`, …) plus `Action`, `TrajectoryGroup`, and `_DEFAULT_TRAJ_NAME`.

That split was historical — the eval lightweight types were a *strict subset* of the training subclasses, so the two-tier hierarchy carried no real type information and forced every caller to remember which import path to use. It also coupled `rllm.types` callers (which should be the lightest layer in the package) to `rllm.agents.agent`, which itself drags in the legacy `BaseAgent` ABC and the `AgentExecutionEngine` execution path that we want to retire.

Folding the training fields into the canonical classes is purely additive — the extra fields default-empty in eval-only paths, so eval callers see no change, and training callers stop carrying duplicate class definitions.

## What changed

### 1. `rllm/types.py` — single source of truth

`Step`, `Trajectory`, `Episode`, `Action`, `TrajectoryGroup`, and `_DEFAULT_TRAJ_NAME` now all live in `rllm/types.py`. The merged `Step` carries both groups of fields:

- **Core / eval fields** (populated by every code path): `id`, `input`, `output`, `action`, `reward`, `done`, `metadata`.
- **Training payloads** (default-empty in eval-only paths): `prompt_ids`, `response_ids`, `logprobs`, `routing_matrices`, `chat_completions`, `observation`, `thought`, `model_response`, `model_output`, `mc_return`, `advantage`, `weight_version`.

`model_post_init` backfill, `to_dict` / `from_dict` / `from_model_output`, and the `info` ↔ `metadata` alias are unchanged — they moved verbatim from the old subclass.

`Trajectory` and `Episode` likewise absorbed their training-extended siblings. Lazy imports of `rllm.tools.tool_base`, `rllm.engine.rollout`, and `rllm.workflows.workflow` are kept inside method bodies so that `rllm.types` itself stays free of top-level legacy coupling.

### 2. `rllm/agents/agent.py` — backward-compat re-export shim

The old definitions are gone; the file now just re-exports from `rllm.types` and keeps the `BaseAgent` ABC locally. The ABC stays put because it is part of the legacy `AgentExecutionEngine` path, which is slated to move to `rllm/v0/` in a follow-up PR.

Class identity is preserved by the re-export, so:

```python
from rllm.agents.agent import Step  # still works
from rllm.types import Step          # canonical
# rllm.agents.agent.Step is rllm.types.Step  -> True
```

### 3. Import swaps across the package (44 files)

Every active in-package caller of `from rllm.agents.agent import …` for the trajectory data types was switched to `from rllm.types import …`. Three files (`rllm/__init__.py`, `rllm/workflows/workflow.py`, `rllm/workflows/simple_workflow.py`) keep a separate `from rllm.agents.agent import BaseAgent` line — `BaseAgent` stays in `rllm.agents.agent` until the v0 relocation.

Files touched by the swap include:

- `rllm/agents/*_agent.py` (concrete agents — code, math, swe, tool, frozenlake, miniwob, webarena, appworld_react)
- `rllm/engine/agent_execution_engine.py`, `rllm/engine/agent_sdk_engine.py`, `rllm/engine/agent_workflow_engine.py`
- `rllm/environments/*` (env_utils, frozenlake)
- `rllm/experimental/**` (buffer, common/*, engine/*, opsd/*, protocol, rollout/completer, test_examples, unified_trainer, verl/*)
- `rllm/integrations/{harbor,verifiers}.py`
- `rllm/rewards/reward_fn.py`, `rllm/sdk/data_process.py`
- `rllm/trainer/{agent_sft_trainer,deprecated/*,distill/advantage,tinker/*}.py`
- `rllm/utils/episode_logger.py`
- `rllm/workflows/*.py`

The legacy-path agents and the `rllm/trainer/deprecated/` files were updated in the third commit specifically so that the upcoming `rllm/v0/` relocation becomes a pure file move rather than a move + import fix-up.

## Why this is safe

- **No semantic changes.** The training-extended classes that used to live in `rllm.agents.agent` were strict supersets of the lightweight versions in `rllm.types`. Folding them together is purely additive — eval callers see the new training fields with empty defaults but never read them.
- **Class identity is preserved.** Existing `from rllm.agents.agent import …` callers continue to receive the exact same class objects via the re-export shim, so isinstance checks, pickling, and Pydantic schema generation are unaffected.
- **Lazy imports.** The training-side helpers (`ModelOutput.from_dict`, `ToolCall`/`ToolOutput` serialization) are still imported inside method bodies, so importing `rllm.types` does not pull in `rllm.engine.rollout`, `rllm.tools.tool_base`, or `rllm.workflows.workflow`.
- **Tests pass with zero new failures** (per the commit message on `dfdeb169`).

## Out of scope / follow-ups

- The `BaseAgent` ABC, the concrete agents under `rllm/agents/*_agent.py`, `AgentExecutionEngine`, `rllm/environments/`, and `rllm/trainer/deprecated/` will move under `rllm/v0/` in a separate PR. After this branch lands, that move is a pure relocation.
- Public-API surface in `rllm/__init__.py` still exports `Action`, `Step`, `Trajectory`, `Episode` lazily — no external rename is needed.

## Test plan

- [ ] `pytest` passes (no new failures vs `main`).
- [ ] `python -c "from rllm.agents.agent import Step, Trajectory, Episode, Action, TrajectoryGroup; from rllm.types import Step as S2; assert Step is S2"` succeeds.
- [ ] `python -c "import rllm; rllm.Step; rllm.Episode; rllm.Trajectory; rllm.Action; rllm.BaseAgent"` succeeds (lazy `__getattr__` path).
- [ ] A representative training rollout (e.g. one of the workflows under `rllm/workflows/`) round-trips `Step.to_dict` / `from_dict` unchanged.
- [ ] A representative eval run (no training fields populated) produces identical `EvalOutput` shapes vs `main`.

