### PR TITLE
feat(harnesses): opencode/mini-swe-agent/oracle + per-task agent flow isolation

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -270,16 +270,27 @@ def _run_eval(
                 console.print(f"  [error]Error loading evaluator '{evaluator_name}': {e}[/]")
                 raise SystemExit(1) from None
         else:
-            evaluator = resolve_evaluator_from_catalog(benchmark)
-            if evaluator is not None:
-                reward_fn_name = catalog_entry.get("reward_fn", "") if catalog_entry else ""
-                evaluator_display = reward_fn_name or type(evaluator).__name__
-            elif catalog_entry and catalog_entry.get("reward_fn"):
-                try:
-                    evaluator = load_evaluator(catalog_entry["reward_fn"])
-                    evaluator_display = catalog_entry["reward_fn"]
-                except (KeyError, ImportError):
-                    pass
+            # ``harbor_reward_fn`` reads ``episode.artifacts['harbor_reward']``,
+            # which is only populated by HarborRuntime. When the user runs a
+            # harbor-sourced dataset through an rllm-native harness (oracle,
+            # opencode, mini-swe-agent, …), the artifact never gets set and
+            # the eval would always score zero. Skip the catalog evaluator in
+            # that case and let ``EvalHooks`` resolve a per-task verifier
+            # (typically ``tests/test.sh`` inside the harbor task dir).
+            _harbor_reward_fn_skipped = catalog_entry and catalog_entry.get("reward_fn") == "harbor_reward_fn" and not _is_harbor_agent
+            if _harbor_reward_fn_skipped:
+                evaluator_display = "per-task (rllm runtime on harbor task)"
+            else:
+                evaluator = resolve_evaluator_from_catalog(benchmark)
+                if evaluator is not None:
+                    reward_fn_name = catalog_entry.get("reward_fn", "") if catalog_entry else ""
+                    evaluator_display = reward_fn_name or type(evaluator).__name__
+                elif catalog_entry and catalog_entry.get("reward_fn"):
+                    try:
+                        evaluator = load_evaluator(catalog_entry["reward_fn"])
+                        evaluator_display = catalog_entry["reward_fn"]
+                    except (KeyError, ImportError):
+                        pass
 
         # Load dataset — auto-pull if not available locally
         dataset = DatasetRegistry.load_dataset(benchmark, split)

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -61,11 +61,14 @@ class TaskContext:
     """Per-task state returned by :meth:`TaskHooks.setup`.
 
     Encapsulates the per-task evaluator (resolved by the hook from a task's
-    [verifier] config, or pre-bound by the caller) and a teardown callback
-    that releases any per-task resources (sandboxes, temp dirs, ...).
+    [verifier] config, or pre-bound by the caller), an optional per-task
+    agent flow (so SandboxedAgentFlow's per-task sandbox can't leak across
+    parallel rollouts), and a teardown callback that releases any per-task
+    resources (sandboxes, temp dirs, ...).
     """
 
     evaluator: Evaluator
+    agent_flow: Any = None  # AgentFlow | None — kept loose for the import-cycle reason below
     teardown: Any = None  # Callable[[], None] | None — kept loose to avoid Callable import loop
 
     def run_teardown(self) -> None:
@@ -471,9 +474,14 @@ class AgentFlowEngine:
                     is_validation=is_validation,
                 )
 
-                # 3. Run agent flow (prefers arun if available, else run in executor)
+                # 3. Run agent flow (prefers arun if available, else run in executor).
+                # The hook may return a per-task agent flow instance (eg. a
+                # SandboxedAgentFlow with the task's sandbox already injected);
+                # use it when present so parallel tasks don't share mutable
+                # ``self._sandbox`` state on the engine-bound ``self.agent_flow``.
+                flow_for_task = ctx.agent_flow if (ctx is not None and ctx.agent_flow is not None) else self.agent_flow
                 logger.debug("[%s] Starting agent flow at %s", uid, session_url)
-                episode = await run_agent_flow(self.agent_flow, task_obj, config, executor=self.executor)
+                episode = await run_agent_flow(flow_for_task, task_obj, config, executor=self.executor)
                 logger.debug("[%s] Agent flow completed, %d trajectories", uid, len(episode.trajectories))
 
                 # 4. Retrieve traces from gateway and enrich episode with token data.

--- a/rllm/eval/_hooks.py
+++ b/rllm/eval/_hooks.py
@@ -78,16 +78,26 @@ class EvalHooks:
             verifier_kind, verifier_config = _detect_verifier(task)
             needs_sandbox = _needs_sandbox(task, verifier_kind) or isinstance(agent_flow, SandboxedAgentFlow)
 
+        # Per-task agent flow instance. SandboxedAgentFlow stores the
+        # active sandbox on ``self._sandbox``; with the engine-bound
+        # ``self.agent_flow`` shared across parallel rollouts, calling
+        # ``set_sandbox`` here would clobber whatever sandbox an in-flight
+        # sibling task is using. ``create_instance`` shallow-copies the
+        # flow so each task owns its own ``_sandbox`` slot.
+        task_flow: AgentFlow = agent_flow
+        if isinstance(agent_flow, SandboxedAgentFlow):
+            task_flow = agent_flow.create_instance()
+
         sandbox = None
         if needs_sandbox:
             sandbox = _create_sandbox_for_task(task, self.sandbox_backend)
             _setup_task_environment(task, sandbox)
-            if isinstance(agent_flow, SandboxedAgentFlow):
-                agent_flow.set_sandbox(sandbox)
+            if isinstance(task_flow, SandboxedAgentFlow):
+                task_flow.set_sandbox(sandbox)
                 # ``on_sandbox_ready`` predates AgentConfig threading the gateway
                 # session URL, so we pass None here — callers that need config
                 # access should read ``self.config`` (set by run_agent_flow).
-                agent_flow.on_sandbox_ready({"task_path": str(task.task_dir)}, None)
+                task_flow.on_sandbox_ready({"task_path": str(task.task_dir)}, None)
 
         # Resolve the evaluator (override beats per-task verifier).
         if self.evaluator_override is not None:
@@ -95,15 +105,15 @@ class EvalHooks:
         else:
             evaluator = _resolve_evaluator(task, sandbox, verifier_kind, verifier_config)
 
-        # Capture sandbox + agent_flow into the teardown closure so the
+        # Capture sandbox + per-task flow into the teardown closure so the
         # right release path runs (SandboxedAgentFlow has its own
         # `teardown_sandbox`, plain agents just close the sandbox).
         def teardown() -> None:
             if sandbox is None:
                 return
-            if isinstance(agent_flow, SandboxedAgentFlow):
+            if isinstance(task_flow, SandboxedAgentFlow):
                 try:
-                    agent_flow.teardown_sandbox()
+                    task_flow.teardown_sandbox()
                 except Exception:
                     logger.exception("teardown_sandbox failed")
             else:
@@ -112,4 +122,9 @@ class EvalHooks:
                 except Exception:
                     logger.exception("sandbox close failed")
 
-        return TaskContext(evaluator=evaluator, teardown=teardown)
+        # Surface ``task_flow`` only when it's a fresh per-task copy;
+        # for non-sandboxed flows we hand the engine the original instance
+        # by leaving ``agent_flow=None`` (engine then falls back to
+        # ``self.agent_flow``).
+        ctx_flow = task_flow if task_flow is not agent_flow else None
+        return TaskContext(evaluator=evaluator, agent_flow=ctx_flow, teardown=teardown)

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -235,16 +235,26 @@ def _setup_task_environment(task: Task, sandbox: Sandbox) -> None:
 
     Honors the agent/verifier user split when configured in task.toml.
     """
-    workdir = task.metadata.get("workdir", "/workspace")
+    # ``workdir`` is unset for tasks (e.g. swesmith) whose Dockerfile
+    # already declares a meaningful WORKDIR (``/testbed``) — forcing
+    # ``/workspace`` would override it and break verifiers that
+    # ``cd``-into-cwd or ``git checkout``. The ``mkdir`` / ``chown``
+    # / ``upload_dir(files)`` steps below only fire when a workdir is
+    # explicitly declared.
+    workdir = task.metadata.get("workdir")
     env_root = task.task_dir / "environment"
     if not env_root.is_dir():
         env_root = task.dataset_dir / "environment"
 
-    _safe_exec(sandbox, f"mkdir -p {workdir}", timeout=30)
+    if workdir:
+        _safe_exec(sandbox, f"mkdir -p {workdir}", timeout=30)
 
     files_dir = env_root / "files"
     if files_dir.is_dir():
-        sandbox.upload_dir(str(files_dir), workdir)
+        # Falls back to ``/workspace`` when files/ ships but no workdir
+        # is declared — preserves the historical default for tasks that
+        # actually rely on it.
+        sandbox.upload_dir(str(files_dir), workdir or "/workspace")
 
     setup_script = env_root / "setup.sh"
     if setup_script.exists():
@@ -259,7 +269,8 @@ def _setup_task_environment(task: Task, sandbox: Sandbox) -> None:
         _safe_exec(sandbox, "mkdir -p /logs/verifier /tmp/rllm /tests", timeout=10)
         _safe_exec(sandbox, "chmod 700 /logs/verifier /tmp/rllm /tests", timeout=10)
         _safe_exec(sandbox, "chown root:root /logs/verifier /tmp/rllm /tests", timeout=10)
-        _safe_exec(sandbox, f"chown -R {agent_user} {workdir}", timeout=30)
+        if workdir:
+            _safe_exec(sandbox, f"chown -R {agent_user} {workdir}", timeout=30)
 
     env_vars = task.metadata.get("env_vars", {}) or task.metadata.get("environment", {}).get("env", {})
     if env_vars:

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -80,10 +80,16 @@ class ShellScriptEvaluator:
                 metadata={"error": f"verifier script {script_name} not found in {tests_dir}"},
             )
 
-        workdir = task.metadata.get("workdir", "/workspace")
+        # Only ``cd`` when the task explicitly declared a workdir.
+        # Otherwise the Dockerfile's WORKDIR wins — required for swesmith
+        # and similar harbor task families whose verifier scripts run
+        # ``git`` and ``pytest`` against ``/testbed`` (the image WORKDIR)
+        # and silently collect zero tests when forced into ``/workspace``.
+        workdir = task.metadata.get("workdir")
+        cd_prefix = f"cd {workdir} && " if workdir else ""
         try:
             self.sandbox.exec(
-                f"chmod +x /tests/{script_name} && cd {workdir} && /tests/{script_name}",
+                f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
                 timeout=self.verifier_timeout,
                 user=v_user,
             )

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -88,7 +88,11 @@ class ShellScriptEvaluator:
                 user=v_user,
             )
         except Exception as e:
-            logger.warning("Test script execution error for %s: %s", task.id, e)
+            # Verifier exit != 0 is the *expected* outcome when an agent
+            # didn't solve the task; the reward (read from reward.txt
+            # below) carries the signal. Log at debug so a benchmark of
+            # 100 unsolved tasks doesn't spam 100 multi-KB stack traces.
+            logger.debug("Verifier exited non-zero for %s: %s", task.id, e)
 
         # Read reward (as verifier — agent may not have read access)
         reward_paths = list(_REWARD_PATHS)

--- a/rllm/harnesses/claude_code.py
+++ b/rllm/harnesses/claude_code.py
@@ -3,8 +3,11 @@
 Implemented as a SandboxedAgentFlow. Installs ``@anthropic-ai/claude-code``
 (npm) inside the sandbox on first use (via ``on_sandbox_ready`` hook),
 then invokes ``claude`` non-interactively. All LLM calls are routed
-through the LiteLLM proxy via ``ANTHROPIC_BASE_URL`` so token-level
-traces are captured by the gateway like host-side harnesses.
+through the rLLM model gateway via ``ANTHROPIC_BASE_URL`` so wire-level
+traces are captured by the gateway.
+
+``run()`` returns ``None``; the gateway captures every LLM call and the
+engine builds the trajectory during ``execute_tasks`` enrichment.
 """
 
 from __future__ import annotations
@@ -13,7 +16,7 @@ import logging
 import shlex
 
 from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
-from rllm.types import Episode, Step, Task, Trajectory
+from rllm.types import AgentConfig, Task
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +47,6 @@ class ClaudeCodeHarness(SandboxedAgentFlow):
     max_concurrent = 4
 
     def on_sandbox_ready(self, task: dict, config) -> None:
-        """Install claude-code if not already present (root)."""
         if self.sandbox is None:
             return
         try:
@@ -52,41 +54,32 @@ class ClaudeCodeHarness(SandboxedAgentFlow):
         except Exception as e:
             raise RuntimeError(f"Failed to install claude-code in sandbox: {e}") from e
 
-    def run(self, task: Task, config) -> Episode:
+    def run(self, task: Task, config: AgentConfig) -> None:
         sandbox = self.sandbox
         if sandbox is None:
             raise RuntimeError("ClaudeCodeHarness requires a sandbox.")
 
+        # The gateway URL is already stamped with the per-session prefix
+        # by the engine, so the CLI's calls hit /sessions/<uid>/v1/...
+        # and the gateway tags every trace with this task's session.
         env = {
-            "ANTHROPIC_BASE_URL": config.base_url,
-            "ANTHROPIC_API_KEY": "sk-rllm-proxy",
+            "ANTHROPIC_BASE_URL": config.base_url.rstrip("/").removesuffix("/v1") or config.base_url,
+            "ANTHROPIC_API_KEY": (config.metadata or {}).get("gateway_auth_token") or "sk-rllm-gateway",
             "ANTHROPIC_MODEL": config.model,
         }
         env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
 
         instruction = str(task.instruction).strip()
-        workdir = task.metadata.get("workdir", "/workspace")
+        workdir = task.metadata.get("workdir")
         agent_timeout = float(task.metadata.get("agent_timeout", 600))
         agent_user = task.metadata.get("agent_user")
 
-        cmd = f"cd {shlex.quote(workdir)} && {env_prefix} claude -p {shlex.quote(instruction)} --output-format text --permission-mode acceptEdits"
+        cd_prefix = f"cd {shlex.quote(workdir)} && " if workdir else ""
+        cmd = f"{cd_prefix}{env_prefix} claude -p {shlex.quote(instruction)} --output-format text --permission-mode acceptEdits"
 
         try:
-            output = sandbox.exec(cmd, timeout=agent_timeout, user=agent_user)
+            sandbox.exec(cmd, timeout=agent_timeout, user=agent_user)
         except Exception as e:
-            output = f"claude-code execution failed: {e}"
-            logger.warning("ClaudeCodeHarness: %s", output)
+            logger.warning("ClaudeCodeHarness execution failed: %s", e)
 
-        step = Step(id="step-0", input=instruction, output=output)
-        trajectory = Trajectory(
-            uid=config.session_uid,
-            name=self.name,
-            task=task.id,
-            steps=[step],
-            output=output,
-        )
-        return Episode(
-            id=config.session_uid,
-            task=task.id,
-            trajectories=[trajectory],
-        )
+        return None

--- a/rllm/harnesses/claude_code.py
+++ b/rllm/harnesses/claude_code.py
@@ -1,85 +1,92 @@
 """ClaudeCodeHarness: runs the Claude Code CLI inside the sandbox.
 
-Implemented as a SandboxedAgentFlow. Installs ``@anthropic-ai/claude-code``
-(npm) inside the sandbox on first use (via ``on_sandbox_ready`` hook),
-then invokes ``claude`` non-interactively. All LLM calls are routed
-through the rLLM model gateway via ``ANTHROPIC_BASE_URL`` so wire-level
-traces are captured by the gateway.
+Subclass of :class:`BaseCliHarness`, so it inherits the install/run
+lifecycle, gateway-trace-driven trajectory wiring (``run() -> None``),
+host-loopback rewrite (so ``127.0.0.1`` resolves to ``host.docker.internal``
+inside Docker), and bearer-token auth handling.
 
-``run()`` returns ``None``; the gateway captures every LLM call and the
-engine builds the trajectory during ``execute_tasks`` enrichment.
+Anthropic's CLI reads ``ANTHROPIC_BASE_URL`` and ``ANTHROPIC_API_KEY``;
+the gateway-routed URL is ``<base>/sessions/<uid>`` (the SDK appends
+``/v1/messages`` itself so we strip a trailing ``/v1``).
 """
 
 from __future__ import annotations
 
-import logging
 import shlex
 
-from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+from rllm.harnesses.cli_harness import BaseCliHarness
 from rllm.types import AgentConfig, Task
 
-logger = logging.getLogger(__name__)
-
-
+# nvm-based bootstrap mirrors :mod:`rllm.harnesses.opencode`. apt-based
+# nodejs/npm installs on swebench testbeds (Ubuntu jammy) routinely
+# fail with stale GPG signatures; ``-qq`` masks the error and the
+# script proceeds to ``npm`` which is then not on PATH.
 _INSTALL_SCRIPT = r"""
 set -e
+export DEBIAN_FRONTEND=noninteractive
 if ! command -v claude >/dev/null 2>&1; then
-    if ! command -v npm >/dev/null 2>&1; then
-        if command -v apt-get >/dev/null 2>&1; then
-            apt-get update -qq && apt-get install -y -qq nodejs npm
-        elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache nodejs npm
-        else
-            echo "Cannot install node/npm: no supported package manager" >&2
-            exit 1
+    if ! command -v node >/dev/null 2>&1; then
+        if ! command -v curl >/dev/null 2>&1; then
+            if command -v apt-get >/dev/null 2>&1; then
+                apt-get update -qq && apt-get install -y -qq curl ca-certificates
+            elif command -v apk >/dev/null 2>&1; then
+                apk add --no-cache curl bash ca-certificates
+            else
+                echo "claude-code install requires curl" >&2
+                exit 1
+            fi
         fi
+        export NVM_DIR="$HOME/.nvm"
+        curl -fsSL -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+        \. "$NVM_DIR/nvm.sh"
+        nvm install 22
     fi
+    [ -s "$HOME/.nvm/nvm.sh" ] && \. "$HOME/.nvm/nvm.sh"
     npm install -g @anthropic-ai/claude-code
 fi
 """
 
 
-class ClaudeCodeHarness(SandboxedAgentFlow):
+class ClaudeCodeHarness(BaseCliHarness):
     """Run Anthropic's Claude Code CLI inside the sandbox."""
 
     name = "claude-code"
     sandbox_backend = "docker"
     max_concurrent = 4
+    stdout_log_path = "/tmp/claude-code.log"
 
-    def on_sandbox_ready(self, task: dict, config) -> None:
-        if self.sandbox is None:
-            return
-        try:
-            self.sandbox.exec(_INSTALL_SCRIPT, timeout=600, user="root")
-        except Exception as e:
-            raise RuntimeError(f"Failed to install claude-code in sandbox: {e}") from e
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
 
-    def run(self, task: Task, config: AgentConfig) -> None:
-        sandbox = self.sandbox
-        if sandbox is None:
-            raise RuntimeError("ClaudeCodeHarness requires a sandbox.")
-
-        # The gateway URL is already stamped with the per-session prefix
-        # by the engine, so the CLI's calls hit /sessions/<uid>/v1/...
-        # and the gateway tags every trace with this task's session.
-        env = {
-            "ANTHROPIC_BASE_URL": config.base_url.rstrip("/").removesuffix("/v1") or config.base_url,
-            "ANTHROPIC_API_KEY": (config.metadata or {}).get("gateway_auth_token") or "sk-rllm-gateway",
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        # Anthropic's SDK appends ``/v1/messages`` itself, so trim a
+        # trailing ``/v1`` from the gateway URL or it doubles up.
+        gateway_url = self._container_url(config.base_url)
+        anthropic_url = gateway_url.rstrip("/").removesuffix("/v1") or gateway_url
+        return {
+            "ANTHROPIC_BASE_URL": anthropic_url,
+            "ANTHROPIC_API_KEY": self.gateway_api_key(config, "ANTHROPIC_API_KEY"),
             "ANTHROPIC_MODEL": config.model,
         }
-        env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
 
-        instruction = str(task.instruction).strip()
-        workdir = task.metadata.get("workdir")
-        agent_timeout = float(task.metadata.get("agent_timeout", 600))
-        agent_user = task.metadata.get("agent_user")
-
-        cd_prefix = f"cd {shlex.quote(workdir)} && " if workdir else ""
-        cmd = f"{cd_prefix}{env_prefix} claude -p {shlex.quote(instruction)} --output-format text --permission-mode acceptEdits"
-
-        try:
-            sandbox.exec(cmd, timeout=agent_timeout, user=agent_user)
-        except Exception as e:
-            logger.warning("ClaudeCodeHarness execution failed: %s", e)
-
-        return None
+    def build_invocation(
+        self,
+        instruction: str,
+        task: Task,
+        config: AgentConfig,
+    ) -> str:
+        # ``--bare`` is the key flag for non-interactive auth: claude
+        # otherwise gates ``-p`` on an OAuth login check (``Not logged
+        # in · Please run /login``) that exits 0 with no trace, even
+        # when ``ANTHROPIC_API_KEY`` is set. Bare mode skips OAuth +
+        # keychain reads and uses the env-var key directly, which is
+        # what we want when routing through the rllm gateway.
+        # Source nvm so the npm-installed ``claude`` binary is on PATH;
+        # silent no-op when node came from a system package.
+        return (
+            f"{self._cd_prefix(task)}"
+            f". $HOME/.nvm/nvm.sh 2>/dev/null; "
+            f"claude --bare -p {shlex.quote(instruction)} "
+            f"--output-format text --permission-mode acceptEdits "
+            f"</dev/null 2>&1 | tee {shlex.quote(self.stdout_log_path)}"
+        )

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -80,12 +80,20 @@ class BaseCliHarness(SandboxedAgentFlow):
         timeout: float | None = None,
         env: dict[str, str] | None = None,
     ) -> str:
-        """Run *command* as the agent user, with *env* prepended."""
+        """Run *command* as the agent user, with *env* exported.
+
+        Uses ``export`` (not the inline ``K=V cmd`` prefix), because
+        invocations like ``cd /workspace && claude ...`` are compound
+        commands. Bash's inline assignment only applies to the *first*
+        command in the chain — ``ANTHROPIC_API_KEY`` would be set for
+        ``cd`` and gone by the time the CLI runs, leaving the agent
+        looking like it had no auth even though we passed it.
+        """
         if self.sandbox is None:
             raise RuntimeError(f"{type(self).__name__} requires a sandbox.")
         if env:
-            prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items() if v is not None)
-            command = f"{prefix} {command}"
+            exports = "; ".join(f"export {k}={shlex.quote(v)}" for k, v in env.items() if v is not None)
+            command = f"{exports}; {command}"
         return self.sandbox.exec(command, timeout=timeout, user=self.agent_user)
 
     @staticmethod

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -1,0 +1,289 @@
+"""Base class for harnesses that wrap a CLI tool installed inside a sandbox.
+
+The pattern is the same across opencode, mini-swe-agent, claude-code, codex:
+
+1. ``install`` — once per sandbox, package-manager + npm/uv/curl install of
+   the CLI binary. Idempotent.
+2. ``build_env`` — assemble the env dict (gateway base URL, auth, model
+   name) that the CLI process will read.
+3. ``write_configs`` — some CLIs also need a config file inside the
+   sandbox (opencode requires ``opencode.json``; mini-swe-agent requires
+   a ``~/.config/mini-swe-agent/.env`` dotenv). Hook with default no-op.
+4. ``build_invocation`` — return the shell command to run the CLI.
+
+``run()`` execs that command and returns ``None``. The gateway sits in
+front of every LLM call the CLI makes, so wire-level traces flow into
+the engine and ``_coerce_to_episode`` (in :mod:`rllm.types`) builds the
+Episode with one empty Trajectory whose Steps get populated from those
+traces during enrichment. No manual stdout parsing or Step construction
+is needed here — the CLI's stdout is captured for debugging via the
+``stdout_log_path`` tee but is otherwise ignored.
+
+The gateway URL the harness sees is already stamped with
+``/sessions/<session_uid>/v1`` upstream, so every LLM call is tagged
+with this task's session in the gateway sqlite. The harness just
+propagates ``config.base_url`` through the appropriate env var
+(``ANTHROPIC_BASE_URL`` / ``OPENAI_BASE_URL``).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import uuid
+from abc import abstractmethod
+
+from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+from rllm.types import AgentConfig, Task
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCliHarness(SandboxedAgentFlow):
+    """Run a CLI agent (opencode, mini-swe-agent, claude-code, …) inside the sandbox.
+
+    Subclasses fill in the install command, env var dict, optional config
+    files, and the invocation. ``run`` returns ``None``; the gateway
+    captures every LLM call and the engine builds the trajectory.
+    """
+
+    # Display name used by the agent registry.
+    name: str = "cli"
+    # Default sandbox backend — overridable via class attr or kwargs.
+    sandbox_backend: str = "docker"
+    # Default container image. Tasks usually override via per-task images.
+    image: str = "python:3.11-slim"
+    # Concurrency hint for the eval runner.
+    max_concurrent: int = 4
+    # Container user the CLI runs as. ``None`` uses the image default.
+    agent_user: str | None = None
+    # Path inside the sandbox where the CLI's stdout is teed.
+    stdout_log_path: str = "/tmp/agent-stdout.log"
+    # Per-call timeouts (seconds). Tasks may override via metadata.
+    install_timeout: int = 600
+    run_timeout: int = 1800
+
+    # ---------------------------------------------------------------------
+    # Sandbox helpers
+    # ---------------------------------------------------------------------
+
+    def _exec_root(self, command: str, timeout: float | None = None) -> str:
+        """Run *command* as root inside the sandbox."""
+        if self.sandbox is None:
+            raise RuntimeError(f"{type(self).__name__} requires a sandbox.")
+        return self.sandbox.exec(command, timeout=timeout, user="root")
+
+    def _exec_agent(
+        self,
+        command: str,
+        timeout: float | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        """Run *command* as the agent user, with *env* prepended."""
+        if self.sandbox is None:
+            raise RuntimeError(f"{type(self).__name__} requires a sandbox.")
+        if env:
+            prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items() if v is not None)
+            command = f"{prefix} {command}"
+        return self.sandbox.exec(command, timeout=timeout, user=self.agent_user)
+
+    @staticmethod
+    def infer_provider(model_name: str) -> str:
+        """Map a bare model name to its likely provider slug.
+
+        rLLM's setup configures bare model names (``gpt-5.4-mini``,
+        ``claude-opus-4-1``) but several CLIs (opencode, mini-swe-agent)
+        require ``provider/model`` form.
+
+        Returns the lowercase provider slug. Defaults to ``openai`` for
+        unknown patterns — works for ``gpt-*``/``o1``/``o3`` and routes
+        cleanly through any OpenAI-compatible proxy.
+        """
+        name = model_name.lower()
+        if any(k in name for k in ("claude", "haiku", "sonnet", "opus")):
+            return "anthropic"
+        if "gemini" in name or "gemma" in name:
+            return "google"
+        if "deepseek" in name:
+            return "deepseek"
+        if "grok" in name:
+            return "xai"
+        if "mistral" in name or "mixtral" in name:
+            return "mistral"
+        if "qwen" in name:
+            return "openai"  # Qwen via OpenAI-compatible endpoints
+        return "openai"
+
+    @staticmethod
+    def gateway_api_key(config: AgentConfig, fallback_env_var: str) -> str:
+        """Return the API key to inject into the sandbox for *fallback_env_var*.
+
+        When the eval gateway is exposed publicly it generates an
+        ``inbound_auth_token`` and stamps it on
+        ``config.metadata["gateway_auth_token"]``. Every provider key
+        the harness writes into the sandbox env (``OPENAI_API_KEY``,
+        ``ANTHROPIC_API_KEY``, …) must be that bearer token, because
+        that's what the gateway's middleware checks. The gateway then
+        replaces the auth header with the route's pre-resolved upstream
+        auth header before forwarding.
+
+        Loopback gateways (no token) keep the current behaviour: pass
+        the user's real key through, or a placeholder if unset.
+        """
+        token = (config.metadata or {}).get("gateway_auth_token")
+        if token:
+            return token
+        import os
+
+        return os.environ.get(fallback_env_var, "sk-rllm-gateway")
+
+    @classmethod
+    def ensure_provider_prefix(cls, model_name: str) -> tuple[str, str, str]:
+        """Return ``(provider, model_id, qualified_name)`` for *model_name*.
+
+        Accepts both bare names (``gpt-4o``) and pre-qualified names
+        (``openai/gpt-4o``); inference fills in the provider when missing.
+        """
+        if "/" in model_name:
+            provider, model_id = model_name.split("/", 1)
+        else:
+            provider = cls.infer_provider(model_name)
+            model_id = model_name
+        return provider, model_id, f"{provider}/{model_id}"
+
+    def _container_url(self, url: str) -> str:
+        """Rewrite host loopback addresses for in-container reachability.
+
+        The gateway binds to 127.0.0.1 on the host. From inside a Docker
+        container, that loopback addresses the container itself, not the
+        host. Docker Desktop (macOS/Windows) resolves the magic hostname
+        ``host.docker.internal`` to the host; on Linux Docker 20.10+ the
+        same hostname works when the container is started with
+        ``--add-host=host.docker.internal:host-gateway``.
+
+        For the ``local`` and ``modal`` backends this is a no-op.
+        """
+        if self.sandbox_backend != "docker":
+            return url
+        return re.sub(
+            r"(https?://)(?:127\.0\.0\.1|localhost)(:\d+|/|$)",
+            r"\1host.docker.internal\2",
+            url,
+        )
+
+    @staticmethod
+    def _cd_prefix(task: Task) -> str:
+        """Return ``cd <workdir> && `` only when the task explicitly sets ``workdir``.
+
+        Without this, a hardcoded ``cd /workspace`` overrides whatever
+        ``WORKDIR`` the task's Dockerfile declared, so verifiers that
+        check ``/app/foo`` (the Dockerfile WORKDIR) instead of
+        ``/workspace/foo`` fail even when the agent did the right thing.
+        Tasks that need a specific workdir set it via
+        ``[environment].workdir`` in task.toml → ``task.metadata['workdir']``.
+        """
+        workdir = task.metadata.get("workdir")
+        return f"cd {shlex.quote(workdir)} && " if workdir else ""
+
+    @staticmethod
+    def _heredoc_write(remote_path: str, content: str) -> str:
+        """Build a shell command that writes *content* to *remote_path*.
+
+        Uses a unique heredoc marker so embedded ``EOF`` strings in the
+        content can't terminate it. The parent directory is created.
+
+        ``remote_path`` MUST be an absolute, fully-resolved path — shell
+        variables like ``$HOME`` won't expand because the path is
+        single-quoted to prevent injection. Callers that need ``$HOME``
+        should hand-roll the heredoc with the path *unquoted* in the
+        shell command.
+        """
+        if "$" in remote_path:
+            raise ValueError(f"_heredoc_write requires a fully-resolved path; got {remote_path!r}. Single-quoting kills $VAR expansion — write the heredoc inline.")
+        marker = f"_RLLM_CLI_EOF_{uuid.uuid4().hex[:8]}"
+        parent = shlex.quote(remote_path.rsplit("/", 1)[0] or "/")
+        path_q = shlex.quote(remote_path)
+        return f"mkdir -p {parent} && cat > {path_q} << '{marker}'\n{content}\n{marker}"
+
+    # ---------------------------------------------------------------------
+    # Hooks subclasses implement
+    # ---------------------------------------------------------------------
+
+    @abstractmethod
+    def install_script(self) -> str:
+        """Return a shell script that installs the CLI in the sandbox.
+
+        Runs as root via ``on_sandbox_ready``. Must be idempotent — the
+        hook may fire on a container where the CLI is already present.
+        """
+
+    @abstractmethod
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        """Return the env vars the CLI needs (auth, base URL, model)."""
+
+    def write_configs(
+        self,
+        task: Task,
+        config: AgentConfig,
+        env: dict[str, str],
+    ) -> None:
+        """Hook: write any in-sandbox config files the CLI requires.
+
+        Default no-op. Override for opencode (opencode.json) and
+        mini-swe-agent (~/.config/mini-swe-agent/.env).
+        """
+
+    @abstractmethod
+    def build_invocation(
+        self,
+        instruction: str,
+        task: Task,
+        config: AgentConfig,
+    ) -> str:
+        """Return the shell command that runs the CLI on *instruction*.
+
+        The command should tee its stdout to ``self.stdout_log_path`` so
+        operators have a captured log to read for debugging — Steps are
+        built from gateway traces, not from this stdout.
+        """
+
+    # ---------------------------------------------------------------------
+    # Lifecycle
+    # ---------------------------------------------------------------------
+
+    def on_sandbox_ready(self, task: dict, config: AgentConfig) -> None:  # noqa: ARG002
+        """Install the CLI inside the sandbox before the first run."""
+        if self.sandbox is None:
+            return
+        try:
+            self._exec_root(self.install_script(), timeout=self.install_timeout)
+        except Exception as e:
+            raise RuntimeError(f"Failed to install {self.name} in sandbox: {e}") from e
+
+    def run(self, task: Task, config: AgentConfig) -> None:
+        """Exec the CLI; let the gateway build the trajectory.
+
+        Returns ``None`` so :func:`rllm.types._coerce_to_episode` builds
+        an empty single-trajectory Episode. The engine then enriches its
+        Steps from the gateway-captured traces during ``execute_tasks``.
+        """
+        if self.sandbox is None:
+            raise RuntimeError(f"{type(self).__name__} requires a sandbox.")
+
+        env = self.build_env(task, config)
+        self.write_configs(task, config, env)
+
+        instruction = str(task.instruction).strip()
+        timeout = float(task.metadata.get("agent_timeout", self.run_timeout))
+        cmd = self.build_invocation(instruction, task, config)
+
+        try:
+            self._exec_agent(cmd, timeout=timeout, env=env)
+        except Exception as e:
+            # Surface as a warning for operator visibility; the engine
+            # still gets None and the gateway traces (if any LLM calls
+            # made it through before the failure) drive enrichment.
+            logger.warning("%s execution failed: %s", type(self).__name__, e)
+
+        return None

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -45,10 +45,16 @@ set -e
 # Noninteractive automatically when there's no TTY; Modal does not).
 export DEBIAN_FRONTEND=noninteractive
 if ! command -v mini-swe-agent >/dev/null 2>&1; then
-    if command -v apt-get >/dev/null 2>&1; then
-        apt-get update -qq && apt-get install -y -qq curl ca-certificates git python3 python3-venv
-    elif command -v apk >/dev/null 2>&1; then
-        apk add --no-cache curl bash ca-certificates git python3 py3-pip
+    # Only fall back to apt when curl is missing — swebench testbeds
+    # have expired Ubuntu jammy repo signatures, so unconditional
+    # ``apt-get update`` fails with GPG errors and stops the script
+    # before uv even gets a chance.
+    if ! command -v curl >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq curl ca-certificates git
+        elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache curl bash ca-certificates git
+        fi
     fi
     if ! command -v uv >/dev/null 2>&1; then
         curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -1,0 +1,159 @@
+"""MiniSweAgentHarness: runs the mini-swe-agent CLI inside the sandbox.
+
+mini-swe-agent uses litellm under the hood, so it picks up
+``OPENAI_API_BASE`` for OpenAI-shaped backends and a model-derived
+provider key (``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` / …). The
+gateway routes by model name regardless.
+
+``run()`` returns ``None``; the gateway captures every LLM call and
+the engine builds the trajectory.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.types import AgentConfig, Task
+
+# Model-name prefix → provider env-var mapping. Mirrors litellm's logic
+# without taking the dependency.
+_PROVIDER_KEYS = (
+    ("anthropic/", "ANTHROPIC_API_KEY"),
+    ("claude", "ANTHROPIC_API_KEY"),  # bare claude-* model names
+    ("openai/", "OPENAI_API_KEY"),
+    ("gpt-", "OPENAI_API_KEY"),
+    ("o1", "OPENAI_API_KEY"),
+    ("deepseek/", "DEEPSEEK_API_KEY"),
+    ("groq/", "GROQ_API_KEY"),
+)
+
+
+def _provider_key_var(model: str) -> str:
+    name = model.lower()
+    for prefix, var in _PROVIDER_KEYS:
+        if name.startswith(prefix) or prefix in name:
+            return var
+    return "OPENAI_API_KEY"
+
+
+_INSTALL_SCRIPT = r"""
+set -e
+# DEBIAN_FRONTEND=noninteractive is mandatory: ``apt-get install python3``
+# pulls in ``tzdata``, which triggers a debconf timezone prompt and
+# hangs forever on Modal sandboxes (Docker exec falls back to
+# Noninteractive automatically when there's no TTY; Modal does not).
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v mini-swe-agent >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates git python3 python3-venv
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl bash ca-certificates git python3 py3-pip
+    fi
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+    uv tool install mini-swe-agent
+fi
+"""
+
+
+class MiniSweAgentHarness(BaseCliHarness):
+    """Run mini-swe-agent inside the sandbox."""
+
+    name = "mini-swe-agent"
+    sandbox_backend = "docker"
+    max_concurrent = 4
+    stdout_log_path = "/tmp/mini-swe-agent.log"
+
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        gateway_url = self._container_url(config.base_url)
+        env: dict[str, str] = {
+            # Legacy v1 wizard-skip (still honoured by some forks); v2
+            # ignores it and instead checks for ~/.config/mini-swe-agent/.env
+            # which we write from ``write_configs``.
+            "MSWEA_CONFIGURED": "true",
+            # Don't fail when the gateway-routed model isn't in litellm's cost table.
+            "MSWEA_COST_TRACKING": "ignore_errors",
+            "OPENAI_API_BASE": gateway_url,
+            "OPENAI_BASE_URL": gateway_url,
+            "ANTHROPIC_BASE_URL": gateway_url.rstrip("/").removesuffix("/v1") or gateway_url,
+        }
+
+        # Forward the provider key litellm will look up. When the
+        # gateway requires inbound auth, this becomes the bearer token
+        # (gateway re-stamps with the real upstream key).
+        api_var = _provider_key_var(config.model)
+        env[api_var] = self.gateway_api_key(config, api_var)
+        return env
+
+    def write_configs(
+        self,
+        task: Task,
+        config: AgentConfig,
+        env: dict[str, str],
+    ) -> None:
+        """Write ``~/.config/mini-swe-agent/.env`` so mini-swe-agent v2 skips the setup wizard.
+
+        v2's wizard fires whenever this file is missing — even with
+        ``MSWEA_CONFIGURED=true`` in the environment. Pre-seeding it
+        with the model + provider key is the only reliable bypass
+        observed across versions ≥ 2.2.
+        """
+        _, _, qualified = self.ensure_provider_prefix(config.model)
+        api_var = _provider_key_var(config.model)
+        api_key = env.get(api_var, self.gateway_api_key(config, api_var))
+
+        # Dotenv lines mini-swe-agent v2 reads on startup. The base
+        # URL must live HERE (not just in process env) because v2 loads
+        # the dotenv with ``override=True`` — it would otherwise unset
+        # ``OPENAI_API_BASE`` we exported in :meth:`build_env`, sending
+        # every call to api.openai.com and bypassing the gateway.
+        gateway_url = self._container_url(config.base_url)
+        dotenv_lines = [
+            f"MSWEA_GLOBAL_MODEL={qualified}",
+            f"{api_var}={api_key}",
+            f"OPENAI_API_BASE={gateway_url}",
+            f"OPENAI_BASE_URL={gateway_url}",
+            f"ANTHROPIC_BASE_URL={gateway_url.rstrip('/').removesuffix('/v1') or gateway_url}",
+            "MSWEA_CONFIGURED=true",
+            "MSWEA_COST_TRACKING=ignore_errors",
+        ]
+        content = "\n".join(dotenv_lines)
+        path = "$HOME/.config/mini-swe-agent/.env"
+        # ``_heredoc_write`` quotes the target path, which kills
+        # ``$HOME`` expansion — write the heredoc inline instead.
+        self._exec_agent(
+            f"mkdir -p $HOME/.config/mini-swe-agent && cat > {path} << 'MSWEA_DOTENV_EOF'\n{content}\nMSWEA_DOTENV_EOF",
+            env=env,
+        )
+
+    def build_invocation(
+        self,
+        instruction: str,
+        task: Task,
+        config: AgentConfig,
+    ) -> str:
+        # mini-swe-agent insists on ``provider/model``; infer the prefix
+        # when the user passed a bare name from rllm setup.
+        _, _, qualified = self.ensure_provider_prefix(config.model)
+
+        # NOTE: gateway routing relies on ``OPENAI_API_BASE`` in the
+        # process environment. ``-c key=value`` overrides on the CLI
+        # are NOT layered on top of mini.yaml in v2 — they replace it,
+        # which breaks the build with missing ``system_template`` etc.
+        # The dotenv we write in :meth:`write_configs` carries the base
+        # URL into the agent's environment so litellm picks it up.
+        return (
+            f"{self._cd_prefix(task)}"
+            f'export PATH="$HOME/.local/bin:$PATH"; '
+            f"mini-swe-agent --yolo "
+            f"--model={shlex.quote(qualified)} "
+            f"--task={shlex.quote(instruction)} "
+            f"--exit-immediately "
+            f"2>&1 | tee {shlex.quote(self.stdout_log_path)}"
+        )

--- a/rllm/harnesses/opencode.py
+++ b/rllm/harnesses/opencode.py
@@ -38,10 +38,15 @@ set -e
 # interactive packages.
 export DEBIAN_FRONTEND=noninteractive
 if ! command -v opencode >/dev/null 2>&1; then
-    if command -v apt-get >/dev/null 2>&1; then
-        apt-get update -qq && apt-get install -y -qq curl ca-certificates
-    elif command -v apk >/dev/null 2>&1; then
-        apk add --no-cache curl bash ca-certificates
+    # Only touch apt when curl is actually missing — running apt-get
+    # update unconditionally bombs on swebench testbeds where the
+    # Ubuntu jammy repo signatures have expired.
+    if ! command -v curl >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq curl ca-certificates
+        elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache curl bash ca-certificates
+        fi
     fi
     if ! command -v node >/dev/null 2>&1; then
         export NVM_DIR="$HOME/.nvm"
@@ -49,6 +54,7 @@ if ! command -v opencode >/dev/null 2>&1; then
         \. "$NVM_DIR/nvm.sh"
         nvm install 22
     fi
+    [ -s "$HOME/.nvm/nvm.sh" ] && \. "$HOME/.nvm/nvm.sh"
     npm install -g opencode-ai@latest
 fi
 opencode --version >/dev/null

--- a/rllm/harnesses/opencode.py
+++ b/rllm/harnesses/opencode.py
@@ -1,0 +1,166 @@
+"""OpenCodeHarness: runs the opencode-ai CLI inside the sandbox.
+
+opencode reads ``OPENAI_BASE_URL`` from env *and* requires the same
+URL be present in ``~/.config/opencode/opencode.json`` as
+``provider.<name>.options.baseURL`` — env var alone is not honored
+when the provider is registered via config.
+
+``run()`` returns ``None``; the gateway captures every LLM call and
+the engine builds the trajectory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+
+from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.types import AgentConfig, Task
+
+# Map ``provider`` (left side of provider/model) to the env var holding
+# the user's real API key. Most providers work with just the env-var-
+# and-config-file combination; add to this table as new ones come up.
+_PROVIDER_AUTH = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "mistral": "MISTRAL_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "xai": "XAI_API_KEY",
+}
+
+_INSTALL_SCRIPT = r"""
+set -e
+# DEBIAN_FRONTEND=noninteractive: Modal exec leaves stdin connected and
+# debconf prompts (e.g. tzdata) hang forever when apt installs pull in
+# interactive packages.
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v opencode >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl bash ca-certificates
+    fi
+    if ! command -v node >/dev/null 2>&1; then
+        export NVM_DIR="$HOME/.nvm"
+        curl -fsSL -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+        \. "$NVM_DIR/nvm.sh"
+        nvm install 22
+    fi
+    npm install -g opencode-ai@latest
+fi
+opencode --version >/dev/null
+"""
+
+
+class OpenCodeHarness(BaseCliHarness):
+    """Run opencode-ai inside the sandbox."""
+
+    name = "opencode"
+    sandbox_backend = "docker"
+    max_concurrent = 4
+    stdout_log_path = "/tmp/opencode.log"
+
+    # Provider name we register the gateway under inside opencode.json.
+    # Has to be NEW (not "openai" / "anthropic"), because opencode treats
+    # those names as known providers and validates the model id against
+    # its bundled ``models.dev`` registry — any custom name (e.g.
+    # ``gpt-5.4-mini`` from ``rllm setup``) raises
+    # ``ProviderModelNotFoundError`` even when listed in our ``models``
+    # block. A custom-named provider with ``npm: @ai-sdk/openai-compatible``
+    # bypasses that validation.
+    _RLLM_PROVIDER_ID = "rllm-gateway"
+
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
+
+    def _split_provider(self, model: str) -> tuple[str, str, str]:
+        """Return ``(provider, model_id, qualified)`` for *model*."""
+        return self.ensure_provider_prefix(model)
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        provider, _, _ = self._split_provider(config.model)
+        gateway_url = self._container_url(config.base_url)
+
+        env: dict[str, str] = {
+            # opencode uses an OpenAI-shaped client for openai/anthropic
+            # alike; the gateway routes by model-name regardless.
+            "OPENAI_BASE_URL": gateway_url,
+            "OPENAI_API_BASE": gateway_url,
+            "ANTHROPIC_BASE_URL": gateway_url.rstrip("/").removesuffix("/v1") or gateway_url,
+            "OPENCODE_FAKE_VCS": "git",
+        }
+
+        # Forward the gateway bearer token (when public URL → public auth)
+        # or the user's actual provider key, or a placeholder. The gateway
+        # re-stamps auth with the real upstream key before forwarding.
+        api_key_var = _PROVIDER_AUTH.get(provider, "OPENAI_API_KEY")
+        env[api_key_var] = self.gateway_api_key(config, api_key_var)
+        return env
+
+    def write_configs(
+        self,
+        task: Task,
+        config: AgentConfig,
+        env: dict[str, str],
+    ) -> None:
+        _, model_id, _ = self._split_provider(config.model)
+        gateway_url = self._container_url(config.base_url)
+        api_key_var = _PROVIDER_AUTH.get(self._split_provider(config.model)[0], "OPENAI_API_KEY")
+        # Same key build_env injected — bearer token when gateway is
+        # exposed, else the user's real provider key.
+        api_key = env.get(api_key_var, self.gateway_api_key(config, api_key_var))
+
+        # ``npm: "@ai-sdk/openai-compatible"`` tells opencode to treat this
+        # as a generic OpenAI-shaped endpoint. Model ids under this provider
+        # are accepted as-is (no models.dev lookup), so arbitrary names
+        # like ``gpt-5.4-mini`` work end-to-end.
+        opencode_config = {
+            "provider": {
+                self._RLLM_PROVIDER_ID: {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "rLLM Gateway",
+                    "options": {
+                        "baseURL": gateway_url,
+                        "apiKey": api_key,
+                    },
+                    "models": {model_id: {}},
+                }
+            }
+        }
+        content = json.dumps(opencode_config, indent=2)
+        # Write via a heredoc whose target path is *unquoted* in the shell
+        # so ``$HOME`` expands at runtime. ``_heredoc_write`` shlex-quotes
+        # its target, which silently turns ``$HOME/.config/opencode/...``
+        # into a literal directory named ``$HOME`` under the cwd — opencode
+        # then sees no config and falls back to its built-in registry,
+        # giving the misleading ``ProviderModelNotFoundError``.
+        marker = f"_RLLM_OPENCODE_EOF_{os.urandom(4).hex()}"
+        cmd = f"mkdir -p $HOME/.config/opencode && cat > $HOME/.config/opencode/opencode.json << '{marker}'\n{content}\n{marker}"
+        self._exec_agent(cmd, env=env)
+
+    def build_invocation(
+        self,
+        instruction: str,
+        task: Task,
+        config: AgentConfig,
+    ) -> str:
+        # Use the custom-provider id we registered, not the inferred one.
+        # opencode looks the model up under whatever provider prefix the
+        # ``--model`` flag carries.
+        _, model_id, _ = self._split_provider(config.model)
+        qualified = f"{self._RLLM_PROVIDER_ID}/{model_id}"
+        # ``</dev/null`` is required: Modal's ``sandbox.exec`` leaves
+        # stdin connected to a live socket that never receives EOF, and
+        # opencode blocks on its initial stdin read forever — the run
+        # hangs after the DB-migration log line with no further output.
+        return (
+            f"{self._cd_prefix(task)}"
+            f". $HOME/.nvm/nvm.sh 2>/dev/null; "
+            f"opencode --model={shlex.quote(qualified)} run "
+            f"--dangerously-skip-permissions "
+            f"-- {shlex.quote(instruction)} "
+            f"</dev/null 2>&1 | tee {shlex.quote(self.stdout_log_path)}"
+        )

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -1,0 +1,85 @@
+"""OracleHarness: run a task's reference ``solution/solve.sh`` in the sandbox.
+
+rLLM-native equivalent of Harbor's ``OracleAgent``. No LLM calls — the
+harness uploads the task's ``solution/`` directory into the sandbox the
+:class:`rllm.eval._hooks.EvalHooks` already built (from
+``environment/Dockerfile``, ``environment/setup.sh``, and
+``[rllm].setup_commands``), executes ``solution/solve.sh``, and lets
+the per-task evaluator (typically :class:`ShellScriptEvaluator` for
+``tests/test.sh``) score the result.
+
+Use it as a smoke-test for a Harbor-style task: confirms the image
+builds, setup runs, and the verifier reports a baseline reward. If the
+oracle reward matches the task README's expected baseline, the task is
+wired up correctly and an LLM-driven harness can be trusted on top of it.
+
+Unlike the LLM-driven CLI harnesses, this one returns an
+:class:`Episode` with one :class:`Step` whose output is the captured
+``solve.sh`` stdout — there are no gateway traces (no LLM calls), and
+that stdout is the only diagnostic signal worth surfacing.
+
+Usage::
+
+    rllm eval /path/to/tasks/dir --agent oracle [--sandbox-backend modal]
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+
+from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+from rllm.types import AgentConfig, Episode, Step, Task, Trajectory
+
+logger = logging.getLogger(__name__)
+
+
+class OracleHarness(SandboxedAgentFlow):
+    """Upload ``solution/`` and run ``solve.sh`` inside the task sandbox."""
+
+    name = "oracle"
+    sandbox_backend = "docker"
+    max_concurrent = 4
+
+    # Mirror Harbor's ``env_paths.solution_dir`` convention so anyone
+    # comparing the two implementations doesn't trip on path drift.
+    _SOLUTION_DIR = "/solution"
+
+    def run(self, task: Task, config: AgentConfig) -> Episode:
+        sandbox = self.sandbox
+        if sandbox is None:
+            raise RuntimeError("OracleHarness requires a sandbox; the eval hooks should set one before run().")
+
+        solution_dir = task.task_dir / "solution"
+        solve_path = solution_dir / "solve.sh"
+        if not solve_path.exists():
+            raise FileNotFoundError(f"Task {task.id!r}: missing reference solution at {solve_path}")
+
+        sandbox.exec(f"mkdir -p {self._SOLUTION_DIR}", user="root")
+        sandbox.upload_dir(str(solution_dir), self._SOLUTION_DIR)
+        container_solve = f"{self._SOLUTION_DIR}/solve.sh"
+        sandbox.exec(f"chmod +x {shlex.quote(container_solve)}", user="root")
+
+        agent_user = task.metadata.get("agent_user")
+        timeout = float(task.metadata.get("agent_timeout", 7200))
+
+        # Honor ``[solution].env`` from task.toml — same shape Harbor's
+        # OracleAgent reads via ``resolve_env_vars``.
+        solution_env = (task.metadata.get("solution", {}) or {}).get("env", {}) or {}
+        env_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in solution_env.items())
+        cmd = (env_prefix + " " if env_prefix else "") + container_solve
+
+        try:
+            output = sandbox.exec(cmd, timeout=timeout, user=agent_user)
+        except Exception as exc:
+            logger.exception("oracle solve.sh failed for task %s", task.id)
+            output = f"[oracle error] {type(exc).__name__}: {exc}"
+
+        step = Step(input=str(task.instruction), output=output)
+        trajectory = Trajectory(
+            uid=config.session_uid,
+            name=self.name,
+            task=task.id,
+            steps=[step],
+        )
+        return Episode(id=config.session_uid, task=task.id, trajectories=[trajectory])

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -15,6 +15,21 @@
       "module": "rllm.harnesses.claude_code",
       "function": "ClaudeCodeHarness",
       "description": "Run the Claude Code CLI inside the sandbox."
+    },
+    "opencode": {
+      "module": "rllm.harnesses.opencode",
+      "function": "OpenCodeHarness",
+      "description": "Run the opencode-ai CLI inside the sandbox."
+    },
+    "mini-swe-agent": {
+      "module": "rllm.harnesses.mini_swe_agent",
+      "function": "MiniSweAgentHarness",
+      "description": "Run mini-swe-agent inside the sandbox."
+    },
+    "oracle": {
+      "module": "rllm.harnesses.oracle",
+      "function": "OracleHarness",
+      "description": "Run the task's reference solution (solution/solve.sh) without an LLM. Smoke-test for verifier + image."
     }
   }
 }

--- a/rllm/sandbox/backends/docker.py
+++ b/rllm/sandbox/backends/docker.py
@@ -56,8 +56,22 @@ class DockerSandbox:
         stdout = (output[0] or b"").decode("utf-8", errors="replace")
         stderr = (output[1] or b"").decode("utf-8", errors="replace")
         if exit_code != 0:
-            logger.warning("Command failed in container %s: %s\nstderr: %s", self.name, command, stderr[:500])
-            raise RuntimeError(f"Command failed (exit {exit_code}) in container {self.name}: {command}\n{stderr[:500]}")
+            # Surface enough context to debug verifier failures inside the
+            # container — the full pytest/setup log can be megabytes; show
+            # the last ~8KB of each stream which is where exit-causing
+            # errors live.
+            tail_chars = 8000
+            stderr_tail = stderr[-tail_chars:] if len(stderr) > tail_chars else stderr
+            stdout_tail = stdout[-tail_chars:] if len(stdout) > tail_chars else stdout
+            logger.warning(
+                "Command failed (exit %d) in container %s: %s\nstdout (tail):\n%s\nstderr (tail):\n%s",
+                exit_code,
+                self.name,
+                command,
+                stdout_tail,
+                stderr_tail,
+            )
+            raise RuntimeError(f"Command failed (exit {exit_code}) in container {self.name}: {command}\nstderr (tail):\n{stderr_tail}\nstdout (tail):\n{stdout_tail}")
         return stdout
 
     def upload_file(self, local_path: str, remote_path: str) -> None:

--- a/rllm/sandbox/backends/docker.py
+++ b/rllm/sandbox/backends/docker.py
@@ -56,22 +56,24 @@ class DockerSandbox:
         stdout = (output[0] or b"").decode("utf-8", errors="replace")
         stderr = (output[1] or b"").decode("utf-8", errors="replace")
         if exit_code != 0:
-            # Surface enough context to debug verifier failures inside the
-            # container — the full pytest/setup log can be megabytes; show
-            # the last ~8KB of each stream which is where exit-causing
-            # errors live.
-            tail_chars = 8000
-            stderr_tail = stderr[-tail_chars:] if len(stderr) > tail_chars else stderr
-            stdout_tail = stdout[-tail_chars:] if len(stdout) > tail_chars else stdout
-            logger.warning(
+            # The raised message stays short — callers print it at WARNING
+            # for *every* failed verifier, and dumping kilobytes of pytest
+            # output for each agent that didn't solve a task spams the
+            # terminal. The full tail goes to ``logger.debug`` so it's
+            # available with ``--log-level=debug`` without polluting the
+            # default run.
+            short_tail = 600
+            err_tail = stderr[-short_tail:] if len(stderr) > short_tail else stderr
+            full_tail = 8000
+            logger.debug(
                 "Command failed (exit %d) in container %s: %s\nstdout (tail):\n%s\nstderr (tail):\n%s",
                 exit_code,
                 self.name,
                 command,
-                stdout_tail,
-                stderr_tail,
+                stdout[-full_tail:] if len(stdout) > full_tail else stdout,
+                stderr[-full_tail:] if len(stderr) > full_tail else stderr,
             )
-            raise RuntimeError(f"Command failed (exit {exit_code}) in container {self.name}: {command}\nstderr (tail):\n{stderr_tail}\nstdout (tail):\n{stdout_tail}")
+            raise RuntimeError(f"Command failed (exit {exit_code}) in container {self.name}: {command}\nstderr (tail):\n{err_tail}")
         return stdout
 
     def upload_file(self, local_path: str, remote_path: str) -> None:

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -183,7 +183,15 @@ def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
         return base
     merged = {**base, **raw}
     env_section = raw.get("environment", {}) or {}
-    merged["workdir"] = env_section.get("workdir", merged.get("workdir", "/workspace"))
+    # Only set workdir when the task explicitly declares one. Otherwise
+    # downstream (``_setup_task_environment`` / ``ShellScriptEvaluator``
+    # / ``BaseCliHarness._cd_prefix``) leaves cwd alone and the
+    # Dockerfile's WORKDIR wins — required for harbor task families
+    # like swesmith whose base image expects ``/testbed`` and whose
+    # test.sh + pytest break when forced into ``/workspace``.
+    declared_workdir = env_section.get("workdir") or merged.get("workdir")
+    if declared_workdir is not None:
+        merged["workdir"] = declared_workdir
     merged["env_vars"] = env_section.get("env", {}) or merged.get("env_vars", {}) or {}
     merged["agent_user"] = raw.get("agent", {}).get("user", merged.get("agent_user"))
     merged["verifier_user"] = raw.get("verifier", {}).get("user", merged.get("verifier_user"))
@@ -436,7 +444,11 @@ def _load_task_from_dir(
     # Lift commonly-used config into top-level metadata for the Runner
     metadata: dict = dict(raw)
     env_section = raw.get("environment", {}) or {}
-    metadata["workdir"] = env_section.get("workdir", "/workspace")
+    # Only set workdir when explicitly declared — see _merge_task_toml_metadata
+    # for the same rationale (Dockerfile WORKDIR vs forced /workspace).
+    declared_workdir = env_section.get("workdir")
+    if declared_workdir is not None:
+        metadata["workdir"] = declared_workdir
     metadata["env_vars"] = env_section.get("env", {}) or {}
     metadata["agent_user"] = raw.get("agent", {}).get("user")
     metadata["verifier_user"] = raw.get("verifier", {}).get("user")

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -126,12 +126,28 @@ def _load_data_dataset(
         else:
             instruction = text
         task_metadata = _build_metadata(row, metadata_fields)
+
+        # Harbor-sourced rows carry a ``task_path`` pointing at the real
+        # on-disk task dir (under ~/.cache/harbor/tasks/<digest>/<name>/).
+        # Root the Task there so ``task.task_dir`` resolves to the dir
+        # that actually contains ``solution/``, ``environment/``,
+        # ``tests/``, and the per-task ``task.toml``. Without this,
+        # harnesses like oracle (which reads ``solution/solve.sh``) and
+        # the auto-detected ``tests/test.sh`` verifier both look at the
+        # rllm dataset root and find nothing.
+        row_task_path = row.get("task_path")
+        if row_task_path:
+            task_dataset_dir = Path(row_task_path)
+            task_metadata = _merge_task_toml_metadata(task_dataset_dir, task_metadata)
+        else:
+            task_dataset_dir = path
+
         tasks.append(
             Task(
                 id=str(row.get("id", idx)),
                 instruction=instruction,
                 metadata=task_metadata,
-                dataset_dir=path,
+                dataset_dir=task_dataset_dir,
                 sub_dir=None,
             )
         )
@@ -140,11 +156,42 @@ def _load_data_dataset(
         tasks=tasks,
         name=config.name,
         split=config.split,
-        harness_name=harness_name or config.default_agent or "simple",
+        harness_name=harness_name or config.default_agent or _default_harness_for(tasks),
         sandbox_backend=sandbox_backend,
         description=config.description,
         category=category or "custom",
     )
+
+
+def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
+    """Merge per-task ``task.toml`` metadata into *base*.
+
+    Same lifting logic as :func:`_load_task_from_dir` (workdir,
+    env_vars, agent_user, verifier_user, verifier_timeout,
+    agent_timeout, setup_commands, plus the full toml under its
+    section keys), but additive on top of an existing metadata dict.
+    Used by the row-with-task_path path so harbor-sourced rows pick
+    up per-task config without losing fields the materialiser put on
+    the row.
+    """
+    config_path = task_dir / "task.toml"
+    if not config_path.exists():
+        return base
+    try:
+        raw = tomllib.loads(config_path.read_text())
+    except Exception:
+        return base
+    merged = {**base, **raw}
+    env_section = raw.get("environment", {}) or {}
+    merged["workdir"] = env_section.get("workdir", merged.get("workdir", "/workspace"))
+    merged["env_vars"] = env_section.get("env", {}) or merged.get("env_vars", {}) or {}
+    merged["agent_user"] = raw.get("agent", {}).get("user", merged.get("agent_user"))
+    merged["verifier_user"] = raw.get("verifier", {}).get("user", merged.get("verifier_user"))
+    merged["verifier_timeout"] = raw.get("verifier", {}).get("timeout_sec", merged.get("verifier_timeout", 600.0))
+    merged["agent_timeout"] = raw.get("agent", {}).get("timeout_sec", merged.get("agent_timeout", 600.0))
+    rllm_section = raw.get("rllm", {}) or {}
+    merged["setup_commands"] = rllm_section.get("setup_commands", merged.get("setup_commands", [])) or []
+    return merged
 
 
 def _resolve_data_file(path: Path, config: DatasetConfig) -> Path:
@@ -283,6 +330,22 @@ def _build_metadata(row: dict, metadata_fields: list[str] | None) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _default_harness_for(tasks: list[Task]) -> str:
+    """Pick a sane default harness given the loaded tasks.
+
+    A task is "sandbox-style" when it (or its dataset dir) ships an
+    ``environment/`` directory — i.e. it expects a container plus a shell
+    verifier. Those tasks need a harness that can act inside the sandbox;
+    ``react`` (one-shot LLM call, no sandbox) would silently produce empty
+    output and let the verifier score the missing submission. Default to
+    ``opencode`` instead.
+    """
+    for task in tasks:
+        if (task.task_dir / "environment").is_dir() or (task.dataset_dir / "environment").is_dir():
+            return "opencode"
+    return "react"
+
+
 def _load_sandbox_dataset(
     path: Path,
     config: DatasetConfig,
@@ -302,7 +365,7 @@ def _load_sandbox_dataset(
         tasks=tasks,
         name=config.name,
         split=config.split,
-        harness_name=harness_name or config.default_agent or "react",
+        harness_name=harness_name or config.default_agent or _default_harness_for(tasks),
         sandbox_backend=sandbox_backend or config.default_sandbox,
         description=config.description,
         category="agentic",
@@ -320,7 +383,7 @@ def _load_single_task(
         tasks=[task],
         name=task.id,
         split="test",
-        harness_name=harness_name or "react",
+        harness_name=harness_name or _default_harness_for([task]),
         sandbox_backend=sandbox_backend,
         description=task.metadata.get("task", {}).get("description", "") if isinstance(task.metadata.get("task"), dict) else "",
         category="agentic",
@@ -341,7 +404,7 @@ def _load_auto_discover(
         tasks=tasks,
         name=path.name,
         split="test",
-        harness_name=harness_name or "react",
+        harness_name=harness_name or _default_harness_for(tasks),
         sandbox_backend=sandbox_backend,
         description=f"Auto-discovered tasks from {path.name}",
         category="agentic",

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -1,0 +1,395 @@
+"""Unit tests for the BaseCliHarness family.
+
+A FakeSandbox captures every ``exec`` call so we can assert on the
+shape of install scripts, env var construction, and config-file
+contents without needing Docker.
+
+These harnesses return ``None`` from ``run()`` — the gateway captures
+LLM calls and the engine builds the trajectory during enrichment. The
+tests therefore assert on side-effects (sandbox calls, config files,
+invocation strings), not on returned Steps/Trajectories.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
+from rllm.harnesses.opencode import OpenCodeHarness
+from rllm.types import AgentConfig, Task
+
+
+@dataclass
+class _ExecCall:
+    command: str
+    user: str | None
+    timeout: float | None
+
+
+@dataclass
+class FakeSandbox:
+    """Captures exec() calls and returns canned stdout."""
+
+    stdout: str = "OK"
+    calls: list[_ExecCall] = field(default_factory=list)
+    fail_on_substring: str | None = None
+
+    def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
+        if self.fail_on_substring and self.fail_on_substring in command:
+            raise RuntimeError(f"sandbox exec failed: {self.fail_on_substring!r}")
+        self.calls.append(_ExecCall(command=command, user=user, timeout=timeout))
+        return self.stdout
+
+    def upload_file(self, *_args, **_kwargs) -> None:  # pragma: no cover - unused
+        pass
+
+    def upload_dir(self, *_args, **_kwargs) -> None:  # pragma: no cover - unused
+        pass
+
+    def close(self) -> None:  # pragma: no cover - unused
+        pass
+
+
+def _make_task(workdir: str | None = None) -> Task:
+    metadata = {"workdir": workdir} if workdir else {}
+    return Task(id="t-1", instruction="fix the bug", metadata=metadata)
+
+
+def _make_config(base_url: str = "http://gw:8000/sessions/eval-0/v1", model: str = "openai/gpt-4o") -> AgentConfig:
+    return AgentConfig(base_url=base_url, model=model, session_uid="eval-0")
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: install on sandbox-ready, run() returns None and execs the CLI
+# ---------------------------------------------------------------------------
+
+
+def test_on_sandbox_ready_runs_install_script_as_root():
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox()
+    h.set_sandbox(sandbox)
+    h.on_sandbox_ready({}, _make_config())
+
+    assert len(sandbox.calls) == 1
+    call = sandbox.calls[0]
+    assert call.user == "root"
+    assert "opencode-ai" in call.command
+
+
+def test_run_returns_none_so_gateway_drives_trajectory():
+    """Harnesses don't build Episodes — the gateway captures LLM calls and
+    the engine's enrichment pass populates Steps from those traces."""
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox(stdout="opencode said hi")
+    h.set_sandbox(sandbox)
+
+    result = h.run(_make_task(), _make_config())
+
+    assert result is None
+
+
+def test_run_execs_cli_against_agent_user_with_env_prefix():
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox()
+    h.set_sandbox(sandbox)
+
+    h.run(_make_task(), _make_config())
+
+    # Last call is the CLI invocation; preceding calls are write_configs.
+    invocation = sandbox.calls[-1]
+    # Invocation runs as the agent user (None on the default image).
+    assert invocation.user is None
+    # Env vars are prefixed onto the command, not exported by the harness.
+    assert "OPENAI_BASE_URL=" in invocation.command
+    assert "opencode --model=" in invocation.command
+
+
+def test_run_swallows_cli_failure_and_returns_none():
+    """A CLI failure should not raise — the gateway-captured traces (up to
+    the point of failure) plus the verifier still drive the reward."""
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox(fail_on_substring="opencode --model")
+    h.set_sandbox(sandbox)
+
+    result = h.run(_make_task(), _make_config())
+
+    assert result is None
+
+
+def test_invocation_omits_cd_when_no_workdir_in_metadata():
+    """No explicit workdir → don't override the Dockerfile's WORKDIR.
+
+    Hardcoding ``cd /workspace`` was breaking tasks (like harbor's
+    hello-world, WORKDIR=/app) because the agent created files in
+    /workspace but the verifier checked /app.
+    """
+    h = OpenCodeHarness()
+    cmd = h.build_invocation("hi", _make_task(), _make_config())
+    assert not cmd.startswith("cd ")
+    # Allow ". $HOME/.nvm/nvm.sh" but not a leading directory change.
+    assert "cd '/" not in cmd and not cmd.startswith("cd /")
+
+
+def test_invocation_includes_cd_when_workdir_set():
+    h = OpenCodeHarness()
+    cmd = h.build_invocation("hi", _make_task(workdir="/app"), _make_config())
+    # shlex.quote leaves simple paths unquoted; quotes only kick in for shell metachars.
+    assert cmd.startswith("cd /app && ")
+    cmd_with_space = h.build_invocation("hi", _make_task(workdir="/work space"), _make_config())
+    assert cmd_with_space.startswith("cd '/work space' && ")
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeHarness — env + config file
+# ---------------------------------------------------------------------------
+
+
+def test_heredoc_write_rejects_paths_with_shell_variables():
+    """$HOME inside _heredoc_write becomes a literal dir name due to single-quoting.
+    The helper must reject these so opencode-style ``$HOME/.config/...`` paths
+    don't silently land in the wrong location."""
+    from rllm.harnesses.cli_harness import BaseCliHarness
+
+    with pytest.raises(ValueError, match=r"\$VAR expansion"):
+        BaseCliHarness._heredoc_write("$HOME/.config/foo.json", "{}")
+
+
+def test_opencode_writes_config_via_unquoted_path_so_home_expands():
+    """opencode's config file goes under $HOME/.config/opencode/opencode.json,
+    so the write command must leave $HOME *unquoted* in the shell. Otherwise
+    the file lands in a literal ``$HOME`` dir under cwd and opencode never
+    finds it."""
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox()
+    h.set_sandbox(sandbox)
+    config = _make_config(model="gpt-5.4-mini")
+    env = h.build_env(_make_task(), config)
+
+    h.write_configs(_make_task(), config, env)
+
+    write_cmd = sandbox.calls[-1].command
+    # $HOME left unquoted so the shell expands it at exec time.
+    assert "mkdir -p $HOME/.config/opencode" in write_cmd
+    assert "cat > $HOME/.config/opencode/opencode.json" in write_cmd
+    # Defensive: path must not be single-quoted around $HOME.
+    assert "'$HOME" not in write_cmd
+
+
+def test_opencode_writes_config_with_custom_provider_to_bypass_models_dev():
+    """opencode validates known-provider model ids against its bundled models.dev
+    registry — ``gpt-5.4-mini`` (or any ``rllm setup`` custom name) raises
+    ProviderModelNotFoundError under provider="openai". The harness must
+    register the gateway as a custom provider via npm:@ai-sdk/openai-compatible
+    so arbitrary model ids work."""
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox()
+    h.set_sandbox(sandbox)
+    config = _make_config(base_url="http://gw:8000/sessions/eval-0/v1", model="openai/gpt-4o")
+    env = h.build_env(_make_task(), config)
+
+    h.write_configs(_make_task(), config, env)
+
+    written = sandbox.calls[-1].command
+    assert sandbox.calls[-1].user is None  # written as agent user
+    assert "opencode.json" in written
+    # Custom provider id, not the inferred "openai" — that's the whole point.
+    assert '"rllm-gateway"' in written
+    # npm package marks it as a generic OpenAI-shaped endpoint.
+    assert '"npm": "@ai-sdk/openai-compatible"' in written
+    # baseURL nested under provider.<name>.options.
+    assert '"baseURL": "http://gw:8000/sessions/eval-0/v1"' in written
+
+
+def test_opencode_invocation_uses_custom_provider_prefix():
+    """--model flag must carry the custom provider id, not the inferred openai/anthropic."""
+    h = OpenCodeHarness()
+    cmd = h.build_invocation(
+        instruction="hi",
+        task=_make_task(),
+        config=_make_config(model="gpt-5.4-mini"),
+    )
+    assert "--model=rllm-gateway/gpt-5.4-mini" in cmd
+
+
+def test_opencode_invocation_detaches_stdin():
+    """opencode blocks on its initial stdin read on Modal sandboxes — the
+    invocation must redirect stdin from /dev/null."""
+    h = OpenCodeHarness()
+    cmd = h.build_invocation("hi", _make_task(), _make_config())
+    assert "</dev/null" in cmd
+
+
+@pytest.mark.parametrize(
+    ("bare_model", "expected_provider", "expected_qualified"),
+    [
+        ("gpt-4o", "openai", "openai/gpt-4o"),
+        ("gpt-5.4-mini", "openai", "openai/gpt-5.4-mini"),
+        ("o1-preview", "openai", "openai/o1-preview"),
+        ("claude-opus-4-1", "anthropic", "anthropic/claude-opus-4-1"),
+        ("claude-haiku-4", "anthropic", "anthropic/claude-haiku-4"),
+        ("gemini-1.5-pro", "google", "google/gemini-1.5-pro"),
+        ("deepseek-coder", "deepseek", "deepseek/deepseek-coder"),
+        ("mistral-large", "mistral", "mistral/mistral-large"),
+        # Pre-qualified names round-trip unchanged.
+        ("openai/gpt-4o", "openai", "openai/gpt-4o"),
+        ("anthropic/claude-opus-4-1", "anthropic", "anthropic/claude-opus-4-1"),
+    ],
+)
+def test_provider_inference(bare_model: str, expected_provider: str, expected_qualified: str):
+    """rllm setup gives bare model names; opencode/mini-swe-agent require
+    provider/model. Harness must bridge that."""
+    h = OpenCodeHarness()
+    provider, _, qualified = h._split_provider(bare_model)
+    assert provider == expected_provider
+    assert qualified == expected_qualified
+
+
+def test_opencode_writes_provider_config_with_model_id_only():
+    """opencode.json registers the bare model id under the custom provider —
+    the inferred upstream provider (openai/anthropic) is informational and
+    used for env-var key selection, not for opencode routing."""
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox()
+    h.set_sandbox(sandbox)
+    config = _make_config(model="claude-opus-4-1")  # bare anthropic name
+    env = h.build_env(_make_task(), config)
+    h.write_configs(_make_task(), config, env)
+
+    written = sandbox.calls[-1].command
+    assert '"rllm-gateway"' in written
+    assert '"claude-opus-4-1"' in written  # model id registered under rllm-gateway
+
+
+# ---------------------------------------------------------------------------
+# MiniSweAgentHarness — provider key derivation, MSWEA_* env, dotenv
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_var"),
+    [
+        ("anthropic/claude-opus-4-1", "ANTHROPIC_API_KEY"),
+        ("claude-opus-4-1", "ANTHROPIC_API_KEY"),
+        ("openai/gpt-4o", "OPENAI_API_KEY"),
+        ("gpt-4o", "OPENAI_API_KEY"),
+        ("o1-preview", "OPENAI_API_KEY"),
+        ("deepseek/deepseek-coder", "DEEPSEEK_API_KEY"),
+        ("groq/llama-3", "GROQ_API_KEY"),
+        # Unknown → defaults to OPENAI_API_KEY.
+        ("totally-unknown", "OPENAI_API_KEY"),
+    ],
+)
+def test_mini_swe_agent_provider_key_var(model: str, expected_var: str):
+    h = MiniSweAgentHarness()
+    env = h.build_env(_make_task(), _make_config(model=model))
+    assert expected_var in env
+
+
+def test_mini_swe_agent_anthropic_base_url_strips_v1():
+    """Anthropic's litellm client appends ``/v1/messages`` itself, so
+    ``ANTHROPIC_BASE_URL`` must NOT end in ``/v1`` or requests double up
+    to ``/v1/v1/messages`` and Anthropic 404s."""
+    h = MiniSweAgentHarness()
+    env = h.build_env(_make_task(), _make_config(base_url="http://gw:8000/sessions/eval-0/v1"))
+    assert env["ANTHROPIC_BASE_URL"] == "http://gw:8000/sessions/eval-0"
+    assert env["OPENAI_BASE_URL"] == "http://gw:8000/sessions/eval-0/v1"
+
+
+def test_mini_swe_agent_writes_dotenv_at_home_path():
+    """v2 reads the dotenv on startup; the base URL must be in the file
+    (not just env) because v2 loads dotenv with override=True."""
+    h = MiniSweAgentHarness()
+    sandbox = FakeSandbox()
+    h.set_sandbox(sandbox)
+    config = _make_config(base_url="http://gw:8000/sessions/eval-0/v1", model="claude-opus-4-1")
+    env = h.build_env(_make_task(), config)
+
+    h.write_configs(_make_task(), config, env)
+
+    written = sandbox.calls[-1].command
+    assert "$HOME/.config/mini-swe-agent/.env" in written
+    assert "MSWEA_GLOBAL_MODEL=anthropic/claude-opus-4-1" in written
+    assert "OPENAI_API_BASE=http://gw:8000/sessions/eval-0/v1" in written
+    assert "ANTHROPIC_BASE_URL=http://gw:8000/sessions/eval-0" in written
+
+
+def test_mini_swe_agent_invocation_uses_qualified_model():
+    h = MiniSweAgentHarness()
+    cmd = h.build_invocation("hi", _make_task(), _make_config(model="gpt-4o"))
+    assert "--model=openai/gpt-4o" in cmd
+    assert "--yolo" in cmd
+    assert "--exit-immediately" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Container URL rewrite (docker → host.docker.internal)
+# ---------------------------------------------------------------------------
+
+
+def test_container_url_rewrites_loopback_for_docker_backend():
+    h = OpenCodeHarness()
+    h.sandbox_backend = "docker"
+    assert h._container_url("http://127.0.0.1:8000/v1") == "http://host.docker.internal:8000/v1"
+    assert h._container_url("http://localhost:9001/sessions/x/v1") == "http://host.docker.internal:9001/sessions/x/v1"
+
+
+def test_container_url_passthrough_for_non_docker_backends():
+    h = OpenCodeHarness()
+    h.sandbox_backend = "modal"
+    assert h._container_url("http://127.0.0.1:8000/v1") == "http://127.0.0.1:8000/v1"
+    h.sandbox_backend = "local"
+    assert h._container_url("http://localhost:9000/v1") == "http://localhost:9000/v1"
+
+
+# ---------------------------------------------------------------------------
+# Gateway auth: bearer token from config.metadata wins over env fallback
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_api_key_uses_metadata_token_when_present():
+    config = AgentConfig(
+        base_url="http://gw/v1",
+        model="gpt-4o",
+        session_uid="eval-0",
+        metadata={"gateway_auth_token": "tok-abc"},
+    )
+    from rllm.harnesses.cli_harness import BaseCliHarness
+
+    assert BaseCliHarness.gateway_api_key(config, "OPENAI_API_KEY") == "tok-abc"
+
+
+def test_gateway_api_key_falls_back_to_env_var(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real-user-key")
+    config = AgentConfig(base_url="http://gw/v1", model="gpt-4o", session_uid="eval-0")
+
+    from rllm.harnesses.cli_harness import BaseCliHarness
+
+    assert BaseCliHarness.gateway_api_key(config, "OPENAI_API_KEY") == "sk-real-user-key"
+
+
+def test_gateway_api_key_returns_placeholder_when_env_unset(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = AgentConfig(base_url="http://gw/v1", model="gpt-4o", session_uid="eval-0")
+
+    from rllm.harnesses.cli_harness import BaseCliHarness
+
+    assert BaseCliHarness.gateway_api_key(config, "OPENAI_API_KEY") == "sk-rllm-gateway"
+
+
+def test_opencode_uses_gateway_token_in_config_when_metadata_set():
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox()
+    h.set_sandbox(sandbox)
+    config = AgentConfig(
+        base_url="http://gw/sessions/eval-0/v1",
+        model="gpt-4o",
+        session_uid="eval-0",
+        metadata={"gateway_auth_token": "tok-xyz"},
+    )
+    env = h.build_env(_make_task(), config)
+    h.write_configs(_make_task(), config, env)
+
+    written = sandbox.calls[-1].command
+    assert '"apiKey": "tok-xyz"' in written

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -90,7 +90,11 @@ def test_run_returns_none_so_gateway_drives_trajectory():
     assert result is None
 
 
-def test_run_execs_cli_against_agent_user_with_env_prefix():
+def test_run_execs_cli_against_agent_user_with_env_exported():
+    """Env vars must be ``export``ed (not inline ``K=V cmd`` prefix), because
+    invocations like ``cd /work && claude ...`` are compound commands and
+    inline assignments only bind to the first command — the auth env would
+    be set for ``cd`` and lost before the CLI runs."""
     h = OpenCodeHarness()
     sandbox = FakeSandbox()
     h.set_sandbox(sandbox)
@@ -101,8 +105,7 @@ def test_run_execs_cli_against_agent_user_with_env_prefix():
     invocation = sandbox.calls[-1]
     # Invocation runs as the agent user (None on the default image).
     assert invocation.user is None
-    # Env vars are prefixed onto the command, not exported by the harness.
-    assert "OPENAI_BASE_URL=" in invocation.command
+    assert "export OPENAI_BASE_URL=" in invocation.command
     assert "opencode --model=" in invocation.command
 
 


### PR DESCRIPTION
## Summary

Adds three rLLM-native sandboxed harnesses (`opencode`, `mini-swe-agent`, `oracle`) on top of the AgentFlowEngine + gateway contract. `run()` returns `None`; the gateway captures every LLM call into the engine's enrichment pass, so harnesses don't manually build Steps/Trajectories anymore. `ClaudeCodeHarness` is updated to the same shape.

Along the way: a per-task state leak in `AgentFlowEngine` (parallel sandboxed tasks were clobbering each other's sandboxes), the loader plumbing needed for `rllm eval harbor:swebench-verified` and `rllm eval harbor:swesmith` to run end-to-end through the rllm-native runtime, several install/auth/env bugs surfaced when actually running the harnesses against real harbor task families, and an output-volume fix for failing verifiers.

## What's new

### Harnesses (`rllm/harnesses/`)

- **`cli_harness.py`** — `BaseCliHarness` factors install / build_env / write_configs / build_invocation. Helpers cover provider inference (bare → `provider/model`), bearer-token-vs-env-var auth, host loopback rewrite (`127.0.0.1` → `host.docker.internal`), `$HOME`-aware heredoc safety, conditional `cd <workdir>` only when the task explicitly sets one, and `export` (not inline `K=V cmd`) for env vars (see fix #3 below).
- **`opencode.py`** — registers the gateway under a custom provider id (`rllm-gateway` via `npm: @ai-sdk/openai-compatible`) so arbitrary model ids from `rllm setup` bypass opencode's `models.dev` validation. The `opencode.json` write leaves `$HOME` unquoted in the shell so it expands.
- **`mini_swe_agent.py`** — writes `~/.config/mini-swe-agent/.env` (v2's wizard ignores `MSWEA_CONFIGURED`); strips `/v1` from `ANTHROPIC_BASE_URL` because litellm appends `/v1/messages` itself.
- **`oracle.py`** — uploads `solution/` and runs `solve.sh`. No LLM calls → no gateway traces, so it returns an Episode with the solve.sh stdout for debugging. Smoke-tests verifier + image wiring.
- **`claude_code.py`** — refactored to subclass `BaseCliHarness` (gets all the helpers for free), `run() → None`, reads `gateway_auth_token` from `config.metadata`.
- **`rllm/registry/agents.json`** — adds the three new entries.

### Loader / eval-runtime fixes that make harbor benchmarks work natively

- **`rllm/tasks/loader.py:_default_harness_for(tasks)`** — picks `opencode` for any benchmark whose tasks ship an `environment/` dir. Wired into all three load paths.
- **`_load_data_dataset`** now honors a row's `task_path`: harbor-sourced JSONL rows root each Task at the actual harbor task dir (under `~/.cache/harbor/tasks/...`) instead of the materialised JSONL root, and `_merge_task_toml_metadata` lifts the per-task `task.toml` (workdir, `agent_user`, `verifier_timeout`, `[solution]`, `setup_commands`, …) into metadata. Without this, oracle couldn't find `solution/solve.sh` and the auto-detected `tests/test.sh` verifier resolved to the wrong path.
- **`rllm/cli/eval.py`** skips the catalog's `harbor_reward_fn` when the agent isn't an explicit `harbor:`-prefixed runtime. That fn reads `episode.artifacts['harbor_reward']`, only populated by `HarborRuntime`; for the rllm-native path it would always score zero. Falls through to per-task verifier resolution.
- **Workdir resolution respects Dockerfile `WORKDIR`** (`loader.py` + `_resolution.py:_setup_task_environment` + `script_evaluator.py`). Previously the loader stamped `/workspace` into metadata as a default when `task.toml` didn't declare a `[environment].workdir`, and `ShellScriptEvaluator` then ran `cd /workspace && /tests/test.sh`. For swesmith (whose base image declares `WORKDIR=/testbed` and whose test.sh runs `git checkout` and `pytest` against cwd), this overrode the image WORKDIR — pytest collected 0 items, the ctrf grader returned `resolved=false`, oracle scored 0/3. Now: workdir stays unset when not declared; downstream skips `cd` / `mkdir` / `chown` and the Dockerfile WORKDIR wins. swesmith oracle now scores 3/3.

### Concurrency fix

`AgentFlowEngine` reused `self.agent_flow` for every parallel task. `EvalHooks.setup` mutated `agent_flow._sandbox` via `set_sandbox`, so with `--max-examples 3` only the last task's sandbox stuck — every parallel `run()` uploaded into the same sandbox while the other verifiers ran against unpatched code. Symptom: oracle reported 1/3 instead of 3/3 with all three patches landing in the same container.

Fix: `EvalHooks` now calls `SandboxedAgentFlow.create_instance()` to get a fresh per-task shallow copy, sets the sandbox on the copy, and surfaces it via a new `TaskContext.agent_flow` field. The engine prefers `ctx.agent_flow` over `self.agent_flow` when set. Non-sandboxed flows (stateless) keep the shared instance.

### Three real harness bugs surfaced by `rllm eval harbor:swebench-verified --agent claude-code`

1. **apt-based Node install fails on swebench testbeds.** Ubuntu jammy in the swebench base images has expired GPG signatures; `apt-get update -qq && apt-get install nodejs npm` returns 0 with only warnings, `-qq` masks the real failure, and the script reaches `npm install -g` with no npm on PATH (exit 127). Fix: switch claude-code to the same nvm-bootstrap pattern opencode uses; only fall back to apt when curl is also missing. Same gating added to opencode/mini-swe-agent so they don't run apt unconditionally either.
2. **claude-code's non-interactive auth gate.** `claude -p` checks for OAuth login even with `ANTHROPIC_API_KEY` set; without a prior interactive `/login`, every invocation prints `Not logged in · Please run /login` and exits 0 with no error to surface, so the gateway sees zero traces and the eval silently scores zero. Fix: `claude --bare` — the CLI's own help describes it as "skip OAuth and keychain reads, Anthropic auth is strictly ANTHROPIC_API_KEY".
3. **Env vars weren't reaching the CLI in the first place.** `_exec_agent` was prefixing commands with inline `K=V K=V cmd` assignments. For compound invocations like `cd /workspace && . nvm.sh; claude ...`, bash binds inline assignments to the *first* command only, so `ANTHROPIC_API_KEY` was set during `cd` and gone before `claude` ran. opencode and mini-swe-agent masked this because they also write env into config files; claude-code reads only from process env, so the bug bit there. Fix: `export K=V; ...` so the assignments propagate.

### Sandbox debugging

`DockerSandbox.exec` was raising with the *first* 500 chars of stderr, burying multi-megabyte verifier-script exit-causing errors behind their setup-phase output. Now logs and raises with the *last* 8KB of both stdout and stderr — without this, the upstream SWE-bench `tests/config.json` data-quality issue I traced (see Test plan below) and the swesmith workdir issue would have been opaque.

Verifier-failure logs demoted from WARNING to DEBUG. Verifier exit != 0 is the *expected* outcome whenever an agent doesn't solve the task — emitting the full stdout/stderr at WARNING level for every unsolved benchmark example dumped thousands of lines of pytest output to the terminal. The reward (read from `reward.txt`) carries the signal; full output is opt-in via `--log-level=debug`.

## Test plan

- [x] `python -m pytest tests/eval/ tests/sandbox/ tests/harnesses/ tests/data/` — 466 passing
- [x] `python -m pytest tests/harnesses/` — 39 new tests, all passing
- [x] Broader suites (`tests/eval/ tests/sandbox/ tests/engine/ tests/cli/`) pass modulo 5 pre-existing failures on `main` unrelated to this PR (`test_remote_runtime` import error, `verl` module-not-package issue, three `tinker_engine` errors with the same root cause)
- [x] `rllm eval harbor:swebench-verified --agent oracle --task-indices 1` → **100.0% (1/1)** (sympy__sympy-11618)
- [x] `rllm eval harbor:swebench-verified --agent oracle --max-examples 3` → **66.7% (2/3)**:
  - idx 0 astropy__astropy-7606 → 0.0 (upstream SWE-bench data-quality issue: phantom `test_compose_roundtrip[]` entry in `tests/config.json`'s `PASS_TO_PASS` — `test_compose_roundtrip` is `@pytest.mark.parametrize`'d so pytest emits names like `test_compose_roundtrip[%]`, no test with literal empty `[]`. Reproducible under `HarborRuntime` too.)
  - idx 1 sympy__sympy-11618 → 1.0 ✓ (patches `sympy/geometry/point.py`)
  - idx 2 sympy__sympy-16792 → 1.0 ✓ (patches `sympy/utilities/codegen.py`)
  - Per-episode inspection confirms each `solve.sh` patched the correct file in its own sandbox — concurrency fix verified.
- [x] `rllm eval harbor:swesmith --agent oracle --task-indices 6,7,8 --model gpt-5.4` → **100.0% (3/3)** in 40s — workdir-resolution fix verified.
- [x] `rllm eval harbor:swebench-verified --agent claude-code --task-indices 4` → claude installs, runs, makes a real API call (downstream gateway → LiteLLM forwarding for Anthropic-format requests is a separate concern, not part of this PR).

## Out of scope (deferred follow-ups)

- **Image caching for the install phase** — the `DockerSandbox.commit` + `pre_setup` flow originally in PR #557. Each task currently pays the cold-install cost (~2 min for opencode/claude-code on first hit per base image). Caching cuts this to ~0 for repeat tasks on the same base image; for SWE-bench Verified (~12 unique base images across ~500 tasks) this is ~16 hours saved on a full-suite run. Out of scope for this PR; planned as a small follow-up commit.
- **Anthropic-format request routing through the gateway** — claude-code (and any Anthropic-native client) sends `/v1/messages` requests; the LiteLLM upstream handles `/v1/chat/completions`. Resolving this is gateway-side, not harness-side.
- **opencode-ai HTTP client hang on long streaming responses** — observed during the SWE-bench investigation: after ~9 tool calls accumulating large source files into the prompt, opencode's HTTP client doesn't recover when the gateway closes the connection during a long upstream response (sockets sit in `CLOSE_WAIT` forever). This is opencode-ai-side; either needs an upstream feature request or a streaming proxy on the gateway.
- **`--runtime {rllm|harbor}` flag** — not added; the routing decision is implicit in the `harbor:` agent prefix.
- **`harbor==0.5.0` bump and `HarborRuntime`-side fixes** from PR #557 — left for a separate PR, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)