### PR TITLE
fix(verl): raise on aborted rollouts and normalize stop_reason at source

### DIFF
--- a/rllm/experimental/rollout/verl_engine.py
+++ b/rllm/experimental/rollout/verl_engine.py
@@ -73,6 +73,11 @@ class VerlEngine(RolloutEngine):
         sampling_params["max_tokens"] = max_tokens
 
         token_output = await self.server_manager.generate(request_id=application_id, prompt_ids=token_input, sampling_params=sampling_params)
+
+        if token_output.stop_reason in ("aborted", "abort"):
+            raise RuntimeError("Rollout aborted")
+        token_output.stop_reason = "length" if len(token_output.token_ids) >= max_tokens else "stop"
+
         return token_output
 
     @override
@@ -109,13 +114,7 @@ class VerlEngine(RolloutEngine):
         token_output = cast(VerlTokenOutput, token_output)
         completion_ids = token_output.token_ids
         logprobs = token_output.log_probs
-
-        # convert the stop reason from verl back to the standard finish reason TODO(listar2000): check backward-compatibility
-        reason_mapping = {"aborted": "abort", "completed": "stop"}
-        if token_output.stop_reason is not None:
-            finish_reason = reason_mapping.get(token_output.stop_reason, token_output.stop_reason)
-        else:
-            finish_reason = "stop"
+        finish_reason = token_output.stop_reason
 
         completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=True)
         # TODO: implement parse_completion for the standard parser


### PR DESCRIPTION
`get_token_output_from_token_input` previously returned the raw `token_output` from the server manager. When rollout was aborted (e.g. weight sync mid-generation), `stop_reason="aborted"` flowed downstream silently and `assemble_model_output` mapped it back to `"abort"` via a reverse-lookup dict. Aborted rollouts should be exceptional, not a quietly-flagged finish reason.

Raise `RuntimeError("Rollout aborted")` directly so the workflow layer can catch it. Normalize the remaining stop_reason to `"length"` / `"stop"` at the source based on whether max_tokens was hit. With normalization at source, `assemble_model_output` no longer needs the reason-mapping dict — `finish_reason = token_output.stop_reason` is sufficient.

## Summary

<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- 
- 
- 

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
