### PR TITLE
docs(cookbooks): convert frozenlake architecture to Mermaid

### DIFF
--- a/docs/cookbooks/frozenlake.mdx
+++ b/docs/cookbooks/frozenlake.mdx
@@ -17,18 +17,16 @@ A multi-turn agent flow that trains a model to navigate procedurally-generated F
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  ├── generate_random_map(seed, size, p)          # deterministic, in-process
-  ├── env = gymnasium.make("FrozenLake-v1", …)
-  └── Multi-turn loop (up to max_steps turns)
-        │
-        ├── client.chat.completions.create(...)   # render grid as text, ask for action
-        ├── parse_action() → env.step(action)
-        └── repeat until terminated / truncated / max_steps
-  │
-  └── episode.artifacts = {"won": bool, "turns": int, "last_action": str}
+```mermaid
+flowchart TD
+    A["AgentFlow.run(task, config)"] --> M["generate_random_map(seed, size, p) — deterministic, in-process"]
+    M --> E["env = gymnasium.make('FrozenLake-v1', ...)"]
+    E --> L["Multi-turn loop (up to max_steps turns)"]
+    L --> C["client.chat.completions.create(...) — render grid as text, ask for action"]
+    C --> P["parse_action() → env.step(action)"]
+    P --> D{"terminated / truncated / max_steps?"}
+    D -->|no| C
+    D -->|yes| R["episode.artifacts = {'won': bool, 'turns': int, 'last_action': str}"]
 ```
 
 The cookbook is fully self-contained — there's no dependency on `rllm.environments`. The map is regenerated deterministically from `(seed, size, p)` every time the flow runs, so the dataset stores only those parameters.


### PR DESCRIPTION
## Summary
- Convert the FrozenLake cookbook's ASCII text-art architecture diagram to a Mintlify-native Mermaid `flowchart TD`.
- Preserve every fact from the original (deterministic `generate_random_map(seed, size, p)`, `gymnasium.make('FrozenLake-v1', ...)`, `max_steps` cap, per-turn render to LLM to parse to step sequence, the three termination conditions, and the artifact dict).
- Part of a batch ASCII to Mermaid migration of cookbook architecture diagrams; sibling PRs convert the other cookbooks.

## Test plan
- [x] `./venv/bin/python -m pytest tests/parser/ -v` (22 passed)
- [x] MDX syntax check: fence opens with ```mermaid on its own line, closes with ``` on its own line, `flowchart TD` is the first line inside the fence, all labels with special characters are double-quoted (single quotes used for nested strings)
- [ ] Visual render check on the Mintlify preview after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)