### PR TITLE
docs(cookbooks): convert geo3k architecture to Mermaid

### DIFF
--- a/docs/cookbooks/geo3k.mdx
+++ b/docs/cookbooks/geo3k.mdx
@@ -17,16 +17,15 @@ A vision-language agent that solves geometry problems with diagram images via th
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  └── Solver
-        └── OpenAI(base_url=config.base_url).chat.completions.create(
-                messages=[system_prompt, {images + question}]
-            )
-            → Trajectory(name="solver", steps=[Step(action=response)])
-  │
-  └── Episode(trajectories=[solver], artifacts={"answer": response})
+```mermaid
+flowchart TD
+    A["AgentFlow.run(task, config)"] --> S["Solver"]
+    S --> C["OpenAI(base_url=config.base_url).chat.completions.create(...)"]
+    C --> M["messages=[system_prompt, image+question]"]
+    C --> R["response"]
+    R --> T["Trajectory(name=&quot;solver&quot;, steps=[Step(action=response)])"]
+    T --> E["Episode(trajectories=[solver], artifacts={&quot;answer&quot;: response})"]
+    A --> E
 ```
 
 The cookbook demonstrates the **multimodal content-block pattern** in an AgentFlow — the `messages` list contains a `{"type": "image_url", "image_url": {"url": f"data:image/png;base64,…"}}` block alongside the text content.


### PR DESCRIPTION
## Summary
- Replace the ASCII text-art architecture diagram in `docs/cookbooks/geo3k.mdx` with a Mintlify-native Mermaid `flowchart TD` so it renders as a real diagram in the Aspen theme.
- All facts preserved: single-turn multimodal solver, `messages=[system_prompt, image+question]`, named `solver` Trajectory, Episode with `artifacts={"answer": response}`.
- Part of a batch ASCII-to-Mermaid migration of cookbook architecture diagrams.

## Test plan
- [x] `pytest tests/parser/` 22 passed
- [x] MDX fence sanity: ` ```mermaid ` opens, ` ``` ` closes, `flowchart TD` first line, special-char labels double-quoted (`&quot;` for embedded double quotes)
- [ ] Visual render check in Mintlify preview after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)