### PR TITLE
feat(model-gateway): upstream-proxy mode + run lifecycle

### DIFF
--- a/rllm-model-gateway/AGENTS.md
+++ b/rllm-model-gateway/AGENTS.md
@@ -2,14 +2,21 @@
 
 ## Overview
 
-A lightweight, standalone Python gateway that sits between RL agents and inference servers (vLLM). It transparently captures every LLM call's token IDs, logprobs, and messages — without requiring any modification to agent code. Agents use standard `OpenAI(base_url=gateway_url)`.
+A standalone Python gateway that sits between RL agents/trainers and inference backends. Captures every LLM call's token IDs, logprobs, and messages — without modifying agent code. Agents use standard `OpenAI(base_url=gateway_url)`.
 
-## Development Setup
+The gateway has two operational modes that can coexist in the same process:
+
+- **Worker pool** — sticky routing across vLLM workers, used by verl/tinker training. The trainer's `GatewayManager` owns the lifecycle (in-process or subprocess) and registers workers via `POST /admin/workers`.
+- **Upstream proxy** — provider-agnostic forwarding to OpenAI-compatible URLs (OpenAI, Anthropic, vLLM, etc.), used by eval and sandboxed CLI-agent harnesses. Routes are matched by `body["model"]`.
+
+If neither a route match nor a worker pool is configured, a request returns 404. Routes take precedence; misses fall through to the worker pool.
+
+## Development setup
 
 This package uses `uv` for dependency management and `hatchling` as the build backend. Do not use setuptools or pip.
 
 ```bash
-cd rllm/rllm-model-gateway
+cd rllm-model-gateway
 uv venv --python 3.11
 source .venv/bin/activate
 uv pip install -e ".[dev]"
@@ -18,115 +25,149 @@ uv pip install -e ".[dev]"
 cd .. && pre-commit install && cd rllm-model-gateway
 ```
 
-To run tests:
+Tests:
 
 ```bash
-# Unit tests (no external dependencies)
-python -m pytest tests/unit/ -x -q
-
-# Integration tests against a real vLLM server (auto-skipped if unreachable)
-python -m pytest tests/integration/ -x -v
+python -m pytest tests/unit/ -x -q                  # no external deps
+python -m pytest tests/integration/ -x -v           # requires vLLM on localhost:4000 (auto-skip otherwise)
 ```
 
-## Package Layout
+## Package layout
 
 ```
 src/rllm_model_gateway/
 ├── __init__.py           # Public API exports
 ├── __main__.py           # python -m rllm_model_gateway
-├── _version.py           # Package version
+├── _version.py
 ├── server.py             # FastAPI app factory + CLI entrypoint
-├── proxy.py              # httpx reverse proxy (non-streaming + SSE streaming)
-├── middleware.py          # ASGI middleware: session extraction + param injection
+├── proxy.py              # httpx reverse proxy: worker-pool + upstream-route paths, SSE streaming
+├── middleware.py         # ASGI middleware: session/metadata extraction, param injection, inbound auth
+├── metadata.py           # RllmMetadata + extract_metadata (header/body/path precedence)
 ├── session_router.py     # Pluggable session-sticky worker routing
 ├── session_manager.py    # Session CRUD lifecycle
 ├── data_process.py       # Token/logprob extraction, response sanitization
-├── models.py             # Pydantic models (TraceRecord, GatewayConfig, etc.)
+├── models.py             # Pydantic models — TraceRecord, GatewayConfig, UpstreamRoute, …
 ├── client.py             # GatewayClient + AsyncGatewayClient
 └── store/
-    ├── base.py           # TraceStore protocol (6 async methods)
-    ├── sqlite_store.py   # SQLite with junction table (default)
+    ├── base.py           # TraceStore protocol
+    ├── sqlite_store.py   # SQLite with run/session/trace tables (default)
     └── memory_store.py   # In-memory (testing)
 ```
 
-## Key Design Decisions
+## Identifying a session
 
-1. **No LiteLLM** — Direct httpx reverse proxy. Session-sticky routing requires custom logic that LiteLLM can't provide, and httpx handles HTTP forwarding + SSE natively. This keeps deps to 6 packages.
+Three sources, in precedence order, field-by-field:
 
-2. **Zero retokenization** — Token IDs come from vLLM's `return_token_ids=True` response field, not from a local tokenizer. The middleware injects this parameter automatically.
+1. **`X-RLLM-*` headers** (canonical): `X-RLLM-Session-Id`, `X-RLLM-Run-Id`, `X-RLLM-Harness`, `X-RLLM-Step-Id`, `X-RLLM-Parent-Span-Id`, `X-RLLM-Project`, `X-RLLM-Experiment`. Stripped before forwarding upstream.
+2. **Body fallback**: `metadata.rllm.{…}` or top-level `rllm.{…}`.
+3. **Legacy URL path**: `/sessions/{sid}/v1/...` — preserved exclusively for `GatewayManager`'s training entry points.
 
-3. **Implicit sessions** — First request to `/sessions/{sid}/v1/chat/completions` auto-creates the session. No explicit creation required.
+Implementation: `metadata.extract_metadata` populates a `RllmMetadata` model into `scope["state"]["rllm_metadata"]`; the proxy reads it when persisting trace records.
 
-4. **ASGI middleware** — `SessionRoutingMiddleware` operates at the ASGI level (not FastAPI middleware) so it can intercept and rewrite the request body before FastAPI route matching.
+## Key design decisions
 
-5. **Pluggable routing** — `RoutingPolicy` protocol allows swapping the worker selection strategy. Default is `StickyLeastLoadedPolicy` (LRU cache + least-loaded fallback, mirroring verl's pattern).
+1. **No litellm.** Direct httpx reverse proxy. Session-sticky routing requires custom logic, and httpx handles HTTP forwarding + SSE natively. Keeps deps to 6 packages. (Note: `rllm/sdk/proxy/litellm_server.py` in the parent repo is a *separate* subsystem still used by the verl/tinker SDK trainer; it is not part of this package.)
 
-6. **Pluggable storage** — `TraceStore` protocol (duck-typed, not ABC). SQLite for single-node, MemoryStore for testing, extensible to DynamoDB/PostgreSQL.
+2. **Provider-agnostic upstream routing.** `UpstreamRoute` carries a fully-resolved `upstream_url`, literal `Authorization` header, and per-route `drop_params`. The gateway does not know about provider conventions — the caller (rllm) resolves provider knowledge before populating routes.
 
-## Request Flow
+3. **Header-stamped metadata over URL stuffing.** The legacy `/sessions/{sid}/v1/...` shape conflates routing with identity. New code stamps `X-RLLM-*` headers on requests; old code keeps working because the middleware still recognizes the URL path.
+
+4. **Zero retokenization.** Token IDs come from vLLM's `return_token_ids=True` response field, not from a local tokenizer. The middleware injects this parameter automatically when targeting the worker pool; for upstream routes that don't return token IDs, traces capture only message-level data.
+
+5. **Implicit sessions.** First request to `/sessions/{sid}/v1/...` (or with `X-RLLM-Session-Id`) auto-creates the session.
+
+6. **ASGI middleware.** `SessionRoutingMiddleware` operates at the ASGI level (not FastAPI middleware) so it can intercept and rewrite the request body before FastAPI route matching.
+
+7. **Pluggable routing + storage.** `RoutingPolicy` (worker selection) and `TraceStore` (persistence) are protocols. Default routing policy: `StickyLeastLoadedPolicy` (LRU + least-loaded). Default store: SQLite.
+
+8. **Run lifecycle.** `GatewayConfig.run_id` tags every persisted trace; the run is registered on startup and ended on shutdown so the cross-run viewer can group sessions by gateway lifetime.
+
+9. **Optional inbound auth.** `inbound_auth_token` requires `Authorization: Bearer <token>` on every request. Used when the gateway is exposed via tunnel for remote-sandbox eval.
+
+## Request flow
+
+### Worker-pool path (training)
 
 ```
 Agent → /sessions/{sid}/v1/chat/completions
   → SessionRoutingMiddleware:
-      1. Extract session_id from URL, rewrite path to /v1/chat/completions
-      2. Inject logprobs=True, return_token_ids=True into body
-  → FastAPI route handler (/v1/{path:path}):
+      1. Extract metadata from headers/body/URL → RllmMetadata
+      2. Strip /sessions/{sid} prefix → /v1/chat/completions
+      3. Inject logprobs=True, return_token_ids=True into body
+  → /v1/{path:path} handler:
       1. SessionManager.ensure_session(sid)
-      2. ReverseProxy.handle(request):
-          a. SessionRouter.route(session_id) → pick worker
-          b. httpx forward to worker
-          c. Extract token_ids + logprobs from response
-          d. Build TraceRecord, persist to store
-          e. Strip vLLM fields from response
-          f. Return clean response to agent
+      2. ReverseProxy.handle:
+          a. body["model"] not in routes → worker-pool path
+          b. SessionRouter.route(session_id) → pick worker
+          c. httpx forward to worker
+          d. Extract token_ids + logprobs from response
+          e. Build TraceRecord, persist
+          f. Strip vLLM fields, return clean response
+```
+
+### Upstream-route path (eval)
+
+```
+Harness → /v1/chat/completions  (with X-RLLM-* headers)
+  → SessionRoutingMiddleware:
+      1. (optional) inbound bearer auth check
+      2. Extract metadata from headers → RllmMetadata
+  → /v1/{path:path} handler:
+      1. SessionManager.ensure_session(sid)
+      2. ReverseProxy.handle:
+          a. body["model"] in routes → upstream-route path
+          b. Strip X-RLLM-* and client auth from forwarded headers
+          c. Inject route.auth_header
+          d. Drop body params in route.drop_params
+          e. httpx forward to route.upstream_url
+          f. Build TraceRecord (without token_ids if upstream doesn't return them), persist
+          g. Return upstream response unchanged
 ```
 
 ## Streaming
 
 For SSE streaming requests (`stream=True`):
-- Chunks forwarded to agent in real-time via `StreamingResponse`
-- Chunks buffered internally for trace assembly
-- `prompt_token_ids` extracted from first chunk only
-- Delta `token_ids` and logprobs accumulated across chunks
-- After `[DONE]`, `build_trace_record_from_chunks()` assembles the trace
 
-## vLLM Response Fields
+- Chunks forwarded to client in real-time via `StreamingResponse`
+- Chunks buffered for trace assembly
+- After `[DONE]`, `build_trace_record_from_chunks` assembles the trace and persists asynchronously (does not block the response)
+
+## vLLM response fields
 
 The gateway strips these vLLM-specific fields before returning to the agent (verified against vLLM 0.11):
 
 | Level | Field | Purpose |
 |-------|-------|---------|
-| Root | `prompt_token_ids` | Captured for trace, stripped from response |
+| Root | `prompt_token_ids` | Captured for trace, stripped |
 | Root | `prompt_logprobs` | Not used (always `null` without explicit request) |
 | Root | `kv_transfer_params` | Disaggregated prefill feature |
-| Choice | `token_ids` | Captured for trace, stripped from response |
+| Choice | `token_ids` | Captured for trace, stripped |
 | Choice | `stop_reason` | vLLM-specific; standard OpenAI uses `finish_reason` |
+
+For upstream routes that don't return these fields (OpenAI, Anthropic, etc.), there's nothing to strip.
+
+## Trace store schema
+
+The SQLite store has three tables:
+
+- `runs` — gateway lifetimes, registered on startup via `run_id`. Carries `run_metadata`, start/end timestamps.
+- `sessions` — per-session metadata, foreign-keyed to `runs.run_id` (nullable for the unstamped bucket).
+- `traces` — `TraceRecord` rows, foreign-keyed to `sessions.session_id`. Indexed on `(run_id, timestamp)` and `(session_id, timestamp)` for cross-run queries.
+
+`MemoryStore` mirrors the same shape with dicts, used for tests.
 
 ## Provenance
 
-| Module | Inspired By | Key Changes |
+| Module | Inspired by | Key changes |
 |--------|------------|-------------|
-| `store/sqlite_store.py` | `rllm/sdk/store/sqlite_store.py` | Simplified schema; added `list_sessions()`, `delete_session()` |
+| `store/sqlite_store.py` | `rllm/sdk/store/sqlite_store.py` | Added run-table; cross-run queries; junction tables |
 | `data_process.py` | `rllm/sdk/data_process.py` | Removed `ModelOutput`/`Step`/`Trajectory` deps; outputs `TraceRecord` |
-| `middleware.py` | `rllm/sdk/proxy/middleware.py` + `litellm_callbacks.py` | Merged session routing + param injection; pure ASGI (no LiteLLM) |
-| `session_router.py` | verl `agent_loop.py` + miles `router.py` | Combined sticky routing (verl LRU) with health checks (miles pattern) |
-| `proxy.py` | miles `router.py` `_do_proxy()` | Added streaming support, trace capture, response sanitization |
+| `middleware.py` | `rllm/sdk/proxy/middleware.py` + `litellm_callbacks.py` | Merged routing + injection + inbound auth; pure ASGI |
+| `session_router.py` | verl `agent_loop.py` + miles `router.py` | Sticky routing (verl LRU) + health checks (miles) |
+| `proxy.py` | miles `router.py` `_do_proxy()` | Streaming, trace capture, response sanitization, upstream-route branch |
 
 ## Dependencies
 
-6 runtime dependencies: `fastapi`, `uvicorn`, `httpx`, `pydantic`, `aiosqlite`, `PyYAML`. No torch/ray/verl/transformers.
+6 runtime deps: `fastapi`, `uvicorn`, `httpx`, `pydantic`, `aiosqlite`, `PyYAML`. No torch/ray/verl/transformers.
 
 Build backend: `hatchling`. Do not use setuptools.
-
-## Usage Example
-
-```python
-from rllm_model_gateway import GatewayClient
-
-client = GatewayClient("http://localhost:9090")
-sid = client.create_session()
-url = client.get_session_url(sid)  # → http://localhost:9090/sessions/{sid}/v1
-
-# Agent uses: OpenAI(base_url=url, api_key="EMPTY")
-# Training retrieves: client.get_session_traces(sid)
-```

--- a/rllm-model-gateway/README.md
+++ b/rllm-model-gateway/README.md
@@ -1,36 +1,63 @@
 # rllm-model-gateway
 
-Lightweight model gateway for capturing LLM call traces during RL agent training. Sits between agents and inference servers (vLLM), transparently recording token IDs, logprobs, and conversation data — with zero modifications to agent code.
+Lightweight model gateway that sits between agents/trainers and inference backends. Captures every LLM call as a `TraceRecord` — token IDs, logprobs, messages, and rLLM session metadata — with zero modifications to agent code.
 
-## Quick Start
+Two operational modes, selectable via configuration:
+
+- **Worker pool** — in-process or HTTP forwarding to vLLM workers with session-sticky routing. Used by verl/tinker training via `GatewayManager`.
+- **Upstream proxy** — forwards to provider URLs (OpenAI, Anthropic, vLLM, anything OpenAI-compatible) with route-specific auth and per-route param stripping. Used by eval and sandboxed CLI-agent harnesses.
+
+The same gateway can act as both at once: routes are looked up by `body["model"]`; unmatched models fall through to the worker pool.
+
+## Quick start
 
 ```bash
-# Create a uv environment
 uv venv --python 3.11
 source .venv/bin/activate
-
-# Install
 uv pip install -e .
 
-# Set up pre-commit hooks (one-time, from the rllm repo root)
-cd .. && pre-commit install && cd rllm-model-gateway
-
-# Start with a vLLM worker
+# Worker-pool mode (training)
 rllm-model-gateway --port 9090 --worker http://localhost:8000/v1
 
-# Or with a config file
+# Upstream-proxy mode (eval) — see "Configuration" below
 rllm-model-gateway --config gateway.yaml
 ```
 
-## Agent Side (Zero rLLM Dependencies)
+## Identifying a session
+
+The gateway extracts session identity from one of three sources, in precedence order:
+
+1. **`X-RLLM-*` headers** (preferred — set by harness shims):
+   - `X-RLLM-Session-Id` (required for tracing)
+   - `X-RLLM-Run-Id`, `X-RLLM-Harness`, `X-RLLM-Step-Id`
+   - `X-RLLM-Parent-Span-Id`, `X-RLLM-Project`, `X-RLLM-Experiment`
+2. **Request body** — `metadata.rllm.{session_id, run_id, …}` or top-level `rllm.{…}`.
+3. **Legacy URL path** — `/sessions/{sid}/v1/...`. Preserved for back-compat with the training proxy entry points (verl/tinker `GatewayManager`).
+
+Precedence is field-by-field — a request can carry `session_id` in the URL and `run_id` in a header, and both contribute. The `X-RLLM-*` headers are gateway-internal and stripped before forwarding upstream.
+
+## Agent side (no rLLM dependency)
 
 ```python
 from openai import OpenAI
 
+# Header-stamped (preferred for new code)
+client = OpenAI(
+    base_url="http://localhost:9090/v1",
+    api_key="EMPTY",
+    default_headers={
+        "X-RLLM-Session-Id": session_id,
+        "X-RLLM-Run-Id": run_id,
+        "X-RLLM-Harness": "claude-code",
+    },
+)
+
+# Path-stamped (legacy / training)
 client = OpenAI(
     base_url=f"http://localhost:9090/sessions/{session_id}/v1",
     api_key="EMPTY",
 )
+
 response = client.chat.completions.create(
     model="Qwen/Qwen2.5-7B",
     messages=[{"role": "user", "content": "Hello"}],
@@ -39,14 +66,13 @@ response = client.chat.completions.create(
 
 Works with any OpenAI-compatible agent framework (ADK, Strands, LangChain, OpenAI Agents SDK, etc.).
 
-## Training Side
+## Training side
 
 ```python
 from rllm_model_gateway import GatewayClient
 
 client = GatewayClient("http://localhost:9090")
 
-# Create session and get URL for the agent
 session_id = client.create_session()
 agent_url = client.get_session_url(session_id)
 # → "http://localhost:9090/sessions/{session_id}/v1"
@@ -55,19 +81,40 @@ agent_url = client.get_session_url(session_id)
 traces = client.get_session_traces(session_id)
 for trace in traces:
     print(trace.prompt_token_ids)       # From vLLM's return_token_ids
-    print(trace.completion_token_ids)   # Per-token IDs, no retokenization needed
-    print(trace.logprobs)               # Per-token logprobs
+    print(trace.completion_token_ids)
+    print(trace.logprobs)
 ```
 
-## Features
+## Eval / upstream-proxy mode
 
-- **Zero agent coupling** — Agents use standard `OpenAI(base_url=...)`, no rLLM imports
-- **Zero retokenization** — Token IDs captured directly from vLLM responses
-- **Partial rollout recovery** — Traces persisted per-call, survive agent crashes
-- **Session-sticky routing** — Multi-turn sessions routed to the same worker for prefix caching
-- **Streaming support** — SSE streaming with real-time chunk forwarding and trace assembly
-- **Pluggable storage** — SQLite (default), in-memory (testing), extensible to DynamoDB/PostgreSQL
-- **Lightweight** — 6 dependencies, no torch/ray/verl/transformers
+Configure routes in YAML; the gateway forwards by model name:
+
+```yaml
+host: 0.0.0.0
+port: 9090
+run_id: "eval-2026-05-03-claude"
+run_metadata:
+  benchmark: swe-bench-verified
+  agent: claude-code
+routes:
+  "claude-sonnet-4":
+    upstream_url: https://api.anthropic.com/v1
+    auth_header: "x-api-key ${ANTHROPIC_API_KEY}"
+    drop_params: [logprobs, return_token_ids]
+  "gpt-4o":
+    upstream_url: https://api.openai.com/v1
+    auth_header: "Bearer ${OPENAI_API_KEY}"
+```
+
+The route's `auth_header` replaces the client's, so harnesses don't need provider keys. `drop_params` strips body fields the upstream rejects (e.g. `max_tokens` for OpenAI o-series).
+
+## Inbound bearer auth
+
+Set `inbound_auth_token` to require `Authorization: Bearer <token>` on every request. Used by remote-sandbox eval, where the gateway is exposed via a public tunnel and the bearer gates access. See `tests/unit/test_inbound_auth.py`.
+
+## Run lifecycle
+
+`GatewayConfig.run_id` (and `run_metadata`) tag every persisted trace with the gateway's lifetime. On startup the run is registered in the store; on shutdown it's marked ended. The cross-run viewer in [rllm-console](../rllm-console/README.md) groups sessions by `run_id`.
 
 ## Development
 
@@ -76,7 +123,10 @@ uv venv --python 3.11
 source .venv/bin/activate
 uv pip install -e ".[dev]"
 
-# Unit tests
+# Set up pre-commit hooks (one-time, from the rllm repo root)
+cd .. && pre-commit install && cd rllm-model-gateway
+
+# Unit tests (no external dependencies)
 python -m pytest tests/unit/ -x -q
 
 # Integration tests (requires vLLM on localhost:4000, auto-skipped otherwise)
@@ -95,37 +145,54 @@ rllm-model-gateway \
   --worker http://vllm-1:8000/v1
 ```
 
-### YAML (`--config gateway.yaml`)
+### YAML
 
 ```yaml
-host: "0.0.0.0"
+host: 0.0.0.0
 port: 9090
-db_path: "~/.rllm/gateway.db"
+db_path: ~/.rllm/gateway.db
+store_worker: sqlite              # or "memory"
+sampling_params_priority: client  # or "session"
 
+# Worker pool (training)
 workers:
-  - url: "http://vllm-0:8000/v1"
-    model_name: "Qwen/Qwen2.5-7B-Instruct"
-  - url: "http://vllm-1:8000/v1"
-    model_name: "Qwen/Qwen2.5-7B-Instruct"
+  - url: http://vllm-0:8000/v1
+    model_name: Qwen/Qwen2.5-7B-Instruct
+
+# Upstream routes (eval) — matched by body["model"]
+routes:
+  "Qwen/Qwen2.5-7B-Instruct":
+    upstream_url: https://api.openai.com/v1
+    auth_header: "Bearer ${OPENAI_API_KEY}"
+
+# Optional run lifecycle (tags every trace)
+run_id: "train-2026-05-03"
+run_metadata:
+  experiment: ablation-7
+
+# Optional inbound auth (require Bearer on every request)
+inbound_auth_token: ${RLLM_GATEWAY_INBOUND_TOKEN}
 ```
 
-### Environment Variables
+### Environment variables
 
 `RLLM_GATEWAY_HOST`, `RLLM_GATEWAY_PORT`, `RLLM_GATEWAY_DB_PATH`, `RLLM_GATEWAY_LOG_LEVEL`, `RLLM_GATEWAY_STORE`
 
-## Embedded Usage
+## Embedded usage
 
 ```python
 from rllm_model_gateway import create_app, GatewayConfig
 
-config = GatewayConfig(port=9090, workers=[...])
+config = GatewayConfig(
+    port=9090,
+    workers=[...],     # worker-pool mode
+    routes={...},      # upstream-proxy mode (additive — same gateway can do both)
+    run_id="my-run",
+)
 app = create_app(config)
-
-import threading, uvicorn
-threading.Thread(target=uvicorn.run, args=(app,), kwargs={"port": 9090}, daemon=True).start()
 ```
 
-## Dynamic Worker Registration
+## Dynamic worker registration
 
 Workers can be added at runtime via the admin API — useful for verl integration where vLLM addresses are only known after initialization:
 
@@ -134,12 +201,31 @@ client = GatewayClient("http://localhost:9090")
 client.add_worker(url="http://vllm-worker-0:8000/v1", model_name="Qwen/Qwen2.5-7B")
 ```
 
-## API Overview
+## Features
+
+- **Two-mode**: worker-pool routing (training) + upstream-proxy routing (eval), composable
+- **Header-stamped metadata**: rLLM identity carried via `X-RLLM-*` headers; never leaks upstream
+- **Zero retokenization**: token IDs come from vLLM's `return_token_ids=True` response field
+- **Run-tagged trace store**: SQLite (default) or in-memory; sessions queryable by `run_id` for cross-run analysis
+- **Streaming**: SSE chunk forwarding with trace assembly post-`[DONE]`
+- **Inbound bearer auth**: optional, for tunneled deployments
+- **Lightweight**: 6 runtime deps, no torch/ray/verl/transformers
+
+## API overview
 
 | Endpoint | Description |
 |----------|-------------|
-| `POST /sessions/{sid}/v1/chat/completions` | Proxy (agent-facing, OpenAI-compatible) |
+| `POST /v1/{path}` | Proxy with header- or body-stamped session id |
+| `POST /sessions/{sid}/v1/{path}` | Legacy path-stamped proxy (training) |
 | `POST /sessions` | Create session with metadata |
-| `GET /sessions/{sid}/traces` | Retrieve traces for a session |
-| `POST /admin/workers` | Register a worker |
-| `GET /health` | Gateway health check |
+| `GET /sessions` | List sessions (filterable by `since`, `limit`) |
+| `GET /sessions/{sid}` | Session info |
+| `GET /sessions/{sid}/traces` | Traces for a session |
+| `DELETE /sessions/{sid}` | Delete session and traces |
+| `GET /traces/{trace_id}` | Single trace |
+| `POST /traces/query` | Cross-session trace fetch |
+| `POST /admin/workers` | Register a vLLM worker |
+| `DELETE /admin/workers/{id}` | Remove worker |
+| `POST /admin/flush` | Drain pending trace writes |
+| `POST /admin/reload` | Hot-reload routes/workers from config |
+| `GET /health` | Liveness check |

--- a/rllm-model-gateway/src/rllm_model_gateway/__init__.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/__init__.py
@@ -6,6 +6,7 @@ from rllm_model_gateway.models import (
     GatewayConfig,
     SessionInfo,
     TraceRecord,
+    UpstreamRoute,
     WorkerConfig,
     WorkerInfo,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "AsyncGatewayClient",
     "GatewayConfig",
     "TraceRecord",
+    "UpstreamRoute",
     "WorkerConfig",
     "WorkerInfo",
     "SessionInfo",

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -20,7 +20,8 @@ from rllm_model_gateway.data_process import (
     build_trace_record_from_chunks,
     strip_vllm_fields,
 )
-from rllm_model_gateway.models import TraceRecord
+from rllm_model_gateway.metadata import RllmMetadata
+from rllm_model_gateway.models import TraceRecord, UpstreamRoute
 from rllm_model_gateway.session_router import SessionRouter
 from rllm_model_gateway.store.base import TraceStore
 
@@ -38,6 +39,23 @@ _HOP_BY_HOP = frozenset(
         "content-length",
         "content-encoding",
         "host",
+    }
+)
+
+# Headers stripped before forwarding to an upstream. The client's auth
+# headers are replaced with the route's ``auth_header`` (if set), and
+# the X-RLLM-* metadata is gateway-internal and never leaks upstream.
+_UPSTREAM_FORWARD_STRIP = frozenset(
+    {
+        "authorization",
+        "x-api-key",
+        "x-rllm-session-id",
+        "x-rllm-run-id",
+        "x-rllm-harness",
+        "x-rllm-step-id",
+        "x-rllm-parent-span-id",
+        "x-rllm-project",
+        "x-rllm-experiment",
     }
 )
 
@@ -79,6 +97,8 @@ class ReverseProxy:
         sync_traces: bool = False,
         max_retries: int = 2,
         local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+        routes: dict[str, UpstreamRoute] | None = None,
+        run_id: str | None = None,
     ) -> None:
         self.router = router
         self.store = store
@@ -86,6 +106,11 @@ class ReverseProxy:
         self.sync_traces = sync_traces
         self.max_retries = max_retries
         self.local_handler = local_handler
+        self.routes: dict[str, UpstreamRoute] = dict(routes or {})
+        # Tag every persisted trace with this run_id so the cross-run
+        # viewer can group by gateway lifetime. Empty string is the
+        # "unstamped" bucket for callers that don't pass a run_id.
+        self._run_id = run_id or ""
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
 
@@ -145,13 +170,33 @@ class ReverseProxy:
         originally_requested_logprobs: bool = False,
     ) -> Response:
         t0 = time.perf_counter()
+        rllm_metadata: RllmMetadata | None = getattr(request.state, "rllm_metadata", None)
+        route = self._lookup_route(request_body)
 
-        if self.local_handler is not None:
+        if route is not None:
+            url = self._build_url(route.upstream_url, request.url.path, str(request.url.query))
+            headers = self._forward_headers(request, extra_strip=_UPSTREAM_FORWARD_STRIP)
+            if route.auth_header:
+                headers["authorization"] = route.auth_header
+            forward_body = self._maybe_drop_params(raw_body, request_body, route.drop_params)
+            resp = await self._send_with_retry(
+                method=request.method,
+                url=url,
+                content=forward_body,
+                headers=headers,
+            )
+            content = resp.content
+            status_code = resp.status_code
+            try:
+                response_body = json.loads(content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                response_body = {}
+        elif self.local_handler is not None:
             # In-process path: call handler directly, no HTTP
             response_body = await self.local_handler(request_body)
             status_code = 200
         else:
-            # HTTP proxy path
+            # HTTP proxy path (worker pool — training)
             worker = self.router.route(session_id)
             url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
             headers = self._forward_headers(request)
@@ -177,7 +222,13 @@ class ReverseProxy:
 
         # Persist trace
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms)
+            trace = build_trace_record(
+                session_id,
+                request_body,
+                response_body,
+                latency_ms,
+                rllm_metadata=rllm_metadata,
+            )
             await self._persist(trace)
 
         # Sanitise response
@@ -209,6 +260,20 @@ class ReverseProxy:
         session_id: str | None,
         originally_requested_logprobs: bool = False,
     ) -> StreamingResponse:
+        rllm_metadata: RllmMetadata | None = getattr(request.state, "rllm_metadata", None)
+        route = self._lookup_route(request_body)
+
+        if route is not None:
+            return await self._handle_streaming_upstream(
+                request,
+                raw_body,
+                request_body,
+                session_id,
+                originally_requested_logprobs,
+                route,
+                rllm_metadata,
+            )
+
         if self.local_handler is not None:
             return await self._handle_streaming_local(request_body, session_id, originally_requested_logprobs)
 
@@ -306,7 +371,99 @@ class ReverseProxy:
                 # finally block may run during GeneratorExit, where await
                 # on real async I/O (e.g. aiosqlite) is not reliable.
                 if session_id and chunks:
-                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms)
+                    trace = build_trace_record_from_chunks(
+                        session_id,
+                        request_body,
+                        chunks,
+                        latency_ms,
+                        rllm_metadata=rllm_metadata,
+                    )
+                    task = asyncio.create_task(
+                        self._safe_store(
+                            trace.trace_id,
+                            trace.session_id,
+                            trace.model_dump(),
+                        )
+                    )
+                    self._pending_traces.add(task)
+                    task.add_done_callback(self._pending_traces.discard)
+
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            status_code=resp.status_code,
+        )
+
+    async def _handle_streaming_upstream(
+        self,
+        request: Request,
+        raw_body: bytes,
+        request_body: dict[str, Any],
+        session_id: str | None,
+        originally_requested_logprobs: bool,
+        route: UpstreamRoute,
+        rllm_metadata: RllmMetadata | None,
+    ) -> StreamingResponse:
+        """Stream a chat-completions response from a configured upstream.
+
+        Same shape as the worker-pool streaming path but skips ``SessionRouter``
+        and uses the upstream's URL + auth header instead.
+        """
+        url = self._build_url(route.upstream_url, request.url.path, str(request.url.query))
+        headers = self._forward_headers(request, extra_strip=_UPSTREAM_FORWARD_STRIP)
+        if route.auth_header:
+            headers["authorization"] = route.auth_header
+        forward_body = self._maybe_drop_params(raw_body, request_body, route.drop_params)
+
+        assert self._http is not None
+        upstream = self._http.stream(
+            method=request.method,
+            url=url,
+            content=forward_body,
+            headers=headers,
+        )
+        resp = await upstream.__aenter__()
+
+        t0 = time.perf_counter()
+        chunks: list[dict[str, Any]] = []
+        needs_strip_vllm = self.strip_vllm
+        needs_strip_logprobs = not originally_requested_logprobs
+
+        async def event_generator():
+            try:
+                async for line in resp.aiter_lines():
+                    if line.startswith("data: "):
+                        data_str = line[6:].strip()
+                        if data_str == "[DONE]":
+                            yield "data: [DONE]\n\n"
+                            continue
+                        try:
+                            chunk = json.loads(data_str)
+                            chunks.append(chunk)
+                            if not needs_strip_vllm and not needs_strip_logprobs:
+                                yield f"data: {data_str}\n\n"
+                            else:
+                                sanitized = strip_vllm_fields(chunk) if needs_strip_vllm else chunk
+                                if needs_strip_logprobs:
+                                    sanitized = _strip_logprobs(sanitized)
+                                yield f"data: {json.dumps(sanitized)}\n\n"
+                            continue
+                        except json.JSONDecodeError:
+                            pass
+                    if not line:
+                        continue
+                    yield line + "\n"
+            finally:
+                await upstream.__aexit__(None, None, None)
+                latency_ms = (time.perf_counter() - t0) * 1000
+                if session_id and chunks:
+                    trace = build_trace_record_from_chunks(
+                        session_id,
+                        request_body,
+                        chunks,
+                        latency_ms,
+                        rllm_metadata=rllm_metadata,
+                    )
                     task = asyncio.create_task(
                         self._safe_store(
                             trace.trace_id,
@@ -456,7 +613,7 @@ class ReverseProxy:
         try:
             data = trace.model_dump()
             if self.sync_traces:
-                await self.store.store_trace(trace.trace_id, trace.session_id, data)
+                await self.store.store_trace(trace.trace_id, trace.session_id, data, self._run_id)
             else:
                 task = asyncio.create_task(self._safe_store(trace.trace_id, trace.session_id, data))
                 self._pending_traces.add(task)
@@ -466,7 +623,7 @@ class ReverseProxy:
 
     async def _safe_store(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
         try:
-            await self.store.store_trace(trace_id, session_id, data)
+            await self.store.store_trace(trace_id, session_id, data, self._run_id)
         except Exception:
             logger.exception("Failed to persist trace %s", trace_id)
 
@@ -484,5 +641,33 @@ class ReverseProxy:
         return url
 
     @staticmethod
-    def _forward_headers(request: Request) -> dict[str, str]:
-        return {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+    def _forward_headers(
+        request: Request,
+        *,
+        extra_strip: frozenset[str] = frozenset(),
+    ) -> dict[str, str]:
+        skip = _HOP_BY_HOP | extra_strip
+        return {k: v for k, v in request.headers.items() if k.lower() not in skip}
+
+    def _lookup_route(self, request_body: dict[str, Any]) -> UpstreamRoute | None:
+        if not self.routes:
+            return None
+        model = request_body.get("model") if isinstance(request_body, dict) else None
+        if not isinstance(model, str):
+            return None
+        return self.routes.get(model)
+
+    @staticmethod
+    def _maybe_drop_params(
+        raw_body: bytes,
+        request_body: dict[str, Any],
+        drop_params: list[str],
+    ) -> bytes:
+        """Return ``raw_body`` untouched, or a re-serialised body with *drop_params* removed."""
+        if not drop_params or not isinstance(request_body, dict):
+            return raw_body
+        present = [k for k in drop_params if k in request_body]
+        if not present:
+            return raw_body
+        mutated = {k: v for k, v in request_body.items() if k not in present}
+        return json.dumps(mutated).encode("utf-8")

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -154,27 +154,34 @@ def create_app(
         strip_vllm=config.strip_vllm_fields,
         sync_traces=config.sync_traces,
         local_handler=local_handler,
+        routes=config.routes,
+        run_id=config.run_id,
     )
     sessions = SessionManager(store)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         await proxy.start()
+        if config.run_id:
+            try:
+                await store.register_run(config.run_id, config.run_metadata)
+            except Exception:
+                logger.exception("register_run failed for run_id=%r", config.run_id)
         if router.workers:
             await router.start_health_checks()
         yield
         await router.stop_health_checks()
         await proxy.stop()
+        if config.run_id:
+            try:
+                await store.end_run(config.run_id)
+            except Exception:
+                logger.exception("end_run failed for run_id=%r", config.run_id)
         await store.close()
 
     app = FastAPI(title="rllm-model-gateway", version="0.1.0", lifespan=lifespan)
 
     # -- Middleware ---------------------------------------------------------
-
-    # TODO: Add API key auth middleware here for securing gateway access
-    # from cloud containers. Validate an API key from the Authorization
-    # header before allowing access to admin and proxy endpoints.
-    # Add corresponding `api_key` field to GatewayConfig and client classes.
 
     app.add_middleware(
         SessionRoutingMiddleware,
@@ -183,6 +190,7 @@ def create_app(
         sessions=sessions,
         sampling_params_priority=config.sampling_params_priority,
         model=config.model,
+        inbound_auth_token=config.inbound_auth_token,
     )
 
     # -- Health endpoints --------------------------------------------------

--- a/rllm-model-gateway/tests/integration/test_provider_routing.py
+++ b/rllm-model-gateway/tests/integration/test_provider_routing.py
@@ -1,0 +1,333 @@
+"""End-to-end test of the upstream-routing flow.
+
+Stands up a fake OpenAI-compatible server alongside the gateway. The
+gateway is configured with a single ``UpstreamRoute`` pointing at it.
+A client posts to the gateway with ``X-RLLM-*`` headers; we then assert
+the body forwards untouched, the auth header gets replaced with the
+route's ``auth_header``, no rLLM scaffolding leaks, and the trace lands
+with full session metadata.
+"""
+
+import json
+import socket
+import threading
+import time
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from rllm_model_gateway import GatewayConfig, UpstreamRoute, create_app
+
+from tests.helpers.gateway_server import GatewayServer
+
+_CANNED_RESPONSE = {
+    "id": "chatcmpl-fake",
+    "object": "chat.completion",
+    "model": "gpt-5-mini",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello from fake provider"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9},
+}
+
+
+def _stream_chunks():
+    """Yield SSE chunks shaped like an OpenAI streaming response."""
+    chunks = [
+        {
+            "id": "chatcmpl-fake",
+            "object": "chat.completion.chunk",
+            "model": "gpt-5-mini",
+            "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-fake",
+            "object": "chat.completion.chunk",
+            "model": "gpt-5-mini",
+            "choices": [{"index": 0, "delta": {"content": "hello from fake provider"}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-fake",
+            "object": "chat.completion.chunk",
+            "model": "gpt-5-mini",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9},
+        },
+    ]
+    for chunk in chunks:
+        yield f"data: {json.dumps(chunk)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+def _build_fake_provider_app() -> FastAPI:
+    app = FastAPI()
+    app.state.requests: list[dict[str, Any]] = []
+    app.state.headers: list[dict[str, str]] = []
+    app.state._lock = threading.Lock()
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        body = await request.json()
+        with app.state._lock:
+            app.state.requests.append(body)
+            app.state.headers.append(dict(request.headers))
+        if body.get("stream"):
+            return StreamingResponse(_stream_chunks(), media_type="text/event-stream")
+        return JSONResponse(content=_CANNED_RESPONSE)
+
+    return app
+
+
+def _reserve_port(host: str = "127.0.0.1") -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
+
+
+class _FakeProvider:
+    def __init__(self) -> None:
+        self.host = "127.0.0.1"
+        self.port = _reserve_port(self.host)
+        self.app = _build_fake_provider_app()
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def requests(self) -> list[dict[str, Any]]:
+        return self.app.state.requests
+
+    @property
+    def headers(self) -> list[dict[str, str]]:
+        return self.app.state.headers
+
+    def start(self) -> None:
+        config = uvicorn.Config(self.app, host=self.host, port=self.port, log_level="error")
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self._thread.start()
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if self._server.started:
+                return
+            time.sleep(0.05)
+        raise RuntimeError("Fake provider failed to start")
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+
+
+@pytest.fixture
+def fake_provider():
+    p = _FakeProvider()
+    p.start()
+    yield p
+    p.stop()
+
+
+@pytest.fixture
+def gateway_with_upstream(fake_provider, tmp_path):
+    config = GatewayConfig(
+        store_worker="sqlite",
+        db_path=str(tmp_path / "traces.db"),
+        sync_traces=True,
+        # Disable vLLM-specific injections — eval-style configuration.
+        add_logprobs=False,
+        add_return_token_ids=False,
+        strip_vllm_fields=False,
+        routes={
+            "gpt-5-mini": UpstreamRoute(
+                upstream_url=f"{fake_provider.url}/v1",
+                auth_header="Bearer sk-fake-test",
+            ),
+        },
+    )
+    app = create_app(config)
+    server = GatewayServer(app, port=0)
+    server.start()
+    yield server, fake_provider
+    server.stop()
+
+
+def test_eval_flow_forwards_body_replaces_auth_and_persists_trace(gateway_with_upstream):
+    """Full upstream flow: client → gateway → upstream, with header-stamped metadata."""
+    gateway, provider = gateway_with_upstream
+
+    resp = httpx.post(
+        f"{gateway.url}/v1/chat/completions",
+        json={
+            "model": "gpt-5-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        headers={
+            "X-RLLM-Session-Id": "sess-abc",
+            "X-RLLM-Run-Id": "run-1",
+            "X-RLLM-Harness": "opencode",
+            "X-RLLM-Step-Id": "2",
+            "Authorization": "Bearer client-original-key",
+            "x-api-key": "client-supplied-anthropic-key",
+        },
+        timeout=10.0,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "hello from fake provider"
+
+    # Upstream sees the body unchanged: model is forwarded as-sent, not rewritten.
+    assert len(provider.requests) == 1
+    fwd_body = provider.requests[0]
+    assert fwd_body["model"] == "gpt-5-mini"
+    assert fwd_body["messages"] == [{"role": "user", "content": "hi"}]
+
+    fwd_headers = provider.headers[0]
+    # Client's Authorization is replaced with the route's auth_header.
+    assert fwd_headers.get("authorization") == "Bearer sk-fake-test"
+    # x-api-key from the client never reaches the upstream.
+    assert "x-api-key" not in fwd_headers
+    # X-RLLM-* headers stay gateway-internal.
+    for h in (
+        "x-rllm-session-id",
+        "x-rllm-run-id",
+        "x-rllm-harness",
+        "x-rllm-step-id",
+    ):
+        assert h not in fwd_headers, f"gateway leaked {h} to upstream"
+
+    # Trace persisted with full metadata.
+    traces_resp = httpx.get(f"{gateway.url}/sessions/sess-abc/traces", timeout=5.0)
+    assert traces_resp.status_code == 200
+    traces = traces_resp.json()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace["session_id"] == "sess-abc"
+    assert trace["run_id"] == "run-1"
+    assert trace["harness"] == "opencode"
+    assert trace["step_id"] == 2
+    assert trace["span_type"] == "llm.call"
+    assert trace["model"] == "gpt-5-mini"
+
+
+def test_eval_flow_streaming(gateway_with_upstream):
+    """Streaming variant: gateway proxies SSE chunks and still records the trace."""
+    gateway, provider = gateway_with_upstream
+
+    with httpx.stream(
+        "POST",
+        f"{gateway.url}/v1/chat/completions",
+        json={
+            "model": "gpt-5-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+        headers={
+            "X-RLLM-Session-Id": "sess-stream",
+            "X-RLLM-Run-Id": "run-s",
+            "X-RLLM-Harness": "react",
+        },
+        timeout=10.0,
+    ) as resp:
+        assert resp.status_code == 200
+        chunks_seen: list[dict[str, Any]] = []
+        for line in resp.iter_lines():
+            if not line.startswith("data: "):
+                continue
+            payload = line[len("data: ") :].strip()
+            if payload == "[DONE]":
+                break
+            chunks_seen.append(json.loads(payload))
+
+    assert chunks_seen, "expected at least one SSE chunk"
+    assert any(chunk.get("choices", [{}])[0].get("delta", {}).get("content") == "hello from fake provider" for chunk in chunks_seen)
+
+    # Drain pending trace writes before reading.
+    httpx.post(f"{gateway.url}/admin/flush", timeout=5.0)
+
+    traces = httpx.get(f"{gateway.url}/sessions/sess-stream/traces", timeout=5.0).json()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace["session_id"] == "sess-stream"
+    assert trace["harness"] == "react"
+    assert trace["run_id"] == "run-s"
+
+
+def test_body_metadata_fallback_when_no_headers(gateway_with_upstream):
+    """Clients that can't set headers can stamp metadata via request body."""
+    gateway, provider = gateway_with_upstream
+
+    resp = httpx.post(
+        f"{gateway.url}/v1/chat/completions",
+        json={
+            "model": "gpt-5-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "metadata": {"rllm": {"session_id": "sess-body", "harness": "claude-code"}},
+        },
+        timeout=10.0,
+    )
+    assert resp.status_code == 200
+
+    # Body-stamped metadata should not leak to the upstream.
+    fwd_body = provider.requests[-1]
+    assert "rllm" not in fwd_body
+    assert "metadata" not in fwd_body  # whole metadata dict was empty after rllm strip
+
+    traces = httpx.get(f"{gateway.url}/sessions/sess-body/traces", timeout=5.0).json()
+    assert len(traces) == 1
+    assert traces[0]["harness"] == "claude-code"
+
+
+def test_drop_params_removes_listed_fields(fake_provider, tmp_path):
+    """A route with drop_params strips those fields from the forwarded body."""
+    config = GatewayConfig(
+        store_worker="memory",
+        db_path=str(tmp_path / "traces.db"),
+        sync_traces=True,
+        add_logprobs=False,
+        add_return_token_ids=False,
+        strip_vllm_fields=False,
+        routes={
+            "gpt-5-mini": UpstreamRoute(
+                upstream_url=f"{fake_provider.url}/v1",
+                auth_header="Bearer sk-fake-test",
+                drop_params=["max_tokens"],
+            ),
+        },
+    )
+    app = create_app(config)
+    server = GatewayServer(app, port=0)
+    server.start()
+    try:
+        resp = httpx.post(
+            f"{server.url}/v1/chat/completions",
+            json={
+                "model": "gpt-5-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "temperature": 0.7,
+            },
+            headers={"X-RLLM-Session-Id": "sess-drop"},
+            timeout=10.0,
+        )
+        assert resp.status_code == 200
+        fwd_body = fake_provider.requests[-1]
+        assert "max_tokens" not in fwd_body
+        assert fwd_body.get("temperature") == 0.7
+    finally:
+        server.stop()


### PR DESCRIPTION
## Summary

Stacked on [#552](https://github.com/rllm-org/rllm/pull/552). Adds a second operational mode that coexists with worker-pool routing — eval and sandboxed CLI agents can now use the gateway as a provider router with full tracing.

- Routes lookup by `body[\"model\"]`; matched requests forward to `UpstreamRoute.upstream_url` with `auth_header` swapped in (so harnesses don't need provider keys) and `drop_params` body fields stripped (e.g. `max_tokens` for OpenAI o-series, `logprobs/return_token_ids` for Anthropic).
- Unmatched models fall through to the existing worker pool.
- Proxy reads `RllmMetadata` from ASGI scope (populated by middleware in #552) and passes it through to the trace builder, so every persisted trace is stamped with run/harness/step/parent-span.
- Run lifecycle: when `GatewayConfig.run_id` is set, the gateway registers a `runs` row on startup and marks it ended on shutdown.
- README + AGENTS.md document both modes, the three session-identity sources with precedence, and the `inbound_auth_token` companion to remote-tunnel deployments.

## Stack

- [PR-1A](https://github.com/rllm-org/rllm/pull/551) — schema v2
- [PR-1B](https://github.com/rllm-org/rllm/pull/552) — header metadata + inbound auth
- **[PR-1C] this** — upstream-proxy mode + run lifecycle

## Test plan

- [x] `python -m pytest tests/` — 245 passed, 16 vLLM-skipped
- [x] 4 new integration tests in `test_provider_routing.py` (route dispatch by model, body forwarding + auth-header replacement, drop_params stripping, end-to-end trace persistence with rllm metadata)

## Follow-ups (separate PRs)

This unlocks the eval-side LiteLLM removal (PR 2 in the umbrella plan), CLI-harness gateway tracing (PR 3), and the rllm-console operator UI (PR 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)