### PR TITLE
feat(examples): add AgentCore MigrationBench training example (verl + Qwen3-Coder-30B)

### DIFF
--- a/examples/agentcore_migrationbench/prepare_migrationbench_data.py
+++ b/examples/agentcore_migrationbench/prepare_migrationbench_data.py
@@ -1,0 +1,165 @@
+"""Prepare MigrationBench dataset for rLLM training with AgentCore runtime.
+
+Prerequisite: run the strands_migration_agent preprocess step first to upload the
+MigrationBench repos to S3. We upload the repos rather than loading them from
+GitHub at training time so the dataset remains available even if an upstream
+repo is deleted or made private.
+
+    https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent
+
+    cd <agentcore-rl-toolkit>/examples/strands_migration_agent
+    python preprocess.py --s3-bucket-name <your-bucket>
+
+This script then downloads only the tiny metadata.json files (~241 bytes each)
+from that same bucket to filter by num_test_cases, and registers train/test
+splits with the rLLM DatasetRegistry. The actual repo tarballs stay in S3 and
+are pulled at runtime by the AgentCore container.
+
+Train: repos from s3://<bucket>/tars/train/ with num_test_cases > 0
+Test:  all repos from s3://<bucket>/tars/test/
+
+Usage:
+    python -m examples.agentcore_migrationbench.prepare_migrationbench_data \\
+        --s3-bucket-name <your-bucket>
+"""
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from rllm.data.dataset import DatasetRegistry
+
+DATASET_NAME = "migration_bench"
+PROMPT_TEMPLATE = "Please help migrate this repo: {repo_path}. There are {num_tests} test cases in it."
+
+
+def list_s3_folders(s3_bucket: str, s3_prefix: str) -> list[str]:
+    """List immediate sub-folder names under an S3 prefix."""
+    result = subprocess.run(
+        ["aws", "s3", "ls", f"s3://{s3_bucket}/{s3_prefix}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    folders = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.strip().split()
+        if parts[0] == "PRE":
+            folders.append(parts[1].rstrip("/"))
+    return folders
+
+
+def download_all_metadata(s3_bucket: str, s3_prefix: str, folders: list[str], dest_dir: Path) -> None:
+    """Download metadata.json for all folders in parallel."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    commands = "\n".join(f"aws s3 cp s3://{s3_bucket}/{s3_prefix}{f}/metadata.json {dest_dir}/{f}.json --quiet" for f in folders)
+    subprocess.run(
+        ["xargs", "-P", "32", "-I", "{}", "bash", "-c", "{}"],
+        input=commands,
+        text=True,
+        check=False,
+    )
+
+
+def build_records(s3_bucket: str, metadata_dir: Path, s3_prefix: str, filter_positive_tests: bool) -> list[dict]:
+    """Load metadata and build dataset records."""
+    records = []
+    for f in sorted(metadata_dir.glob("*.json")):
+        try:
+            with open(f) as fh:
+                meta = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if filter_positive_tests and meta.get("num_test_cases", 0) <= 0:
+            continue
+
+        folder_name = f.stem
+        records.append(
+            {
+                "prompt": PROMPT_TEMPLATE,
+                "repo_uri": f"s3://{s3_bucket}/{s3_prefix}{folder_name}/{folder_name}.tar.gz",
+                "metadata_uri": f"s3://{s3_bucket}/{s3_prefix}{folder_name}/metadata.json",
+                "require_maximal_migration": False,
+                "data_source": "migration_bench",
+                "num_test_cases": meta.get("num_test_cases", 0),
+                "num_loc": meta.get("num_loc", 0),
+                "repo": meta.get("repo", folder_name),
+            }
+        )
+    return records
+
+
+def print_stats(records: list[dict], split: str):
+    """Print summary statistics."""
+    test_counts = [r["num_test_cases"] for r in records]
+    pos = [t for t in test_counts if t > 0]
+
+    print(f"\n  {split.upper()}: {len(records)} repos")
+    if not pos:
+        return
+
+    buckets = [(1, 5), (6, 10), (11, 20), (21, 50), (51, 100), (101, 500), (501, float("inf"))]
+    for lo, hi in buckets:
+        label = f"{lo}-{int(hi)}" if hi != float("inf") else f"{lo}+"
+        count = sum(1 for t in pos if lo <= t <= hi)
+        if count:
+            print(f"    tests {label:<10} {count:>5} ({count / len(pos) * 100:.1f}%)")
+
+    neg = sum(1 for t in test_counts if t <= 0)
+    if neg:
+        print(f"    tests <= 0 (filtered): {neg}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--s3-bucket-name", required=True)
+    args = parser.parse_args()
+    s3_bucket = args.s3_bucket_name
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        # Train
+        print("Fetching train metadata...")
+        train_folders = list_s3_folders(s3_bucket, "tars/train/")
+        print(f"  {len(train_folders)} repos found")
+        download_all_metadata(s3_bucket, "tars/train/", train_folders, tmpdir / "train")
+        train_records = build_records(s3_bucket, tmpdir / "train", "tars/train/", filter_positive_tests=True)
+        print_stats(train_records, "train")
+
+        # Test
+        print("\nFetching test metadata...")
+        test_folders = list_s3_folders(s3_bucket, "tars/test/")
+        print(f"  {len(test_folders)} repos found")
+        download_all_metadata(s3_bucket, "tars/test/", test_folders, tmpdir / "test")
+        test_records = build_records(s3_bucket, tmpdir / "test", "tars/test/", filter_positive_tests=False)
+        print_stats(test_records, "test")
+
+    # Register
+    print("\nRegistering datasets...")
+    DatasetRegistry.register_dataset(
+        name=DATASET_NAME,
+        data=train_records,
+        split="train",
+        source="AmazonScience/migration-bench-java-full",
+        description=f"Java 8→17 migration benchmark, train ({len(train_records)} repos with tests > 0)",
+        category="code",
+    )
+    DatasetRegistry.register_dataset(
+        name=DATASET_NAME,
+        data=test_records,
+        split="test",
+        source="AmazonScience/migration-bench-java-selected",
+        description=f"Java 8→17 migration benchmark, test ({len(test_records)} repos)",
+        category="code",
+    )
+    print(f"  {DATASET_NAME}/train: {len(train_records)} examples")
+    print(f"  {DATASET_NAME}/test:  {len(test_records)} examples")
+    print(f'\nLoad with: DatasetRegistry.load_dataset("{DATASET_NAME}", "train")')
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentcore_migrationbench/train_agentcore_migrationbench_verl.py
+++ b/examples/agentcore_migrationbench/train_agentcore_migrationbench_verl.py
@@ -1,0 +1,38 @@
+"""Train a migration agent on MigrationBench using Verl backend + AgentCore remote runtime.
+
+The agent runs inside an AgentCore container and migrates Java 8→17 repos.
+Build/deploy the agent and upload the dataset to S3 by following:
+    https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent
+
+Usage:
+    # 1. Build + deploy the agent and upload data (see strands_migration_agent README).
+    # 2. Register the dataset locally from the same S3 bucket:
+    python -m examples.agentcore_migrationbench.prepare_migrationbench_data \\
+        --s3-bucket-name <your-bucket>
+
+    # 3. Then train:
+    bash examples/agentcore_migrationbench/train_agentcore_migrationbench_verl.sh
+"""
+
+import hydra
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.experimental.unified_trainer import AgentTrainer
+
+
+@hydra.main(config_path="pkg://rllm.experimental.config", config_name="unified", version_base=None)
+def main(config):
+    train_dataset = DatasetRegistry.load_dataset("migration_bench", "train")
+    test_dataset = DatasetRegistry.load_dataset("migration_bench", "test")
+
+    trainer = AgentTrainer(
+        backend="verl",
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=test_dataset,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentcore_migrationbench/train_agentcore_migrationbench_verl.sh
+++ b/examples/agentcore_migrationbench/train_agentcore_migrationbench_verl.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Tested on a single node with 8x NVIDIA B200 (180 GiB HBM each).
+# Requires megatron deps: bash scripts/install_megatron.sh <cu128|cu129|cu130|...>
+set -eux
+
+# Load environment variables (AGENTCORE_AGENT_ARN, AGENTCORE_S3_BUCKET)
+set -a && source .env && set +a
+
+export VLLM_ALLREDUCE_USE_SYMM_MEM=0
+
+# Clean up stale ZMQ sockets from previous runs
+rm -f /tmp/rl-colocate-zmq-*.sock
+
+MODEL_PATH=Qwen/Qwen3-Coder-30B-A3B-Instruct
+
+MAX_CONTEXT_LENGTH=131072
+MAX_PROMPT_LENGTH=122880
+MAX_RESPONSE_LENGTH=8192
+
+TP=2
+EP=2
+CP=2
+MAX_TOKENS_PER_GPU=$((MAX_CONTEXT_LENGTH / CP))
+
+# LoRA configuration
+LORA_RANK=64
+LORA_ALPHA=128
+
+# actor_rollout_ref.actor.megatron.param_offload=True is required for
+# verl 0.7.1 to work around device mismatch errors caused by unconditional param offloading
+python -m examples.agentcore_migrationbench.train_agentcore_migrationbench_verl \
+    rllm/backend=verl \
+    model_engine=megatron \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.algorithm.rollout_correction.bypass_mode=true \
+    data.train_batch_size=32 \
+    data.val_batch_size=300 \
+    data.max_prompt_length=$MAX_PROMPT_LENGTH \
+    data.max_response_length=$MAX_RESPONSE_LENGTH \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    +actor_rollout_ref.model.lora.rank=$LORA_RANK \
+    +actor_rollout_ref.model.lora.alpha=$LORA_ALPHA \
+    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-5 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=32 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_dynamic_bsz=true \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$MAX_TOKENS_PER_GPU \
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=1 \
+    actor_rollout_ref.actor.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=$TP \
+    actor_rollout_ref.actor.megatron.context_parallel_size=$CP \
+    actor_rollout_ref.actor.megatron.sequence_parallel=true \
+    actor_rollout_ref.actor.megatron.use_dist_checkpointing=False \
+    actor_rollout_ref.actor.megatron.use_mbridge=True \
+    actor_rollout_ref.actor.megatron.vanilla_mbridge=False \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1 \
+    actor_rollout_ref.actor.megatron.param_offload=true \
+    actor_rollout_ref.actor.megatron.optimizer_offload=true \
+    actor_rollout_ref.actor.megatron.grad_offload=true \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_cpu_offload=True \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_offload_fraction=1.0 \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-sum \
+    actor_rollout_ref.actor.checkpoint.save_contents='["model","optimizer","extra"]' \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=8 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=true \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=$MAX_TOKENS_PER_GPU \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=qwen3_coder \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.max_model_len=$MAX_CONTEXT_LENGTH \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.0 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=true \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=$MAX_TOKENS_PER_GPU \
+    actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=1 \
+    actor_rollout_ref.ref.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=$TP \
+    actor_rollout_ref.ref.megatron.context_parallel_size=$CP \
+    actor_rollout_ref.ref.megatron.sequence_parallel=true \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger="['console','wandb']" \
+    trainer.project_name=agentcore-migrationbench \
+    trainer.experiment_name="coder-30b-bsz32-bypass" \
+    trainer.val_before_train=true \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=5 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    rllm.remote_runtime.enabled=true \
+    rllm.remote_runtime.backend=agentcore \
+    rllm.remote_runtime.agentcore.agent_runtime_arn=$AGENTCORE_AGENT_ARN \
+    rllm.remote_runtime.agentcore.s3_bucket=$AGENTCORE_S3_BUCKET \
+    rllm.remote_runtime.agentcore.tps_limit=10 \
+    rllm.remote_runtime.session_timeout=1800 \


### PR DESCRIPTION
## Summary

- Adds an AgentCore MigrationBench training example (verl + Qwen3-Coder-30B) under `examples/agentcore_migrationbench/`.
- `prepare_migrationbench_data.py` registers train/test splits with `DatasetRegistry` by reading `metadata.json` from S3 — repos are uploaded to S3 up front (via the toolkit's `preprocess.py`) so the dataset stays available even if an upstream GitHub repo is deleted or made private.
- The S3 bucket is passed via `--s3-bucket-name` (matching the flag used by `strands_migration_agent/preprocess.py`) — no hardcoded bucket.

## Prerequisites

Build + deploy the AgentCore agent and upload the dataset to S3 by following the Strands migration agent example:

https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent

```bash
cd <agentcore-rl-toolkit>/examples/strands_migration_agent
python preprocess.py --s3-bucket-name <your-bucket>
# then follow the README to deploy the agent (config.toml + deploy.py)
```

## Usage

```bash
# Register the dataset locally from the same S3 bucket:
python -m examples.agentcore_migrationbench.prepare_migrationbench_data \
    --s3-bucket-name <your-bucket>

# Train (expects AGENTCORE_AGENT_ARN and AGENTCORE_S3_BUCKET in .env):
bash examples/agentcore_migrationbench/train_agentcore_migrationbench_verl.sh
```

## Hardware

Tested on a single node with 8x NVIDIA B200 (180 GiB HBM each).

## Test plan

Script improved performance from 44% to 59% pass@1 on the validation set. 

<img width="1193" height="793" alt="Screenshot 2026-05-18 at 3 06 38 PM" src="https://github.com/user-attachments/assets/e3174242-9deb-4572-85f2-8c279bd6a182" />

