### PR TITLE
fix(verl): skip ref mesh DP lookup when ref_in_actor (LoRA) is enabled

### DIFF
--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -383,7 +383,9 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             so the registered mesh is ``"ref"``.
         """
         dp_sizes: list[int] = []
-        if self.use_reference_policy and self.ref_policy_wg.world_size != 0:
+        # ref_in_actor (LoRA): ref log-probs run on the actor mesh with
+        # no_lora_adapter=True, and the "ref" mesh is not registered.
+        if self.use_reference_policy and not self.ref_in_actor and self.ref_policy_wg.world_size != 0:
             dp_sizes.append(self._get_dp_size(self.ref_policy_wg, "ref"))
         if self.actor_rollout_wg.world_size != 0:
             dp_sizes.append(self._get_dp_size(self.actor_rollout_wg, "actor"))


### PR DESCRIPTION
## Summary

`VerlBackend._get_aggregate_dp_size` unconditionally queried the `"ref"` mesh on `ref_policy_wg` whenever `use_reference_policy` was true. On the LoRA path, `ref_in_actor=True` and `ref_policy_wg` is aliased to
`actor_rollout_wg` — which only registers the `"actor"` mesh — so the lookup crashes with:

```
AssertionError: ref is not registered in ActorRolloutRefWorker at verl/single_controller/base/worker.py:114 (_query_dispatch_info) called from _get_dp_size(self.ref_policy_wg, "ref") in _get_aggregate_dp_size at verl_backend.py:387
```

Guarding the `"ref"` branch on `not self.ref_in_actor` matches how ref log-probs are actually computed in `process_backend_batch` (LoRA path uses the `"actor"` mesh with `no_lora_adapter=True`).

## Reproduce

Any verl training that simultaneously uses **LoRA** and a **reference policy with KL loss** hits this in the first training step (inside `process_backend_batch` → `_pad_dataproto_to_world_size` → `_get_aggregate_dp_size`). Concretely, starting from `examples/agentcore_math/train_agentcore_math_verl.sh`, flipping these two config values triggers the crash:

```
actor_rollout_ref.actor.use_kl_loss=True         # was False
actor_rollout_ref.actor.kl_loss_coef=0.001       # any non-zero value
actor_rollout_ref.actor.kl_loss_type=low_var_kl
# LoRA already enabled in the script:
#   +actor_rollout_ref.model.lora.rank=16
#   +actor_rollout_ref.model.lora.alpha=16
```

The required conditions are:
- `need_reference_policy(config)` → `use_kl_loss=True`
- `ref_in_actor` → `lora.rank > 0` or `lora_adapter_path` set
- `trainer.balance_batch=True` (default), which is what routes through
  `_pad_dataproto_to_world_size` → `_get_aggregate_dp_size`

## Test plan

Verified on 8×A100 40GB with the config above (Qwen3-4B-Instruct-2507, megatron TP=8, LoRA rank=16, `use_kl_loss=True`):

- Without the fix: training crashes at step 1 with `AssertionError: ref is not registered in ActorRolloutRefWorker`.
- With the fix: step 1 completes cleanly.
