### PR TITLE
feat(cookbooks): add langgraph_math, deprecate SDK callback handler

### DIFF
--- a/cookbooks/langgraph_math/README.md
+++ b/cookbooks/langgraph_math/README.md
@@ -1,0 +1,122 @@
+# LangGraph Math
+
+A multi-turn math agent authored with [LangGraph](https://github.com/langchain-ai/langgraph)'s `create_react_agent`, trained end-to-end with rLLM. Demonstrates that any LangGraph agent integrates with rLLM training **without writing a callback handler** — pointing LangChain's `ChatOpenAI` at `config.base_url` is enough, because the rLLM model gateway captures every LLM call.
+
+This cookbook is the AgentFlow-protocol counterpart of the legacy `rllm.sdk.integrations.langgraph` callback-handler approach (now deprecated; see [Migration](#migration)). It is intentionally a near-clone of [`cookbooks/math_tool_agent/`](../math_tool_agent/) so you can compare a hand-rolled tool loop against a LangGraph one on the same dataset.
+
+## Why so little code?
+
+```python
+@rllm.rollout(name="langgraph-math")
+async def langgraph_math(task: Task, config: AgentConfig) -> None:
+    llm = ChatOpenAI(model=config.model, base_url=config.base_url, api_key="EMPTY", temperature=1.0)
+    agent = create_react_agent(llm, tools=[calculate], prompt=SYSTEM_PROMPT)
+    await agent.ainvoke({"messages": [("user", task.instruction)]})
+    return None
+```
+
+That's the whole agent. No callback handler, no message format conversion, no manual `Step`/`Trajectory` construction. The mechanism:
+
+- LangChain's `ChatOpenAI(base_url=…)` issues OpenAI Chat Completions requests against the gateway session URL the trainer provides.
+- The gateway middleware extracts the session id from the URL path (`/sessions/{sid}/v1/...`) and persists every request/response as a `TraceRecord` keyed by that session.
+- The flow returns `None`. The framework's coercion (`rllm.types._coerce_to_episode`) builds an empty single-trajectory `Episode`. During enrichment the gateway's traces become the trajectory's `Step`s, populated with prompt/response token IDs and per-token logprobs ready for training.
+- The evaluator reads the agent's final assistant message from `episode.trajectories[-1].steps[-1].model_response` and grades it against ground truth.
+
+Because the trajectory's `name` is `"langgraph-math"` (set on `@rllm.rollout`), all rollouts of the same task hash to the same `f"{task_id}:langgraph-math"` key when the trainer builds `TrajectoryGroup`s for GRPO advantage computation.
+
+## Architecture
+
+```
+AgentFlow.run(task, config) → None
+  │
+  └── LangGraph create_react_agent (recursion limit 25)
+        │
+        ├── ChatOpenAI(base_url=config.base_url)
+        │     → POST /sessions/{sid}/v1/chat/completions
+        │     → gateway captures TraceRecord (model, messages, token_ids, logprobs)
+        │
+        ├── @tool calculate(expression) → safe AST eval
+        │
+        └── repeat until LLM emits no more tool calls
+```
+
+## Installation
+
+```bash
+# From the rllm repo root
+uv pip install -e ".[tinker]"                          # rllm + tinker backend
+uv pip install --no-deps -e cookbooks/langgraph_math   # this cookbook + LangGraph deps
+```
+
+After installation:
+
+```bash
+rllm agent list   # should show "langgraph_math" as a plugin
+```
+
+## Dataset
+
+Same datasets as `cookbooks/math_tool_agent/` so you can compare learning curves:
+
+```bash
+rllm dataset pull deepscaler_math   # ~40K competition math problems
+rllm dataset pull math500           # 500-problem test benchmark
+```
+
+## Training
+
+### Tinker (single-machine)
+
+```bash
+bash cookbooks/langgraph_math/train_tinker.sh
+```
+
+Or directly via the Python API:
+
+```bash
+python cookbooks/langgraph_math/train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3-4B-Instruct-2507 \
+    model.lora_rank=32 \
+    training.group_size=8
+```
+
+### Verl (distributed GPU)
+
+```bash
+uv pip install -e ".[verl]"
+bash scripts/install_megatron.sh <cu128|cu129|...>
+bash cookbooks/langgraph_math/train_verl.sh
+```
+
+## Tests
+
+```bash
+pytest cookbooks/langgraph_math/test.py -v
+```
+
+The tests cover the calculator's safe-eval whitelist, answer-extraction patterns, and the evaluator's behavior over synthetic Episodes — including the case where the assistant turn is several Steps back behind tool messages.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `langgraph_math.py` | `langgraph_math` — LangGraph `create_react_agent` AgentFlow |
+| `evaluator.py` | `langgraph_math_evaluator` — reads answer from gateway-captured trajectory |
+| `train.py` | Python API training script (Hydra config) |
+| `train_tinker.sh` | Tinker backend — single-machine training |
+| `train_verl.sh` | Verl backend — distributed multi-GPU training |
+| `pyproject.toml` | Plugin metadata and entry points |
+| `test.py` | Unit tests for calculator, parsing, and evaluation |
+
+## Migration
+
+If you previously used `rllm.sdk.integrations.langgraph.RLLMTrajectoryCallbackHandler` to capture LangChain's LLM calls into rLLM `Trajectory` objects in-process, that path is **deprecated** for training. The gateway now provides token-accurate trace capture out of the band, so for any LangGraph agent that uses `ChatOpenAI` (or any other LangChain client that accepts a `base_url`) the integration collapses to:
+
+```python
+llm = ChatOpenAI(base_url=config.base_url, api_key="EMPTY", model=config.model)
+# ...build your graph as usual...
+return None
+```
+
+The callback handler still works for non-rLLM-training contexts where you need in-process trajectory snapshots, but for training under `AgentTrainer` you should use this cookbook's pattern instead.

--- a/cookbooks/langgraph_math/evaluator.py
+++ b/cookbooks/langgraph_math/evaluator.py
@@ -1,0 +1,86 @@
+"""Evaluator for the LangGraph math agent.
+
+The flow returns ``None``, so ``episode.artifacts`` is empty. The evaluator
+extracts the answer directly from the final assistant message captured by
+the gateway — that's the canonical "evaluator parses the Trajectory" pattern.
+"""
+
+from __future__ import annotations
+
+import re
+
+import rllm
+from rllm.eval.types import EvalOutput, Signal
+from rllm.rewards.math_utils.utils import grade_answer_mathd, grade_answer_sympy
+from rllm.types import Episode
+
+
+def _extract_boxed(text: str) -> str | None:
+    """Extract the contents of the last ``\\boxed{...}`` with balanced braces."""
+    idx = text.rfind(r"\boxed{")
+    if idx < 0:
+        return None
+    start = idx + len(r"\boxed{")
+    depth = 1
+    i = start
+    while i < len(text) and depth > 0:
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i].strip()
+        i += 1
+    return None
+
+
+def _extract_answer(text: str) -> str:
+    """Try multiple patterns to extract the final answer from assistant text."""
+    boxed = _extract_boxed(text)
+    if boxed is not None:
+        return boxed
+    m = re.search(r"<answer>(.*?)</answer>", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    m = re.search(r"####\s*(.+?)(?:\n|$)", text)
+    if m:
+        return m.group(1).strip()
+    m = re.search(r"(?:the\s+)?(?:final\s+)?answer\s+is[:\s]*([+-]?\d[\d,]*(?:\.\d+)?)", text, re.IGNORECASE)
+    if m:
+        return m.group(1).replace(",", "")
+    numbers = re.findall(r"(?<!\w)([+-]?\d[\d,]*\.?\d*)(?!\w)", text)
+    if numbers:
+        return numbers[-1].replace(",", "")
+    return ""
+
+
+def _last_assistant_text(episode: Episode) -> str:
+    """Return the last assistant message content from the gateway-captured trajectory.
+
+    Walks back through Steps until it finds one with a non-empty
+    ``model_response``. The trailing Step in a tool-using ReAct agent is
+    always an assistant message (LangGraph stops once the LLM returns text
+    without further tool calls).
+    """
+    if not episode.trajectories:
+        return ""
+    for step in reversed(episode.trajectories[-1].steps):
+        if step.model_response:
+            return step.model_response
+    return ""
+
+
+@rllm.evaluator
+def langgraph_math_evaluator(task: dict, episode: Episode) -> EvalOutput:
+    """Grade the agent's answer against ground truth using symbolic math comparison."""
+    answer_text = _extract_answer(_last_assistant_text(episode))
+    ground_truth = str(task.get("answer") or task.get("ground_truth") or "")
+
+    is_correct = grade_answer_mathd(answer_text, ground_truth) or grade_answer_sympy(answer_text, ground_truth)
+    reward = 1.0 if is_correct else 0.0
+    return EvalOutput(
+        reward=reward,
+        is_correct=is_correct,
+        signals=[Signal(name="accuracy", value=reward)],
+    )

--- a/cookbooks/langgraph_math/langgraph_math.py
+++ b/cookbooks/langgraph_math/langgraph_math.py
@@ -1,0 +1,163 @@
+"""LangGraph-authored math agent that trains via rLLM's AgentFlow protocol.
+
+The agent is a LangGraph ``create_react_agent`` with a single calculator tool.
+Because LangChain's ``ChatOpenAI`` accepts ``base_url``, we point it at the
+gateway session URL from :class:`rllm.types.AgentConfig` and the gateway
+captures every LLM call automatically — no callback handler required.
+
+The flow returns ``None``; the framework auto-builds the Episode and the
+evaluator pulls the answer out of the gateway-captured trajectory.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+import rllm
+from rllm.types import AgentConfig, Task
+
+SYSTEM_PROMPT = """\
+You are a math assistant that solves competition math problems step by step.
+You have access to a calculator tool and you MUST use it.
+
+IMPORTANT rules you must follow:
+1. You MUST call the calculator tool at least once before giving your final answer. \
+Answers given without any prior tool call will be marked wrong.
+2. Do NOT perform arithmetic in your head — every computation must go through the calculator.
+3. Break the problem into small steps. Make one tool call per step, then reason about the result.
+4. When you have the final answer, put it in \\boxed{ANSWER} in your response.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Calculator (lifted from cookbooks/math_tool_agent — same safe-eval whitelist)
+# ---------------------------------------------------------------------------
+
+
+_SAFE_NAMES: dict[str, object] = {
+    "pi": math.pi,
+    "e": math.e,
+    "tau": math.tau,
+    "inf": math.inf,
+    "abs": abs,
+    "round": round,
+    "min": min,
+    "max": max,
+    "sum": sum,
+    "pow": pow,
+    "sqrt": math.sqrt,
+    "exp": math.exp,
+    "log": math.log,
+    "log2": math.log2,
+    "log10": math.log10,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "asin": math.asin,
+    "acos": math.acos,
+    "atan": math.atan,
+    "atan2": math.atan2,
+    "sinh": math.sinh,
+    "cosh": math.cosh,
+    "tanh": math.tanh,
+    "floor": math.floor,
+    "ceil": math.ceil,
+    "trunc": math.trunc,
+    "factorial": math.factorial,
+    "gcd": math.gcd,
+    "lcm": math.lcm,
+    "comb": math.comb,
+    "binom": math.comb,
+    "perm": math.perm,
+    "degrees": math.degrees,
+    "radians": math.radians,
+}
+
+_ALLOWED_NODES: tuple[type, ...] = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Constant,
+    ast.Name,
+    ast.Load,
+    ast.Call,
+    ast.List,
+    ast.Tuple,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    ast.USub,
+    ast.UAdd,
+)
+
+
+def _safe_eval(expression: str) -> str:
+    if len(expression) > 200:
+        return "Error: expression too long"
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as e:
+        return f"Error: {e.msg}"
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            return f"Error: disallowed syntax ({type(node).__name__})"
+        if isinstance(node, ast.Name) and node.id not in _SAFE_NAMES:
+            return f"Error: unknown name '{node.id}'"
+    try:
+        result = eval(compile(tree, "<expr>", "eval"), {"__builtins__": {}}, _SAFE_NAMES)
+    except Exception as e:
+        return f"Error: {e}"
+    if isinstance(result, bool):
+        return str(result)
+    if isinstance(result, int):
+        return str(result)
+    if isinstance(result, float):
+        if result == int(result):
+            return str(int(result))
+        return str(round(result, 6))
+    return str(result)
+
+
+@tool
+def calculate(expression: str) -> str:
+    """Evaluate a mathematical expression.
+
+    Supports +, -, *, /, //, **, %, parentheses, and a fixed whitelist of
+    functions (sqrt, log, sin, cos, factorial, comb, ...) and constants
+    (pi, e, tau).
+    """
+    return _safe_eval(expression)
+
+
+# ---------------------------------------------------------------------------
+# AgentFlow
+# ---------------------------------------------------------------------------
+
+
+@rllm.rollout(name="langgraph-math")
+async def langgraph_math(task: Task, config: AgentConfig) -> None:
+    """Multi-turn math agent built with LangGraph's create_react_agent.
+
+    Returns None: the gateway captures every LLM call (because the LLM client
+    is pointed at config.base_url), and the framework auto-builds a single
+    Trajectory whose Steps come from those traces. The evaluator extracts the
+    answer from the last assistant message.
+    """
+    llm = ChatOpenAI(
+        model=config.model,
+        base_url=config.base_url,
+        api_key="EMPTY",
+        temperature=1.0,
+    )
+    agent = create_react_agent(llm, tools=[calculate], prompt=SYSTEM_PROMPT)
+    await agent.ainvoke({"messages": [("user", task.instruction)]})
+    return None

--- a/cookbooks/langgraph_math/pyproject.toml
+++ b/cookbooks/langgraph_math/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "langgraph-math"
+version = "0.1.0"
+description = "LangGraph-authored math agent plugin for rLLM (AgentFlow protocol)"
+requires-python = ">=3.10"
+dependencies = [
+    "rllm",
+    "langgraph>=0.2",
+    "langchain-openai>=0.2",
+    "langchain-core>=0.3",
+]
+
+[tool.setuptools]
+py-modules = ["langgraph_math", "evaluator"]
+
+# Plugin discovery: rllm CLI finds these by name
+[project.entry-points."rllm.agents"]
+langgraph_math = "langgraph_math:langgraph_math"
+
+[project.entry-points."rllm.evaluators"]
+langgraph_math = "evaluator:langgraph_math_evaluator"

--- a/cookbooks/langgraph_math/test.py
+++ b/cookbooks/langgraph_math/test.py
@@ -1,0 +1,118 @@
+"""Tests for the LangGraph math cookbook."""
+
+from evaluator import _extract_answer, _extract_boxed, langgraph_math_evaluator
+from langgraph_math import _safe_eval
+
+from rllm.types import Episode, Step, Trajectory
+
+# -- Calculator tests ----------------------------------------------------------
+
+
+def test_safe_eval_basic():
+    assert _safe_eval("2 + 3") == "5"
+    assert _safe_eval("34 * 17") == "578"
+
+
+def test_safe_eval_float():
+    assert _safe_eval("10 / 4") == "2.5"
+    assert _safe_eval("10 / 2") == "5"
+
+
+def test_safe_eval_parentheses():
+    assert _safe_eval("(10 + 5) * 3") == "45"
+
+
+def test_safe_eval_power():
+    assert _safe_eval("2 ** 10") == "1024"
+
+
+def test_safe_eval_sqrt():
+    assert _safe_eval("sqrt(64 + 225)") == "17"
+
+
+def test_safe_eval_combinatorics():
+    assert _safe_eval("comb(5, 2)") == "10"
+    assert _safe_eval("factorial(5)") == "120"
+
+
+def test_safe_eval_rejects_invalid():
+    assert "Error" in _safe_eval("import os")
+    assert "Error" in _safe_eval("__import__('os')")
+    assert "Error" in _safe_eval("(1).bit_length()")
+
+
+# -- Answer extraction tests ---------------------------------------------------
+
+
+def test_extract_boxed():
+    assert _extract_boxed(r"Therefore \boxed{42}") == "42"
+    assert _extract_boxed(r"\boxed{\frac{1}{2}}") == r"\frac{1}{2}"
+    assert _extract_boxed("no boxed here") is None
+
+
+def test_extract_answer_boxed():
+    assert _extract_answer(r"Therefore \boxed{42}") == "42"
+
+
+def test_extract_answer_natural():
+    assert _extract_answer("The final answer is 42.") == "42"
+
+
+# -- Evaluator tests -----------------------------------------------------------
+#
+# The new convention: evaluator reads from
+# episode.trajectories[-1].steps[-1].model_response. No artifacts mirroring.
+
+
+def _episode_with_last_response(text: str) -> Episode:
+    return Episode(
+        trajectories=[Trajectory(name="langgraph-math", steps=[Step(model_response=text)])],
+    )
+
+
+def test_evaluator_correct():
+    task = {"answer": "10"}
+    episode = _episode_with_last_response(r"After computing, \boxed{10}")
+    result = langgraph_math_evaluator.evaluate(task, episode)
+    assert result.is_correct is True
+    assert result.reward == 1.0
+
+
+def test_evaluator_wrong():
+    task = {"answer": "10"}
+    episode = _episode_with_last_response(r"\boxed{9}")
+    result = langgraph_math_evaluator.evaluate(task, episode)
+    assert result.is_correct is False
+
+
+def test_evaluator_no_response():
+    task = {"answer": "10"}
+    episode = Episode(trajectories=[Trajectory(name="langgraph-math", steps=[])])
+    result = langgraph_math_evaluator.evaluate(task, episode)
+    assert result.is_correct is False
+
+
+def test_evaluator_walks_back_past_empty_steps():
+    """Tool-result steps may have empty model_response; walk back to the assistant turn."""
+    task = {"answer": "10"}
+    episode = Episode(
+        trajectories=[
+            Trajectory(
+                name="langgraph-math",
+                steps=[
+                    Step(model_response="I'll calculate 5 + 5"),
+                    Step(model_response=""),  # tool message turn
+                    Step(model_response=r"The answer is \boxed{10}"),
+                ],
+            )
+        ]
+    )
+    result = langgraph_math_evaluator.evaluate(task, episode)
+    assert result.is_correct is True
+
+
+def test_evaluator_latex_fraction():
+    task = {"answer": r"\frac{1}{2}"}
+    episode = _episode_with_last_response(r"\boxed{0.5}")
+    result = langgraph_math_evaluator.evaluate(task, episode)
+    assert result.is_correct is True

--- a/cookbooks/langgraph_math/train.py
+++ b/cookbooks/langgraph_math/train.py
@@ -1,0 +1,41 @@
+"""Train the LangGraph math agent using the Python API.
+
+Usage (from rllm repo root):
+    python cookbooks/langgraph_math/train.py
+
+Or with Hydra overrides:
+    python cookbooks/langgraph_math/train.py model.name=Qwen/Qwen3-1.7B training.group_size=4
+"""
+
+import hydra
+from evaluator import langgraph_math_evaluator
+from langgraph_math import langgraph_math
+from omegaconf import DictConfig
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.experimental.unified_trainer import AgentTrainer
+
+
+@hydra.main(config_path="pkg://rllm.experimental.config", config_name="unified", version_base=None)
+def main(config: DictConfig):
+    train_dataset = DatasetRegistry.load_dataset("deepscaler_math", "train")
+    test_dataset = DatasetRegistry.load_dataset("math500", "test")
+
+    if train_dataset is None:
+        raise RuntimeError("deepscaler_math train split not found. Run: rllm dataset pull deepscaler_math")
+    if test_dataset is None:
+        raise RuntimeError("math500 test split not found. Run: rllm dataset pull math500")
+
+    trainer = AgentTrainer(
+        backend=config.rllm.get("backend", "tinker"),
+        agent_flow=langgraph_math,
+        evaluator=langgraph_math_evaluator,
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=test_dataset,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/langgraph_math/train_tinker.sh
+++ b/cookbooks/langgraph_math/train_tinker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Train the LangGraph math agent via train.py with Hydra overrides.
+#
+# Prerequisites:
+#   1. Install rllm with tinker extras:  uv pip install -e ".[tinker]"
+#   2. Install this cookbook:             uv pip install --no-deps -e cookbooks/langgraph_math
+#   3. Pull the datasets:                rllm dataset pull deepscaler_math && rllm dataset pull math500
+#
+# To enable UI logging, append: rllm.trainer.logger=[console,ui]
+
+set -euo pipefail
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3-4B-Instruct-2507 \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    data.train_batch_size=32 \
+    data.val_batch_size=500 \
+    data.max_prompt_length=8192 \
+    data.max_response_length=2048 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.project_name=langgraph_math \
+    rllm.trainer.experiment_name=qwen3-4b-instruct \
+    rllm.trainer.logger=[console,ui] \
+    "$@"

--- a/cookbooks/langgraph_math/train_verl.sh
+++ b/cookbooks/langgraph_math/train_verl.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Train the LangGraph math agent with the verl (distributed GPU) backend.
+#
+# Prerequisites:
+#   1. Install rllm with verl extras:     uv pip install -e ".[verl]"
+#   2. Install this cookbook:              uv pip install --no-deps -e cookbooks/langgraph_math
+#   3. Pull the datasets:                 rllm dataset pull deepscaler_math && rllm dataset pull math500
+
+set -euo pipefail
+
+unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
+
+MODEL_PATH=Qwen/Qwen3-4B-Instruct-2507
+
+python -u train.py \
+    rllm/backend=verl \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.algorithm.use_rllm=true \
+    data.train_batch_size=32 \
+    data.val_batch_size=256 \
+    data.max_prompt_length=2048 \
+    data.max_response_length=20480 \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    +actor_rollout_ref.model.lora.rank=32 \
+    +actor_rollout_ref.model.lora.alpha=32 \
+    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=32768 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    +actor_rollout_ref.rollout.max_model_len=32768 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.n=4 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.6 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    trainer.logger="['console','ui']" \
+    trainer.project_name=langgraph_math \
+    trainer.experiment_name=qwen3-4b-instruct-verl \
+    trainer.val_before_train=false \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    "$@"

--- a/docs/cookbooks/langgraph_math.mdx
+++ b/docs/cookbooks/langgraph_math.mdx
@@ -1,0 +1,158 @@
+---
+title: LangGraph Math
+description: LangGraph create_react_agent trained via the AgentFlow protocol
+---
+
+A multi-turn math agent authored with [LangGraph](https://github.com/langchain-ai/langgraph)'s `create_react_agent`, trained end-to-end with rLLM. Demonstrates that any LangGraph agent integrates with rLLM training **without writing a callback handler** — pointing LangChain's `ChatOpenAI` at `config.base_url` is enough, because the rLLM model gateway captures every LLM call.
+
+This cookbook is the AgentFlow-protocol counterpart of the legacy [`rllm.sdk.integrations.langgraph`](/sdk/integrations) callback-handler approach (now deprecated). It is intentionally a near-clone of [`cookbooks/math_tool_agent`](/cookbooks/math_tool_agent) so you can compare a hand-rolled tool loop against a LangGraph one on the same dataset.
+
+## Pattern
+
+| Aspect | Value |
+|---|---|
+| Loop shape | Multi-turn (LangGraph `recursion_limit=25`) |
+| Tools | One: `calculate` — AST-based safe arithmetic interpreter |
+| Termination | LangGraph stops when the LLM emits no further tool calls |
+| Reward shape | `1.0` if final answer matches ground truth (mathd + sympy), else `0.0` |
+| Return type | `None` — the gateway captures everything; the framework auto-builds the Episode |
+
+## Why so little code?
+
+```python
+@rllm.rollout(name="langgraph-math")
+async def langgraph_math(task: Task, config: AgentConfig) -> None:
+    llm = ChatOpenAI(
+        model=config.model,
+        base_url=config.base_url,
+        api_key="EMPTY",
+        temperature=1.0,
+    )
+    agent = create_react_agent(llm, tools=[calculate], prompt=SYSTEM_PROMPT)
+    await agent.ainvoke({"messages": [("user", task.instruction)]})
+    return None
+```
+
+That's the whole agent. No callback handler, no message format conversion, no manual `Step` / `Trajectory` construction. The mechanism:
+
+- LangChain's `ChatOpenAI(base_url=…)` issues OpenAI Chat Completions requests against the gateway session URL the trainer provides.
+- The gateway middleware extracts the session id from the URL path (`/sessions/{sid}/v1/...`) and persists every request/response as a `TraceRecord` keyed by that session.
+- The flow returns `None`. The framework's coercion (`rllm.types._coerce_to_episode`) builds an empty single-trajectory `Episode`. During enrichment the gateway's traces become the trajectory's `Step`s, populated with prompt/response token IDs and per-token logprobs ready for training.
+- The evaluator reads the agent's final assistant message from `episode.trajectories[-1].steps[-1].model_response` and grades it against ground truth.
+
+Because the trajectory's `name` is `"langgraph-math"` (set on `@rllm.rollout`), all rollouts of the same task hash to the same `f"{task_id}:langgraph-math"` key when the trainer builds `TrajectoryGroup`s for GRPO advantage computation.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A["AgentFlow.run(task, config) -> None"] --> B["LangGraph create_react_agent"]
+    B --> C["ChatOpenAI(base_url=config.base_url)"]
+    C --> D["POST /sessions/{sid}/v1/chat/completions"]
+    D --> E["Gateway captures TraceRecord (model, messages, token_ids, logprobs)"]
+    E --> F{"tool calls?"}
+    F -->|yes| G["@tool calculate -> safe AST eval"]
+    G --> C
+    F -->|no| H["Done; framework auto-builds Episode from gateway traces"]
+```
+
+## Install
+
+```bash
+uv pip install -e ".[tinker]"                          # rllm + tinker backend
+uv pip install --no-deps -e cookbooks/langgraph_math   # this cookbook + LangGraph deps
+rllm agent list                                         # should show "langgraph_math"
+```
+
+## Datasets
+
+Same datasets as [`math_tool_agent`](/cookbooks/math_tool_agent) so you can compare learning curves between a hand-rolled tool loop and a LangGraph one:
+
+```bash
+rllm dataset pull deepscaler_math   # ~40K AIME/AMC/Omni-MATH/STILL competition math (train)
+rllm dataset pull math500           # 500-problem test benchmark
+```
+
+## Eval
+
+```bash
+rllm eval math500 \
+    --agent langgraph_math \
+    --evaluator langgraph_math \
+    --model Qwen/Qwen3-4B-Instruct-2507 \
+    --base-url http://localhost:8000/v1 \
+    --max-examples 20
+```
+
+## Training
+
+```bash
+# Tinker (single-machine LoRA)
+bash cookbooks/langgraph_math/train_tinker.sh
+
+# Verl (distributed GPU)
+bash cookbooks/langgraph_math/train_verl.sh
+```
+
+The tool-call training uses verl's vLLM tool-call parser (already wired into `train_verl.sh`):
+
+```bash
++actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true
++actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes
+```
+
+## Evaluator
+
+The flow returned `None`, so `episode.artifacts` is empty. The evaluator extracts the answer directly from the gateway-captured trajectory — that's the canonical "evaluator parses the Trajectory" pattern under AgentFlow:
+
+```python
+def _last_assistant_text(episode: Episode) -> str:
+    """Walk back through Steps to find the last assistant message."""
+    if not episode.trajectories:
+        return ""
+    for step in reversed(episode.trajectories[-1].steps):
+        if step.model_response:
+            return step.model_response
+    return ""
+
+@rllm.evaluator
+def langgraph_math_evaluator(task: dict, episode: Episode) -> EvalOutput:
+    answer_text = _extract_answer(_last_assistant_text(episode))
+    ground_truth = str(task.get("answer") or task.get("ground_truth") or "")
+    is_correct = grade_answer_mathd(answer_text, ground_truth) or grade_answer_sympy(answer_text, ground_truth)
+    return EvalOutput(
+        reward=1.0 if is_correct else 0.0,
+        is_correct=is_correct,
+        signals=[Signal(name="accuracy", value=1.0 if is_correct else 0.0)],
+    )
+```
+
+The walk-back loop matters: in a tool-using ReAct agent, the trajectory ends with an assistant turn, but tool-message Steps in between have empty `model_response`. The evaluator walks backwards until it finds the last assistant turn.
+
+## Files
+
+| File | Description |
+|---|---|
+| `langgraph_math.py` | The `create_react_agent` AgentFlow + safe calculator |
+| `evaluator.py` | Reads answer from gateway-captured trajectory |
+| `train.py` + `train_{tinker,verl}.sh` | Hydra entry points |
+| `pyproject.toml` | Plugin entry-point declarations |
+| `test.py` | Unit tests for calculator, parsing, and evaluation |
+
+## Migration from `rllm.sdk.integrations.langgraph`
+
+If you previously used `RLLMTrajectoryCallbackHandler` to capture LangChain's LLM calls into rLLM `Trajectory` objects in-process, that path is **deprecated** for training. The gateway now provides token-accurate trace capture out of band, so for any LangGraph agent that uses `ChatOpenAI` (or any other LangChain client that accepts a `base_url`) the integration collapses to:
+
+```python
+llm = ChatOpenAI(base_url=config.base_url, api_key="EMPTY", model=config.model)
+# ...build your graph as usual...
+return None
+```
+
+The callback handler still works for non-rLLM-training contexts where you need in-process trajectory snapshots, but for training under `AgentTrainer` you should use this cookbook's pattern instead.
+
+## On GitHub
+
+<Card title="cookbooks/langgraph_math" icon="github" href="https://github.com/rllm-org/rllm/tree/main/cookbooks/langgraph_math">
+  Full source, README, and runnable launch scripts
+</Card>

--- a/docs/cookbooks/overview.mdx
+++ b/docs/cookbooks/overview.mdx
@@ -19,6 +19,7 @@ Each cookbook is a plain async function that calls an OpenAI-compatible endpoint
 | [`frozenlake`](/cookbooks/frozenlake) | Multi-turn gym | Navigates procedurally-generated FrozenLake grids; demonstrates direct integration with a Gymnasium environment. |
 | [`math`](/cookbooks/math) | Single-turn | Solves competition / textbook math with `\boxed{}` answer extraction. |
 | [`math_tool_agent`](/cookbooks/math_tool_agent) | Multi-turn + tool | Solves math with a calculator tool via native OpenAI function calling. |
+| [`langgraph_math`](/cookbooks/langgraph_math) | Multi-turn + tool (LangGraph) | Same math + calculator task as `math_tool_agent`, authored with LangGraph's `create_react_agent`. Demonstrates that any LangGraph agent integrates with rLLM training without writing a callback handler. |
 | [`deepcoder`](/cookbooks/deepcoder) | Single-turn | Competition coding with `\`\`\`python\`\`\`` answer extraction; the evaluator runs the code against hidden tests. |
 | [`finqa`](/cookbooks/finqa) | Multi-turn + 4 tools | Financial QA over SEC 10-K tables: `get_table_names` / `get_table_info` / `sql_query` / `calculator`, judge-LLM grading. |
 | [`geo3k`](/cookbooks/geo3k) | VLM single-turn | Multimodal geometry on the Geometry3K dataset. |
@@ -90,6 +91,7 @@ The cleanest starting point is to copy an existing cookbook that matches your in
 |---|---|
 | One LLM call, parse answer | [`cookbooks/math`](https://github.com/rllm-org/rllm/tree/main/cookbooks/math) |
 | Multi-turn with a tool | [`cookbooks/math_tool_agent`](https://github.com/rllm-org/rllm/tree/main/cookbooks/math_tool_agent) |
+| Built with LangGraph | [`cookbooks/langgraph_math`](https://github.com/rllm-org/rllm/tree/main/cookbooks/langgraph_math) |
 | Multi-turn with multiple tools + complex grading | [`cookbooks/finqa`](https://github.com/rllm-org/rllm/tree/main/cookbooks/finqa) |
 | Drives a Gym environment | [`cookbooks/frozenlake`](https://github.com/rllm-org/rllm/tree/main/cookbooks/frozenlake) |
 | Solver + judge multi-agent | [`cookbooks/solver_judge_flow`](https://github.com/rllm-org/rllm/tree/main/cookbooks/solver_judge_flow) |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -120,6 +120,7 @@
               "cookbooks/frozenlake",
               "cookbooks/math",
               "cookbooks/math_tool_agent",
+              "cookbooks/langgraph_math",
               "cookbooks/deepcoder",
               "cookbooks/finqa",
               "cookbooks/geo3k",

--- a/docs/examples/sdk-langgraph.mdx
+++ b/docs/examples/sdk-langgraph.mdx
@@ -3,6 +3,12 @@ title: LangGraph Integration
 description: Train a LangGraph RAG agent with rLLM SDK tracing
 ---
 
+<Warning>
+  **Deprecated for training use.** This tutorial uses the SDK callback-handler approach to capture LangChain LLM calls in-process. For training under `AgentTrainer`, the rLLM model gateway now captures token-accurate traces by URL-routed sessions automatically — pointing `ChatOpenAI` at `config.base_url` is sufficient and the callback handler is no longer required. See the [`langgraph_math` cookbook](/cookbooks/langgraph_math) for the AgentFlow-protocol replacement pattern.
+
+  The SDK approach is preserved here for non-training contexts where you need in-process trajectory snapshots without a gateway.
+</Warning>
+
 In this tutorial, you'll train a retrieval-augmented generation (RAG) agent built with LangGraph. This demonstrates that rLLM SDK works seamlessly with popular agent frameworks—your LangGraph code runs unchanged.
 
 {/* <Frame>

--- a/docs/sdk/integrations.mdx
+++ b/docs/sdk/integrations.mdx
@@ -7,6 +7,10 @@ The rLLM SDK integrates seamlessly with popular agent frameworks and infrastruct
 
 ## LangGraph Integration
 
+<Warning>
+  **Deprecated for training use.** The patterns below use the SDK's traced chat clients (`get_chat_client` / `get_chat_client_async`) to capture LangChain LLM calls in-process. For training under `AgentTrainer`, the rLLM model gateway captures token-accurate traces by URL-routed sessions automatically — pointing `ChatOpenAI` at `config.base_url` is sufficient. See the [`langgraph_math` cookbook](/cookbooks/langgraph_math) for the AgentFlow-protocol replacement pattern.
+</Warning>
+
 [LangGraph](https://github.com/langchain-ai/langgraph) is a library for building stateful, multi-actor applications with LLMs. The rLLM SDK tracks all LLM calls made through LangGraph agents.
 
 ### Basic Setup

--- a/rllm/sdk/integrations/langgraph.py
+++ b/rllm/sdk/integrations/langgraph.py
@@ -1,11 +1,24 @@
 """LangGraph / LangChain integration for rLLM trajectory tracking.
 
+.. deprecated:: 0.2
+
+   ``RLLMTrajectoryCallbackHandler`` is deprecated for training use. The
+   rLLM model gateway now captures LLM calls by URL-routed sessions, so
+   any LangGraph agent whose ``ChatOpenAI`` client is pointed at
+   ``config.base_url`` is automatically traced — no callback handler
+   needed. See ``cookbooks/langgraph_math/`` for the AgentFlow-protocol
+   replacement pattern.
+
+   This module is kept for non-training contexts where you need
+   in-process trajectory snapshots without a gateway. For training
+   under ``rllm.experimental.unified_trainer.AgentTrainer``, migrate to
+   the AgentFlow pattern shown in the cookbook.
+
 Provides ``RLLMTrajectoryCallbackHandler``, a LangChain
 ``BaseCallbackHandler`` that captures all LLM calls during LangGraph
-agent execution and builds rLLM ``Trajectory`` objects for SFT
-distillation and RL training.
+agent execution and builds rLLM ``Trajectory`` objects.
 
-Usage::
+Usage (legacy)::
 
     from langchain_openai import ChatOpenAI
     from langgraph.prebuilt import create_react_agent
@@ -30,6 +43,7 @@ import json
 import logging
 import time
 import uuid
+import warnings
 from typing import Any
 
 from rllm.sdk.protocol import (
@@ -236,6 +250,13 @@ class RLLMTrajectoryCallbackHandler(BaseCallbackHandler):  # type: ignore[misc]
     def __init__(self) -> None:
         if not _LANGCHAIN_AVAILABLE:
             raise ImportError("LangChain is required for RLLMTrajectoryCallbackHandler. Install it with: pip install langchain-core langchain-openai")
+        warnings.warn(
+            "RLLMTrajectoryCallbackHandler is deprecated for training use. "
+            "Point ChatOpenAI at config.base_url and return None from your @rllm.rollout — "
+            "the gateway captures traces automatically. See cookbooks/langgraph_math/.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self._traces: list[Trace] = []
         self._trajectories: list[Trajectory] = []


### PR DESCRIPTION
## Summary

- New `cookbooks/langgraph_math/` — a LangGraph-authored math agent trained via the AgentFlow protocol. Mirrors `cookbooks/math_tool_agent` task and dataset for direct comparison between hand-rolled and LangGraph tool loops.
- The agent body is ~6 lines: `ChatOpenAI(base_url=config.base_url)` + `create_react_agent` + `ainvoke` + `return None`. The gateway captures every LLM call by URL-routed session, the framework auto-builds the Episode (per #560), and the evaluator pulls the answer from `episode.trajectories[-1].steps[-1].model_response` walking back past tool-message Steps.
- Deprecates `rllm.sdk.integrations.langgraph.RLLMTrajectoryCallbackHandler` for training use. The handler still works for non-training contexts where users want in-process trajectory snapshots without a gateway, but `__init__` now emits a `DeprecationWarning` pointing to the cookbook.

## Why this is small

The previous SDK approach (`rllm/sdk/integrations/langgraph.py`) is ~400 lines of `BaseCallbackHandler` plumbing whose only job is to capture LangChain's LLM calls into in-process `Trajectory` objects. With the URL-routed gateway as the universal trace-capture surface, that's all dead weight — any LangChain client that accepts a `base_url` is automatically traced, and the AgentFlow `return None` path ties it to training.

## Files

- `cookbooks/langgraph_math/{langgraph_math.py,evaluator.py,train.py,test.py,pyproject.toml,README.md,train_tinker.sh,train_verl.sh}` — full cookbook, mirrors `math_tool_agent` layout.
- `rllm/sdk/integrations/langgraph.py` — `__init__` emits `DeprecationWarning`; module docstring carries `.. deprecated::` block pointing to the cookbook.
- `docs/cookbooks/langgraph_math.mdx` — new cookbook page.
- `docs/cookbooks/overview.mdx` — cookbook listed in the available-cookbooks table and the authoring matrix.
- `docs/docs.json` — added to navigation under Cookbooks.
- `docs/examples/sdk-langgraph.mdx`, `docs/sdk/integrations.mdx` — deprecation banners pointing to the cookbook.

## Test plan

- [x] `pytest cookbooks/langgraph_math/test.py` — 15/15 pass (calculator safe-eval, answer extraction, evaluator over synthetic Episodes including the walk-back-past-empty-Steps case)
- [x] Smoke: `langgraph_math` is recognized as `AgentFlow`, `langgraph_math_evaluator` as `Evaluator`
- [x] Smoke: `RLLMTrajectoryCallbackHandler.__init__` emits `DeprecationWarning`
- [x] End-to-end: `rllm eval math500 --agent langgraph_math --evaluator langgraph_math --max-examples 20` against a vLLM endpoint
- [x] End-to-end: `bash cookbooks/langgraph_math/train_tinker.sh` for a few steps to confirm gateway → enriched Trajectory → GRPO grouping flow works on the new cookbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)