### PR TITLE
feat(verl): patch zmq IPC id to depend on job id (volcengine/verl#6246)

### DIFF
--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -320,10 +320,13 @@ class UnifiedTrainer:
         # we start from step (1 + original start batch index)
         trainer_state.global_step += 1
 
-        # Run the training loop
-        await self._fit_async(trainer_state)
-
-        await self.backend.on_train_end(trainer_state)
+        try:
+            await self._fit_async(trainer_state)
+        finally:
+            try:
+                await self.backend.on_train_end(trainer_state)
+            except Exception:
+                logger.exception(f"{self.backend.__class__.__name__}.on_train_end() failed during fit_async() cleanup")
 
     async def _fit_async(self, trainer_state: TrainerState) -> None:
         """Dispatch to sync or concurrent training based on config."""

--- a/rllm/experimental/verl/_vllm_zmq_extension.py
+++ b/rllm/experimental/verl/_vllm_zmq_extension.py
@@ -1,0 +1,39 @@
+"""vLLM colocate worker extension that overrides the ZMQ IPC path.
+
+Backports volcengine/verl#6246 for verl 0.7.1 (our pin), which keys the
+weight-transfer IPC socket on the GPU UUID alone and so collides whenever
+two verl jobs land on the same physical GPU. The PR adds the Ray job id
+to the path; we mirror that here.
+
+This subclass lives in its own module — NOT inlined into ``patch.py`` —
+for a load-bearing reason. ``patch.py:apply_all_verl_patches`` runs as
+the Ray ``runtime_env.worker_process_setup_hook``, BEFORE Ray sets the
+worker's ``CUDA_VISIBLE_DEVICES``. Importing
+``verl.workers.rollout.vllm_rollout.utils`` to derive a subclass at hook
+time pulls in vLLM internals, which call ``torch.cuda.is_initialized()``
+and pin every rank to GPU 0 — surfaces later as
+``ncclInvalidUsage: Duplicate GPU detected: rank 0 and rank 1 both on
+CUDA device 29000`` during FSDP init. Keeping the import isolated here,
+and only resolving the FQN inside the vLLM mp-spawn worker via
+``resolve_obj_by_qualname`` (after Ray has set CUDA_VISIBLE_DEVICES),
+sidesteps that.
+"""
+
+from __future__ import annotations
+
+import os
+
+from verl.workers.rollout.vllm_rollout.utils import (
+    get_device_uuid,
+    vLLMColocateWorkerExtension,
+)
+
+
+class RLLMColocateWorkerExtension(vLLMColocateWorkerExtension):
+    """``vLLMColocateWorkerExtension`` with Ray-job-id-aware IPC path."""
+
+    def _get_zmq_handle(self) -> str:
+        if not hasattr(self, "device_uuid") or not self.device_uuid:
+            self.device_uuid = get_device_uuid(self.device.index)
+        job_id = os.environ.get("VERL_RAY_JOB_ID", "0")
+        return f"ipc:///tmp/rl-colocate-zmq-{job_id}-{self.device_uuid}.sock"

--- a/rllm/experimental/verl/patch.py
+++ b/rllm/experimental/verl/patch.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 _VERL_DYNAMIC_BATCH_PATCHED = False
 _VERL_QWEN3_VL_DUMMY_INPLACE_PATCHED = False
 _VERL_TENSORDICT_JAGGED_PATCHED = False
+_VERL_ZMQ_JOBID_PATCHED = False
 
 
 # ---------------------------------------------------------------------------
@@ -261,10 +262,138 @@ def patch_verl_tensordict_jagged_layout() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Verl colocated weight-transfer IPC path: include Ray job id (backport PR #6246)
+# ---------------------------------------------------------------------------
+
+
+def patch_verl_zmq_jobid_path() -> None:
+    """Backport `volcengine/verl#6246` for the colocated weight-transfer IPC path.
+
+    Verl 0.7.1 (our pin) keys the ZMQ IPC socket on the GPU UUID alone:
+    ``/tmp/rl-colocate-zmq-<uuid>.sock``. Two independent verl jobs on the
+    same physical GPU — same user across runs OR different users on a
+    multi-tenant host — both bind() the same path; the second fails with
+    ``zmq.error.ZMQError: Address already in use`` on the first
+    ``update_weights`` call. On a host with sticky-bit ``/tmp``, a stale
+    socket left by another user trips the same error indefinitely because
+    libzmq's bind-time ``unlink()`` returns ``EACCES``.
+
+    PR #6246 (merged on verl main; not in any tagged release as of verl
+    0.7.1) prepends ``ray.get_runtime_context().get_job_id()`` to the path
+    on both the sender (``ServerAdapter`` in the Ray actor) and the
+    receiver (``vLLMColocateWorkerExtension._get_zmq_handle`` in the vLLM
+    mp-spawn worker subprocess), bridged by the ``VERL_RAY_JOB_ID`` env var.
+
+    vLLM in a Ray actor forces multiprocessing 'spawn'
+    (``vllm.utils.system_utils._maybe_force_spawn``), so a Python-level
+    monkey-patch of ``vLLMColocateWorkerExtension._get_zmq_handle`` in
+    the Ray actor never reaches the receiver — fresh interpreter, no
+    inherited module state. Instead, we redirect vLLM to import a
+    different class entirely: RLLMColocateWorkerExtension.
+
+    The redirect itself is done by patching ``AsyncEngineArgs.create_engine_config``
+    to swap ``self.worker_extension_cls`` just before ``parallel_config`` is built.
+    """
+    global _VERL_ZMQ_JOBID_PATCHED
+    if _VERL_ZMQ_JOBID_PATCHED:
+        return
+
+    # We MUST NOT import the verl rollout submodules here. Importing
+    # ``verl.workers.rollout.vllm_rollout`` triggers the package's
+    # ``__init__.py`` which loads vLLM internals, and vLLM platform init
+    # calls into CUDA (current_platform.get_device_uuid etc.) — that pins
+    # every Ray worker to GPU 0 because this function runs as
+    # ``runtime_env.worker_process_setup_hook`` BEFORE Ray sets the
+    # worker's CUDA_VISIBLE_DEVICES. The downstream symptom is FSDP init
+    # failing with "ncclInvalidUsage: Duplicate GPU detected".
+    #
+    # Defer patch application via a ``builtins.__import__`` wrapper that
+    # fires when the user actually imports the target modules — which
+    # happens after Ray has set CUDA_VISIBLE_DEVICES. Each patch is
+    # independent: the sender's actor process may never import the bridge
+    # module and vice versa, so we apply each one as soon as ITS own
+    # target class appears, using a per-class marker attribute to avoid
+    # re-wrapping. The wrapper uninstalls itself once all three classes
+    # in this process have been patched.
+    import builtins
+    import os
+    import sys
+
+    import ray
+
+    _VERL_FQN = "verl.workers.rollout.vllm_rollout.utils.vLLMColocateWorkerExtension"
+    _RLLM_FQN = "rllm.experimental.verl._vllm_zmq_extension.RLLMColocateWorkerExtension"
+    _MARK = "_rllm_zmq_jobid_patched"
+
+    _orig_import = builtins.__import__
+
+    def _try_apply():
+        # ``_orig=...`` default-arg trick captures each original callable
+        # at def time so the three closures don't all bind the last value
+        # of a shared loop variable.
+        m = sys.modules.get("verl.workers.rollout.vllm_rollout.vllm_rollout")
+        ServerAdapter = getattr(m, "ServerAdapter", None) if m is not None else None
+        if ServerAdapter is not None and not getattr(ServerAdapter, _MARK, False):
+
+            def _sa_init(self, *a, _orig=ServerAdapter.__init__, **kw):
+                _orig(self, *a, **kw)
+                job_id = ray.get_runtime_context().get_job_id()
+                self.zmq_handle = f"ipc:///tmp/rl-colocate-zmq-{job_id}-{self.device_uuid}.sock"
+
+            ServerAdapter.__init__ = _sa_init
+            setattr(ServerAdapter, _MARK, True)
+
+        m = sys.modules.get("verl.workers.rollout.vllm_rollout.vllm_async_server")
+        vLLMHttpServer = getattr(m, "vLLMHttpServer", None) if m is not None else None
+        if vLLMHttpServer is not None and not getattr(vLLMHttpServer, _MARK, False):
+
+            def _hs_init(self, *a, _orig=vLLMHttpServer.__init__, **kw):
+                os.environ["VERL_RAY_JOB_ID"] = ray.get_runtime_context().get_job_id()
+                _orig(self, *a, **kw)
+
+            vLLMHttpServer.__init__ = _hs_init
+            setattr(vLLMHttpServer, _MARK, True)
+
+        m = sys.modules.get("vllm.engine.arg_utils")
+        AsyncEngineArgs = getattr(m, "AsyncEngineArgs", None) if m is not None else None
+        if AsyncEngineArgs is not None and not getattr(AsyncEngineArgs, _MARK, False):
+
+            def _cec(self, *a, _orig=AsyncEngineArgs.create_engine_config, **kw):
+                if getattr(self, "worker_extension_cls", "") == _VERL_FQN:
+                    self.worker_extension_cls = _RLLM_FQN
+                return _orig(self, *a, **kw)
+
+            AsyncEngineArgs.create_engine_config = _cec
+            setattr(AsyncEngineArgs, _MARK, True)
+
+        if (
+            ServerAdapter is not None
+            and getattr(ServerAdapter, _MARK, False)
+            and vLLMHttpServer is not None
+            and getattr(vLLMHttpServer, _MARK, False)
+            and AsyncEngineArgs is not None
+            and getattr(AsyncEngineArgs, _MARK, False)
+        ):
+            # All three landed — uninstall to drop per-import overhead.
+            builtins.__import__ = _orig_import
+            global _VERL_ZMQ_JOBID_PATCHED
+            _VERL_ZMQ_JOBID_PATCHED = True
+            logger.info("Patched zmq jobid path in verl and vLLM (backport of volcengine/verl#6246)")
+
+    def _wrapped_import(name, globals=None, locals=None, fromlist=(), level=0):
+        mod = _orig_import(name, globals, locals, fromlist, level)
+        _try_apply()
+        return mod
+
+    builtins.__import__ = _wrapped_import
+
+
+# ---------------------------------------------------------------------------
 # Worker-side entry point (used as Ray runtime_env worker_process_setup_hook)
 # ---------------------------------------------------------------------------
 
 _ALL_VERL_PATCHES = {
+    "patch_verl_zmq_jobid_path": patch_verl_zmq_jobid_path,
     "patch_verl_dynamic_batch_sync": patch_verl_dynamic_batch_sync,
     "patch_verl_qwen3_vl_dummy_inplace": patch_verl_qwen3_vl_dummy_inplace,
     "patch_verl_tensordict_jagged_layout": patch_verl_tensordict_jagged_layout,

--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -618,8 +618,17 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             _send_actor_update(sub_batch, loss_name)
 
     def shutdown(self) -> None:
-        """Placeholder, just use the BackendProtocol's default shutdown method."""
-        pass
+        """Free GPU memory held by the rollout replicas.
+
+        Without this, a crash mid-training (or anywhere ``on_train_end``
+        does not get to run) leaves the vLLM replicas awake on every GPU,
+        holding tens of GB each until the Ray actors are torn down.
+        """
+        try:
+            if self.checkpoint_manager is not None:
+                self.checkpoint_manager.sleep_replicas()
+        except Exception:
+            logger.exception("VerlBackend.shutdown: sleep_replicas failed")
 
     # =========================================================================
     # Async hook methods - leverage RayPPOTrainer utilities where possible

--- a/rllm/experimental/verl/verl_launcher.py
+++ b/rllm/experimental/verl/verl_launcher.py
@@ -113,11 +113,13 @@ class VerlTrainerLauncher(TrainerLauncher):
             self.config.data.val_files = val_dataset.get_verl_data_path()
 
     def train(self):
+        own_ray = False
         if not ray.is_initialized():
             from rllm.trainer.ray_init_utils import get_ray_init_settings
 
             ray_init_settings = get_ray_init_settings(self.config)
             ray.init(runtime_env=get_ppo_ray_runtime_env(), **ray_init_settings)
+            own_ray = True
 
         # Capture Hydra CLI overrides while we're still in the Hydra-decorated
         # process; the Ray actor below cannot read HydraConfig itself.
@@ -128,15 +130,22 @@ class VerlTrainerLauncher(TrainerLauncher):
         except (ValueError, AttributeError, ImportError):
             hydra_overrides = []
 
-        runner = VerlTaskRunner.remote()  # type: ignore
+        try:
+            runner = VerlTaskRunner.remote()  # type: ignore
 
-        ray.get(
-            runner.run.remote(
-                config=self.config,
-                workflow_class=self.workflow_class,
-                workflow_args=self.workflow_args,
-                store=self.store,
-                hydra_overrides=hydra_overrides,
-                **self.kwargs,
+            ray.get(
+                runner.run.remote(
+                    config=self.config,
+                    workflow_class=self.workflow_class,
+                    workflow_args=self.workflow_args,
+                    store=self.store,
+                    hydra_overrides=hydra_overrides,
+                    **self.kwargs,
+                )
             )
-        )
+        finally:
+            if own_ray:
+                try:
+                    ray.shutdown()
+                except Exception:
+                    logger.exception("ray.shutdown during launcher cleanup failed")


### PR DESCRIPTION
> **Stacked on top of #568** — review #568 first; this PR's diff is rebased onto #568's branch.
> **Draft** — design choices are non-trivial and likely warrant discussion before review (see "Design notes / open questions" below).

## Summary

Verl 0.7.1 (our pin) keys the colocated weight-transfer ZMQ IPC socket on the GPU UUID alone: `/tmp/rl-colocate-zmq-<uuid>.sock`. Two independent verl jobs on the same physical GPU — same user across runs OR different users on a multi-tenant host — both `bind()` the same path; the second fails with `zmq.error.ZMQError: Address already in use` on the first `update_weights` call. On a host with sticky-bit `/tmp`, a stale socket left by another user trips the same error indefinitely because libzmq's bind-time `unlink()` returns `EACCES`. This PR backports `volcengine/verl#6246` (merged upstream, not yet in any tagged release) which keys the path on the Ray job id so each Ray job owns a disjoint set of socket files.

## Type of change

- [x] Fix (backport)

## What changed

- `rllm/experimental/verl/_vllm_zmq_extension.py` — new module containing `RLLMColocateWorkerExtension`, a subclass of verl's `vLLMColocateWorkerExtension` whose only override is `_get_zmq_handle` reading `VERL_RAY_JOB_ID` from the env. Lives in its own module **on purpose** — see "Design notes" below.
- `rllm/experimental/verl/patch.py` — new `patch_verl_zmq_jobid_path` wired into `_ALL_VERL_PATCHES`. Three monkey-patches applied lazily via a `builtins.__import__` wrapper that fires when each target class first appears in `sys.modules`:
  1. `ServerAdapter.__init__` (sender, Ray actor): rebuild `zmq_handle` with the job id mixed in.
  2. `vLLMHttpServer.__init__` (bridge): set `VERL_RAY_JOB_ID` env var before `launch_server` forks the vLLM subprocess; the subprocess inherits env vars even with mp 'spawn'.
  3. `AsyncEngineArgs.create_engine_config` (redirect): swap `worker_extension_cls` from verl's FQN to `rllm.experimental.verl._vllm_zmq_extension.RLLMColocateWorkerExtension`. vLLM's `vllm/v1/worker/worker_base.py:262` resolves the FQN via `resolve_obj_by_qualname` and injects it as a base of the worker class, so our subclass's override flows through without any actor-side patch needing to propagate into the mp-spawn worker.

## Design notes / open questions

This is the part that warrants a real conversation before merge. The constraints landed us in a corner that's worth understanding before deciding whether to keep this approach.

1. **Why a subclass + redirect, instead of just rebinding `_get_zmq_handle`?** vLLM in a Ray actor *forces* multiprocessing 'spawn' (`vllm.utils.system_utils._maybe_force_spawn:134`). The receiver of the ZMQ socket runs in that mp-spawn worker — a fresh interpreter that does not inherit Python-level monkey-patches from the parent Ray actor. Rebinding `vLLMColocateWorkerExtension._get_zmq_handle` in the actor is invisible to the spawn worker. Two ways to bridge:
   - Edit verl's source on disk (durable across subprocess imports). Robust but means the rLLM repo carries a destructive transformation of installed verl files.
   - Redirect `worker_extension_cls` to a class we ship in rLLM, so the subprocess imports our class via vLLM's normal `resolve_obj_by_qualname` path.

   This PR uses the second. The redirect itself is one runtime monkey-patch on `AsyncEngineArgs.create_engine_config` (the last chokepoint where the FQN is mutable before it gets serialized into `parallel_config` and sent to the subprocess).

2. **Why a separate `_vllm_zmq_extension.py` module rather than inlining the subclass in `patch.py`?** Importing `verl.workers.rollout.vllm_rollout.utils` to *define* the subclass triggers the package's `__init__.py`, which transitively pulls in vLLM internals that call into CUDA at import time. The patch entry point runs as the Ray `runtime_env.worker_process_setup_hook` — *before* Ray sets per-worker `CUDA_VISIBLE_DEVICES`. Eager import of the verl rollout package at hook time pins every rank to GPU 0 and crashes FSDP init later with `ncclInvalidUsage: Duplicate GPU detected`. Keeping the subclass in its own module means the Ray actor never imports it; only the vLLM mp-spawn worker does, after CUDA is set up.

3. **Why a `builtins.__import__` wrapper rather than eager runtime monkey-patches?** Same reason as (2). The patches in this function need their target classes to exist (`ServerAdapter`, `vLLMHttpServer`, `AsyncEngineArgs`) — but importing them at hook time triggers CUDA init. The wrapper defers each patch until its target class first appears in `sys.modules`, which is during normal user-code imports inside the Ray worker, after Ray's CUDA setup. Per-class `_rllm_zmq_jobid_patched` marker attributes track per-target state; the wrapper uninstalls itself once all three have applied so it doesn't add per-import overhead for the rest of the run.

   Sibling patches in `patch.py` don't need this dance because their targets (`verl.utils.seqlen_balancing`, `verl.utils.tensordict_utils`, `verl.models.transformers.qwen3_vl`) don't touch CUDA on import — verified in this branch's investigation.

   Open: is `builtins.__import__` wrapping considered too magic? Alternatives we considered and rejected: (a) source-edit verl on disk (carry destructive transformations); (b) `sitecustomize.py` (pollutes the venv globally); (c) wait for all three before applying any (rejected because the sender's actor process never imports the bridge module and vice versa). Happy to revisit if there's a cleaner mechanism.

4. **Two patches on `__init__` plus one on a config method.** ServerAdapter and vLLMHttpServer get `__init__` wrapped (default-arg trick captures the original). `AsyncEngineArgs.create_engine_config` is wrapped to swap the class FQN before `parallel_config` is built. They're three different patch shapes because they target three different hook points; can't be unified without losing clarity.

## Validation

- [x] `pre-commit run --all-files`
- [x] Manual validation performed on 4×H100 / Qwen3-0.6B / math500
- [ ] Targeted tests: not run

Validation details:
- Worker hook leaves `torch.cuda.is_initialized() == False`.
- Each of the three patches rebinds on first import of its target module (verified separately and end-to-end).
- FSDP init succeeds across all 4 ranks (no Duplicate GPU error).
- Weight transfer over the new `ipc:///tmp/rl-colocate-zmq-<job_id>-<uuid>.sock` path works on both sender (Ray actor) and receiver (vLLM spawn worker via the redirected subclass).
- Val (step 0): math500 mean 0.597, accuracy 59.8%, 86s.
- Step 1: reward 0.43, grad_norm 0.28, throughput 2290 tok/s, `update_weights` 1.4s.
- `__import__` uninstalls itself once all three patches have landed.

## Breaking changes / migration notes

- New env var `VERL_RAY_JOB_ID` set by patched `vLLMHttpServer.__init__`. Internal-only contract between sender and receiver; no user-facing surface.
- ZMQ socket path changes from `/tmp/rl-colocate-zmq-<uuid>.sock` to `/tmp/rl-colocate-zmq-<job_id>-<uuid>.sock`. Old stale sockets from before this PR still litter `/tmp` on existing hosts but are now ignored by both sides.

## Docs / examples

- [x] Not needed

## Related issues / PRs

- Backports `volcengine/verl#6246`.
- Stacked on top of #568 (Verl GPU-memory cleanup). Review #568 first — once it merges, I'll rebase this branch onto `main`.