### PR TITLE
docs(cookbooks): convert finqa architecture to Mermaid

### DIFF
--- a/docs/cookbooks/finqa.mdx
+++ b/docs/cookbooks/finqa.mdx
@@ -17,25 +17,30 @@ A multi-turn ReAct-style financial-QA agent that answers questions about SEC 10-
 
 ## Architecture
 
-```
-AgentFlow.run(task, config)
-  │
-  └── Multi-turn loop (up to 20 turns, native OpenAI tool calls)
-        │
-        ├── client.chat.completions.create(messages, tools=TOOL_SPECS)
-        │
-        ├── If msg.tool_calls is empty → that's the final answer, break.
-        │
-        └── Else: dispatch each tool call → append a `tool` message → repeat.
-              (track table_name in `accessed_tables` whenever
-               `get_table_info` is invoked, for the table-access bonus)
-  │
-  └── episode.artifacts = {"answer": full_response, "accessed_tables": [...], "turns": N}
+```mermaid
+flowchart TD
+    subgraph Run["AgentFlow.run(task, config)"]
+        A["Multi-turn loop (up to 20 turns, native OpenAI tool calls)"]
+        B["client.chat.completions.create(messages, tools=TOOL_SPECS)"]
+        C{"msg.tool_calls empty?"}
+        D["Final answer; break"]
+        E["Dispatch each tool call: get_table_names, get_table_info, sql_query, calculator"]
+        F["Append 'tool' message; if get_table_info, track table_name in accessed_tables (table-access bonus)"]
+        G["episode.artifacts = {'answer': full_response, 'accessed_tables': [...], 'turns': N}"]
+        A --> B --> C
+        C -- "Yes" --> D --> G
+        C -- "No" --> E --> F --> B
+    end
 
-Evaluator.evaluate(task, episode)
-  │
-  └── extract FINAL ANSWER from artifacts["answer"], grade via judge LLM,
-      add table-access bonus, return EvalOutput.
+    subgraph Eval["Evaluator.evaluate(task, episode)"]
+        H["Extract FINAL ANSWER from artifacts['answer']"]
+        I["Grade via judge LLM"]
+        J["Add table-access bonus"]
+        K["Return EvalOutput"]
+        H --> I --> J --> K
+    end
+
+    G -- "episode.artifacts" --> H
 ```
 
 [Model Weights](https://huggingface.co/rLLM/rLLM-FinQA-4B) | [Dataset](https://huggingface.co/datasets/rLLM/finqa)


### PR DESCRIPTION
## Summary
- Replace the ASCII text-art architecture diagram in `docs/cookbooks/finqa.mdx` with a Mintlify-native Mermaid `flowchart TD` (with two `subgraph` blocks for `AgentFlow.run` and `Evaluator.evaluate`, connected by an `episode.artifacts` edge) so it renders as a real diagram in the Aspen theme.
- All facts preserved: 20-turn cap, all 4 tool names (`get_table_names`, `get_table_info`, `sql_query`, `calculator`), empty-tool-calls termination, `accessed_tables` tracking on `get_table_info`, artifact keys, FINAL ANSWER extraction + judge LLM grade + table-access bonus + `EvalOutput` return.
- Part of a batch ASCII-to-Mermaid migration of cookbook architecture diagrams.

## Test plan
- [x] `pytest tests/parser/` 22 passed
- [x] MDX fence sanity: ` ```mermaid ` opens, ` ``` ` closes, `flowchart TD` first line, both subgraphs balanced, special-char labels double-quoted
- [ ] Visual render check in Mintlify preview after merge

> Note: PR #530 currently includes the same `docs/cookbooks/finqa.mdx` diff bundled with `solver_judge_flow.mdx` due to a worktree-branch collision during parallel PR creation. The finqa change should land via this PR; PR #530 will be cleaned to contain only `solver_judge_flow.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)