### PR TITLE
feat(model-gateway): X-RLLM-* headers + inbound bearer auth

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/data_process.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/data_process.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from typing import Any
 
+from rllm_model_gateway.metadata import RllmMetadata
 from rllm_model_gateway.models import TraceRecord
 
 logger = logging.getLogger(__name__)
@@ -127,6 +128,18 @@ def strip_vllm_fields(response: dict[str, Any]) -> dict[str, Any]:
 # ------------------------------------------------------------------
 
 
+def _metadata_fields(rllm_metadata: RllmMetadata | None) -> dict[str, Any]:
+    """Project RllmMetadata onto the TraceRecord field set (excluding session_id)."""
+    if rllm_metadata is None:
+        return {}
+    return {
+        "run_id": rllm_metadata.run_id,
+        "harness": rllm_metadata.harness,
+        "step_id": rllm_metadata.step_id,
+        "parent_span_id": rllm_metadata.parent_span_id,
+    }
+
+
 def build_trace_record(
     session_id: str,
     request_body: dict[str, Any],
@@ -134,6 +147,7 @@ def build_trace_record(
     latency_ms: float,
     *,
     metadata: dict[str, Any] | None = None,
+    rllm_metadata: RllmMetadata | None = None,
 ) -> TraceRecord:
     """Assemble a ``TraceRecord`` from raw request/response dicts."""
     choices = response_body.get("choices") or []
@@ -162,6 +176,7 @@ def build_trace_record(
         metadata=metadata or {},
         raw_request=request_body,
         raw_response=response_body,
+        **_metadata_fields(rllm_metadata),
     )
 
 
@@ -172,6 +187,7 @@ def build_trace_record_from_chunks(
     latency_ms: float,
     *,
     metadata: dict[str, Any] | None = None,
+    rllm_metadata: RllmMetadata | None = None,
 ) -> TraceRecord:
     """Assemble a ``TraceRecord`` from accumulated streaming SSE chunks.
 
@@ -246,4 +262,5 @@ def build_trace_record_from_chunks(
         metadata=metadata or {},
         raw_request=request_body,
         raw_response=None,  # Too large for streaming; individual chunks not stored
+        **_metadata_fields(rllm_metadata),
     )

--- a/rllm-model-gateway/src/rllm_model_gateway/metadata.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/metadata.py
@@ -1,0 +1,141 @@
+"""rLLM session/harness metadata extraction.
+
+Defines the canonical contract for stamping session identity on a model
+call: HTTP headers (preferred), request-body fallback, and the legacy
+``/sessions/{sid}/v1/...`` URL path (for training back-compat).
+
+Precedence: header > body > URL path. The first non-empty value wins
+per field.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel
+
+# ------------------------------------------------------------------
+# Header names (lowercase — HTTP headers are case-insensitive but
+# ASGI delivers them in lowercase)
+# ------------------------------------------------------------------
+
+HEADER_SESSION_ID = "x-rllm-session-id"
+HEADER_RUN_ID = "x-rllm-run-id"
+HEADER_HARNESS = "x-rllm-harness"
+HEADER_STEP_ID = "x-rllm-step-id"
+HEADER_PARENT_SPAN_ID = "x-rllm-parent-span-id"
+HEADER_PROJECT = "x-rllm-project"
+HEADER_EXPERIMENT = "x-rllm-experiment"
+
+
+_SESSION_PATH_RE = re.compile(r"/sessions/([^/]+)(?:/v1(?:/.*)?)?$")
+
+
+class RllmMetadata(BaseModel):
+    """Session-level identity stamped on a model call."""
+
+    session_id: str | None = None
+    run_id: str | None = None
+    harness: str | None = None
+    step_id: int | None = None
+    parent_span_id: str | None = None
+    project: str | None = None
+    experiment: str | None = None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _coerce_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def extract_metadata(
+    *,
+    headers: Mapping[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+    path: str | None = None,
+) -> RllmMetadata:
+    """Build ``RllmMetadata`` from headers, body, and URL path.
+
+    Args:
+        headers: Lowercased header name → value. Empty values are ignored.
+        body: Parsed JSON body. Looks for ``metadata.rllm`` (a dict).
+            Also accepts a top-level ``rllm`` key for clients that don't
+            nest under ``metadata``.
+        path: Original request path. Used only as a last-resort fallback
+            for ``session_id`` via the legacy ``/sessions/{sid}/...`` shape.
+
+    Precedence is field-by-field: header → body → URL path. Missing
+    values stay ``None`` rather than raising.
+    """
+    headers = headers or {}
+    body = body or {}
+
+    body_rllm: dict[str, Any] = {}
+    md = body.get("metadata")
+    if isinstance(md, dict) and isinstance(md.get("rllm"), dict):
+        body_rllm = md["rllm"]
+    elif isinstance(body.get("rllm"), dict):
+        body_rllm = body["rllm"]
+
+    def _str_field(header_name: str, body_key: str) -> str | None:
+        return _coerce_str(headers.get(header_name)) or _coerce_str(body_rllm.get(body_key))
+
+    session_id = _str_field(HEADER_SESSION_ID, "session_id")
+    run_id = _str_field(HEADER_RUN_ID, "run_id")
+    harness = _str_field(HEADER_HARNESS, "harness")
+    parent_span_id = _str_field(HEADER_PARENT_SPAN_ID, "parent_span_id")
+    project = _str_field(HEADER_PROJECT, "project")
+    experiment = _str_field(HEADER_EXPERIMENT, "experiment")
+
+    step_id = _coerce_int(headers.get(HEADER_STEP_ID))
+    if step_id is None:
+        step_id = _coerce_int(body_rllm.get("step_id"))
+
+    if not session_id and path:
+        m = _SESSION_PATH_RE.search(path)
+        if m:
+            session_id = m.group(1)
+
+    return RllmMetadata(
+        session_id=session_id,
+        run_id=run_id,
+        harness=harness,
+        step_id=step_id,
+        parent_span_id=parent_span_id,
+        project=project,
+        experiment=experiment,
+    )
+
+
+def headers_from_scope(scope: dict[str, Any]) -> dict[str, str]:
+    """Convert ASGI ``scope['headers']`` to a lowercase-keyed dict.
+
+    Last value wins on duplicates — fine for the X-RLLM-* headers
+    which are single-valued.
+    """
+    raw = scope.get("headers") or []
+    out: dict[str, str] = {}
+    for item in raw:
+        try:
+            key, value = item
+        except (TypeError, ValueError):
+            continue
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
+        if isinstance(value, bytes):
+            value = value.decode("latin-1")
+        out[key.lower()] = value
+    return out

--- a/rllm-model-gateway/src/rllm_model_gateway/middleware.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/middleware.py
@@ -1,9 +1,22 @@
-"""SessionRoutingMiddleware — extracts session ID from URL and injects sampling params.
+"""SessionRoutingMiddleware — extracts rLLM session/harness metadata and
+injects sampling params.
 
-Handles the ``/sessions/{sid}/v1/...`` URL pattern (inspired by miles router).
+Three sources of session identity, in precedence order:
 
-Injects ``logprobs=True`` and ``return_token_ids=True`` (when configured)
-into the request body before forwarding.
+1. ``X-RLLM-*`` headers (canonical convention; harness shims stamp these).
+2. Body fallback: ``request.metadata.rllm`` or top-level ``request.rllm``.
+3. Legacy URL path: ``/sessions/{sid}/v1/...`` — kept for back-compat with
+   the existing training proxy entry points.
+
+After this middleware runs, downstream handlers can read:
+- ``scope["state"]["session_id"]`` — the extracted session ID (or ``None``).
+- ``scope["state"]["rllm_metadata"]`` — full ``RllmMetadata`` (run_id,
+  harness, step_id, parent_span_id, project, experiment).
+- ``scope["state"]["originally_requested_logprobs"]`` — used by the proxy
+  to strip injected logprobs from the response.
+
+The URL path is rewritten to strip the ``/sessions/{sid}`` prefix so that
+downstream route matching sees ``/v1/chat/completions``, etc.
 """
 
 import json
@@ -13,20 +26,37 @@ from typing import Any
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from rllm_model_gateway.metadata import (
+    RllmMetadata,
+    extract_metadata,
+    headers_from_scope,
+)
+
 logger = logging.getLogger(__name__)
 
 _SESSION_PATH_RE = re.compile(r"/sessions/([^/]+)(/v1(?:/.*)?)$")
 
+_BEARER_PREFIX = "bearer "
+
+
+async def _send_401(send: Send) -> None:
+    """Send a minimal 401 Unauthorized so callers get a clean failure mode."""
+    body = b'{"error": {"message": "missing or invalid bearer token", "type": "auth_error"}}'
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"www-authenticate", b'Bearer realm="rllm-gateway"'),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
 
 class SessionRoutingMiddleware:
-    """Pure-ASGI middleware that rewrites paths and injects sampling parameters.
-
-    After this middleware runs, downstream handlers can read:
-    - ``scope["state"]["session_id"]`` — the extracted session ID (or ``None``)
-
-    The URL path is rewritten to strip the ``/sessions/{sid}`` prefix so that
-    downstream route matching sees ``/v1/chat/completions``, etc.
-    """
+    """Pure-ASGI middleware that rewrites paths and injects sampling parameters."""
 
     def __init__(
         self,
@@ -37,6 +67,7 @@ class SessionRoutingMiddleware:
         sessions: Any | None = None,
         sampling_params_priority: str = "client",
         model: str | None = None,
+        inbound_auth_token: str | None = None,
     ) -> None:
         if sampling_params_priority not in ("client", "session"):
             raise ValueError(f"sampling_params_priority must be 'client' or 'session', got {sampling_params_priority!r}")
@@ -46,41 +77,72 @@ class SessionRoutingMiddleware:
         self.sessions = sessions  # SessionManager — for per-session sampling params
         self.sampling_params_priority = sampling_params_priority
         self.model = model
+        # When set, every inbound HTTP request must carry
+        # ``Authorization: Bearer <inbound_auth_token>``. Used by the
+        # eval gateway when exposed via a public tunnel — without this,
+        # anyone who guesses the tunnel URL can burn provider credits.
+        self.inbound_auth_token = inbound_auth_token
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
-        path: str = scope["path"]
-        session_id: str | None = None
+        headers = headers_from_scope(scope)
+        original_path: str = scope["path"]
 
-        # Extract session_id from /sessions/{sid}/v1/...
-        m = _SESSION_PATH_RE.search(path)
+        # Inbound auth check — runs before any body parsing or routing.
+        if self.inbound_auth_token is not None and not self._auth_ok(headers):
+            await _send_401(send)
+            return
+
+        # Strip /sessions/{sid}/v1 prefix so downstream routes see /v1/...
+        new_path = original_path
+        m = _SESSION_PATH_RE.search(original_path)
         if m:
-            session_id = m.group(1)
-            path = m.group(2)  # already starts with /v1
-
-        # Store extracted data in scope state
-        state = scope.setdefault("state", {})
-        state["session_id"] = session_id
-
-        # Rewrite path
-        scope["path"] = path
-        # Also update raw_path if present
+            new_path = m.group(2)
+        scope["path"] = new_path
         if "raw_path" in scope:
-            scope["raw_path"] = path.encode("utf-8")
+            scope["raw_path"] = new_path.encode("utf-8")
 
-        # Inject sampling parameters into POST request bodies (chat completions, etc.)
+        state = scope.setdefault("state", {})
+
         method = scope.get("method", "").upper()
-        needs_injection = self.add_logprobs or self.add_return_token_ids or self.sessions is not None
-        if method == "POST" and needs_injection:
-            await self._inject_params(scope, receive, send, session_id)
+        needs_body_inspection = method == "POST" and (self.add_logprobs or self.add_return_token_ids or self.sessions is not None)
+
+        if needs_body_inspection:
+            await self._inject_params(scope, receive, send, headers=headers, original_path=original_path)
         else:
+            metadata = extract_metadata(headers=headers, path=original_path)
+            self._populate_state(state, metadata)
             await self.app(scope, receive, send)
 
-    async def _inject_params(self, scope: Scope, receive: Receive, send: Send, session_id: str | None = None) -> None:
-        """Read body, inject sampling params, then forward with mutated body."""
+    def _auth_ok(self, headers: dict[str, str]) -> bool:
+        """Constant-time check that the request carries our bearer token."""
+        import hmac
+
+        auth = headers.get("authorization", "")
+        if not auth.lower().startswith(_BEARER_PREFIX):
+            return False
+        presented = auth[len(_BEARER_PREFIX) :].strip()
+        # ``compare_digest`` to avoid leaking the token via timing.
+        return hmac.compare_digest(presented, self.inbound_auth_token or "")
+
+    @staticmethod
+    def _populate_state(state: dict[str, Any], metadata: RllmMetadata) -> None:
+        state["rllm_metadata"] = metadata
+        state["session_id"] = metadata.session_id
+
+    async def _inject_params(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        *,
+        headers: dict[str, str],
+        original_path: str,
+    ) -> None:
+        """Read body, extract metadata + inject sampling params, then forward with mutated body."""
         body_parts: list[bytes] = []
         more = True
         while more:
@@ -89,18 +151,23 @@ class SessionRoutingMiddleware:
             more = msg.get("more_body", False)
 
         raw = b"".join(body_parts)
+        payload: dict[str, Any] = {}
         if raw:
             try:
-                payload = json.loads(raw)
-                if isinstance(payload, dict):
-                    # Record whether the client originally requested logprobs
-                    # so the proxy can strip them from the response if not.
-                    state = scope["state"]
-                    state["originally_requested_logprobs"] = "logprobs" in payload and payload["logprobs"]
-                    self._mutate(payload, session_id)
-                    raw = json.dumps(payload).encode("utf-8")
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict):
+                    payload = parsed
             except (json.JSONDecodeError, UnicodeDecodeError):
-                pass  # non-JSON body — forward as-is
+                payload = {}
+
+        metadata = extract_metadata(headers=headers, body=payload, path=original_path)
+        state = scope["state"]
+        self._populate_state(state, metadata)
+
+        if payload:
+            state["originally_requested_logprobs"] = "logprobs" in payload and payload["logprobs"]
+            self._mutate(payload, metadata.session_id)
+            raw = json.dumps(payload).encode("utf-8")
 
         # Build a receive that replays the (possibly mutated) body once,
         # then delegates to the original receive for disconnect detection.
@@ -121,7 +188,7 @@ class SessionRoutingMiddleware:
         await self.app(scope, patched_receive, send)
 
     def _mutate(self, payload: dict[str, Any], session_id: str | None = None) -> None:
-        """Inject ``logprobs``, ``return_token_ids``, and session sampling params."""
+        """Inject sampling params and strip rLLM scaffolding from the body."""
         if self.add_logprobs and "logprobs" not in payload:
             payload["logprobs"] = True
         if self.add_return_token_ids and "return_token_ids" not in payload:
@@ -139,3 +206,10 @@ class SessionRoutingMiddleware:
                     for key, value in sp.items():
                         if key not in payload:
                             payload[key] = value
+        # Strip rLLM-specific body fields so providers never see them.
+        payload.pop("rllm", None)
+        md = payload.get("metadata")
+        if isinstance(md, dict):
+            md.pop("rllm", None)
+            if not md:
+                payload.pop("metadata", None)

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -12,6 +12,14 @@ class TraceRecord(BaseModel):
     trace_id: str
     session_id: str
     model: str = ""
+    # rLLM session metadata — populated by middleware from headers/body/URL.
+    # All optional so existing training writers (which only stamp session_id)
+    # remain valid; eval and harness-stamped requests fill these in.
+    run_id: str | None = None
+    harness: str | None = None
+    step_id: int | None = None
+    parent_span_id: str | None = None
+    span_type: str = "llm.call"
     # Input
     messages: list[dict[str, Any]] = Field(default_factory=list)
     prompt_token_ids: list[int] = Field(default_factory=list)
@@ -104,12 +112,38 @@ class SessionInfo(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+class UpstreamRoute(BaseModel):
+    """Map a model name to an OpenAI-compatible upstream endpoint.
+
+    The gateway treats this as opaque routing: it does not know about
+    providers, auth shapes, or model-name conventions. The caller
+    (typically rllm) resolves any provider knowledge — choice of
+    upstream URL, the literal ``Authorization`` header value to use,
+    and any params the upstream rejects — and hands the gateway a
+    fully-resolved route to forward to.
+    """
+
+    upstream_url: str  # e.g. "http://127.0.0.1:4000/v1" or "https://api.openai.com/v1"
+    # Full ``Authorization`` header value, e.g. ``"Bearer sk-..."``.
+    # ``None`` means the gateway forwards no auth header upstream.
+    auth_header: str | None = None
+    # Body fields to strip before forwarding (e.g. ``"max_tokens"`` for
+    # OpenAI o-series models that reject it). The gateway treats this as
+    # a generic body-shaping list; it doesn't interpret which model needs
+    # what.
+    drop_params: list[str] = Field(default_factory=list)
+
+
 class GatewayConfig(BaseModel):
     """Top-level gateway configuration."""
 
     host: str = "0.0.0.0"
     port: int = 9090
     workers: list[WorkerConfig] = Field(default_factory=list)
+    # Map model name → upstream route. The gateway looks up
+    # ``body["model"]`` and forwards to the matching route; falls
+    # through to the worker-pool path if no match.
+    routes: dict[str, UpstreamRoute] = Field(default_factory=dict)
     db_path: str | None = None
     store_worker: str = "sqlite"
     add_logprobs: bool = True
@@ -121,3 +155,15 @@ class GatewayConfig(BaseModel):
     sync_traces: bool = False
     sampling_params_priority: str = "client"
     model: str | None = None  # When set, overrides ``body.model``
+    # Identifier of the gateway run — eval CLI sets this to the run dir
+    # basename, training/harness shims pick something globally unique.
+    # When set, every trace persisted by this gateway is tagged with it
+    # and a row is registered in the ``runs`` table on startup.
+    run_id: str | None = None
+    # Free-form metadata for the run (benchmark, model, agent, source,
+    # …). Surfaced by the cross-run viewer.
+    run_metadata: dict[str, Any] = Field(default_factory=dict)
+    # When set, every inbound request must carry
+    # ``Authorization: Bearer <inbound_auth_token>``. Generated per-run
+    # by the eval gateway when a public URL is exposed; never persisted.
+    inbound_auth_token: str | None = None

--- a/rllm-model-gateway/tests/unit/test_inbound_auth.py
+++ b/rllm-model-gateway/tests/unit/test_inbound_auth.py
@@ -1,0 +1,145 @@
+"""Inbound bearer-token auth on SessionRoutingMiddleware.
+
+When the gateway is exposed via a public tunnel, requests must carry
+``Authorization: Bearer <token>`` or get rejected before the body even
+parses. Without this check, anyone who guesses the tunnel URL can burn
+provider credits.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from rllm_model_gateway.middleware import SessionRoutingMiddleware
+
+
+class _FakeApp:
+    """Records that the inner ASGI app was reached."""
+
+    def __init__(self) -> None:
+        self.called = False
+
+    async def __call__(self, scope, receive, send) -> None:  # type: ignore[no-untyped-def]
+        self.called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+
+def _make_scope(*, auth_header: str | None = None) -> dict[str, Any]:
+    headers = []
+    if auth_header is not None:
+        headers.append((b"authorization", auth_header.encode()))
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": "/v1/health",
+        "raw_path": b"/v1/health",
+        "headers": headers,
+    }
+
+
+async def _call(middleware: SessionRoutingMiddleware, scope: dict[str, Any]) -> tuple[int, bytes]:
+    """Drive the middleware once and capture the (status, body) response."""
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.disconnect"}
+
+    async def send(msg) -> None:  # type: ignore[no-untyped-def]
+        sent.append(msg)
+
+    await middleware(scope, receive, send)
+    status = next(m["status"] for m in sent if m["type"] == "http.response.start")
+    body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    return status, body
+
+
+@pytest.mark.asyncio
+async def test_no_token_configured_means_no_check_runs():
+    """Loopback eval (no public URL): inbound_auth_token=None → bypass check entirely."""
+    inner = _FakeApp()
+    mw = SessionRoutingMiddleware(inner, inbound_auth_token=None)
+
+    status, _ = await _call(mw, _make_scope())  # no Authorization header
+
+    assert status == 200
+    assert inner.called is True
+
+
+@pytest.mark.asyncio
+async def test_correct_bearer_token_passes_through():
+    inner = _FakeApp()
+    mw = SessionRoutingMiddleware(inner, inbound_auth_token="tok_abc")
+
+    status, _ = await _call(mw, _make_scope(auth_header="Bearer tok_abc"))
+
+    assert status == 200
+    assert inner.called is True
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header_is_401():
+    inner = _FakeApp()
+    mw = SessionRoutingMiddleware(inner, inbound_auth_token="tok_abc")
+
+    status, body = await _call(mw, _make_scope())
+
+    assert status == 401
+    assert b"bearer" in body.lower()
+    assert inner.called is False  # short-circuited before the inner app
+
+
+@pytest.mark.asyncio
+async def test_wrong_token_is_401():
+    inner = _FakeApp()
+    mw = SessionRoutingMiddleware(inner, inbound_auth_token="tok_correct")
+
+    status, _ = await _call(mw, _make_scope(auth_header="Bearer tok_wrong"))
+
+    assert status == 401
+    assert inner.called is False
+
+
+@pytest.mark.asyncio
+async def test_non_bearer_scheme_is_401():
+    """Basic auth, API-key headers, etc. don't satisfy the bearer requirement."""
+    inner = _FakeApp()
+    mw = SessionRoutingMiddleware(inner, inbound_auth_token="tok_abc")
+
+    status, _ = await _call(mw, _make_scope(auth_header="Basic dXNlcjpwdw=="))
+
+    assert status == 401
+    assert inner.called is False
+
+
+@pytest.mark.asyncio
+async def test_bearer_scheme_is_case_insensitive():
+    """Some clients send lower-case 'bearer'. RFC 6750 allows it; reject it and they break."""
+    inner = _FakeApp()
+    mw = SessionRoutingMiddleware(inner, inbound_auth_token="tok_abc")
+
+    status, _ = await _call(mw, _make_scope(auth_header="bearer tok_abc"))
+
+    assert status == 200
+
+
+@pytest.mark.asyncio
+async def test_websocket_scope_bypasses_check():
+    """Auth is for HTTP requests; WS upgrades aren't a thing on this gateway,
+    but the middleware should not crash if one shows up."""
+    inner = _FakeApp()
+    mw = SessionRoutingMiddleware(inner, inbound_auth_token="tok_abc")
+    scope = {"type": "websocket", "path": "/", "headers": []}
+
+    async def receive():
+        return {"type": "websocket.disconnect"}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    # Should hit the websocket fast-path that just delegates.
+    await mw(scope, receive, send)
+    assert inner.called is True

--- a/rllm-model-gateway/tests/unit/test_metadata.py
+++ b/rllm-model-gateway/tests/unit/test_metadata.py
@@ -1,0 +1,111 @@
+"""Tests for rllm session/harness metadata extraction."""
+
+from rllm_model_gateway.metadata import (
+    HEADER_HARNESS,
+    HEADER_PARENT_SPAN_ID,
+    HEADER_PROJECT,
+    HEADER_RUN_ID,
+    HEADER_SESSION_ID,
+    HEADER_STEP_ID,
+    extract_metadata,
+    headers_from_scope,
+)
+
+
+class TestExtractMetadataFromHeaders:
+    def test_all_headers_present(self):
+        headers = {
+            HEADER_SESSION_ID: "sess-1",
+            HEADER_RUN_ID: "run-7",
+            HEADER_HARNESS: "claude-code",
+            HEADER_STEP_ID: "3",
+            HEADER_PARENT_SPAN_ID: "span-parent",
+            HEADER_PROJECT: "demo",
+        }
+        md = extract_metadata(headers=headers)
+        assert md.session_id == "sess-1"
+        assert md.run_id == "run-7"
+        assert md.harness == "claude-code"
+        assert md.step_id == 3
+        assert md.parent_span_id == "span-parent"
+        assert md.project == "demo"
+        assert md.experiment is None
+
+    def test_empty_header_value_treated_as_missing(self):
+        md = extract_metadata(headers={HEADER_SESSION_ID: "  "})
+        assert md.session_id is None
+
+    def test_invalid_step_id_falls_back_to_none(self):
+        md = extract_metadata(headers={HEADER_STEP_ID: "not-a-number"})
+        assert md.step_id is None
+
+
+class TestExtractMetadataBodyFallback:
+    def test_metadata_rllm_nested(self):
+        body = {"metadata": {"rllm": {"session_id": "sess-2", "harness": "react"}}}
+        md = extract_metadata(body=body)
+        assert md.session_id == "sess-2"
+        assert md.harness == "react"
+
+    def test_top_level_rllm_key(self):
+        body = {"rllm": {"session_id": "sess-3", "run_id": "run-1", "step_id": 5}}
+        md = extract_metadata(body=body)
+        assert md.session_id == "sess-3"
+        assert md.run_id == "run-1"
+        assert md.step_id == 5
+
+    def test_body_ignored_when_not_dict(self):
+        md = extract_metadata(body={"metadata": "not-a-dict"})
+        assert md.session_id is None
+
+
+class TestExtractMetadataPathFallback:
+    def test_session_path_legacy(self):
+        md = extract_metadata(path="/sessions/legacy-sid/v1/chat/completions")
+        assert md.session_id == "legacy-sid"
+
+    def test_session_path_short(self):
+        md = extract_metadata(path="/sessions/foo")
+        assert md.session_id == "foo"
+
+    def test_no_session_in_path(self):
+        md = extract_metadata(path="/v1/chat/completions")
+        assert md.session_id is None
+
+
+class TestExtractMetadataPrecedence:
+    def test_header_beats_body(self):
+        headers = {HEADER_SESSION_ID: "from-header"}
+        body = {"metadata": {"rllm": {"session_id": "from-body"}}}
+        md = extract_metadata(headers=headers, body=body)
+        assert md.session_id == "from-header"
+
+    def test_header_beats_path(self):
+        headers = {HEADER_SESSION_ID: "from-header"}
+        md = extract_metadata(headers=headers, path="/sessions/from-path/v1/foo")
+        assert md.session_id == "from-header"
+
+    def test_body_beats_path(self):
+        body = {"rllm": {"session_id": "from-body"}}
+        md = extract_metadata(body=body, path="/sessions/from-path/v1/foo")
+        assert md.session_id == "from-body"
+
+    def test_field_level_merge(self):
+        # Header has session_id; body has run_id. Both contribute.
+        headers = {HEADER_SESSION_ID: "h-sess"}
+        body = {"rllm": {"run_id": "b-run"}}
+        md = extract_metadata(headers=headers, body=body)
+        assert md.session_id == "h-sess"
+        assert md.run_id == "b-run"
+
+
+class TestHeadersFromScope:
+    def test_lowercases_and_decodes(self):
+        scope = {"headers": [(b"X-RLLM-Session-Id", b"abc"), (b"Content-Type", b"application/json")]}
+        out = headers_from_scope(scope)
+        assert out["x-rllm-session-id"] == "abc"
+        assert out["content-type"] == "application/json"
+
+    def test_empty(self):
+        assert headers_from_scope({}) == {}
+        assert headers_from_scope({"headers": []}) == {}


### PR DESCRIPTION
## Summary

Stacked on [#551](https://github.com/rllm-org/rllm/pull/551). Header-stamped session metadata becomes the canonical identity carrier; body fields and the legacy `/sessions/{sid}/v1/...` URL form are kept as field-by-field fallbacks. rLLM headers are stripped before forwarding upstream so they never leak to providers.

- New `metadata.py`: `RllmMetadata` dataclass + `extract_metadata()` with precedence header > body > path, merged field-by-field (so a request can carry `session_id` in the URL and `run_id` in a header and both contribute).
- Middleware attaches `RllmMetadata` to ASGI scope and gains an optional inbound-auth gate: when a bearer token is configured, every request must present `Authorization: Bearer <token>` (HMAC-compared) or get 401. Used by remote-sandbox eval where the gateway is exposed via a public tunnel.
- `TraceRecord` gains the rLLM identity fields (`run_id`, `harness`, `step_id`, `parent_span_id`, `span_type`); `data_process.build_trace_record` populates them from `RllmMetadata` when present.
- `models.py` carries the future-facing config fields (`UpstreamRoute`, `routes`, `run_id`, `run_metadata`, `inbound_auth_token`) so the upstream-proxy PR can wire them up without further model churn.

## Stack

- [PR-1A](https://github.com/rllm-org/rllm/pull/551) — schema v2
- **[PR-1B] this** — header metadata + inbound auth
- [PR-1C](https://github.com/rllm-org/rllm/pull/new/pr-1c-upstream) — upstream-proxy mode (depends on this)

## Test plan

- [x] `python -m pytest tests/unit/` — 242 passed
- [x] 15 new tests in `test_metadata.py` (header/body/path precedence, field-level merge, scope-shape decoding)
- [x] 7 new tests in `test_inbound_auth.py` (token absent → open, presented → 200, missing/wrong → 401, HMAC compare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)