### PR TITLE
fix(agentflow_engine): preserve action when merging agent steps with traces

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -190,7 +190,12 @@ def enrich_episode_with_traces(
             # when agent_populates_steps is True.
             for agent_step in traj.steps:
                 step = training_steps[trace_idx]
-                # Preserve reward and done from agent's step
+                # Preserve agent-side fields (the trace doesn't carry these — it
+                # only holds the raw LLM call). Without ``action`` here, eval
+                # paths that read ``traj.steps[-1].action`` (e.g. parsed
+                # ``<answer>...</answer>`` from the cookbook flows) silently see
+                # ``None`` and grade every rollout as wrong.
+                step.action = agent_step.action
                 step.reward = agent_step.reward
                 step.done = agent_step.done
                 trace_idx += 1

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -191,10 +191,7 @@ def enrich_episode_with_traces(
             for agent_step in traj.steps:
                 step = training_steps[trace_idx]
                 # Preserve agent-side fields (the trace doesn't carry these — it
-                # only holds the raw LLM call). Without ``action`` here, eval
-                # paths that read ``traj.steps[-1].action`` (e.g. parsed
-                # ``<answer>...</answer>`` from the cookbook flows) silently see
-                # ``None`` and grade every rollout as wrong.
+                # only holds the raw LLM call) -- action, reward, done
                 step.action = agent_step.action
                 step.reward = agent_step.reward
                 step.done = agent_step.done


### PR DESCRIPTION
## Summary

`enrich_episode_with_traces` (in `rllm/engine/agentflow_engine.py`) replaces each agent-side `Step` with a trace-derived `Step` so training payloads like `prompt_ids` / `response_ids` / `logprobs` flow through. The merge loop currently inherits only `reward` and `done` from the agent step — `action` is silently dropped to its default `None`.

## Why this matters

For any AgentFlow that **puts a parsed / derived value on `Step.action` and reads it back in the evaluator**, every `compute_score(str(None), …)` returns 0. Every rollout grades "Incorrect" even when its final answer is right. Reward is uniformly 0.0, advantages collapse to zero, `grad_norm` is zero, and training never moves.

Concrete instance from `cookbooks/solver_judge_flow`:

```python
parsed = _parse_answer(content)        # "<answer>13 + 2 + 1</answer>"
return Trajectory(
    name="solver",
    steps=[Step(..., action=parsed)],   # set on agent step
)
```

…then in the evaluator:

```python
answer = traj.steps[-1].action          # was None — now correctly "<answer>13 + 2 + 1</answer>"
score  = compute_score(str(answer), ground_truth)
```

## Fix

Add `step.action = agent_step.action` to the agent-step / trace-step merge loop next to the existing `reward` / `done` lines. The trace doesn't carry `action` (it's an agent-side concept), so this is the only path that can populate it.

## Verification

Same script, before vs after, on 4×H100 with Qwen3-0.6B on countdown:

|                      | Before | After |
|---|---:|---:|
| val/reward/solver    | 0.000 | **0.701** |
| val/reward/judge     | 0.000 | **0.681** |
| val/pass@1           | 0.000 | **0.680** |
| step:1 reward/solver | 0.000 | 0.605 |
| step:1 grad_norm     | 0.000 | 0.486 |
| step:2 reward/solver | 0.000 | **0.705** (+0.10 in one PPO step) |
| step:2 grad_norm     | 0.000 | 0.515 |

GRPO advantage std ≈ 0.87 with proper per-task variance.

## Test plan

- [x] `pytest tests/engine/test_agentflow_engine.py` passes
- [x] Side-by-side reward/grad_norm comparison on a real verl run (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
