### PR TITLE
refactor(verl): pass server_manager directly into VerlEngine

### DIFF
--- a/rllm/experimental/rollout/verl_engine.py
+++ b/rllm/experimental/rollout/verl_engine.py
@@ -1,30 +1,28 @@
+import logging
 import uuid
 from typing import cast
 
 from omegaconf import DictConfig
 from typing_extensions import override
-from verl.experimental.agent_loop.agent_loop import AgentLoopManager, AsyncLLMServerManager
+from verl.experimental.agent_loop.agent_loop import AsyncLLMServerManager
 
 from rllm.experimental.rollout.rollout_engine import ModelOutput, RolloutEngine
 from rllm.experimental.rollout.types import TokenInput, Tokenizer, TokenOutput, VerlTokenOutput
 from rllm.parser import ChatTemplateParser
 from rllm.workflows import TerminationEvent, TerminationReason
 
+logger = logging.getLogger(__name__)
+
 
 class VerlEngine(RolloutEngine):
-    def __init__(self, config: DictConfig, rollout_manager: AgentLoopManager, tokenizer: Tokenizer, processor=None, **kwargs):
+    def __init__(self, config: DictConfig, server_manager: AsyncLLMServerManager, tokenizer: Tokenizer, processor=None, **kwargs):
         super().__init__()
         self.config = config
 
         if config.actor_rollout_ref.rollout.name not in ["vllm", "sglang"]:
             raise ValueError(f"VerlEngine only supports vllm or sglang rollout, but got {config.actor_rollout_ref.rollout.name}")
 
-        assert rollout_manager.global_load_balancer is not None, "global_load_balancer is not available. Issues with RayPPOTrainer's `init_workers()` function."
-
-        self.rollout_manager: AgentLoopManager = rollout_manager
-        # reconstruct the servers list from the server_addresses and server_handles (Verl 0.7.0+)
-        servers = zip(rollout_manager.server_addresses, rollout_manager.server_handles, strict=True)
-        self.server_manager = AsyncLLMServerManager(config, servers=servers, load_balancer_handle=rollout_manager.global_load_balancer)
+        self.server_manager = server_manager
 
         self.tokenizer = tokenizer
         self.processor = processor
@@ -48,8 +46,8 @@ class VerlEngine(RolloutEngine):
             logprobs=1,
         )
 
-        print(f"train_sampling_params: {self.train_sampling_params}")
-        print(f"val_sampling_params: {self.val_sampling_params}")
+        logger.info(f"train_sampling_params: {self.train_sampling_params}")
+        logger.info(f"val_sampling_params: {self.val_sampling_params}")
 
     @property
     def supports_token_in_token_out(self) -> bool:

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -189,10 +189,18 @@ class VerlBackend(BackendProtocol[Iterable, DataProto], RayPPOTrainer):
         else:
             logger.warning("RayWorkerGroup.set_loss_fn not available — skipping custom loss injection")
 
-        # Step 3: initialize the rollout engine
+        # Step 3: build the AsyncLLMServerManager from the rollout manager and pass it directly
+        from verl.experimental.agent_loop.agent_loop import AsyncLLMServerManager
+
+        rollout_manager = self.async_rollout_manager
+        assert rollout_manager.global_load_balancer is not None, "global_load_balancer is not available. Issues with RayPPOTrainer's `init_workers()` function."
+        servers = zip(rollout_manager.server_addresses, rollout_manager.server_handles, strict=True)
+        server_manager = AsyncLLMServerManager(self.config, servers=servers, load_balancer_handle=rollout_manager.global_load_balancer)
+
+        # Step 4: initialize the rollout engine
         self.rollout_engine = VerlEngine(
             config=self.config,
-            rollout_manager=self.async_rollout_manager,
+            server_manager=server_manager,
             tokenizer=self.tokenizer,
             processor=self.processor,
         )


### PR DESCRIPTION
`VerlEngine.__init__` previously took an `AgentLoopManager` and reconstructed an `AsyncLLMServerManager` internally. Move that construction up to the caller (`VerlBackend.init_rollout_engine`) and have `VerlEngine` accept the `AsyncLLMServerManager` directly. This decouples `VerlEngine` from the `AgentLoopManager` plumbing and lets future callers (e.g. async/separated mode) hand in a custom server manager.

Also swap the two `print` calls for `logger.info` and add a `logger` to the module.

## Summary

<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Docs
- [x] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- 
- 
- 

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
