### PR TITLE
docs(cookbooks): convert deepcoder architecture to Mermaid

### DIFF
--- a/docs/cookbooks/deepcoder.mdx
+++ b/docs/cookbooks/deepcoder.mdx
@@ -16,18 +16,22 @@ A single-turn coding agent for competition-style programming problems. The model
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  ├── one LLM call via OpenAI(base_url=config.base_url)
-  │     model outputs reasoning + ```python ... ```
-  │
-  └── store full response in episode.artifacts["answer"]
+```mermaid
+flowchart TD
+    subgraph Run["AgentFlow.run(task, config)"]
+        A["one LLM call via OpenAI(base_url=config.base_url)"]
+        B["model outputs reasoning + python code block"]
+        C["store full response in episode.artifacts[&quot;answer&quot;]"]
+        A --> B --> C
+    end
 
-Evaluator.evaluate(task, episode)
-  │
-  └── RewardCodeFn extracts last ```python``` block, runs against
-      task.metadata["ground_truth"] (hidden tests)
+    subgraph Eval["Evaluator.evaluate(task, episode)"]
+        D["RewardCodeFn extracts last python block"]
+        E["run against task.metadata[&quot;ground_truth&quot;] (hidden tests)"]
+        D --> E
+    end
+
+    Run -- "episode.artifacts" --> Eval
 ```
 
 Long chain-of-thought reasoning happens *inside* the assistant message — there is no multi-turn revise/feedback loop. This matches the original deepcoder training setup.


### PR DESCRIPTION
## Summary
- Replace the ASCII text-art architecture diagram in `docs/cookbooks/deepcoder.mdx` with a Mintlify-native Mermaid `flowchart TD`.
- Two `subgraph` blocks (`AgentFlow.run` and `Evaluator.evaluate`) connected by a labeled `episode.artifacts` edge to make the two-stage handoff visible.
- All facts preserved: single LLM call via `OpenAI(base_url=config.base_url)`, `episode.artifacts["answer"]`, `RewardCodeFn` extracts the last python block and runs it against `task.metadata["ground_truth"]` (hidden tests).

Part of a batch ASCII to Mermaid migration of cookbook architecture diagrams so they render natively in the Aspen-themed Mintlify docs site.

## Test plan
- [x] `./venv/bin/python -m pytest tests/parser/ -v` — 22 passed
- [x] MDX syntax check: fence is `mermaid`, `flowchart TD` is the first line, both subgraphs opened/closed, labels with special chars are double-quoted, no raw backticks in labels (`"` escaped via `&quot;`)
- [ ] Visual check in Mintlify preview after merge

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>