### PR TITLE
fix(unified_trainer): guard _gateway against None before starting

### DIFF
--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -312,7 +312,7 @@ class UnifiedTrainer:
 
         await self.backend.on_train_start(trainer_state)
 
-        if hasattr(self, "_gateway"):
+        if hasattr(self, "_gateway") and self._gateway is not None:
             self._gateway.start(self.backend.rollout_engine)
 
         if self.rllm_config.trainer.get("val_before_train", True):


### PR DESCRIPTION
`hasattr(self, "_gateway")` returned True even when the attribute had been set to None elsewhere, causing an AttributeError on `.start()`. Mirrors the existing guard at the other call site.

## Summary

<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- 
- 
- 

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
