### PR TITLE
examples(agentcore_math): enable bypass mode and make verl example fit on 8xA100 (40GB)

### DIFF
--- a/examples/agentcore_math/train_agentcore_math_verl.sh
+++ b/examples/agentcore_math/train_agentcore_math_verl.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Requires megatron deps: bash scripts/install_megatron.sh <cu128|cu129|cu130|...>
+# Tested on 8x A100 40GB. Parallelism (TP=8, SP=true) and gpu_memory_utilization
+# are tuned for this configuration; larger GPUs likely support lower TP.
 set -eux
 
 # Load environment variables (AGENTCORE_AGENT_ARN, AGENTCORE_S3_BUCKET)
@@ -14,12 +16,17 @@ MODEL_PATH=Qwen/Qwen3-4B-Instruct-2507
 
 # actor_rollout_ref.actor.megatron.param_offload=True is required for
 # verl 0.7.1 to work around device mismatch errors caused by unconditional param offloading
+#
+# actor_rollout_ref.rollout.engine_kwargs.vllm.tokenizer_mode=slow avoids the
+# 'Already borrowed' race in Hermes2ProToolParser.__init__ (vllm-project/vllm#34932).
+# Fix landed in vllm PR #38168, first released in vllm 0.18.1; remove this override
+# once rllm's vllm==0.17.0 pin is bumped past 0.18.1.
 python -m examples.agentcore_math.train_agentcore_math_verl \
     rllm/backend=verl \
     model_engine=megatron \
     algorithm.adv_estimator=grpo \
     algorithm.norm_adv_by_std_in_grpo=true \
-    rllm.algorithm.use_rllm=true \
+    rllm.algorithm.rollout_correction.bypass_mode=true \
     data.train_batch_size=64 \
     data.val_batch_size=256 \
     data.max_prompt_length=14336 \
@@ -36,20 +43,22 @@ python -m examples.agentcore_math.train_agentcore_math_verl \
     actor_rollout_ref.actor.ppo_max_token_len_per_gpu=16384 \
     actor_rollout_ref.actor.use_kl_loss=False \
     actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=1 \
-    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=1 \
-    actor_rollout_ref.actor.megatron.sequence_parallel=false \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=8 \
+    actor_rollout_ref.actor.megatron.sequence_parallel=true \
     actor_rollout_ref.actor.megatron.use_dist_checkpointing=False \
     actor_rollout_ref.actor.megatron.use_mbridge=True \
     actor_rollout_ref.actor.megatron.vanilla_mbridge=False \
     actor_rollout_ref.actor.megatron.param_offload=True \
     actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-sum \
     actor_rollout_ref.model.use_remove_padding=True \
-    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=8 \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.mode=async \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.tokenizer_mode=slow \
+    actor_rollout_ref.rollout.max_model_len=16384 \
     actor_rollout_ref.rollout.enforce_eager=False \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
@@ -59,9 +68,9 @@ python -m examples.agentcore_math.train_agentcore_math_verl \
     actor_rollout_ref.rollout.val_kwargs.do_sample=True \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
     actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=1 \
-    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=1 \
-    actor_rollout_ref.ref.megatron.sequence_parallel=false \
-    trainer.logger="['console','ui']" \
+    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=8 \
+    actor_rollout_ref.ref.megatron.sequence_parallel=true \
+    trainer.logger="['console','wandb']" \
     trainer.project_name=agentcore-math \
     trainer.experiment_name=gsm8k-agentcore-verl-megatron-4b-instruct \
     trainer.val_before_train=false \

--- a/rllm/experimental/common/visualization.py
+++ b/rllm/experimental/common/visualization.py
@@ -195,6 +195,10 @@ def visualize_trajectory_last_steps(
         print(_format_token(prompt_str, config.masked_token_style))
         print("----------------")
 
+        if len(response_ids) == 0:
+            print(_format_token("<empty response>", config.masked_token_style))
+            continue
+
         # for response string, we simply highlight the last token
         response_str_prev = abbreviate_string(tokenizer.decode(response_ids[:-1]))
         response_str_last = tokenizer.decode([response_ids[-1]])


### PR DESCRIPTION
## Summary

Update the verl agentcore_math example to (1) match the tinker sibling's rollout-correction posture via bypass mode, and (2) broaden hardware support so the script now runs on 8 x 40GB+ GPUs (verified on 8x A100 40GB). (3) fix a couple issues that come with higher TP degree.

### `examples/agentcore_math/train_agentcore_math_verl.sh`

- **Enable bypass mode** (`rllm.algorithm.rollout_correction.bypass_mode=true`) so π_old = π_rollout, skipping the actor's log-prob recomputation. This mirrors what the tinker sibling script effectively does by construction (tinker's `training_logprobs` come from the sampler pass). Trade-off: drops `actor/entropy` and `training/rollout_probs_diff_*` metrics, since both are computed only on the non-bypass path in `verl_backend.py`. All loss/advantage/reward/timing metrics are preserved.
- **Drop deprecated `rllm.algorithm.use_rllm=true`.** Now a no-op with DeprecationWarning since #537.
- **Work around vllm-project/vllm#34932** via `+actor_rollout_ref.rollout.engine_kwargs.vllm.tokenizer_mode=slow`. Avoids the `Already borrowed` race in `Hermes2ProToolParser.__init__` under concurrent `/v1/chat/completions` load, which caused ~2% of rollout requests to 400 and occasionally produced empty trajectories. Upstream fix is vLLM PR #38168, first released in vllm 0.18.1; inline comment notes to remove this override once rllm's `vllm==0.17.0` pin bumps past 0.18.1. This issue happens when TP>1.
- **Set `rollout.max_model_len=16384`** to match `max_prompt_length + max_response_length`.

### `rllm/experimental/common/visualization.py`

- Guard `response_ids[-1]` access in `visualize_trajectory_last_steps`. Previously crashed the trainer when a trajectory had an empty response. This is orthogonal to the vLLM tokenizer race — agent timeouts or tool errors can produce the same shape. Now prints `<empty response>` and continues.

## Tests

- [x] Run on 8x A100 40GB — completed `total_epochs=1`. Training was stable and converges fast. 
- [x] Verified bypass mode is in effect by absence of `actor/entropy` and `training/rollout_probs_diff_*` in logs (both gated on the non-bypass branch in `verl_backend.py`).
- [x] Zero `Already borrowed` / 400 Bad Request errors under the slow-tokenizer override.

<img width="1145" height="794" alt="Screenshot 2026-05-05 at 11 54 35 AM" src="https://github.com/user-attachments/assets/2c48a418-dddd-46c9-8ee0-a2a36df8a0a4" />
