### PR TITLE
docs(cookbooks): convert solver_judge_flow architecture to Mermaid

### DIFF
--- a/docs/cookbooks/finqa.mdx
+++ b/docs/cookbooks/finqa.mdx
@@ -17,25 +17,30 @@ A multi-turn ReAct-style financial-QA agent that answers questions about SEC 10-
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  └── Multi-turn loop (up to 20 turns, native OpenAI tool calls)
-        │
-        ├── client.chat.completions.create(messages, tools=TOOL_SPECS)
-        │
-        ├── If msg.tool_calls is empty → that's the final answer, break.
-        │
-        └── Else: dispatch each tool call → append a `tool` message → repeat.
-              (track table_name in `accessed_tables` whenever
-               `get_table_info` is invoked, for the table-access bonus)
-  │
-  └── episode.artifacts = {"answer": full_response, "accessed_tables": [...], "turns": N}
+```mermaid
+flowchart TD
+    subgraph Run["AgentFlow.run(task, config)"]
+        A["Multi-turn loop (up to 20 turns, native OpenAI tool calls)"]
+        B["client.chat.completions.create(messages, tools=TOOL_SPECS)"]
+        C{"msg.tool_calls empty?"}
+        D["Final answer; break"]
+        E["Dispatch each tool call: get_table_names, get_table_info, sql_query, calculator"]
+        F["Append 'tool' message; if get_table_info, track table_name in accessed_tables (table-access bonus)"]
+        G["episode.artifacts = {'answer': full_response, 'accessed_tables': [...], 'turns': N}"]
+        A --> B --> C
+        C -- "Yes" --> D --> G
+        C -- "No" --> E --> F --> B
+    end
 
-Evaluator.evaluate(task, episode)
-  │
-  └── extract FINAL ANSWER from artifacts["answer"], grade via judge LLM,
-      add table-access bonus, return EvalOutput.
+    subgraph Eval["Evaluator.evaluate(task, episode)"]
+        H["Extract FINAL ANSWER from artifacts['answer']"]
+        I["Grade via judge LLM"]
+        J["Add table-access bonus"]
+        K["Return EvalOutput"]
+        H --> I --> J --> K
+    end
+
+    G -- "episode.artifacts" --> H
 ```
 
 [Model Weights](https://huggingface.co/rLLM/rLLM-FinQA-4B) | [Dataset](https://huggingface.co/datasets/rLLM/finqa)

--- a/docs/cookbooks/solver_judge_flow.mdx
+++ b/docs/cookbooks/solver_judge_flow.mdx
@@ -19,18 +19,37 @@ This cookbook is the canonical example of returning **multiple named trajectorie
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  ├── Solver (N parallel threads)
-  │     └── client.chat.completions.create(...)
-  │         → Trajectory(name="solver", steps=[Step(action=parsed_answer)])
-  │
-  └── Judge
-        └── client.chat.completions.create(...)
-            → Trajectory(name="judge", steps=[Step(action=selected_answer)])
-  │
-  └── Episode(trajectories=[solver_0, ..., solver_{N-1}, judge])
+```mermaid
+flowchart TD
+    Run["AgentFlow.run(task, config)"]
+    Solver["Solver (N parallel)"]
+    S1["Solver_1: client.chat.completions.create(...)"]
+    S2["Solver_2: client.chat.completions.create(...)"]
+    Sdots["…"]
+    SN["Solver_N: client.chat.completions.create(...)"]
+    T1["Trajectory(name='solver', steps=[Step(action=parsed_answer)])"]
+    T2["Trajectory(name='solver', steps=[Step(action=parsed_answer)])"]
+    TN["Trajectory(name='solver', steps=[Step(action=parsed_answer)])"]
+    Judge["Judge: client.chat.completions.create(...)"]
+    TJ["Trajectory(name='judge', steps=[Step(action=selected_answer)])"]
+    Episode["Episode(trajectories=[solver_0, ..., solver_{N-1}, judge])"]
+
+    Run --> Solver
+    Solver --> S1
+    Solver --> S2
+    Solver --> Sdots
+    Solver --> SN
+    S1 --> T1
+    S2 --> T2
+    SN --> TN
+    T1 --> Judge
+    T2 --> Judge
+    TN --> Judge
+    Judge --> TJ
+    T1 --> Episode
+    T2 --> Episode
+    TN --> Episode
+    TJ --> Episode
 ```
 
 The evaluator scores each trajectory independently. GRPO then groups by name across rollouts: all `solver` trajectories for one task into one group; all `judge` trajectories into another.


### PR DESCRIPTION
## Summary
- Replace the ASCII text-art architecture diagram in `docs/cookbooks/solver_judge_flow.mdx` with a Mintlify-native Mermaid `flowchart TD` so it renders natively in the Aspen theme.
- Preserves every fact from the original: N parallel solver calls (rendered as `Solver_1`, `Solver_2`, `…`, `Solver_N`), each producing `Trajectory(name='solver', steps=[Step(action=parsed_answer)])`, the single Judge producing `Trajectory(name='judge', steps=[Step(action=selected_answer)])`, and the final `Episode(trajectories=[solver_0, ..., solver_{N-1}, judge])`.
- Part of a batch ASCII-to-Mermaid migration of cookbook architecture diagrams.

## Test plan
- [x] `./venv/bin/python -m pytest tests/parser/ -v` — 22 passed
- [x] MDX fence sanity check: ```` ```mermaid ```` opens, ```` ``` ```` closes, `flowchart TD` is the first line, every label with special chars is double-quoted (single quotes for nested string literals).
- [ ] Visual render check in Mintlify preview after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)