### PR TITLE
fix(verl): validate float conversion logic in UnifiedTrainer

### DIFF
--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -732,7 +732,11 @@ class UnifiedTrainer:
 
             for episode, data_source in zip(val_episodes, data_sources, strict=True):
                 for key, value in episode.metrics.items():
-                    workflow_metrics_by_source[data_source][key].append(float(value))
+                    # episode.metrics can contain non-numeric values -- skip in the workflow metrics.
+                    try:
+                        workflow_metrics_by_source[data_source][key].append(float(value))
+                    except (TypeError, ValueError):
+                        continue
 
             for key, value in reward_metrics.items():
                 val_metrics[f"val/{key}"].append(value)


### PR DESCRIPTION
## Summary

When running `cookbooks/math`'s Verl example, the `agent_flow_engine.py` now populates `episode.metrics` with `EvalOutput.metadata` -- which can contain string or other non-numeric values. This would cause the validation step in the `UnifiedTrainer` to fail. This fix should be very obvious.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- Add a try-catch handling of the passing from `episode.metrics` to the `workflow_metrics` (we require conversion to float here since we will aggregate the metrics across episodes).

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- The script now runs

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
