### PR TITLE
docs(cookbooks): convert math_tool_agent architecture to Mermaid

### DIFF
--- a/docs/cookbooks/math_tool_agent.mdx
+++ b/docs/cookbooks/math_tool_agent.mdx
@@ -16,17 +16,15 @@ A multi-turn agent that solves competition math problems by calling a calculator
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  └── Multi-turn loop (up to 5 turns)
-        │
-        ├── client.chat.completions.create(messages, tools=TOOLS)
-        │     model outputs reasoning + <tool_call>...</tool_call>
-        │
-        ├── parse tool call → execute calculator → inject result
-        │
-        └── repeat until model outputs <answer>NUMBER</answer>
+```mermaid
+flowchart TD
+    A["AgentFlow.run(task, config)"] --> B["Multi-turn loop (up to 5 turns)"]
+    B --> C["client.chat.completions.create(messages, tools=TOOLS)"]
+    C --> D["model outputs reasoning + &lt;tool_call&gt;...&lt;/tool_call&gt;"]
+    D --> E{"tool call or final answer?"}
+    E -->|tool call| F["parse tool call -> execute calculator -> inject result"]
+    F --> B
+    E -->|"&lt;answer&gt;NUMBER&lt;/answer&gt;"| G["Done"]
 ```
 
 The evaluator checks the final `<answer>` against the ground truth via numeric comparison.


### PR DESCRIPTION
## Summary
- Replaces the ASCII flow diagram in `docs/cookbooks/math_tool_agent.mdx` with a Mintlify-native Mermaid `flowchart TD`.
- Preserves all original facts: 5-turn loop cap, `TOOLS` arg, `<tool_call>...</tool_call>` syntax, and `<answer>NUMBER</answer>` termination.
- Part of a batch ASCII to Mermaid migration of cookbook architecture diagrams.

## Test plan
- [x] `./venv/bin/python -m pytest tests/parser/ -v` (22 passed)
- [x] `npx mintlify@latest broken-links` (no broken links)
- [x] Verified fence opens with ` ```mermaid `, closes with ` ``` `, `flowchart TD` is the first line, and node labels containing parens/angles/brackets are double-quoted