### PR TITLE
fix(verl+geo3k): make Qwen3-VL geo3k cookbook actually train

### DIFF
--- a/cookbooks/geo3k/geo3k_flow.py
+++ b/cookbooks/geo3k/geo3k_flow.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import re
 
 from openai import AsyncOpenAI
 
@@ -31,7 +32,7 @@ async def geo3k_flow(task: Task, config: AgentConfig) -> Episode:
     """Single-turn VLM geometry solver."""
     client = AsyncOpenAI(base_url=config.base_url, api_key="EMPTY")
     question = task.instruction
-    images = task.metadata.get("images", [])
+    images = task.metadata.get("images") or []
 
     user_content = _build_vlm_content(question, images) if images else question
 
@@ -69,26 +70,63 @@ def _detect_mime(data: bytes) -> str:
     return "image/png"
 
 
-def _build_vlm_content(text: str, images: list) -> list[dict]:
-    """Build OpenAI multimodal content blocks from text + image data."""
-    content: list[dict] = []
-    for img in images:
-        if img is None:
-            continue
-        if isinstance(img, bytes):
-            mime = _detect_mime(img)
-            encoded = base64.b64encode(img).decode("utf-8")
-            data_uri = f"data:{mime};base64,{encoded}"
-        elif isinstance(img, str):
-            data_uri = img  # assume already a URI or URL
+def _img_to_data_uri(img) -> str:
+    """Normalize one image (bytes / dict / str / PIL) to a data URI string."""
+    # Verl-format dataset row: ``{"bytes": <png-bytes>, "path": "..."}``.
+    if isinstance(img, dict):
+        if "bytes" in img and img["bytes"] is not None:
+            img = img["bytes"]
+        elif "path" in img and img["path"]:
+            img = img["path"]  # treat as URL/URI below
         else:
-            # PIL Image — convert to bytes
-            import io
+            raise ValueError(f"image dict missing usable 'bytes' or 'path': keys={list(img.keys())}")
+    if isinstance(img, bytes):
+        mime = _detect_mime(img)
+        return f"data:{mime};base64,{base64.b64encode(img).decode('utf-8')}"
+    if isinstance(img, str):
+        return img  # assume already a URI or URL
+    # PIL Image — convert to bytes.
+    import io
 
-            buf = io.BytesIO()
-            img.save(buf, format="PNG")
-            encoded = base64.b64encode(buf.getvalue()).decode("utf-8")
-            data_uri = f"data:image/png;base64,{encoded}"
-        content.append({"type": "image_url", "image_url": {"url": data_uri}})
-    content.append({"type": "text", "text": text})
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode('utf-8')}"
+
+
+def _build_vlm_content(text: str, images: list) -> list[dict]:
+    """Build OpenAI multimodal content blocks from text containing ``<image>`` markers.
+
+    Mirrors verl's ``rl_dataset._build_messages`` (verl/utils/dataset/rl_dataset.py:_build_messages):
+    splits the text on ``<image>`` / ``<video>`` markers and interleaves
+    ``image_url`` blocks at each marker position. This is critical because the
+    chat template expands an image content block into one image placeholder —
+    if the literal ``<image>`` ALSO survives in the rendered text, vLLM emits
+    a malformed prompt where one image is shown and the literal ``<image>``
+    string is appended (the model then "doesn't see" the image properly).
+    """
+    valid_images = [img for img in images if img is not None]
+    if not valid_images:
+        return [{"type": "text", "text": text}]
+
+    segments = [s for s in re.split(r"(<image>|<video>)", text) if s != ""]
+    content: list[dict] = []
+    img_idx = 0
+    for seg in segments:
+        if seg == "<image>":
+            if img_idx >= len(valid_images):
+                raise ValueError(f"<image> marker count exceeds image count ({len(valid_images)}) in {text!r}")
+            content.append({"type": "image_url", "image_url": {"url": _img_to_data_uri(valid_images[img_idx])}})
+            img_idx += 1
+        elif seg == "<video>":
+            # Geo3K is image-only; surface unexpected video markers.
+            raise NotImplementedError("<video> markers not supported in geo3k_flow")
+        else:
+            content.append({"type": "text", "text": seg})
+
+    # If the source text didn't include ``<image>`` markers (some datasets
+    # omit them), prepend any unconsumed images so the model still sees them.
+    while img_idx < len(valid_images):
+        content.insert(0, {"type": "image_url", "image_url": {"url": _img_to_data_uri(valid_images[img_idx])}})
+        img_idx += 1
+
     return content

--- a/docs/guides/ray-runtime-env.mdx
+++ b/docs/guides/ray-runtime-env.mdx
@@ -51,6 +51,7 @@ Any variable in your shell whose name starts with one of these prefixes is forwa
 | HuggingFace | `HF_`, `TOKENIZERS_`, `DATASETS_` |
 | Training frameworks | `TORCH_`, `PYTORCH_`, `DEEPSPEED_`, `MEGATRON_` |
 | CUDA / NCCL | `NCCL_`, `CUDA_`, `CUBLAS_`, `CUDNN_`, `NV_`, `NVIDIA_` |
+| rLLM extension hooks | `RLLM_` (used by `RLLM_EXTRA_WORKER_SETUP_HOOK`; see below) |
 
 So, to bump vLLM's logging level for a single run, you can just export it before launching training:
 
@@ -99,6 +100,39 @@ ray job submit \
 ```
 
 `get_ppo_ray_runtime_env()` reads this dict from `RAY_JOB_CONFIG_JSON_ENV_VAR` (which the Ray job runtime sets for you), pops the listed keys from its own `env_vars` so they cannot collide, and only sets `working_dir=None` when the job config does not specify a `working_dir`. Without that handling Ray's `ray.init()` would refuse to merge and raise unless you also exported `RAY_OVERRIDE_JOB_RUNTIME_ENV=1`.
+
+## Worker process setup hook
+
+Beyond environment variables, rLLM also wires a `worker_process_setup_hook` into the runtime env. Ray invokes this once at the start of every worker interpreter, before any user code runs. rLLM points it at `rllm.experimental.verl.patch.apply_all_verl_patches`, which monkey-patches the verl modules that the FSDP / vLLM workers re-import on startup.
+
+This matters because verl is pinned (currently 0.7.1) and rLLM ships small backports for known issues — e.g. the qwen3-VL inplace-add fix from [verl#5881](https://github.com/volcengine/verl/pull/5881), the NCCL-deadlock fix on dynamic-batching from [verl#5750](https://github.com/volcengine/verl/issues/5750), and the jagged-NestedTensor `_ragged_idx` preservation fix from [verl#6127](https://github.com/volcengine/verl/pull/6127). Ray spawns each worker as a fresh Python interpreter that re-imports verl from disk, so a driver-side `import verl; verl.X = patched_X` never propagates. The setup hook runs the patches *inside* every worker.
+
+If your `--runtime-env-json` already specifies a `worker_process_setup_hook`, rLLM steps out of the way (same precedence rule as for `env_vars`): the job-submitted hook wins and rLLM does not register its own. In that case you are responsible for calling `apply_all_verl_patches()` yourself if you want the verl backports.
+
+### Adding your own setup hook (`RLLM_EXTRA_WORKER_SETUP_HOOK`)
+
+Sometimes you need to apply environment-specific tweaks on every worker — for example, disabling cuDNN on a host whose cuDNN install is broken, or pointing Triton at a per-PID cache to avoid races between concurrent FSDP workers. These do not belong in rLLM itself (they are properties of one machine), so we expose an extension point instead of asking you to fork the runtime env.
+
+Set the `RLLM_EXTRA_WORKER_SETUP_HOOK` environment variable to `"<absolute-path-to-file.py>:<function-name>"`. `apply_all_verl_patches` reads it on every worker, loads the file via `importlib.util.spec_from_file_location` (so it works even when the file is not on `sys.path` — e.g. lives under a gitignored `tmp/` directory), and calls the named function. Failures are logged but never re-raised.
+
+```python title="my_local_setup.py"
+def apply():
+    import torch
+    torch.backends.cudnn.enabled = False  # workaround broken cuDNN install
+    import os
+    os.environ.setdefault("TRITON_CACHE_DIR", f"/tmp/triton-cache-{os.getpid()}")
+```
+
+```python title="train.py"
+import os
+from pathlib import Path
+
+# Set BEFORE importing rllm — get_ppo_ray_runtime_env() reads it via
+# the RLLM_ forwarded prefix and propagates it to every Ray worker.
+os.environ["RLLM_EXTRA_WORKER_SETUP_HOOK"] = f"{Path(__file__).parent / 'my_local_setup.py'}:apply"
+```
+
+The `RLLM_` prefix is in `FORWARD_PREFIXES`, so the variable is forwarded to workers without any extra config. The hook runs *after* rLLM's verl patches.
 
 ## Programmatic access
 

--- a/rllm/data/dataset.py
+++ b/rllm/data/dataset.py
@@ -364,18 +364,28 @@ class DatasetRegistry:
         return [{col: col_dict[col][i] for col in col_dict} for i in range(num_rows)]
 
     @classmethod
-    def _strip_binary_columns(cls, data_list: list[dict[str, Any]], bin_cols: list[str]) -> list[dict[str, Any]]:
-        """Return copies of rows with binary columns set to ``None``.
+    def _wrap_binary_columns_for_parquet(cls, data_list: list[dict[str, Any]], bin_cols: list[str]) -> list[dict[str, Any]]:
+        """Wrap binary columns into verl-compatible ``{"bytes": ..., "path": ""}`` dicts.
 
-        Used for verl postprocessing where image data isn't needed.
+        Parquet stores raw ``bytes``/``list[bytes]`` fine, but verl's data path
+        (``verl/utils/dataset/rl_dataset.py:_build_messages``) expects each
+        image element to be either a PIL ``Image`` or a dict with a ``bytes``
+        key. We standardise on ``[{"bytes": <png-bytes>, "path": ""}, ...]``
+        so the same parquet works for both verl's native pipeline AND rLLM's
+        agent flows (which read via ``task.metadata["images"]``).
         """
-        stripped = []
+        wrapped = []
         for row in data_list:
             new_row = dict(row)
             for col in bin_cols:
-                new_row[col] = None
-            stripped.append(new_row)
-        return stripped
+                val = new_row.get(col)
+                if isinstance(val, bytes):
+                    new_row[col] = {"bytes": val, "path": ""}
+                elif isinstance(val, list):
+                    new_row[col] = [{"bytes": item, "path": ""} if isinstance(item, bytes) else item for item in val]
+                # leave None / other types untouched
+            wrapped.append(new_row)
+        return wrapped
 
     @classmethod
     def _verl_path_for(cls, dataset_path: str) -> str:
@@ -425,9 +435,12 @@ class DatasetRegistry:
             dataset_path = os.path.join(cls._DATASET_DIR, rel_path)
             cls._save_arrow_ipc(data_list, dataset_path)
 
-            # Strip binary columns for verl postprocessing (images not needed)
-            stripped = cls._strip_binary_columns(data_list, bin_cols)
-            verl_data = cls.apply_verl_postprocessing(stripped)
+            # Wrap binary columns as {"bytes": ..., "path": ""} dicts so they
+            # round-trip through parquet AND match verl's expected image format.
+            # Images flow through into ``extra_info`` so rLLM agent flows can
+            # read them via ``task.metadata["images"]``.
+            wrapped = cls._wrap_binary_columns_for_parquet(data_list, bin_cols)
+            verl_data = cls.apply_verl_postprocessing(wrapped)
             verl_dataset_path = cls._verl_path_for(dataset_path)
             verl_data_df = pd.DataFrame(verl_data)
             verl_data_df.to_parquet(verl_dataset_path)

--- a/rllm/experimental/verl/patch.py
+++ b/rllm/experimental/verl/patch.py
@@ -317,6 +317,12 @@ def patch_verl_tensordict_jagged_layout() -> None:
 # Worker-side entry point (used as Ray runtime_env worker_process_setup_hook)
 # ---------------------------------------------------------------------------
 
+_ALL_VERL_PATCHES = {
+    "patch_verl_dynamic_batch_sync": patch_verl_dynamic_batch_sync,
+    "patch_verl_qwen3_vl_dummy_inplace": patch_verl_qwen3_vl_dummy_inplace,
+    "patch_verl_tensordict_jagged_layout": patch_verl_tensordict_jagged_layout,
+}
+
 
 def apply_all_verl_patches() -> None:
     """Apply every Verl patch that is safe to run unconditionally on workers.
@@ -341,20 +347,11 @@ def apply_all_verl_patches() -> None:
     the ``rllm.sdk.enable`` config flag and should only be applied when SDK
     instrumentation is requested.
     """
-    try:
-        patch_verl_dynamic_batch_sync()
-    except Exception:  # pragma: no cover — patch is best-effort
-        logger.exception("patch_verl_dynamic_batch_sync failed in worker setup hook")
-
-    try:
-        patch_verl_qwen3_vl_dummy_inplace()
-    except Exception:  # pragma: no cover — patch is best-effort
-        logger.exception("patch_verl_qwen3_vl_dummy_inplace failed in worker setup hook")
-
-    try:
-        patch_verl_tensordict_jagged_layout()
-    except Exception:  # pragma: no cover — patch is best-effort
-        logger.exception("patch_verl_tensordict_jagged_layout failed in worker setup hook")
+    for patch_name, patch_func in _ALL_VERL_PATCHES.items():
+        try:
+            patch_func()
+        except Exception:  # pragma: no cover — patch is best-effort
+            logger.exception(f"{patch_name} failed in worker setup hook")
 
     _run_extra_worker_setup_hook()
 

--- a/rllm/experimental/verl/patch.py
+++ b/rllm/experimental/verl/patch.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 _VERL_DYNAMIC_BATCH_PATCHED = False
 _VLLM_SDK_PATCHED = False
+_VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED = False
 
 
 # ---------------------------------------------------------------------------
@@ -114,3 +115,95 @@ def patch_vllm_for_sdk() -> None:
     vLLMReplica.__init__ = _patched_init
     _VLLM_SDK_PATCHED = True
     logger.info("Patched vLLMReplica for SDK instrumentation")
+
+
+# ---------------------------------------------------------------------------
+# Verl qwen3_vl: out-of-place add in dummy visual forward (backport PR #5881)
+# ---------------------------------------------------------------------------
+
+
+def patch_verl_qwen3_vl_dummy_inplace() -> None:
+    """Backport `volcengine/verl#5881` for ``verl.models.transformers.qwen3_vl``.
+
+    The dummy/no-image branch of ``_get_input_embeds`` mutates ``inputs_embeds``
+    inplace::
+
+        inputs_embeds += 0.0 * image_embeds.mean()
+        for emb in dummy_deepstack_image_embeds or []:
+            inputs_embeds += 0.0 * emb.mean()
+
+    ``inputs_embeds`` is produced by ``model.get_input_embeddings()(input_ids)``
+    and is a leaf with ``requires_grad=True`` after FSDP wrapping; the inplace
+    ``+=`` raises a RuntimeError on the autograd backward and, in our 0.7.1
+    pin, also surfaces as ``CUDNN_STATUS_NOT_INITIALIZED`` on the preceding
+    ``model.visual(...)`` call due to the way the failure propagates inside
+    Conv3d's cuDNN workspace setup. PR #5881 (merged main 2026-04-07; not in
+    0.7.1) replaces both lines with out-of-place addition.
+
+    We patch by re-exec'ing a fixed source of ``_get_input_embeds`` in the
+    module's global namespace; ``qwen3_vl_base_forward`` looks up
+    ``_get_input_embeds`` from module globals at call time, so the rebound
+    function is picked up automatically.
+    """
+    global _VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED
+    if _VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED:
+        return
+
+    import inspect
+
+    from verl.models.transformers import qwen3_vl as mod
+
+    src = inspect.getsource(mod._get_input_embeds)
+    new_src = src.replace(
+        "inputs_embeds += 0.0 * image_embeds.mean()",
+        "inputs_embeds = inputs_embeds + 0.0 * image_embeds.mean()",
+    ).replace(
+        "inputs_embeds += 0.0 * emb.mean()",
+        "inputs_embeds = inputs_embeds + 0.0 * emb.mean()",
+    )
+
+    if new_src == src:
+        # Upstream already fixed (e.g. user bumped verl past 0.7.1).
+        _VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED = True
+        logger.info("qwen3_vl PR #5881 patch: source already uses out-of-place add; nothing to patch.")
+        return
+
+    # Compile and exec into the module's globals so the rebound function shares
+    # the module's namespace (torch, Optional, etc.) and so callers in the
+    # same module (qwen3_vl_base_forward) pick up the patched version on the
+    # next attribute lookup.
+    exec(compile(new_src, mod.__file__, "exec"), mod.__dict__)
+
+    _VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED = True
+    logger.info("Patched verl qwen3_vl._get_input_embeds: dummy visual path now uses out-of-place addition (backport of volcengine/verl#5881)")
+
+
+# ---------------------------------------------------------------------------
+# Worker-side entry point (used as Ray runtime_env worker_process_setup_hook)
+# ---------------------------------------------------------------------------
+
+
+def apply_all_verl_patches() -> None:
+    """Apply every Verl patch that is safe to run unconditionally on workers.
+
+    Designed to be wired in as ``runtime_env.worker_process_setup_hook =
+    "rllm.experimental.verl.patch:apply_all_verl_patches"`` so that each Ray
+    worker process applies the patches in its own interpreter (driver-side
+    monkey-patches do not propagate to worker processes).
+
+    Each patch below is lazy and idempotent, so it is safe to call this
+    repeatedly and from any process.
+
+    Note: ``patch_vllm_for_sdk`` is NOT included here — it is gated behind
+    the ``rllm.sdk.enable`` config flag and should only be applied when SDK
+    instrumentation is requested.
+    """
+    try:
+        patch_verl_dynamic_batch_sync()
+    except Exception:  # pragma: no cover — patch is best-effort
+        logger.exception("patch_verl_dynamic_batch_sync failed in worker setup hook")
+
+    try:
+        patch_verl_qwen3_vl_dummy_inplace()
+    except Exception:  # pragma: no cover — patch is best-effort
+        logger.exception("patch_verl_qwen3_vl_dummy_inplace failed in worker setup hook")

--- a/rllm/experimental/verl/patch.py
+++ b/rllm/experimental/verl/patch.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 _VERL_DYNAMIC_BATCH_PATCHED = False
 _VLLM_SDK_PATCHED = False
 _VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED = False
-_CUDNN_DISABLED = False
+_VERL_TENSORDICT_JAGGED_PATCHED = False
 
 
 # ---------------------------------------------------------------------------
@@ -180,38 +180,142 @@ def patch_verl_qwen3_vl_dummy_inplace() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Worker-side entry point (used as Ray runtime_env worker_process_setup_hook)
+# Verl tensordict utils: preserve _ragged_idx when rebuilding 3D NestedTensors
+# (backport PR #6127)
 # ---------------------------------------------------------------------------
 
 
-def patch_disable_cudnn() -> None:
-    """Disable cuDNN globally for the current process.
+def patch_verl_tensordict_jagged_layout() -> None:
+    """Backport `volcengine/verl#6127` for ``verl.utils.tensordict_utils``.
 
-    Workaround for environments where ``cudnnCreate`` returns
-    ``CUDNN_STATUS_NOT_INITIALIZED`` for any conv (1d/2d/3d) or for the
-    cuDNN-backed scaled-dot-product attention kernel — even from a
-    minimal `torch.nn.Conv2d` call. With cuDNN disabled, conv ops fall
-    back to cuBLAS/native kernels and SDPA falls back to FlashAttention
-    or the math/mem-efficient backend, all of which run fine on H100.
+    Fixes a bug in the rebuilding of 3D jagged NestedTensors after
+    selection / chunking. ``torch.nested.as_nested_tensor(tensors,
+    layout=torch.jagged)`` is ambiguous when all input tensors share the
+    same last-dimension length — torch picks the wrong dimension as the
+    jagged axis. For mRoPE ``position_ids`` with per-sample shape
+    ``(num_heads, seq_len)``, this produces a rebuilt nested tensor whose
+    ``_ragged_idx`` is 1 (heads dim) instead of 2 (seq dim), causing two
+    downstream crashes:
 
-    Apply at process start (before any conv/SDPA call) so the flag
-    sticks before the first cuDNN handle attempt.
+    - ``index_select_tensor_dict`` → ``unbind()`` →
+      ``torch.split(values, [batch_size], dim=ragged_idx-1)`` fails because
+      ``values`` has total length = sum-of-row-lengths, not batch_size
+      (hits the ``use_dynamic_bsz=True`` micro-batch partitioning path).
+    - rmpad path's rotary cos/sin gets shape ``(B,)`` instead of ``(B, S)``
+      and ``apply_rotary_pos_emb`` crashes with
+      ``RuntimeError: The size of tensor a (<S>) must match the size of
+      tensor b (<B>) at non-singleton dimension 2``.
+
+    The fix introduces a ``nested_tensor_from_tensor_list(tensors,
+    ragged_idx)`` helper that explicitly preserves the intended ragged
+    dimension via ``torch.nested.nested_tensor_from_jagged`` plus an
+    explicit ``_ragged_idx`` set, and uses it in ``concat_nested_tensors``,
+    ``chunk_tensordict``, and ``index_select_tensor_dict``.
+
+    Merged into verl main 2026-04-24; not in 0.7.1.
     """
-    global _CUDNN_DISABLED
-    if _CUDNN_DISABLED:
+    global _VERL_TENSORDICT_JAGGED_PATCHED
+    if _VERL_TENSORDICT_JAGGED_PATCHED:
         return
 
     import torch
+    from tensordict import TensorDict
+    from verl.utils import tensordict_utils as tu
 
-    torch.backends.cudnn.enabled = False
-    try:
-        torch.backends.cuda.enable_cudnn_sdp(False)
-    except AttributeError:
-        # Older torch versions don't expose enable_cudnn_sdp.
-        pass
+    if hasattr(tu, "nested_tensor_from_tensor_list"):
+        # Upstream already provides the helper (e.g. user bumped verl past 0.7.1).
+        _VERL_TENSORDICT_JAGGED_PATCHED = True
+        logger.info("verl tensordict jagged-layout patch: upstream already provides nested_tensor_from_tensor_list; nothing to patch.")
+        return
 
-    _CUDNN_DISABLED = True
-    logger.info("Disabled torch.backends.cudnn (and cuDNN-SDP) — env-level workaround")
+    def nested_tensor_from_tensor_list(tensors, ragged_idx=None):
+        assert len(tensors) > 0, "Must provide at least one tensor"
+        sample_dim = tensors[0].dim()
+        if ragged_idx is None:
+            ragged_idx = sample_dim
+        assert ragged_idx == sample_dim, f"Only last-dimension ragged tensors are supported. Got {ragged_idx=} and {sample_dim=}"
+
+        if sample_dim == 1:
+            return torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
+
+        values = torch.cat(tensors, dim=-1)
+        lengths = torch.tensor([t.shape[-1] for t in tensors], dtype=torch.long, device=values.device)
+        offsets = torch.zeros(len(tensors) + 1, dtype=torch.long, device=values.device)
+        torch.cumsum(lengths, dim=0, out=offsets[1:])
+
+        nested_tensor = torch.nested.nested_tensor_from_jagged(values=values, offsets=offsets)
+        nested_tensor._ragged_idx = ragged_idx
+        return nested_tensor
+
+    def concat_nested_tensors(tensors):
+        for tensor in tensors:
+            assert tensor.is_nested and tensor.is_contiguous()
+        unbind_tensors = []
+        for tensor in tensors:
+            assert len(tensor.shape) >= 2, f"nested tensor must have 2 or more dimensions. Got {tensor.shape}"
+            unbind_tensors.extend(list(tensor.unbind(0)))
+        return nested_tensor_from_tensor_list(unbind_tensors, ragged_idx=tensors[0].dim() - 1)
+
+    def chunk_tensordict(td, chunks):
+        assert isinstance(td, TensorDict) and len(td) % chunks == 0, f"expecting td with length divisible by chunks, but got {len(td)} and {chunks}"
+        chunk_size = len(td) // chunks
+        nested_keys = {key for key, val in td.items() if isinstance(val, torch.Tensor) and val.is_nested}
+        new_td = TensorDict({k: v for k, v in td.items() if k not in nested_keys}, batch_size=td.batch_size, device=td.device)
+        tds = new_td.chunk(chunks=chunks)
+        for key in nested_keys:
+            nt = td[key]
+            try:
+                tensors = nt.unbind(dim=0)
+            except RuntimeError:
+                padded = nt.to_padded_tensor(0)
+                padded_chunks = padded.chunk(chunks, dim=0)
+                offsets = nt.offsets()
+                lengths = offsets.diff().tolist()
+                for i, chunk_td in enumerate(tds):
+                    chunk_lengths = lengths[i * chunk_size : (i + 1) * chunk_size]
+                    chunk_tensors = [padded_chunks[i][j, :seq_len] for j, seq_len in enumerate(chunk_lengths)]
+                    chunk_td[key] = nested_tensor_from_tensor_list(chunk_tensors, ragged_idx=nt.dim() - 1)
+                continue
+            for i, chunk_td in enumerate(tds):
+                chunk_td[key] = nested_tensor_from_tensor_list(list(tensors[i * chunk_size : (i + 1) * chunk_size]), ragged_idx=nt.dim() - 1)
+        return tds
+
+    def index_select_tensor_dict(batch, indices):
+        if isinstance(indices, list):
+            indices = torch.tensor(indices)
+        assert indices.dim() == 1, "indices must be a 1D tensor"
+        data_dict = {}
+        batch_size = indices.shape[0]
+        if batch is not None:
+            for key, tensor in batch.items():
+                if isinstance(tensor, torch.Tensor) and not tensor.is_nested:
+                    data_dict[key] = tensor[indices]
+                elif isinstance(tensor, torch.Tensor) and tensor.is_nested:
+                    tensor_lst = tensor.unbind()
+                    selected_tensors = [tensor_lst[idx] for idx in indices]
+                    data_dict[key] = nested_tensor_from_tensor_list(selected_tensors, ragged_idx=tensor.dim() - 1)
+                else:
+                    if tensor.shape:
+                        data_dict[key] = tensor[indices]
+                    else:
+                        data_dict[key] = tensor
+            selected_batch = TensorDict(source=data_dict, batch_size=batch_size)
+        else:
+            selected_batch = None
+        return selected_batch
+
+    tu.nested_tensor_from_tensor_list = nested_tensor_from_tensor_list
+    tu.concat_nested_tensors = concat_nested_tensors
+    tu.chunk_tensordict = chunk_tensordict
+    tu.index_select_tensor_dict = index_select_tensor_dict
+
+    _VERL_TENSORDICT_JAGGED_PATCHED = True
+    logger.info("Patched verl.utils.tensordict_utils: rebuild jagged NestedTensors with explicit _ragged_idx (backport of volcengine/verl#6127)")
+
+
+# ---------------------------------------------------------------------------
+# Worker-side entry point (used as Ray runtime_env worker_process_setup_hook)
+# ---------------------------------------------------------------------------
 
 
 def apply_all_verl_patches() -> None:
@@ -225,49 +329,18 @@ def apply_all_verl_patches() -> None:
     Each patch below is lazy and idempotent, so it is safe to call this
     repeatedly and from any process.
 
+    Optional extension hook: if the ``RLLM_EXTRA_WORKER_SETUP_HOOK``
+    environment variable is set, this function will additionally invoke the
+    callable it names. The value is ``"<absolute-file-path.py>:<func>"``;
+    the function is loaded directly from the file via ``importlib.util`` so
+    it does not need to live in a package on ``sys.path``. This is intended
+    for environment-specific workarounds (e.g. disabling cuDNN on a host
+    with a broken cuDNN install) that should not be baked into rLLM itself.
+
     Note: ``patch_vllm_for_sdk`` is NOT included here — it is gated behind
     the ``rllm.sdk.enable`` config flag and should only be applied when SDK
     instrumentation is requested.
     """
-    # Unmissable side-effects so we can verify (after the run) that this hook
-    # actually executed inside each Ray worker process. The marker file is the
-    # primary signal; the stderr print is a secondary one in case worker stdout
-    # logging is suppressed.
-    import os
-    import sys
-
-    pid = os.getpid()
-    try:
-        os.makedirs("/tmp/geo3k_run", exist_ok=True)
-        with open(f"/tmp/geo3k_run/setup_hook.{pid}.marker", "w") as f:
-            f.write(f"apply_all_verl_patches ran in pid={pid}\n")
-    except Exception:
-        pass
-    try:
-        print(f"[apply_all_verl_patches] pid={pid} setup hook running", file=sys.stderr, flush=True)
-    except Exception:
-        pass
-
-    # Per-process Triton cache dir so concurrent FSDP/vLLM workers don't race
-    # on the shared ``~/.triton/cache`` directory (manifests as
-    # ``ImportError: __triton_launcher.cpython-...so`` or
-    # ``FileNotFoundError: cross_entropy_fwd_kernel.llir`` when one worker
-    # reads a kernel another worker is mid-compile on). MUST be set before
-    # any ``import triton`` in this process.
-    try:
-        triton_dir = f"/tmp/triton-cache-{pid}"
-        os.makedirs(triton_dir, exist_ok=True)
-        os.environ.setdefault("TRITON_CACHE_DIR", triton_dir)
-    except Exception:
-        pass
-
-    # cuDNN must be disabled BEFORE any torch op that would create a cuDNN
-    # handle (conv/SDPA). Doing it first in this hook is the safest place.
-    try:
-        patch_disable_cudnn()
-    except Exception:  # pragma: no cover — patch is best-effort
-        logger.exception("patch_disable_cudnn failed in worker setup hook")
-
     try:
         patch_verl_dynamic_batch_sync()
     except Exception:  # pragma: no cover — patch is best-effort
@@ -277,3 +350,48 @@ def apply_all_verl_patches() -> None:
         patch_verl_qwen3_vl_dummy_inplace()
     except Exception:  # pragma: no cover — patch is best-effort
         logger.exception("patch_verl_qwen3_vl_dummy_inplace failed in worker setup hook")
+
+    try:
+        patch_verl_tensordict_jagged_layout()
+    except Exception:  # pragma: no cover — patch is best-effort
+        logger.exception("patch_verl_tensordict_jagged_layout failed in worker setup hook")
+
+    _run_extra_worker_setup_hook()
+
+
+def _run_extra_worker_setup_hook() -> None:
+    """Optionally invoke a user-supplied setup hook from RLLM_EXTRA_WORKER_SETUP_HOOK.
+
+    Format: ``"<absolute path to .py file>:<function name>"``. The function
+    is loaded via ``importlib.util.spec_from_file_location`` so it works
+    even when the file is not on ``sys.path`` (e.g. lives under a
+    gitignored ``tmp/`` directory). Failures are logged but never raised —
+    this is a best-effort extension point and must not crash worker init.
+    """
+    import os
+
+    spec_str = os.environ.get("RLLM_EXTRA_WORKER_SETUP_HOOK")
+    if not spec_str:
+        return
+
+    path, _, func_name = spec_str.rpartition(":")
+    if not path or not func_name:
+        logger.warning(
+            "RLLM_EXTRA_WORKER_SETUP_HOOK=%r is malformed; expected '<file.py>:<func>'",
+            spec_str,
+        )
+        return
+
+    try:
+        import importlib.util
+
+        mod_name = f"_rllm_extra_setup_hook_{os.getpid()}"
+        spec = importlib.util.spec_from_file_location(mod_name, path)
+        if spec is None or spec.loader is None:
+            logger.warning("RLLM_EXTRA_WORKER_SETUP_HOOK: could not load spec for %s", path)
+            return
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        getattr(mod, func_name)()
+    except Exception:
+        logger.exception("RLLM_EXTRA_WORKER_SETUP_HOOK=%r failed", spec_str)

--- a/rllm/experimental/verl/patch.py
+++ b/rllm/experimental/verl/patch.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 _VERL_DYNAMIC_BATCH_PATCHED = False
 _VLLM_SDK_PATCHED = False
 _VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED = False
+_CUDNN_DISABLED = False
 
 
 # ---------------------------------------------------------------------------
@@ -183,11 +184,41 @@ def patch_verl_qwen3_vl_dummy_inplace() -> None:
 # ---------------------------------------------------------------------------
 
 
+def patch_disable_cudnn() -> None:
+    """Disable cuDNN globally for the current process.
+
+    Workaround for environments where ``cudnnCreate`` returns
+    ``CUDNN_STATUS_NOT_INITIALIZED`` for any conv (1d/2d/3d) or for the
+    cuDNN-backed scaled-dot-product attention kernel — even from a
+    minimal `torch.nn.Conv2d` call. With cuDNN disabled, conv ops fall
+    back to cuBLAS/native kernels and SDPA falls back to FlashAttention
+    or the math/mem-efficient backend, all of which run fine on H100.
+
+    Apply at process start (before any conv/SDPA call) so the flag
+    sticks before the first cuDNN handle attempt.
+    """
+    global _CUDNN_DISABLED
+    if _CUDNN_DISABLED:
+        return
+
+    import torch
+
+    torch.backends.cudnn.enabled = False
+    try:
+        torch.backends.cuda.enable_cudnn_sdp(False)
+    except AttributeError:
+        # Older torch versions don't expose enable_cudnn_sdp.
+        pass
+
+    _CUDNN_DISABLED = True
+    logger.info("Disabled torch.backends.cudnn (and cuDNN-SDP) — env-level workaround")
+
+
 def apply_all_verl_patches() -> None:
     """Apply every Verl patch that is safe to run unconditionally on workers.
 
     Designed to be wired in as ``runtime_env.worker_process_setup_hook =
-    "rllm.experimental.verl.patch:apply_all_verl_patches"`` so that each Ray
+    "rllm.experimental.verl.patch.apply_all_verl_patches"`` so that each Ray
     worker process applies the patches in its own interpreter (driver-side
     monkey-patches do not propagate to worker processes).
 
@@ -198,6 +229,45 @@ def apply_all_verl_patches() -> None:
     the ``rllm.sdk.enable`` config flag and should only be applied when SDK
     instrumentation is requested.
     """
+    # Unmissable side-effects so we can verify (after the run) that this hook
+    # actually executed inside each Ray worker process. The marker file is the
+    # primary signal; the stderr print is a secondary one in case worker stdout
+    # logging is suppressed.
+    import os
+    import sys
+
+    pid = os.getpid()
+    try:
+        os.makedirs("/tmp/geo3k_run", exist_ok=True)
+        with open(f"/tmp/geo3k_run/setup_hook.{pid}.marker", "w") as f:
+            f.write(f"apply_all_verl_patches ran in pid={pid}\n")
+    except Exception:
+        pass
+    try:
+        print(f"[apply_all_verl_patches] pid={pid} setup hook running", file=sys.stderr, flush=True)
+    except Exception:
+        pass
+
+    # Per-process Triton cache dir so concurrent FSDP/vLLM workers don't race
+    # on the shared ``~/.triton/cache`` directory (manifests as
+    # ``ImportError: __triton_launcher.cpython-...so`` or
+    # ``FileNotFoundError: cross_entropy_fwd_kernel.llir`` when one worker
+    # reads a kernel another worker is mid-compile on). MUST be set before
+    # any ``import triton`` in this process.
+    try:
+        triton_dir = f"/tmp/triton-cache-{pid}"
+        os.makedirs(triton_dir, exist_ok=True)
+        os.environ.setdefault("TRITON_CACHE_DIR", triton_dir)
+    except Exception:
+        pass
+
+    # cuDNN must be disabled BEFORE any torch op that would create a cuDNN
+    # handle (conv/SDPA). Doing it first in this hook is the safest place.
+    try:
+        patch_disable_cudnn()
+    except Exception:  # pragma: no cover — patch is best-effort
+        logger.exception("patch_disable_cudnn failed in worker setup hook")
+
     try:
         patch_verl_dynamic_batch_sync()
     except Exception:  # pragma: no cover — patch is best-effort

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -220,10 +220,15 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         Returns:
             VerlEngine: The initialized rollout engine.
         """
-        # Apply Verl patches
-        from rllm.experimental.verl.patch import patch_verl_dynamic_batch_sync
+        # Apply Verl patches (driver-side; workers run them via runtime_env
+        # worker_process_setup_hook -> rllm.experimental.verl.patch:apply_all_verl_patches)
+        from rllm.experimental.verl.patch import (
+            patch_verl_dynamic_batch_sync,
+            patch_verl_qwen3_vl_dummy_inplace,
+        )
 
         patch_verl_dynamic_batch_sync()
+        patch_verl_qwen3_vl_dummy_inplace()
 
         # If SDK is enabled, instrument vLLM replicas before creating workers
         sdk_enabled = self.full_config.rllm.get("sdk", {}).get("enable", False)

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -220,15 +220,13 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         Returns:
             VerlEngine: The initialized rollout engine.
         """
-        # Apply Verl patches (driver-side; workers run them via runtime_env
-        # worker_process_setup_hook -> rllm.experimental.verl.patch:apply_all_verl_patches)
-        from rllm.experimental.verl.patch import (
-            patch_verl_dynamic_batch_sync,
-            patch_verl_qwen3_vl_dummy_inplace,
-        )
+        # Apply driver-side patches. Most verl monkey-patches only affect
+        # worker code paths (FSDP / vLLM), so they live in the worker hook
+        # at rllm.experimental.verl.patch:apply_all_verl_patches (wired via
+        # runtime_env.worker_process_setup_hook in ray_runtime_env.py).
+        from rllm.experimental.verl.patch import patch_verl_tensordict_jagged_layout
 
-        patch_verl_dynamic_batch_sync()
-        patch_verl_qwen3_vl_dummy_inplace()
+        patch_verl_tensordict_jagged_layout()
 
         # If SDK is enabled, instrument vLLM replicas before creating workers
         sdk_enabled = self.full_config.rllm.get("sdk", {}).get("enable", False)

--- a/rllm/trainer/verl/ray_runtime_env.py
+++ b/rllm/trainer/verl/ray_runtime_env.py
@@ -102,4 +102,11 @@ def get_ppo_ray_runtime_env():
     # Only set working_dir=None when the job config doesn't specify one (avoid merge conflict)
     if job_runtime_env.get("working_dir") is None:
         runtime_env["working_dir"] = None
+    # Apply rLLM's verl patches (PR #5881 backport, dynamic-batch sync, etc.) on every
+    # Ray worker process so the patches take effect inside FSDP workers — driver-side
+    # monkey-patches do not propagate. The hook function is lazy and idempotent.
+    if job_runtime_env.get("worker_process_setup_hook") is None:
+        # Ray expects a dotted import path (no colon); it does
+        # ``module.rpartition('.') -> module + attr`` to load the hook.
+        runtime_env["worker_process_setup_hook"] = "rllm.experimental.verl.patch.apply_all_verl_patches"
     return runtime_env

--- a/rllm/trainer/verl/ray_runtime_env.py
+++ b/rllm/trainer/verl/ray_runtime_env.py
@@ -38,6 +38,7 @@ FORWARD_PREFIXES = [
     "CUDNN_",
     "NV_",
     "NVIDIA_",
+    "RLLM_",
 ]
 
 

--- a/tests/data/test_arrow_ipc.py
+++ b/tests/data/test_arrow_ipc.py
@@ -172,19 +172,33 @@ class TestVerlPathFromArrow:
 
 
 # ---------------------------------------------------------------------------
-# strip binary columns
+# wrap binary columns for parquet
 # ---------------------------------------------------------------------------
 
 
-class TestStripBinaryColumns:
-    def test_strips(self):
+class TestWrapBinaryColumnsForParquet:
+    def test_wraps_scalar_bytes(self):
         data = [{"text": "q", "img": b"data", "label": 1}]
-        result = DatasetRegistry._strip_binary_columns(data, ["img"])
-        assert result[0]["img"] is None
+        result = DatasetRegistry._wrap_binary_columns_for_parquet(data, ["img"])
+        assert result[0]["img"] == {"bytes": b"data", "path": ""}
         assert result[0]["text"] == "q"
         assert result[0]["label"] == 1
         # Original unchanged
         assert data[0]["img"] == b"data"
+
+    def test_wraps_list_of_bytes(self):
+        data = [{"text": "q", "imgs": [b"a", b"b"], "label": 1}]
+        result = DatasetRegistry._wrap_binary_columns_for_parquet(data, ["imgs"])
+        assert result[0]["imgs"] == [
+            {"bytes": b"a", "path": ""},
+            {"bytes": b"b", "path": ""},
+        ]
+        assert data[0]["imgs"] == [b"a", b"b"]
+
+    def test_leaves_none_untouched(self):
+        data = [{"text": "q", "img": None}]
+        result = DatasetRegistry._wrap_binary_columns_for_parquet(data, ["img"])
+        assert result[0]["img"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes the `cookbooks/geo3k` cookbook actually trainable end-to-end on the **Verl backend** with `Qwen/Qwen3-VL-2B-Instruct`. Branched from `main` after a long iterative debug session against an 8×H100 box. Five distinct issues had to be fixed; details below.

**Tinker backend with geo3k is *not* tested in this PR** — only Verl. The data-layer fix (parquet round-trips images) and the geo3k_flow `<image>` placeholder fix are backend-agnostic and should also benefit the Tinker path, but I haven't run `geo3k_local_tinker.sh` to confirm. Leaving that for a follow-up.

## What was broken

| # | Layer | Symptom | Resolution |
| - | ----- | ------- | ---------- |
| 1 | rLLM dataset | `apply_verl_postprocessing` stripped binary columns to `None`, so `extra_info[\"images\"]` was empty in the verl parquet — the agent flow received no images and the model trained on text-only prompts. | Replace `_strip_binary_columns` with `_wrap_binary_columns_for_parquet` that wraps each `bytes` as `{\"bytes\": ..., \"path\": \"\"}` (verl's canonical image format). Images flow through `extra_info[\"images\"]` for rLLM agent flows and are also valid for verl-native consumers. |
| 2 | geo3k_flow | The dataset's `question` field has a literal `<image>` placeholder at the start (`\"<image>Find x.\"`). The old `_build_vlm_content` appended that text *as-is* alongside an `image_url` block — vLLM's chat template then rendered both the expanded image AND the literal `<image>` token, producing a malformed prompt. | Mirror verl's `rl_dataset._build_messages`: split the user content on `(<image>\|<video>)` markers and interleave `image_url` blocks at marker positions. Strict `<image>`-count check; centralized `_img_to_data_uri` helper handles raw bytes / `{\"bytes\": ...}` dict / data URI / PIL. |
| 3 | verl 0.7.1 | `Conv*d`/SDPA crashed with `CUDNN_STATUS_NOT_INITIALIZED` on this host (4-line stock-torch reproducer; nothing to do with rLLM/verl). | Not committed to rLLM. The fix is now an environment-specific worker setup hook the user can plug in; see the new `RLLM_EXTRA_WORKER_SETUP_HOOK` extension point below. |
| 4 | verl 0.7.1 | `prepare_dynamic_batch` deadlocks on imbalanced micro-batch counts across DP ranks ([verl#5750](https://github.com/volcengine/verl/issues/5750)); inplace `+=` in the qwen3-VL no-image dummy path crashes ([verl#5881](https://github.com/volcengine/verl/pull/5881)); `index_select_tensor_dict` / `chunk_tensordict` lose `_ragged_idx` when sample seq lengths coincide ([verl#6127](https://github.com/volcengine/verl/pull/6127), causing both the dynamic-batching `unbind` failure and the rmpad rotary shape mismatch). | Three idempotent monkey-patches in `rllm/experimental/verl/patch.py`, applied in **every Ray worker process** via `runtime_env.worker_process_setup_hook` — driver-side mutation does not propagate because Ray workers re-import verl from disk. |
| 5 | rLLM Ray runtime env | Driver-only patches were silently a no-op for the actual call sites. | Register `rllm.experimental.verl.patch.apply_all_verl_patches` as `runtime_env.worker_process_setup_hook` in `get_ppo_ray_runtime_env()`. Add `RLLM_` to `FORWARD_PREFIXES` so user extension hooks can be wired via env var. |

## Code changes

- `rllm/data/dataset.py` — `_strip_binary_columns` → `_wrap_binary_columns_for_parquet`. Images now survive the `.parquet` round-trip as `{\"bytes\": <png-bytes>, \"path\": \"\"}` dicts.
- `cookbooks/geo3k/geo3k_flow.py` — proper `<image>`-marker interleaving (mirrors verl), handles all three image shapes, raises on marker/image mismatch.
- `rllm/experimental/verl/patch.py` — three new patches: `patch_verl_qwen3_vl_dummy_inplace` ([verl#5881](https://github.com/volcengine/verl/pull/5881)), `patch_verl_tensordict_jagged_layout` ([verl#6127](https://github.com/volcengine/verl/pull/6127)). Existing `patch_verl_dynamic_batch_sync` ([verl#5750](https://github.com/volcengine/verl/issues/5750)) was already there but driver-only and effectively a no-op; now reachable from the worker hook. Plus `apply_all_verl_patches` umbrella + `RLLM_EXTRA_WORKER_SETUP_HOOK` extension point for environment-specific tweaks (file-path-based loader so user hooks can live in a gitignored `tmp/` dir).
- `rllm/experimental/verl/verl_backend.py` — drop the two no-op driver-side patch calls (`patch_verl_dynamic_batch_sync` + `patch_verl_qwen3_vl_dummy_inplace` only matter inside workers); keep one driver-side `patch_verl_tensordict_jagged_layout()` call because `DataProto.chunk` runs in the driver and ships chunks with baked-in `_ragged_idx`. `patch_vllm_for_sdk` stays driver-side (Ray pickles the actor class, so driver-side mutation is correct there).
- `rllm/trainer/verl/ray_runtime_env.py` — register the worker hook; add `RLLM_` to `FORWARD_PREFIXES`.

## Docs

- `docs/guides/ray-runtime-env.mdx` — new section documenting the worker setup hook (why driver-only mutation doesn't work, and how `apply_all_verl_patches` is wired) and the `RLLM_EXTRA_WORKER_SETUP_HOOK` extension point.

## Tests

- `tests/data/test_arrow_ipc.py` — renamed `TestStripBinaryColumns` → `TestWrapBinaryColumnsForParquet`. Coverage for scalar bytes, list-of-bytes, and `None`.

## Verification

Before, the gateway trace had:
```
user: '<image>Find $PS$.'   ← string content, no image_url block
prompt_token_ids count: 0
```

After:
```
user: [image_url block (data URI), text='Use parallelogram $JKLM$ to find $m \angle KJL$.']
prompt_token_ids count: 328
<|image_pad|> count: 240
literal '<image>' substring? False
user portion: <|im_start|>user\n<|vision_start|><|image_pad|>×240<|vision_end|>Use parallelogram...
```

This matches the canonical Qwen3-VL prompt shape. Training reached `Generating trajectories: 76/256 @ 4-5it/s` cleanly on the same host (with the env-specific cuDNN-disable hook in place via `RLLM_EXTRA_WORKER_SETUP_HOOK`); I stopped early once the prompt-layer fix was confirmed at the trace level.

## Out of scope / left for follow-up

- **Tinker backend with geo3k**: untested. The data-layer + flow-layer fixes are backend-agnostic and should apply, but I haven't run it.
- **Broken host cuDNN**: not an rLLM bug. Real fix is a system-level cuDNN/torch update; the workaround lives in user space via `RLLM_EXTRA_WORKER_SETUP_HOOK`.
- **Top-level `images` for verl-native pipeline**: not added. Doing so requires the `prompt` field (currently a placeholder) to also have `<image>` markers, which is out of scope for the agent-flow fix.

## Test plan

- [x] CI green
- [ ] `bash tmp/geo3k/geo3k_local.sh` (or your equivalent) reaches step ≥1 cleanly with vision tokens in the gateway trace
- [x] `pytest tests/data/test_arrow_ipc.py` passes (verified locally)
- [ ] (follow-up) Tinker backend with geo3k

🤖 Generated with [Claude Code](https://claude.com/claude-code)