### PR TITLE
docs(cookbooks): convert math architecture to Mermaid

### DIFF
--- a/docs/cookbooks/math.mdx
+++ b/docs/cookbooks/math.mdx
@@ -18,18 +18,22 @@ This is the no-tool counterpart to [`math_tool_agent`](/cookbooks/math_tool_agen
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  ├── one LLM call via OpenAI(base_url=config.base_url)
-  │     model outputs reasoning + \boxed{ANSWER}
-  │
-  └── store full response in episode.artifacts["answer"]
+```mermaid
+flowchart TD
+    subgraph Run["AgentFlow.run(task, config)"]
+        L["one LLM call via OpenAI(base_url=config.base_url)"]
+        O["model outputs reasoning + \boxed{ANSWER}"]
+        A["store full response in episode.artifacts['answer']"]
+        L --> O --> A
+    end
 
-Evaluator.evaluate(task, episode)
-  │
-  └── extract last \boxed{...}, grade against task.metadata["ground_truth"]
-      via mathd + sympy
+    subgraph Eval["Evaluator.evaluate(task, episode)"]
+        E["extract last \boxed{...}"]
+        G["grade against task.metadata['ground_truth'] via mathd + sympy"]
+        E --> G
+    end
+
+    Run -- "episode.artifacts" --> Eval
 ```
 
 ## Install


### PR DESCRIPTION
## Summary
- Replace the ASCII text-art architecture diagram in `docs/cookbooks/math.mdx` with a Mintlify-native Mermaid `flowchart TD`.
- Preserves all facts: single LLM call via `OpenAI(base_url=config.base_url)`, `\boxed{ANSWER}` output shape, `episode.artifacts["answer"]` handoff, evaluator extraction of last `\boxed{...}`, grading against `task.metadata["ground_truth"]` via mathd + sympy.
- Uses two `subgraph` blocks (`AgentFlow.run` and `Evaluator.evaluate`) connected by a labeled `episode.artifacts` edge.

Part of a batch ASCII -> Mermaid migration of cookbook architecture diagrams.

## Test plan
- [x] `./venv/bin/python -m pytest tests/parser/ -v` (22 passed)
- [x] MDX syntax check: fence is `mermaid`, opens/closes on own lines, all special-char labels double-quoted, `flowchart TD` first line, both subgraphs properly closed with `end`.
- [ ] Visual check on Mintlify preview after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)