### PR TITLE
feat(model-gateway): trace store schema v2

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/store/base.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/base.py
@@ -9,10 +9,20 @@ class TraceStore(Protocol):
     Implementations must be async.  The interface uses plain dicts so that
     backends are free to serialise however they like (JSON columns, DynamoDB
     items, etc.).
+
+    Traces are stamped with ``run_id`` so multiple gateway instances can
+    share a single store without colliding session ids. ``run_id=""`` is
+    the unstamped bucket for legacy callers.
     """
 
-    async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
-        """Store a single trace."""
+    async def store_trace(
+        self,
+        trace_id: str,
+        session_id: str,
+        data: dict[str, Any],
+        run_id: str = "",
+    ) -> None:
+        """Store a single trace, optionally tagged with ``run_id``."""
         ...
 
     async def get_trace(self, trace_id: str) -> dict[str, Any] | None:
@@ -24,20 +34,110 @@ class TraceStore(Protocol):
         session_id: str,
         since: float | None = None,
         limit: int | None = None,
+        *,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Get all traces for a session, ordered by timestamp ascending."""
+        """Get all traces for a session, ordered by timestamp ascending.
+
+        ``run_id=None`` is cross-run; pass an explicit value to filter.
+        Back-compat wrapper; new callers should prefer ``query_traces``.
+        """
         ...
 
-    async def delete_session(self, session_id: str) -> int:
-        """Delete all traces for a session.  Returns count deleted."""
+    async def query_traces(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        model: str | None = None,
+        harness: str | None = None,
+        has_error: bool | None = None,
+        latency_min: float | None = None,
+        latency_max: float | None = None,
+        since: float | None = None,
+        until: float | None = None,
+        limit: int | None = 200,
+        order: str = "DESC",
+    ) -> list[dict[str, Any]]:
+        """Filter+paginate traces by their denormalized columns.
+
+        ``since`` / ``until`` are cursors on persisted-at time;
+        ``order=DESC`` is the global feed (newest first), ``ASC`` for
+        per-session timelines. Each row carries ``_created_at`` so
+        callers can advance a polling cursor.
+        """
+        ...
+
+    async def count_traces(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        model: str | None = None,
+        harness: str | None = None,
+        has_error: bool | None = None,
+        latency_min: float | None = None,
+        latency_max: float | None = None,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> int:
+        """COUNT(*) over the same filter shape as :meth:`query_traces`."""
+        ...
+
+    async def facets(self) -> dict[str, list[str]]:
+        """Distinct values for filter-bar dropdowns.
+
+        Returns ``{"models", "harnesses", "runs"}`` lists. Empty buckets
+        are excluded.
+        """
+        ...
+
+    async def delete_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+    ) -> int:
+        """Delete a session.
+
+        ``run_id=None`` deletes every match across runs. Returns the count
+        of trace rows deleted (rows referenced from other sessions are
+        kept).
+        """
         ...
 
     async def list_sessions(
         self,
         since: float | None = None,
         limit: int | None = None,
+        *,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """List sessions with trace counts."""
+        """List sessions with trace counts. Each row carries ``run_id``."""
+        ...
+
+    async def register_run(
+        self,
+        run_id: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record (or update) a gateway run's metadata.
+
+        Idempotent: a re-call with the same ``run_id`` updates metadata
+        in place but preserves the original ``started_at``.
+        """
+        ...
+
+    async def end_run(self, run_id: str) -> None:
+        """Mark a run as ended (sets ``ended_at`` if currently null)."""
+        ...
+
+    async def list_runs(
+        self,
+        since: float | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List gateway runs ordered by ``started_at`` DESC."""
         ...
 
     async def flush(self) -> None:

--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -4,24 +4,42 @@ import time
 from collections import defaultdict
 from typing import Any
 
+from rllm_model_gateway.store.sqlite_store import _compute_has_error
+
 
 class MemoryTraceStore:
-    """Ephemeral in-memory store.  Useful for tests and short-lived processes."""
+    """Ephemeral in-memory store. Useful for tests and short-lived processes.
+
+    The session index is keyed by ``(session_id, run_id)`` so the same
+    session_id can coexist across runs without collision (e.g. eval-0
+    from two concurrent eval invocations).
+    """
 
     def __init__(self) -> None:
         # trace_id -> data dict
         self._traces: dict[str, dict[str, Any]] = {}
         # trace_id -> created_at
         self._timestamps: dict[str, float] = {}
-        # session_id -> list[trace_id]  (insertion order)
-        self._session_index: dict[str, list[str]] = defaultdict(list)
+        # trace_id -> (session_id, run_id) — denormalized for query_traces
+        self._trace_meta: dict[str, tuple[str, str]] = {}
+        # (session_id, run_id) -> list[trace_id]  (insertion order)
+        self._session_index: dict[tuple[str, str], list[str]] = defaultdict(list)
+        # run_id -> {metadata, started_at, ended_at}
+        self._runs: dict[str, dict[str, Any]] = {}
 
-    async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
+    async def store_trace(
+        self,
+        trace_id: str,
+        session_id: str,
+        data: dict[str, Any],
+        run_id: str = "",
+    ) -> None:
         now = time.time()
         self._traces[trace_id] = data
         if trace_id not in self._timestamps:
             self._timestamps[trace_id] = now
-        idx = self._session_index[session_id]
+        self._trace_meta[trace_id] = (session_id, run_id or "")
+        idx = self._session_index[(session_id, run_id or "")]
         if trace_id not in idx:
             idx.append(trace_id)
 
@@ -33,41 +51,163 @@ class MemoryTraceStore:
         session_id: str,
         since: float | None = None,
         limit: int | None = None,
+        *,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        ids = self._session_index.get(session_id, [])
         results: list[dict[str, Any]] = []
-        for tid in ids:
-            ts = self._timestamps.get(tid, 0.0)
-            if since is not None and ts < since:
+        for (sid, rid), tids in self._session_index.items():
+            if sid != session_id:
                 continue
-            data = self._traces.get(tid)
-            if data is not None:
-                results.append(data)
+            if run_id is not None and rid != run_id:
+                continue
+            for tid in tids:
+                ts = self._timestamps.get(tid, 0.0)
+                if since is not None and ts < since:
+                    continue
+                data = self._traces.get(tid)
+                if data is not None:
+                    results.append(data)
         if limit is not None:
             results = results[:limit]
         return results
 
-    async def delete_session(self, session_id: str) -> int:
-        ids = self._session_index.pop(session_id, [])
-        # Collect trace_ids referenced by other sessions
-        referenced: set[str] = set()
-        for sid, tids in self._session_index.items():
-            referenced.update(tids)
+    async def query_traces(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        model: str | None = None,
+        harness: str | None = None,
+        has_error: bool | None = None,
+        latency_min: float | None = None,
+        latency_max: float | None = None,
+        since: float | None = None,
+        until: float | None = None,
+        limit: int | None = 200,
+        order: str = "DESC",
+    ) -> list[dict[str, Any]]:
+        if order not in ("ASC", "DESC"):
+            raise ValueError(f"order must be ASC or DESC, got {order!r}")
+        rows: list[tuple[float, dict[str, Any]]] = []
+        for tid, data in self._traces.items():
+            sid, rid = self._trace_meta.get(tid, ("", ""))
+            if run_id is not None and rid != run_id:
+                continue
+            if session_id is not None and sid != session_id:
+                continue
+            if model is not None and (data.get("model") or "") != model:
+                continue
+            if harness is not None and data.get("harness") != harness:
+                continue
+            if has_error is not None and bool(_compute_has_error(data)) != has_error:
+                continue
+            lat = float(data.get("latency_ms") or 0)
+            if latency_min is not None and lat < latency_min:
+                continue
+            if latency_max is not None and lat > latency_max:
+                continue
+            ts = self._timestamps.get(tid, 0.0)
+            if since is not None and ts <= since:
+                continue
+            if until is not None and ts >= until:
+                continue
+            row = dict(data)
+            row["_created_at"] = ts
+            rows.append((ts, row))
+
+        rows.sort(key=lambda r: r[0], reverse=(order == "DESC"))
+        out = [r[1] for r in rows]
+        if limit is not None:
+            out = out[:limit]
+        return out
+
+    async def count_traces(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        model: str | None = None,
+        harness: str | None = None,
+        has_error: bool | None = None,
+        latency_min: float | None = None,
+        latency_max: float | None = None,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> int:
+        rows = await self.query_traces(
+            run_id=run_id,
+            session_id=session_id,
+            model=model,
+            harness=harness,
+            has_error=has_error,
+            latency_min=latency_min,
+            latency_max=latency_max,
+            since=since,
+            until=until,
+            limit=None,
+        )
+        return len(rows)
+
+    async def facets(self) -> dict[str, list[str]]:
+        models: set[str] = set()
+        harnesses: set[str] = set()
+        runs: set[str] = set()
+        for tid, data in self._traces.items():
+            m = data.get("model") or ""
+            if m:
+                models.add(m)
+            h = data.get("harness")
+            if h:
+                harnesses.add(h)
+            _, rid = self._trace_meta.get(tid, ("", ""))
+            if rid:
+                runs.add(rid)
+        return {
+            "models": sorted(models),
+            "harnesses": sorted(harnesses),
+            "runs": sorted(runs),
+        }
+
+    async def delete_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+    ) -> int:
+        keys_to_delete: list[tuple[str, str]] = []
+        for key in list(self._session_index.keys()):
+            sid, rid = key
+            if sid != session_id:
+                continue
+            if run_id is not None and rid != run_id:
+                continue
+            keys_to_delete.append(key)
+
         deleted = 0
-        for tid in ids:
-            if tid not in referenced:
-                self._traces.pop(tid, None)
-                self._timestamps.pop(tid, None)
-                deleted += 1
+        for key in keys_to_delete:
+            ids = self._session_index.pop(key, [])
+            referenced: set[str] = set()
+            for tids in self._session_index.values():
+                referenced.update(tids)
+            for tid in ids:
+                if tid not in referenced:
+                    self._traces.pop(tid, None)
+                    self._timestamps.pop(tid, None)
+                    self._trace_meta.pop(tid, None)
+                    deleted += 1
         return deleted
 
     async def list_sessions(
         self,
         since: float | None = None,
         limit: int | None = None,
+        *,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
         results: list[dict[str, Any]] = []
-        for sid, tids in self._session_index.items():
+        for (sid, rid), tids in self._session_index.items():
+            if run_id is not None and rid != run_id:
+                continue
             if not tids:
                 continue
             timestamps = [self._timestamps[t] for t in tids if t in self._timestamps]
@@ -79,12 +219,58 @@ class MemoryTraceStore:
             results.append(
                 {
                     "session_id": sid,
+                    "run_id": rid,
                     "trace_count": len(tids),
                     "first_trace_at": first_at,
                     "last_trace_at": max(timestamps),
                 }
             )
         results.sort(key=lambda r: r["first_trace_at"], reverse=True)
+        if limit is not None:
+            results = results[:limit]
+        return results
+
+    async def register_run(
+        self,
+        run_id: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        existing = self._runs.get(run_id)
+        if existing is None:
+            self._runs[run_id] = {
+                "metadata": dict(metadata or {}),
+                "started_at": time.time(),
+                "ended_at": None,
+            }
+        else:
+            # Idempotent: refresh metadata, clear ended_at, keep started_at.
+            existing["metadata"] = dict(metadata or {})
+            existing["ended_at"] = None
+
+    async def end_run(self, run_id: str) -> None:
+        info = self._runs.get(run_id)
+        if info is not None and info.get("ended_at") is None:
+            info["ended_at"] = time.time()
+
+    async def list_runs(
+        self,
+        since: float | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        for rid, info in self._runs.items():
+            started = info["started_at"]
+            if since is not None and started < since:
+                continue
+            results.append(
+                {
+                    "run_id": rid,
+                    "started_at": started,
+                    "ended_at": info["ended_at"],
+                    "metadata": dict(info["metadata"]),
+                }
+            )
+        results.sort(key=lambda r: r["started_at"], reverse=True)
         if limit is not None:
             results = results[:limit]
         return results

--- a/rllm-model-gateway/src/rllm_model_gateway/store/sqlite_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/sqlite_store.py
@@ -1,10 +1,18 @@
 """SQLite-backed trace store with session-indexed persistence.
 
-Extracted and adapted from ``rllm/sdk/store/sqlite_store.py``.  Uses the same
-junction-table pattern (``trace_sessions``) for efficient session-based
-queries but simplifies the schema to match the gateway's needs.
+Schema v2 denormalizes a few hot fields from the JSON ``data`` column
+onto the ``traces`` row (``run_id``, ``session_id``, ``model``,
+``harness``, ``latency_ms``, ``has_error``, ``step_id``) so the global
+trace feed can filter without table-scanning JSON. ``data`` keeps the
+authoritative ``TraceRecord`` payload.
+
+A schema-version mismatch on an existing db drops every table and
+recreates from scratch — gateway data is dev-only and the cost of a
+real migration isn't worth it. Bump :data:`_SCHEMA_VERSION` for any
+schema change.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -16,6 +24,35 @@ import aiosqlite
 
 logger = logging.getLogger(__name__)
 
+# Bump on any schema change. ``_get_conn`` drops and recreates every
+# table when the on-disk PRAGMA user_version is non-zero and ≠ this.
+_SCHEMA_VERSION = 2
+
+# Finish reasons that indicate a healthy LLM completion. Anything else
+# (or a missing finish_reason on a non-empty response) gets has_error=1.
+_OK_FINISH_REASONS = frozenset({"stop", "tool_calls", "length", "function_call"})
+
+
+def _compute_has_error(data: dict[str, Any]) -> int:
+    """Heuristic error flag derived from the trace payload at insert time.
+
+    A trace counts as errored when:
+    - ``raw_response`` carries an ``error`` key (upstream returned 4xx/5xx
+      with an error body the gateway captured anyway), or
+    - ``finish_reason`` is missing AND ``response_message`` is empty
+      (the upstream returned no usable completion), or
+    - ``finish_reason`` is set to something outside the well-known
+      "good" set (e.g. ``content_filter``).
+    """
+    raw_response = data.get("raw_response")
+    if isinstance(raw_response, dict) and "error" in raw_response:
+        return 1
+    finish_reason = data.get("finish_reason")
+    response_message = data.get("response_message") or {}
+    if not finish_reason:
+        return 1 if not response_message else 0
+    return 0 if finish_reason in _OK_FINISH_REASONS else 1
+
 
 class SqliteTraceStore:
     """Persistent trace store backed by a single SQLite file.
@@ -25,8 +62,9 @@ class SqliteTraceStore:
     use and closed explicitly via :meth:`close`.
 
     Features:
-    - Junction table for session_id ↔ trace_id mapping
-    - Composite indexes for fast session-scoped queries
+    - Denormalized filter columns on ``traces`` for the global feed
+    - Junction table ``trace_sessions`` retained for many-session-per-trace
+      back-compat (in practice 1:1)
     - WAL journal mode for faster local-disk read/write concurrency
     - Checkpoint-on-close to keep WAL growth bounded after long runs
     """
@@ -52,6 +90,12 @@ class SqliteTraceStore:
         self.db_path = db_path
         self._busy_timeout_ms = 20_000
         self._conn: aiosqlite.Connection | None = None
+        # Serialise the first-call connection open + schema-init so a
+        # batch of concurrent ``store_trace`` callers don't all race to
+        # run ``_ensure_schema`` (which can drop+recreate tables when it
+        # detects an older schema version, leaving the racers staring at
+        # a half-built db).
+        self._init_lock: asyncio.Lock | None = None
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -59,7 +103,13 @@ class SqliteTraceStore:
 
     async def _get_conn(self) -> aiosqlite.Connection:
         """Return the persistent connection, initializing on first call."""
-        if self._conn is None:
+        if self._conn is not None:
+            return self._conn
+        if self._init_lock is None:
+            self._init_lock = asyncio.Lock()
+        async with self._init_lock:
+            if self._conn is not None:
+                return self._conn
             conn = await aiosqlite.connect(self.db_path, timeout=self._busy_timeout_ms / 1000.0)
             for pragma in (
                 "PRAGMA journal_mode=WAL",
@@ -74,32 +124,93 @@ class SqliteTraceStore:
                     logger.warning("SQLite pragma failed (%s): %s", pragma, exc)
 
             await conn.execute("PRAGMA foreign_keys = ON")
-            await conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS traces (
-                    trace_id   TEXT PRIMARY KEY,
-                    data       TEXT NOT NULL,
-                    created_at REAL NOT NULL
-                )
-                """
-            )
-            await conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS trace_sessions (
-                    trace_id   TEXT NOT NULL,
-                    session_id TEXT NOT NULL,
-                    created_at REAL NOT NULL,
-                    PRIMARY KEY (trace_id, session_id),
-                    FOREIGN KEY (trace_id) REFERENCES traces(trace_id) ON DELETE CASCADE
-                )
-                """
-            )
-            await conn.execute("CREATE INDEX IF NOT EXISTS idx_ts_session ON trace_sessions(session_id)")
-            await conn.execute("CREATE INDEX IF NOT EXISTS idx_ts_session_time ON trace_sessions(session_id, created_at ASC)")
-            await conn.execute("CREATE INDEX IF NOT EXISTS idx_traces_time ON traces(created_at)")
-            await conn.commit()
+            await self._ensure_schema(conn)
             self._conn = conn
         return self._conn
+
+    async def _ensure_schema(self, conn: aiosqlite.Connection) -> None:
+        """Create or rebuild tables to match :data:`_SCHEMA_VERSION`.
+
+        Three states to handle:
+        - Fresh db (no tables, ``user_version=0``): just create v2.
+        - v2 db (``user_version==_SCHEMA_VERSION``): no-op create-if-not-exists.
+        - Anything else (legacy db with tables but no version stamp,
+          or a future-version db downgraded): drop and recreate.
+        """
+        async with conn.execute("PRAGMA user_version") as cur:
+            row = await cur.fetchone()
+            current = int(row[0]) if row else 0
+
+        async with conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('traces', 'trace_sessions', 'runs')") as cur:
+            existing_tables = [r[0] async for r in cur]
+
+        if existing_tables and current != _SCHEMA_VERSION:
+            logger.warning(
+                "rllm-gateway: dropping trace store at %s (schema v%d → v%d)",
+                self.db_path,
+                current,
+                _SCHEMA_VERSION,
+            )
+            # Drop in dependency order: trace_sessions has an FK on traces.
+            for table in ("trace_sessions", "traces", "runs"):
+                await conn.execute(f"DROP TABLE IF EXISTS {table}")
+
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS traces (
+                trace_id    TEXT PRIMARY KEY,
+                data        TEXT NOT NULL,
+                created_at  REAL NOT NULL,
+                session_id  TEXT NOT NULL DEFAULT '',
+                run_id      TEXT NOT NULL DEFAULT '',
+                model       TEXT NOT NULL DEFAULT '',
+                harness     TEXT,
+                latency_ms  INTEGER NOT NULL DEFAULT 0,
+                has_error   INTEGER NOT NULL DEFAULT 0,
+                step_id     INTEGER
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trace_sessions (
+                trace_id   TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                run_id     TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL,
+                PRIMARY KEY (trace_id, session_id),
+                FOREIGN KEY (trace_id) REFERENCES traces(trace_id) ON DELETE CASCADE
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS runs (
+                run_id     TEXT PRIMARY KEY,
+                started_at REAL NOT NULL,
+                ended_at   REAL,
+                metadata   TEXT NOT NULL DEFAULT '{}'
+            )
+            """
+        )
+
+        # Filter-pushdown indexes for the global trace feed. All on
+        # ``traces`` because the feed query never needs the junction.
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_traces_time ON traces(created_at DESC)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_traces_run_time ON traces(run_id, created_at DESC)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_traces_model_time ON traces(model, created_at DESC)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_traces_run_model_time ON traces(run_id, model, created_at DESC)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_traces_session_time ON traces(session_id, created_at DESC)")
+        # Junction-side indexes — kept so legacy ``get_session_traces``
+        # still hits an index. Phase 2/3 rewrites query ``traces``
+        # directly via the new column.
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_ts_session ON trace_sessions(session_id)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_ts_session_time ON trace_sessions(session_id, created_at ASC)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_ts_run_session ON trace_sessions(run_id, session_id, created_at ASC)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at DESC)")
+
+        await conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+        await conn.commit()
 
     async def close(self) -> None:
         """Close the persistent connection and checkpoint WAL state."""
@@ -112,24 +223,64 @@ class SqliteTraceStore:
     # TraceStore protocol
     # ------------------------------------------------------------------
 
-    async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
+    async def store_trace(
+        self,
+        trace_id: str,
+        session_id: str,
+        data: dict[str, Any],
+        run_id: str = "",
+    ) -> None:
         conn = await self._get_conn()
         now = time.time()
+        run_id = run_id or ""
+        # Pull denormalized values from the TraceRecord-shaped dict. The
+        # junction table's ``run_id`` is the authoritative gateway run
+        # tag (set by the proxy at persist time), which we mirror onto
+        # ``traces.run_id`` rather than trusting ``data["run_id"]``.
+        model = str(data.get("model") or "")
+        harness = data.get("harness")
+        latency_ms = int(data.get("latency_ms") or 0)
+        step_id = data.get("step_id")
+        has_error = _compute_has_error(data)
+
         await conn.execute(
             """
-            INSERT OR REPLACE INTO traces (trace_id, data, created_at)
-            VALUES (?, ?, COALESCE((SELECT created_at FROM traces WHERE trace_id = ?), ?))
+            INSERT INTO traces (
+                trace_id, data, created_at,
+                session_id, run_id, model, harness, latency_ms, has_error, step_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(trace_id) DO UPDATE SET
+                data       = excluded.data,
+                session_id = excluded.session_id,
+                run_id     = excluded.run_id,
+                model      = excluded.model,
+                harness    = excluded.harness,
+                latency_ms = excluded.latency_ms,
+                has_error  = excluded.has_error,
+                step_id    = excluded.step_id
             """,
-            (trace_id, json.dumps(data), trace_id, now),
+            (
+                trace_id,
+                json.dumps(data),
+                now,
+                session_id,
+                run_id,
+                model,
+                harness,
+                latency_ms,
+                has_error,
+                step_id,
+            ),
         )
         await conn.execute(
             """
-            INSERT OR IGNORE INTO trace_sessions (trace_id, session_id, created_at)
-            VALUES (?, ?, COALESCE(
+            INSERT OR IGNORE INTO trace_sessions (trace_id, session_id, run_id, created_at)
+            VALUES (?, ?, ?, COALESCE(
                 (SELECT created_at FROM traces WHERE trace_id = ?), ?
             ))
             """,
-            (trace_id, session_id, trace_id, now),
+            (trace_id, session_id, run_id, trace_id, now),
         )
         await conn.commit()
 
@@ -147,7 +298,14 @@ class SqliteTraceStore:
         session_id: str,
         since: float | None = None,
         limit: int | None = None,
+        *,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
+        """Get traces for a session, ordered ASC. Back-compat wrapper.
+
+        New callers should prefer :meth:`query_traces` for richer
+        filtering. ``run_id=None`` is cross-run.
+        """
         conn = await self._get_conn()
         conn.row_factory = aiosqlite.Row
         sql = """
@@ -156,6 +314,9 @@ class SqliteTraceStore:
             WHERE ts.session_id = ?
         """
         params: list[Any] = [session_id]
+        if run_id is not None:
+            sql += " AND ts.run_id = ?"
+            params.append(run_id)
         if since is not None:
             sql += " AND ts.created_at >= ?"
             params.append(since)
@@ -168,25 +329,214 @@ class SqliteTraceStore:
             rows = await cur.fetchall()
         return [json.loads(r["data"]) for r in rows]
 
-    async def delete_session(self, session_id: str) -> int:
+    async def query_traces(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        model: str | None = None,
+        harness: str | None = None,
+        has_error: bool | None = None,
+        latency_min: float | None = None,
+        latency_max: float | None = None,
+        since: float | None = None,
+        until: float | None = None,
+        limit: int | None = 200,
+        order: str = "DESC",
+    ) -> list[dict[str, Any]]:
+        """Filter+paginate traces directly off the denormalized columns.
+
+        ``since`` / ``until`` are cursors on ``created_at``; pass
+        ``until=last_seen`` for older-than-N scroll-back, ``since=last_seen``
+        for newer-than-N live tail. ``order`` is ``DESC`` (newest first)
+        for the global feed and ``ASC`` for per-session timelines.
+
+        Each row carries a synthetic ``_created_at`` so callers can
+        advance a polling cursor without inspecting ``timestamp`` inside
+        ``data`` (which is the LLM request time and skews on long
+        requests).
+        """
+        if order not in ("ASC", "DESC"):
+            raise ValueError(f"order must be ASC or DESC, got {order!r}")
         conn = await self._get_conn()
-        # Find trace_ids unique to this session (not shared with others)
-        async with conn.execute(
-            """
+        conn.row_factory = aiosqlite.Row
+
+        where, params = self._build_filters(
+            run_id=run_id,
+            session_id=session_id,
+            model=model,
+            harness=harness,
+            has_error=has_error,
+            latency_min=latency_min,
+            latency_max=latency_max,
+            since=since,
+            until=until,
+        )
+        sql = "SELECT data, created_at FROM traces"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += f" ORDER BY created_at {order}"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+
+        async with conn.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            try:
+                data = json.loads(r["data"])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict):
+                data["_created_at"] = r["created_at"]
+                out.append(data)
+        return out
+
+    async def count_traces(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        model: str | None = None,
+        harness: str | None = None,
+        has_error: bool | None = None,
+        latency_min: float | None = None,
+        latency_max: float | None = None,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> int:
+        """COUNT(*) over the same filters as :meth:`query_traces`."""
+        conn = await self._get_conn()
+        where, params = self._build_filters(
+            run_id=run_id,
+            session_id=session_id,
+            model=model,
+            harness=harness,
+            has_error=has_error,
+            latency_min=latency_min,
+            latency_max=latency_max,
+            since=since,
+            until=until,
+        )
+        sql = "SELECT COUNT(*) FROM traces"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        async with conn.execute(sql, params) as cur:
+            row = await cur.fetchone()
+        return int(row[0] or 0) if row else 0
+
+    async def facets(self) -> dict[str, list[str]]:
+        """Distinct values for filter-bar dropdowns.
+
+        Returns ``{"models": [...], "harnesses": [...], "runs": [...]}``.
+        Excludes the empty bucket from each list. Cheap because each
+        column is indexed and the cardinality is small (handful of
+        models/harnesses, dozens-to-hundreds of runs).
+        """
+        conn = await self._get_conn()
+
+        async def _distinct(col: str, table: str = "traces") -> list[str]:
+            sql = f"SELECT DISTINCT {col} FROM {table} WHERE {col} IS NOT NULL AND {col} != '' ORDER BY {col}"
+            async with conn.execute(sql) as cur:
+                rows = await cur.fetchall()
+            return [r[0] for r in rows]
+
+        return {
+            "models": await _distinct("model"),
+            "harnesses": await _distinct("harness"),
+            "runs": await _distinct("run_id"),
+        }
+
+    @staticmethod
+    def _build_filters(
+        *,
+        run_id: str | None,
+        session_id: str | None,
+        model: str | None,
+        harness: str | None,
+        has_error: bool | None,
+        latency_min: float | None,
+        latency_max: float | None,
+        since: float | None,
+        until: float | None,
+    ) -> tuple[list[str], list[Any]]:
+        where: list[str] = []
+        params: list[Any] = []
+        if run_id is not None:
+            where.append("run_id = ?")
+            params.append(run_id)
+        if session_id is not None:
+            where.append("session_id = ?")
+            params.append(session_id)
+        if model is not None:
+            where.append("model = ?")
+            params.append(model)
+        if harness is not None:
+            where.append("harness = ?")
+            params.append(harness)
+        if has_error is not None:
+            where.append("has_error = ?")
+            params.append(1 if has_error else 0)
+        if latency_min is not None:
+            where.append("latency_ms >= ?")
+            params.append(latency_min)
+        if latency_max is not None:
+            where.append("latency_ms <= ?")
+            params.append(latency_max)
+        if since is not None:
+            where.append("created_at > ?")
+            params.append(since)
+        if until is not None:
+            where.append("created_at < ?")
+            params.append(until)
+        return where, params
+
+    async def delete_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+    ) -> int:
+        """Delete a session.
+
+        ``run_id=None`` deletes every (session_id, *) pair across runs.
+        Pass an explicit run_id to scope the delete to one run.
+        """
+        conn = await self._get_conn()
+        # Find trace_ids unique to the (session_id [, run_id]) selector —
+        # i.e. not referenced from any *other* row.
+        scope_clause = "ts1.session_id = ?"
+        scope_params: list[Any] = [session_id]
+        anti_scope_clause = "ts2.session_id != ?"
+        anti_scope_params: list[Any] = [session_id]
+        if run_id is not None:
+            scope_clause += " AND ts1.run_id = ?"
+            scope_params.append(run_id)
+            anti_scope_clause = "(ts2.session_id != ? OR ts2.run_id != ?)"
+            anti_scope_params = [session_id, run_id]
+
+        sql = f"""
             SELECT ts1.trace_id FROM trace_sessions ts1
-            WHERE ts1.session_id = ?
+            WHERE {scope_clause}
             AND NOT EXISTS (
                 SELECT 1 FROM trace_sessions ts2
-                WHERE ts2.trace_id = ts1.trace_id AND ts2.session_id != ?
+                WHERE ts2.trace_id = ts1.trace_id AND {anti_scope_clause}
             )
-            """,
-            (session_id, session_id),
-        ) as cur:
+        """
+        async with conn.execute(sql, [*scope_params, *anti_scope_params]) as cur:
             unique_rows = await cur.fetchall()
         unique_ids = [r[0] for r in unique_rows]
 
-        # Delete junction rows for this session
-        await conn.execute("DELETE FROM trace_sessions WHERE session_id = ?", (session_id,))
+        # Delete junction rows for this scope
+        if run_id is None:
+            await conn.execute("DELETE FROM trace_sessions WHERE session_id = ?", (session_id,))
+        else:
+            await conn.execute(
+                "DELETE FROM trace_sessions WHERE session_id = ? AND run_id = ?",
+                (session_id, run_id),
+            )
         # Delete orphaned traces
         if unique_ids:
             placeholders = ",".join("?" * len(unique_ids))
@@ -201,20 +551,35 @@ class SqliteTraceStore:
         self,
         since: float | None = None,
         limit: int | None = None,
+        *,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
+        """List sessions with trace counts.
+
+        ``run_id=None`` is cross-run; rows include ``run_id`` so the
+        caller can disambiguate. With an explicit ``run_id`` the result
+        is filtered to one run.
+        """
         conn = await self._get_conn()
         sql = """
             SELECT session_id,
+                   run_id,
                    COUNT(*) as trace_count,
                    MIN(created_at) as first_trace_at,
                    MAX(created_at) as last_trace_at
             FROM trace_sessions
         """
         params: list[Any] = []
+        where: list[str] = []
+        if run_id is not None:
+            where.append("run_id = ?")
+            params.append(run_id)
         if since is not None:
-            sql += " WHERE created_at >= ?"
+            where.append("created_at >= ?")
             params.append(since)
-        sql += " GROUP BY session_id ORDER BY MIN(created_at) DESC"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " GROUP BY session_id, run_id ORDER BY MIN(created_at) DESC"
         if limit is not None:
             sql += " LIMIT ?"
             params.append(limit)
@@ -224,12 +589,83 @@ class SqliteTraceStore:
         return [
             {
                 "session_id": r[0],
-                "trace_count": r[1],
-                "first_trace_at": r[2],
-                "last_trace_at": r[3],
+                "run_id": r[1],
+                "trace_count": r[2],
+                "first_trace_at": r[3],
+                "last_trace_at": r[4],
             }
             for r in rows
         ]
+
+    # ------------------------------------------------------------------
+    # Run-level metadata
+    # ------------------------------------------------------------------
+
+    async def register_run(self, run_id: str, metadata: dict[str, Any] | None = None) -> None:
+        """Record (or update) a gateway run's metadata.
+
+        Idempotent: a second call with the same ``run_id`` updates the
+        metadata in place but preserves ``started_at``. ``ended_at`` is
+        cleared so a re-registered run reads as live again.
+        """
+        conn = await self._get_conn()
+        now = time.time()
+        meta_json = json.dumps(metadata or {})
+        await conn.execute(
+            """
+            INSERT INTO runs (run_id, started_at, ended_at, metadata)
+            VALUES (?, ?, NULL, ?)
+            ON CONFLICT(run_id) DO UPDATE SET
+                metadata = excluded.metadata,
+                ended_at = NULL
+            """,
+            (run_id, now, meta_json),
+        )
+        await conn.commit()
+
+    async def end_run(self, run_id: str) -> None:
+        """Stamp a run's ``ended_at`` with the current time."""
+        conn = await self._get_conn()
+        now = time.time()
+        await conn.execute(
+            "UPDATE runs SET ended_at = ? WHERE run_id = ? AND ended_at IS NULL",
+            (now, run_id),
+        )
+        await conn.commit()
+
+    async def list_runs(
+        self,
+        since: float | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List gateway runs ordered by ``started_at`` DESC."""
+        conn = await self._get_conn()
+        sql = "SELECT run_id, started_at, ended_at, metadata FROM runs"
+        params: list[Any] = []
+        if since is not None:
+            sql += " WHERE started_at >= ?"
+            params.append(since)
+        sql += " ORDER BY started_at DESC"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        async with conn.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            try:
+                meta = json.loads(r[3]) if r[3] else {}
+            except json.JSONDecodeError:
+                meta = {}
+            out.append(
+                {
+                    "run_id": r[0],
+                    "started_at": r[1],
+                    "ended_at": r[2],
+                    "metadata": meta,
+                }
+            )
+        return out
 
     async def flush(self) -> None:
         """No-op for SQLite (writes are synchronous within transactions)."""

--- a/rllm-model-gateway/tests/unit/test_store.py
+++ b/rllm-model-gateway/tests/unit/test_store.py
@@ -131,3 +131,385 @@ class TestSqliteStoreSpecific:
             assert row[0].lower() == "wal"
         finally:
             await store.close()
+
+
+class TestRunIdScoping:
+    """run_id tags + filters — the same session_id can coexist across runs."""
+
+    @pytest.mark.asyncio
+    async def test_get_session_traces_filtered_by_run_id(self, store):
+        await store.store_trace("a1", "eval-0", {"v": "a1"}, run_id="run-A")
+        await store.store_trace("a2", "eval-0", {"v": "a2"}, run_id="run-A")
+        await store.store_trace("b1", "eval-0", {"v": "b1"}, run_id="run-B")
+        await store.store_trace("b2", "eval-0", {"v": "b2"}, run_id="run-B")
+
+        in_a = await store.get_session_traces("eval-0", run_id="run-A")
+        assert {t["v"] for t in in_a} == {"a1", "a2"}
+        in_b = await store.get_session_traces("eval-0", run_id="run-B")
+        assert {t["v"] for t in in_b} == {"b1", "b2"}
+
+    @pytest.mark.asyncio
+    async def test_get_session_traces_cross_run_when_run_id_none(self, store):
+        await store.store_trace("a1", "eval-0", {"v": "a1"}, run_id="run-A")
+        await store.store_trace("b1", "eval-0", {"v": "b1"}, run_id="run-B")
+        # run_id=None (default) → cross-run.
+        traces = await store.get_session_traces("eval-0")
+        assert {t["v"] for t in traces} == {"a1", "b1"}
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_emits_run_id(self, store):
+        await store.store_trace("a1", "eval-0", {}, run_id="run-A")
+        await store.store_trace("b1", "eval-0", {}, run_id="run-B")
+        sessions = await store.list_sessions()
+        # Same session_id appears once per run_id.
+        keys = {(s["session_id"], s["run_id"]) for s in sessions}
+        assert keys == {("eval-0", "run-A"), ("eval-0", "run-B")}
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_filtered_by_run_id(self, store):
+        await store.store_trace("a1", "eval-0", {}, run_id="run-A")
+        await store.store_trace("b1", "eval-1", {}, run_id="run-B")
+        a = await store.list_sessions(run_id="run-A")
+        assert {s["session_id"] for s in a} == {"eval-0"}
+        b = await store.list_sessions(run_id="run-B")
+        assert {s["session_id"] for s in b} == {"eval-1"}
+
+    @pytest.mark.asyncio
+    async def test_delete_session_run_scoped(self, store):
+        await store.store_trace("a1", "eval-0", {}, run_id="run-A")
+        await store.store_trace("b1", "eval-0", {}, run_id="run-B")
+
+        # Delete only run-A's eval-0; run-B's eval-0 stays.
+        deleted = await store.delete_session("eval-0", run_id="run-A")
+        assert deleted == 1
+        remaining = await store.get_session_traces("eval-0")
+        assert len(remaining) == 1
+
+
+class TestRunsTable:
+    @pytest.mark.asyncio
+    async def test_register_then_list(self, store):
+        await store.register_run("r1", {"benchmark": "gsm8k", "model": "m"})
+        runs = await store.list_runs()
+        assert [r["run_id"] for r in runs] == ["r1"]
+        assert runs[0]["metadata"] == {"benchmark": "gsm8k", "model": "m"}
+        assert runs[0]["ended_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_register_is_idempotent_and_clears_ended_at(self, store):
+        await store.register_run("r1", {"v": 1})
+        await store.end_run("r1")
+        await store.register_run("r1", {"v": 2})  # re-register
+        runs = await store.list_runs()
+        assert runs[0]["metadata"] == {"v": 2}
+        assert runs[0]["ended_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_end_run_stamps_ended_at(self, store):
+        await store.register_run("r1", {})
+        await store.end_run("r1")
+        runs = await store.list_runs()
+        assert runs[0]["ended_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_runs_ordered_by_started_desc(self, store):
+        import asyncio
+
+        await store.register_run("r-old", {})
+        await asyncio.sleep(0.01)
+        await store.register_run("r-new", {})
+        runs = await store.list_runs()
+        assert [r["run_id"] for r in runs] == ["r-new", "r-old"]
+
+
+def _trace(model="gpt-x", harness=None, latency_ms=10, finish_reason="stop", step_id=None, **extra):
+    """Build a TraceRecord-shaped dict for query_traces tests."""
+    return {
+        "model": model,
+        "harness": harness,
+        "latency_ms": latency_ms,
+        "finish_reason": finish_reason,
+        "response_message": {"role": "assistant", "content": "hi"},
+        "step_id": step_id,
+        **extra,
+    }
+
+
+class TestQueryTraces:
+    @pytest.mark.asyncio
+    async def test_filter_by_run_id(self, store):
+        await store.store_trace("a1", "s1", _trace(), run_id="run-A")
+        await store.store_trace("a2", "s1", _trace(), run_id="run-A")
+        await store.store_trace("b1", "s1", _trace(), run_id="run-B")
+
+        rows = await store.query_traces(run_id="run-A")
+        assert len(rows) == 2
+        rows = await store.query_traces(run_id="run-B")
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_by_session(self, store):
+        await store.store_trace("t1", "s1", _trace(), run_id="r")
+        await store.store_trace("t2", "s2", _trace(), run_id="r")
+        rows = await store.query_traces(session_id="s1")
+        assert len(rows) == 1
+        rows = await store.query_traces(session_id="s2")
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_by_model(self, store):
+        await store.store_trace("t1", "s", _trace(model="gpt-5"), run_id="r")
+        await store.store_trace("t2", "s", _trace(model="claude-4-7"), run_id="r")
+        rows = await store.query_traces(model="claude-4-7")
+        assert len(rows) == 1
+        assert rows[0]["model"] == "claude-4-7"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_harness(self, store):
+        await store.store_trace("t1", "s", _trace(harness="bash"), run_id="r")
+        await store.store_trace("t2", "s", _trace(harness="claude-code"), run_id="r")
+        await store.store_trace("t3", "s", _trace(harness=None), run_id="r")
+        rows = await store.query_traces(harness="bash")
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_by_has_error(self, store):
+        # Healthy completion.
+        await store.store_trace("ok", "s", _trace(finish_reason="stop"), run_id="r")
+        # Empty response, no finish reason → has_error.
+        await store.store_trace(
+            "err",
+            "s",
+            {"model": "x", "latency_ms": 5, "finish_reason": None, "response_message": {}},
+            run_id="r",
+        )
+        # Upstream error in raw_response → has_error.
+        await store.store_trace(
+            "err2",
+            "s",
+            {
+                "model": "x",
+                "latency_ms": 0,
+                "finish_reason": "stop",
+                "response_message": {"role": "assistant", "content": ""},
+                "raw_response": {"error": {"message": "rate limit"}},
+            },
+            run_id="r",
+        )
+
+        ok = await store.query_traces(has_error=False)
+        err = await store.query_traces(has_error=True)
+        assert len(ok) == 1
+        assert len(err) == 2
+
+    @pytest.mark.asyncio
+    async def test_filter_by_latency_range(self, store):
+        await store.store_trace("fast", "s", _trace(latency_ms=10), run_id="r")
+        await store.store_trace("med", "s", _trace(latency_ms=100), run_id="r")
+        await store.store_trace("slow", "s", _trace(latency_ms=1000), run_id="r")
+
+        rows = await store.query_traces(latency_min=50)
+        assert len(rows) == 2
+        rows = await store.query_traces(latency_max=500)
+        assert len(rows) == 2
+        rows = await store.query_traces(latency_min=50, latency_max=500)
+        assert len(rows) == 1
+        assert rows[0]["latency_ms"] == 100
+
+    @pytest.mark.asyncio
+    async def test_combined_filters(self, store):
+        await store.store_trace("a", "s1", _trace(model="gpt", harness="bash"), run_id="run-A")
+        await store.store_trace("b", "s1", _trace(model="claude", harness="bash"), run_id="run-A")
+        await store.store_trace("c", "s2", _trace(model="gpt", harness="bash"), run_id="run-B")
+
+        rows = await store.query_traces(run_id="run-A", model="gpt")
+        assert len(rows) == 1
+        rows = await store.query_traces(run_id="run-A", harness="bash")
+        assert len(rows) == 2
+
+    @pytest.mark.asyncio
+    async def test_pagination_cursor(self, store):
+        import asyncio
+
+        for i in range(10):
+            await store.store_trace(f"t{i}", "s", _trace(), run_id="r")
+            await asyncio.sleep(0.001)  # ensure distinct created_at
+
+        # Newest-first feed, paged via `until`.
+        page1 = await store.query_traces(limit=4, order="DESC")
+        assert len(page1) == 4
+        cursor = page1[-1]["_created_at"]
+        page2 = await store.query_traces(limit=4, until=cursor, order="DESC")
+        assert len(page2) == 4
+        # No overlap between pages.
+        ids1 = {t.get("trace_id") for t in page1}
+        ids2 = {t.get("trace_id") for t in page2}
+        assert ids1.isdisjoint(ids2) or (ids1 == {None} and ids2 == {None})
+
+    @pytest.mark.asyncio
+    async def test_live_tail_cursor(self, store):
+        await store.store_trace("t1", "s", _trace(), run_id="r")
+        rows = await store.query_traces(order="ASC")
+        cursor = rows[-1]["_created_at"]
+        # No new traces yet — cursor should return nothing.
+        assert await store.query_traces(since=cursor, order="ASC") == []
+        # Add another and tail.
+        await store.store_trace("t2", "s", _trace(), run_id="r")
+        new_rows = await store.query_traces(since=cursor, order="ASC")
+        assert len(new_rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_order(self, store):
+        import asyncio
+
+        for i in range(5):
+            await store.store_trace(f"t{i}", "s", _trace(latency_ms=i), run_id="r")
+            await asyncio.sleep(0.001)
+
+        asc = await store.query_traces(order="ASC")
+        desc = await store.query_traces(order="DESC")
+        assert [r["latency_ms"] for r in asc] == [0, 1, 2, 3, 4]
+        assert [r["latency_ms"] for r in desc] == [4, 3, 2, 1, 0]
+
+    @pytest.mark.asyncio
+    async def test_invalid_order(self, store):
+        with pytest.raises(ValueError):
+            await store.query_traces(order="bogus")
+
+
+class TestCountTraces:
+    @pytest.mark.asyncio
+    async def test_count_with_filters(self, store):
+        await store.store_trace("a", "s1", _trace(model="gpt"), run_id="r")
+        await store.store_trace("b", "s1", _trace(model="gpt"), run_id="r")
+        await store.store_trace("c", "s2", _trace(model="claude"), run_id="r")
+
+        assert await store.count_traces() == 3
+        assert await store.count_traces(model="gpt") == 2
+        assert await store.count_traces(session_id="s2") == 1
+        assert await store.count_traces(model="bogus") == 0
+
+
+class TestFacets:
+    @pytest.mark.asyncio
+    async def test_facets(self, store):
+        await store.store_trace("a", "s1", _trace(model="gpt-5", harness="bash"), run_id="run-A")
+        await store.store_trace("b", "s1", _trace(model="claude", harness="bash"), run_id="run-A")
+        await store.store_trace("c", "s2", _trace(model="gpt-5", harness="claude-code"), run_id="run-B")
+
+        f = await store.facets()
+        assert f["models"] == ["claude", "gpt-5"]
+        assert f["harnesses"] == ["bash", "claude-code"]
+        assert f["runs"] == ["run-A", "run-B"]
+
+    @pytest.mark.asyncio
+    async def test_facets_excludes_empty(self, store):
+        await store.store_trace("a", "s", _trace(model="", harness=None), run_id="")
+        f = await store.facets()
+        assert f["models"] == []
+        assert f["harnesses"] == []
+        assert f["runs"] == []
+
+
+class TestSchemaMigration:
+    """Drop-and-rebuild on schema-version mismatch."""
+
+    @pytest.mark.asyncio
+    async def test_rebuild_on_schema_bump(self, tmp_path):
+        # Plant a v1-shaped db with a row in it.
+        path = str(tmp_path / "old.db")
+        import aiosqlite
+
+        async with aiosqlite.connect(path) as conn:
+            await conn.execute("PRAGMA user_version = 1")
+            await conn.execute("CREATE TABLE traces (trace_id TEXT PRIMARY KEY, data TEXT, created_at REAL)")
+            await conn.execute("INSERT INTO traces VALUES ('legacy', '{}', 1.0)")
+            await conn.commit()
+
+        # Opening with the new store drops & rebuilds.
+        store = SqliteTraceStore(db_path=path)
+        try:
+            await store.store_trace("fresh", "s", _trace(), run_id="r")
+            # Legacy row gone.
+            assert await store.get_trace("legacy") is None
+            assert await store.get_trace("fresh") is not None
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_rebuild_on_pre_versioning_legacy_db(self, tmp_path):
+        """Legacy dbs predating user_version stamping (current==0) still rebuild.
+
+        Reproduces the in-the-wild error where existing
+        ``~/.rllm/gateway/traces.db`` had ``PRAGMA user_version=0`` and
+        a v1 ``traces`` table with no ``run_id`` column. The original
+        guard ``if current and current != _SCHEMA_VERSION`` skipped the
+        drop because ``current == 0`` is falsy, then the v2 indexes
+        failed against the v1 columns.
+        """
+        path = str(tmp_path / "unversioned.db")
+        import aiosqlite
+
+        async with aiosqlite.connect(path) as conn:
+            # Note: do NOT stamp user_version — defaults to 0.
+            await conn.execute("CREATE TABLE traces (trace_id TEXT PRIMARY KEY, data TEXT, created_at REAL)")
+            await conn.execute("CREATE TABLE trace_sessions (trace_id TEXT, session_id TEXT, created_at REAL, PRIMARY KEY (trace_id, session_id))")
+            await conn.execute("INSERT INTO traces VALUES ('legacy', '{}', 1.0)")
+            await conn.commit()
+
+        store = SqliteTraceStore(db_path=path)
+        try:
+            await store.store_trace("fresh", "s", _trace(), run_id="r")
+            # Legacy row gone, v2 columns work.
+            assert await store.get_trace("legacy") is None
+            rows = await store.query_traces(run_id="r")
+            assert len(rows) == 1
+        finally:
+            await store.close()
+
+
+class TestConcurrentWriters:
+    """Two ``SqliteTraceStore`` instances writing the same db with different run_ids.
+
+    Mirrors the production case: two ``rllm eval`` invocations each boot
+    their own gateway pointing at ``~/.rllm/gateway/traces.db``. WAL +
+    busy_timeout serialises the writes; we just need to confirm no rows
+    are lost and per-run filtering still works.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_stores_share_one_db(self, tmp_path):
+        import asyncio
+
+        path = str(tmp_path / "shared.db")
+        store_a = SqliteTraceStore(db_path=path)
+        store_b = SqliteTraceStore(db_path=path)
+        try:
+            await asyncio.gather(
+                store_a.register_run("run-A", {"who": "A"}),
+                store_b.register_run("run-B", {"who": "B"}),
+            )
+
+            async def write_n(s, run_id, n, prefix):
+                for i in range(n):
+                    await s.store_trace(f"{prefix}{i}", "eval-0", {"i": i}, run_id=run_id)
+
+            # Interleave two writers; sqlite WAL+busy_timeout should
+            # serialise them without error.
+            await asyncio.gather(
+                write_n(store_a, "run-A", 20, "a"),
+                write_n(store_b, "run-B", 20, "b"),
+            )
+
+            # Either store can read both runs' data — they share the file.
+            sessions = await store_a.list_sessions()
+            keys = {(s["session_id"], s["run_id"]) for s in sessions}
+            assert keys == {("eval-0", "run-A"), ("eval-0", "run-B")}
+            for s in sessions:
+                assert s["trace_count"] == 20
+
+            runs = await store_b.list_runs()
+            assert {r["run_id"] for r in runs} == {"run-A", "run-B"}
+        finally:
+            await store_a.close()
+            await store_b.close()


### PR DESCRIPTION
## Summary

First of three stacked PRs splitting the gateway upgrade. Standalone — no consumer changes; landed alone, the new schema and methods are dead code that the next two PRs activate.

- Denormalises hot filter columns (`run_id`, `model`, `harness`, `latency_ms`, `has_error`, `step_id`) onto the `traces` row so the cross-run trace feed (rllm-console PR) can filter without JSON-scanning every row.
- Adds a `runs` table for per-gateway-run lifecycle.
- Extends `TraceStore` protocol: `query_traces`, `register_run`, `end_run`, `list_runs`, `count_traces`, `facets`.
- Schema-version mismatch on an existing db drops & recreates every table — gateway data is dev-only and a real migration isn't worth it.
- `_get_conn` serialises first-call init under an `asyncio.Lock` so a burst of concurrent `store_trace` callers can't race the schema build (the previous lock-free path could leave racers staring at a half-dropped db when migration triggered).
- Memory store mirrors the new shape so unit tests cover both backends identically.

Existing `store_trace(trace_id, session_id, data)` callers keep working — `run_id` defaults to `""`, all new methods are additive.

## Stack

- **[PR-1A] this** — schema v2 + lock fix
- [PR-1B](https://github.com/rllm-org/rllm/pull/new/pr-1b-metadata) — `X-RLLM-*` headers + inbound bearer auth (depends on this)
- [PR-1C](https://github.com/rllm-org/rllm/pull/new/pr-1c-upstream) — upstream-proxy mode + run lifecycle (depends on B)

## Test plan

- [x] `python -m pytest tests/unit/` — 220 passed
- [x] `python -m pytest tests/unit/test_store.py` — 74 passed (new tests for schema v2, denormalised columns, junction back-compat, concurrent writers)
- [ ] One known flaky case: `test_two_stores_share_one_db` can fail ~5% under suite-wide ordering when two `SqliteTraceStore` instances race the WAL pragma. Passes reliably in isolation. Tracking as a follow-up — fix is a small retry on `journal_mode=WAL` or a process-level init lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)