### PR TITLE
fix(config): always init configs via from_config

### DIFF
--- a/rllm/experimental/common/config.py
+++ b/rllm/experimental/common/config.py
@@ -112,6 +112,15 @@ class TransformConfig:
     # Reward configuration
     broadcast: bool = True  # If True, use trajectory-level rewards; if False, use per-step rewards
 
+    @classmethod
+    def from_config(cls, transform_config: DictConfig, *, broadcast: bool = True) -> "TransformConfig":
+        return cls(
+            impute_missing_names=transform_config.get("impute_missing_names", True),
+            default_traj_name=transform_config.get("default_traj_name", _DEFAULT_TRAJ_NAME),
+            drop_unnamed_traj=transform_config.get("drop_unnamed_traj", False),
+            broadcast=broadcast,
+        )
+
 
 @dataclass
 class RejectionSamplingConfig:
@@ -132,6 +141,18 @@ class RejectionSamplingConfig:
     # Filter out episode groups where all rollouts have the same is_correct (no gradient signal).
     # Applied at the accumulator level in async training, before groups enter the buffer.
     filter_uniform_groups: bool = False
+
+    @classmethod
+    def from_config(cls, config: DictConfig) -> "RejectionSamplingConfig":
+        mode = config.get("mode", None)
+        if mode is None:
+            mode = "episode" if config.get("enable", False) else "none"
+        return cls(
+            mode=mode,
+            min_trajs_per_group=config.get("min_trajs_per_group", 2),
+            min_partial_solve_tasks=config.get("min_partial_solve_tasks", 1),
+            filter_uniform_groups=config.get("filter_uniform_groups", False),
+        )
 
 
 @dataclass
@@ -212,35 +233,36 @@ class AlgorithmConfig:
     router_replay: bool = False
 
     @classmethod
-    def from_config(cls, config: DictConfig) -> "AlgorithmConfig":
+    def from_config(cls, algorithm_config: DictConfig, *, stepwise_advantage_mode: str = "broadcast", estimator_map: dict | None = None) -> "AlgorithmConfig":
         """Create an AlgorithmConfig from a dictionary configuration.
 
         Args:
-            config: Dictionary configuration.
+            algorithm_config: Dictionary configuration.
         Returns:
             AlgorithmConfig: The AlgorithmConfig built from the configuration.
         """
-        rc_section = config.rllm.algorithm.get("rollout_correction", {})
+        rc_section = algorithm_config.get("rollout_correction", {})
         rollout_correction = RolloutCorrectionConfig(
             tis_mode=rc_section.get("tis_mode", None),
             bypass_mode=rc_section.get("bypass_mode", None),
             tis_cap=rc_section.get("tis_cap", 2.0),
         )
         return cls(
-            estimator=rLLMAdvantageEstimator(config.algorithm.adv_estimator),
-            stepwise_advantage_mode=config.rllm.stepwise_advantage.mode,
-            norm_adv_by_std_in_grpo=config.rllm.algorithm.get("norm_adv_by_std_in_grpo", True),
-            use_rllm=config.rllm.stepwise_advantage.get("use_rllm", False),
-            use_precomputed_advantage=config.rllm.algorithm.get("use_precomputed_advantage", False),
-            loss_fn=config.rllm.algorithm.get("loss_fn", None),
-            lr_schedule=config.rllm.algorithm.get("lr_schedule", "constant"),
-            warmup_steps_ratio=config.rllm.algorithm.get("warmup_steps_ratio", 0.0),
-            kl_beta=config.rllm.algorithm.get("kl_beta", 0.0),
-            eps_clip=config.rllm.algorithm.get("eps_clip", 0.2),
-            eps_clip_high=config.rllm.algorithm.get("eps_clip_high", None),
-            loss_agg_mode=config.rllm.algorithm.get("loss_agg_mode", None),
+            estimator=rLLMAdvantageEstimator(algorithm_config.adv_estimator),
+            estimator_map=estimator_map or {},
+            stepwise_advantage_mode=stepwise_advantage_mode,
+            norm_adv_by_std_in_grpo=algorithm_config.get("norm_adv_by_std_in_grpo", True),
+            use_rllm=algorithm_config.get("use_rllm", None),
+            use_precomputed_advantage=algorithm_config.get("use_precomputed_advantage", False),
+            loss_fn=algorithm_config.get("loss_fn", None),
+            lr_schedule=algorithm_config.get("lr_schedule", "constant"),
+            warmup_steps_ratio=algorithm_config.get("warmup_steps_ratio", 0.0),
+            kl_beta=algorithm_config.get("kl_beta", 0.0),
+            eps_clip=algorithm_config.get("eps_clip", 0.2),
+            eps_clip_high=algorithm_config.get("eps_clip_high", None),
+            loss_agg_mode=algorithm_config.get("loss_agg_mode", None),
             rollout_correction=rollout_correction,
-            router_replay=config.rllm.algorithm.get("router_replay", False),
+            router_replay=algorithm_config.get("router_replay", False),
         )
 
     def __post_init__(self):

--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -251,33 +251,16 @@ class UnifiedTrainer:
         # validate backend-specific configs
         self.backend.validate_config()
 
-        # compact filtering config (used for filtering out episodes that are not valid)
         self.cf_config = CompactFilteringConfig.from_config(self.rllm_config.compact_filtering)
-
-        # transform config (used for transforming episodes to trajectory groups)
-        self.transform_config = TransformConfig(broadcast=self.rllm_config.stepwise_advantage.mode == "broadcast")
-
-        # rejection sampling config (used for rejection sampling)
-        rs_mode = "episode" if self.rllm_config.rejection_sample.enable else "none"
-
-        self.rs_config = RejectionSamplingConfig(
-            mode=rs_mode,
-            min_partial_solve_tasks=self.rllm_config.rejection_sample.min_partial_solve_tasks,
-            min_trajs_per_group=self.rllm_config.rejection_sample.min_trajs_per_group,
-            filter_uniform_groups=self.rllm_config.rejection_sample.get("filter_uniform_groups", False),
+        self.transform_config = TransformConfig.from_config(
+            self.rllm_config.get("transform", {}),
+            broadcast=self.rllm_config.stepwise_advantage.mode == "broadcast",
         )
-
-        # algorithm config (used for rLLM-native advantage computation)
-        self.algorithm_config = AlgorithmConfig(
-            estimator=self.rllm_config.algorithm.adv_estimator,
-            estimator_map=self.traj_group_adv_estimator_map,  # TODO(listar2000): see if we can make this configurable in config as well
+        self.rs_config = RejectionSamplingConfig.from_config(self.rllm_config.rejection_sample)
+        self.algorithm_config = AlgorithmConfig.from_config(
+            self.rllm_config.algorithm,
             stepwise_advantage_mode=self.rllm_config.stepwise_advantage.mode,
-            norm_adv_by_std_in_grpo=self.rllm_config.algorithm.get("norm_adv_by_std_in_grpo", True),
-            use_rllm=self.rllm_config.algorithm.get("use_rllm", False),
-            use_precomputed_advantage=self.rllm_config.algorithm.get("use_precomputed_advantage", False),
-            loss_fn=self.rllm_config.algorithm.get("loss_fn", None),
-            lr_schedule=self.rllm_config.algorithm.get("lr_schedule", "constant"),
-            warmup_steps_ratio=self.rllm_config.algorithm.get("warmup_steps_ratio", 0.0),
+            estimator_map=self.traj_group_adv_estimator_map,
         )
 
     def _setup_logging(self):

--- a/rllm/trainer/tinker/tinker_policy_trainer.py
+++ b/rllm/trainer/tinker/tinker_policy_trainer.py
@@ -107,8 +107,14 @@ class TinkerPolicyTrainer:
         self.training_client = None
         # fill in the default versions of the configs if not provided
         self.cf_config = cf_config or CompactFilteringConfig.from_config(self.config.rllm.compact_filtering)
-        self.transform_config = transform_config or TransformConfig()
-        self.algorithm_config = algorithm_config or AlgorithmConfig.from_config(self.config)
+        self.transform_config = transform_config or TransformConfig.from_config(
+            self.config.rllm.get("transform", {}),
+            broadcast=self.config.rllm.stepwise_advantage.mode == "broadcast",
+        )
+        self.algorithm_config = algorithm_config or AlgorithmConfig.from_config(
+            self.config.rllm.algorithm,
+            stepwise_advantage_mode=self.config.rllm.stepwise_advantage.mode,
+        )
 
     async def initialize_async(self, resume_from_checkpoint: bool = True):
         """

--- a/tests/unified_trainer/test_algorithm_config.py
+++ b/tests/unified_trainer/test_algorithm_config.py
@@ -47,12 +47,12 @@ def _make_config(norm_adv_by_std_in_grpo: bool = True):
 def test_norm_adv_by_std_in_grpo_true_from_algorithm():
     """norm_adv_by_std_in_grpo=True is read from rllm.algorithm, not stepwise_advantage."""
     config = _make_config(norm_adv_by_std_in_grpo=True)
-    algo_config = AlgorithmConfig.from_config(config)
+    algo_config = AlgorithmConfig.from_config(config.rllm.algorithm, stepwise_advantage_mode=config.rllm.stepwise_advantage.mode)
     assert algo_config.norm_adv_by_std_in_grpo is True
 
 
 def test_norm_adv_by_std_in_grpo_false_from_algorithm():
     """norm_adv_by_std_in_grpo=False is read from rllm.algorithm, not stepwise_advantage."""
     config = _make_config(norm_adv_by_std_in_grpo=False)
-    algo_config = AlgorithmConfig.from_config(config)
+    algo_config = AlgorithmConfig.from_config(config.rllm.algorithm, stepwise_advantage_mode=config.rllm.stepwise_advantage.mode)
     assert algo_config.norm_adv_by_std_in_grpo is False


### PR DESCRIPTION
UnifiedTrainer was constructing AlgorithmConfig manually and never passing rollout_correction=, so RolloutCorrectionConfig defaults (tis_mode=None, bypass_mode=None, tis_cap=5.0) silently overrode the yaml values — TIS, bypass_mode, etc. were unreachable from the rllm namespace.

Fix it by routing every config through its classmethod and adopting one convention: each from_config takes only its own sub-config; cross-cutting values (broadcast, stepwise_advantage_mode, estimator_map) come in as keyword args.

- AlgorithmConfig.from_config now reads from the algorithm sub-config (was reading config.algorithm.adv_estimator and config.rllm.stepwise_advantage for unrelated fields); takes stepwise_advantage_mode + estimator_map as kwargs.
- TransformConfig.from_config takes the transform sub-config + broadcast kwarg (was none; manual TransformConfig(broadcast=...) call replaced).
- RejectionSamplingConfig.from_config added (was a hand-built call deriving mode from rejection_sample.enable).
- UnifiedTrainer._validate_and_setup_configs collapses ~25 lines into four from_config calls.
- TinkerPolicyTrainer updated to match (AlgorithmConfig + TransformConfig callers).

## Summary

<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- 
- 
- 

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
