### PR TITLE
fix(verl): release GPU memory on Verl backend interrupts

### DIFF
--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -320,10 +320,13 @@ class UnifiedTrainer:
         # we start from step (1 + original start batch index)
         trainer_state.global_step += 1
 
-        # Run the training loop
-        await self._fit_async(trainer_state)
-
-        await self.backend.on_train_end(trainer_state)
+        try:
+            await self._fit_async(trainer_state)
+        finally:
+            try:
+                await self.backend.on_train_end(trainer_state)
+            except Exception:
+                logger.exception(f"{self.backend.__class__.__name__}.on_train_end() failed during fit_async() cleanup")
 
     async def _fit_async(self, trainer_state: TrainerState) -> None:
         """Dispatch to sync or concurrent training based on config."""

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -618,8 +618,17 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             _send_actor_update(sub_batch, loss_name)
 
     def shutdown(self) -> None:
-        """Placeholder, just use the BackendProtocol's default shutdown method."""
-        pass
+        """Free GPU memory held by the rollout replicas.
+
+        Without this, a crash mid-training (or anywhere ``on_train_end``
+        does not get to run) leaves the vLLM replicas awake on every GPU,
+        holding tens of GB each until the Ray actors are torn down.
+        """
+        try:
+            if self.checkpoint_manager is not None:
+                self.checkpoint_manager.sleep_replicas()
+        except Exception:
+            logger.exception("VerlBackend.shutdown: sleep_replicas failed")
 
     # =========================================================================
     # Async hook methods - leverage RayPPOTrainer utilities where possible

--- a/rllm/experimental/verl/verl_launcher.py
+++ b/rllm/experimental/verl/verl_launcher.py
@@ -113,11 +113,13 @@ class VerlTrainerLauncher(TrainerLauncher):
             self.config.data.val_files = val_dataset.get_verl_data_path()
 
     def train(self):
+        own_ray = False
         if not ray.is_initialized():
             from rllm.trainer.ray_init_utils import get_ray_init_settings
 
             ray_init_settings = get_ray_init_settings(self.config)
             ray.init(runtime_env=get_ppo_ray_runtime_env(), **ray_init_settings)
+            own_ray = True
 
         # Capture Hydra CLI overrides while we're still in the Hydra-decorated
         # process; the Ray actor below cannot read HydraConfig itself.
@@ -128,15 +130,22 @@ class VerlTrainerLauncher(TrainerLauncher):
         except (ValueError, AttributeError, ImportError):
             hydra_overrides = []
 
-        runner = VerlTaskRunner.remote()  # type: ignore
+        try:
+            runner = VerlTaskRunner.remote()  # type: ignore
 
-        ray.get(
-            runner.run.remote(
-                config=self.config,
-                workflow_class=self.workflow_class,
-                workflow_args=self.workflow_args,
-                store=self.store,
-                hydra_overrides=hydra_overrides,
-                **self.kwargs,
+            ray.get(
+                runner.run.remote(
+                    config=self.config,
+                    workflow_class=self.workflow_class,
+                    workflow_args=self.workflow_args,
+                    store=self.store,
+                    hydra_overrides=hydra_overrides,
+                    **self.kwargs,
+                )
             )
-        )
+        finally:
+            if own_ray:
+                try:
+                    ray.shutdown()
+                except Exception:
+                    logger.exception("ray.shutdown during launcher cleanup failed")


### PR DESCRIPTION
## Summary

A crashed or Ctrl-C'd verl run leaves vLLM rollout replicas awake on every GPU, holding tens of GB each, plus orphaned `AsyncvLLMServer` Ray actors with their mp-spawn vLLM worker subprocesses. Root cause: `VerlBackend.shutdown()` was a placeholder, so the launcher's `try/finally` calling `trainer.shutdown()` did nothing for verl-specific resources, and Ray was never explicitly torn down. This PR adds three small cleanup hooks so an interrupted run actually releases its GPU memory.

## Type of change

- [x] Fix

## What changed

- `rllm/experimental/verl/verl_backend.py` — `VerlBackend.shutdown()` now calls `checkpoint_manager.sleep_replicas()` so GPU memory is dropped on every exit path, not just clean training completion. Errors are logged and swallowed so shutdown can't raise.
- `rllm/experimental/unified_trainer.py` — `UnifiedTrainer.fit_async` wraps the training loop in `try/finally` so `backend.on_train_end` runs after a mid-loop crash. The `val_only` and pre-training-validation paths intentionally bypass `on_train_end` to match prior behavior (avoids surprising tinker checkpoint saves on val-only or validation-error paths).
- `rllm/experimental/verl/verl_launcher.py` — `VerlTrainerLauncher.train` now tracks whether it created the Ray cluster and calls `ray.shutdown()` in a `finally` block if so, reaping `AsyncvLLMServer` actors and their vLLM mp child workers together. If Ray was already running on entry, it's left alone.

## Validation

- [x] `pre-commit run --all-files` (ruff + ruff-format)
- [x] Manual validation performed
- [ ] Targeted tests: not run

Validation details:
- Verified the chain end-to-end on a 4×H100 host with Qwen3-0.6B / math500: full val (math500 mean 0.597, accuracy 59.8%, 86s) followed by step 1 (reward 0.43, grad_norm 0.28, throughput 2290 tok/s, update_weights 1.4s) — confirms the changes don't regress the happy path. Crash-path coverage relies on `sleep_replicas` being idempotent (it is) and `ray.shutdown()` being a no-op when we don't own the cluster.

## Breaking changes / migration notes

- `UnifiedTrainer.fit_async` now calls `backend.on_train_end` from a `finally` block when training raises mid-loop. For `VerlBackend` this is a no-op (default protocol method). `TinkerBackend.on_train_end` saves a final checkpoint — that now runs on crash too. We kept the `val_only` and pre-training-validation paths the same as before (they still skip `on_train_end`) to avoid the more surprising behavior change of saving a checkpoint after a `val_only` run or after validation itself raised.

## Docs / examples

- [x] Not needed

## Related issues / PRs

- Stacked-on-top draft (ZMQ-jobid IPC backport, separate design discussion): coming as a follow-up PR.
