### PR TITLE
fix(verl): don't truncate merged multi-turn responses to per-turn cap

### DIFF
--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -333,7 +333,12 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         assert trainer_state.episodes is not None, "Episodes are not set"
         episodes: list[Episode] = trainer_state.episodes
         assert self.rollout_engine is not None, "rollout_engine is not initialized."
-        batch = transform_episodes_to_dataproto(episodes, self.rollout_engine, self.config.data.max_prompt_length, self.config.data.max_response_length)
+        # data.max_response_length is the per-turn generation cap at rollout
+        # time, but merged multi-turn responses concatenate [A0, obs1, A1, ...]
+        # and can grow up to the full context window - so using max_total_length to
+        # bound the sequence
+        max_total_length = self.config.data.max_prompt_length + self.config.data.max_response_length
+        batch = transform_episodes_to_dataproto(episodes, self.rollout_engine, self.config.data.max_prompt_length, max_total_length)
         # Lift per-batch merge metrics (batch/steps_per_traj,
         # batch/step_response_length) out of meta_info so they show up in
         # the standard trainer_state.metrics path. Same metric names the


### PR DESCRIPTION
## Bug

`VerlBackend.transform_to_backend_batch` passed `data.max_response_length` as the response-pad/truncate bound to `transform_episodes_to_dataproto`. But `data.max_response_length` is the **per-turn generation cap** used at rollout time, not the bound on a merged row.

`_process_trajectory` (`rllm/experimental/verl/transform.py`) collapses a multi-turn trajectory into a single row whose response is the concatenation `[A0, obs1, A1, obs2, A2, ...]`. The merged response length can therefore substantially exceed `max_response_length`. Inside `_pad_sequence_batch` the extra tokens were silently cut off.

## Impact

For any multi-turn agent whose merged `actions + observations` exceeded the per-turn cap, later turns (including the final action tokens) were dropped before loss computation. Effects:

- Trailing action tokens and their `response_mask=1` entries were discarded, so the policy was not trained on the later turns of long trajectories.
- `rollout_log_probs`, advantages, and rewards were similarly truncated, biasing the gradient toward the earliest turns.
- Silent: no warning was emitted, the shapes downstream stayed valid, so the bug only surfaced as a training-quality regression on longer trajectories.

Basically you might have a 100k rollout and then everything after 8k is truncated!

## Fix

Bound the merged response by `max_prompt_length + max_response_length` (the full context window the model supports) instead of the per-turn generation cap. Scoped to the unified-trainer `VerlBackend` path used by current agentcore training. The legacy `AgentWorkflowEngine.transform_results_for_verl` call site was left as-is (used only by deprecated trainers and archived examples).
