### PR TITLE
feat(trainer): add Fireworks backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ tinker = [
     "tinker-cookbook @ git+https://github.com/thinking-machines-lab/tinker-cookbook.git#egg=tinker-cookbook ; python_version >= '3.11'",
 ]
 
+fireworks = [
+    "fireworks-ai[training]==1.2.0a65 ; python_version >= '3.11'",
+    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@7163b526444da815e78c805b6c3a47ea20bb6872#subdirectory=training ; python_version >= '3.11'",
+]
+
 opentelemetry = [
     "opentelemetry-sdk",
 ]

--- a/rllm/experimental/config/rllm/backend/fireworks.yaml
+++ b/rllm/experimental/config/rllm/backend/fireworks.yaml
@@ -1,0 +1,95 @@
+# @package _global_
+
+# Fireworks Backend Configuration for rLLM
+# This config is used when training agents with Fireworks backend
+# Unified configuration supporting both workflow and agent training modes
+
+# Fireworks-specific settings
+fireworks_base_url: "https://api.fireworks.ai"  # Fireworks service URL
+fuse_forward_backward_and_optim_step: false  # Must be false for Fireworks backend
+
+# Model Configuration
+model:
+  name: accounts/fireworks/models/qwen3-4b
+  lora_rank: 0         # LoRA rank 0 means no LoRA fine-tuning, which is compatible with Fireworks backend
+
+# Training Configuration (fireworks-specific)
+training:
+  group_size: ???  # Number of rollouts per prompt
+  learning_rate: 1e-5
+  beta1: 0.9
+  beta2: 0.999
+  eps: 1e-8
+  weight_decay: 0.01
+  grad_clip_norm: 1.0
+  max_length: null  # Auto-derived from training shape if null
+  client_timeout: 1800  # Timeout for forward / forward_backward / optim_step calls (seconds)
+  resume_from_fireworks_job_id: null  # Source trainer job id for loading a DCP checkpoint
+  resume_from_dcp_checkpoint: null  # Explicit DCP name to load; null uses latest on the source/current job
+
+deployment:
+  deployment_id: "rllm-deploy-${now:%Y%m%d-%H%M%S}"
+  deployment_shape: null  # Auto-derived from training shape if null
+  deployment_region: null          # Region for deployment; falls back to training_infra.region
+  deployment_accelerator_type: null  # Accelerator for deployment; falls back to training_infra.accelerator_type
+  hot_load_bucket_type: FW_HOSTED  # Bucket type for hot-load snapshots
+  deployment_timeout_s: 5400       # Timeout for deployment creation/readiness (90 min)
+  deployment_extra_args: null      # Extra Helm args for the deployment
+  tokenizer_model: Qwen/Qwen3-4B
+  sample_timeout: 600              # HTTP read timeout for sampling completions (10 min)
+  disable_speculative_decoding: true  # Disable EAGLE speculation for hotload compatibility
+  replica_count: 1              # Pin deployment to a fixed replica count (null = 1)
+  extra_values: null               # Extra Helm values dict (e.g. {"priorityClass": "deployment"})
+
+hotload:
+  hot_load_timeout: 600            # Timeout for hotload_and_wait (seconds)
+  hot_load_before_training: false  # Push initial weights to deployment before first step
+  dcp_timeout: 2700                # Timeout for DCP save_state / load_state_with_optimizer (45 min)
+  warmup_after_hotload: true       # Send warmup request after hotloading to prime caches
+  warmup_max_retries: 10           # Max retries for post-hotload warmup
+  reset_prompt_cache: true         # Purge KV cache on deployment after hotloading weights
+
+training_infra:
+  training_shape_id: qwen3-4b-minimum-h200
+  ref_training_shape_id: null      # Shape for reference trainer; falls back to training_shape_id
+  region: null
+  custom_image_tag: null           # Custom Docker image tag
+  accelerator_type: null           # GPU type (auto-resolved from training shape)
+  accelerator_count: null          # Number of GPUs (auto-resolved from training shape)
+  skip_validations: false          # Skip control plane training shape validations
+  node_count: 1                    # Number of training nodes
+  extra_args: null                 # Extra CLI args for the trainer job
+
+# Validation Configuration
+validation:
+  group_size: ???
+
+# Rollout Engine Configuration
+rollout_engine:
+  reasoning_effort: "medium"
+  accumulate_reasoning: false
+  disable_thinking: false
+
+# Data Configuration
+data:
+  train_files: null
+  val_files: null
+  max_prompt_length: 2048
+  max_response_length: 2048
+  train_batch_size: 64
+  val_batch_size: -1
+
+# Overriding the rLLM-common config with Fireworks-specific ones
+# Only override if the algorithm values are not None, otherwise still use the rLLM-common config
+rllm:
+  backend: fireworks
+  rollout:
+    n: ${oc.select:training.group_size, 8}
+    n_val: ${oc.select:validation.group_size, 1}
+    train:
+      top_k: 0 # -1 is not accepted
+    val:
+      top_k: 0 # -1 is not accepted
+  algorithm:
+    rollout_correction:
+      bypass_mode: True

--- a/rllm/experimental/fireworks/__init__.py
+++ b/rllm/experimental/fireworks/__init__.py
@@ -1,0 +1,9 @@
+from rllm.experimental.fireworks.fireworks_backend import FireworksBackend
+from rllm.experimental.fireworks.fireworks_launcher import FireworksTrainerLauncher
+from rllm.experimental.fireworks.fireworks_policy_trainer import FireworksPolicyTrainer
+
+__all__ = [
+    "FireworksBackend",
+    "FireworksTrainerLauncher",
+    "FireworksPolicyTrainer",
+]

--- a/rllm/experimental/fireworks/fireworks_backend.py
+++ b/rllm/experimental/fireworks/fireworks_backend.py
@@ -290,6 +290,7 @@ class FireworksBackend(TinkerBackend):
         loss_fn = alg.get("loss_fn", None)
         loss_agg_mode = alg.get("loss_agg_mode", None)
         eps_clip_high = alg.get("eps_clip_high", None)
+        router_replay = alg.get("router_replay", "disabled")
         rc = alg.get("rollout_correction", {})
         tis_mode = rc.get("tis_mode", None)
         bypass_mode = rc.get("bypass_mode", True)
@@ -305,6 +306,9 @@ class FireworksBackend(TinkerBackend):
         if loss_agg_mode not in valid_loss_agg_modes:
             raise ValueError(f"rllm.algorithm.loss_agg_mode must be null, 'token-mean', 'seq-mean-token-sum', or 'seq-mean-token-mean' for the Fireworks backend, got {loss_agg_mode!r}")
         logger.info("Fireworks loss aggregation mode: %s", loss_agg_mode or "backend default")
+
+        if router_replay == "R2":
+            raise ValueError("rllm.algorithm.router_replay='R2' is not supported by the Fireworks backend; use 'R3' or 'disabled'.")
 
         # rollout_correction.tis_mode validation
         if tis_mode is not None and tis_mode not in ("token", "sequence"):

--- a/rllm/experimental/fireworks/fireworks_backend.py
+++ b/rllm/experimental/fireworks/fireworks_backend.py
@@ -1,0 +1,457 @@
+"""
+Fireworks backend implementation for the UnifiedTrainer.
+
+Inherits from ``TinkerBackend`` and overrides only what differs:
+infrastructure setup (Fireworks DeploymentManager / TrainerJobManager),
+rollout engine (FireworksEngine), and checkpoint lifecycle hooks
+(weight syncing via ``WeightSyncer`` instead of Tinker sampler paths).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING
+
+from fireworks.training.sdk import (
+    DeploymentManager,
+    DeploymentSampler,
+    TrainerJobManager,
+    WeightSyncer,
+)
+from omegaconf import DictConfig
+from training.utils import (
+    ReconnectableClient,
+    ResourceCleanup,
+    create_trainer_job,
+    setup_deployment,
+)
+from training.utils.config import DeployConfig, InfraConfig
+from transformers import AutoTokenizer
+
+# fix:fireworks - tinker 0.15.0 sends project_id=None, server rejects it
+# from tinker.types import CreateSessionRequest
+# _orig_model_dump = CreateSessionRequest.model_dump
+# def _patched_model_dump(self, **kwargs):
+#     result = _orig_model_dump(self, **kwargs)
+#     if result.get("project_id") is None:
+#         result.pop("project_id", None)
+#     return result
+# CreateSessionRequest.model_dump = _patched_model_dump
+# fix:fireworks - optim_step sends grad_accumulation_normalization via extra_body, server rejects it
+# from fireworks.training.sdk.client import FiretitanTrainingClient
+# from tinker.lib.public_interfaces.training_client import TrainingClient
+# FiretitanTrainingClient.optim_step = TrainingClient.optim_step
+# from training.utils.client import ReconnectableClient as _RC
+# _orig_rc_optim_step = _RC.optim_step
+# def _patched_rc_optim_step(self, params, grad_accumulation_normalization=None):
+#     return self._client.optim_step(params).result(timeout=self._default_timeout)
+# _RC.optim_step = _patched_rc_optim_step
+from rllm.experimental.common import simple_timer
+from rllm.experimental.fireworks.fireworks_policy_trainer import FireworksPolicyTrainer
+from rllm.experimental.rollout import FireworksEngine, RolloutEngine
+from rllm.trainer.tinker.tinker_backend import TinkerBackend
+from rllm.trainer.tinker.tinker_metrics_utils import (
+    update_training_metrics,
+)
+
+if TYPE_CHECKING:
+    from rllm.experimental.unified_trainer import TrainerState
+
+logger = logging.getLogger(__name__)
+logging.getLogger("fireworks.training.sdk.deployment").setLevel(logging.WARNING)
+
+
+class FireworksBackend(TinkerBackend):
+    """Fireworks backend for the unified trainer.
+
+    Extends ``TinkerBackend`` with Fireworks-specific infrastructure:
+        - ``FireworksEngine`` for rollout (via ``DeploymentSampler``)
+        - ``FireworksPolicyTrainer`` for gradient updates (via ``ReconnectableClient``)
+        - ``WeightSyncer`` for hot-loading checkpoints into an inference deployment
+
+    Inherited unchanged from ``TinkerBackend``:
+        - ``get_dataloader``, ``shutdown``
+        - ``generate_episodes``, ``transform_to_backend_batch``
+        - ``process_backend_batch``, ``compute_advantages``, ``update_policy``
+        - ``on_epoch_start/end``, ``on_validation_start/end``
+    """
+
+    name: str = "fireworks"
+
+    def __init__(self, config: DictConfig, **kwargs):
+        # Intentionally skip TinkerBackend.__init__ to avoid creating a
+        # tinker.ServiceClient; we set up Fireworks-specific clients instead.
+        from rllm.experimental.protocol import BackendProtocol
+
+        BackendProtocol.__init__(self, config, **kwargs)
+
+        self.full_config = config
+
+        self.policy_trainer: FireworksPolicyTrainer | None = None
+        self.tokenizer = None
+        self.rollout_engine: FireworksEngine | None = None
+
+        # In TinkerBackend this is a tinker.SamplingClient; here it's a
+        # DeploymentSampler, but both get passed to set_sampling_client().
+        self.sampling_client: DeploymentSampler | None = None
+        self._algorithm_config = None
+
+        self._policy_updated_this_step: bool = False
+
+        self.learning_rate = config.training.get("learning_rate", 1e-6)
+        self.beta1 = config.training.get("beta1", 0.9)
+        self.beta2 = config.training.get("beta2", 0.95)
+        self.eps = config.training.get("eps", 1e-8)
+        self.weight_decay = config.training.get("weight_decay", 0.01)
+        self.grad_clip_norm = config.training.get("grad_clip_norm", 1.0)
+
+        # Fireworks-specific handles (populated in _init_fireworks_infra)
+        self.weight_syncer: WeightSyncer | None = None
+        self._policy_rc: ReconnectableClient | None = None
+        self._rlor_mgr: TrainerJobManager | None = None
+        self._deploy_mgr: DeploymentManager | None = None
+        self._cleanup: ResourceCleanup | None = None
+
+    # ------------------------------------------------------------------
+    # Fireworks infrastructure setup
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_infra_config(cfg_section: DictConfig) -> InfraConfig:
+        """Convert an OmegaConf ``training_infra`` section to an ``InfraConfig`` dataclass."""
+        return InfraConfig(
+            training_shape_id=cfg_section.get("training_shape_id"),
+            ref_training_shape_id=cfg_section.get("ref_training_shape_id"),
+            region=cfg_section.get("region"),
+            custom_image_tag=cfg_section.get("custom_image_tag"),
+            accelerator_type=cfg_section.get("accelerator_type"),
+            accelerator_count=cfg_section.get("accelerator_count"),
+            node_count=cfg_section.get("node_count", 1),
+            extra_args=list(cfg_section.get("extra_args") or []),
+        )
+
+    @staticmethod
+    def _to_deploy_config(cfg_section: DictConfig) -> DeployConfig:
+        """Convert an OmegaConf ``deployment`` section to a ``DeployConfig`` dataclass."""
+        return DeployConfig(
+            deployment_id=cfg_section.get("deployment_id"),
+            deployment_shape=cfg_section.get("deployment_shape"),
+            deployment_region=cfg_section.get("deployment_region"),
+            deployment_accelerator_type=cfg_section.get("deployment_accelerator_type"),
+            hot_load_bucket_type=cfg_section.get("hot_load_bucket_type", "FW_HOSTED"),
+            deployment_timeout_s=cfg_section.get("deployment_timeout_s", 5400),
+            deployment_extra_args=list(cfg_section.get("deployment_extra_args") or []) or None,
+            tokenizer_model=cfg_section.get("tokenizer_model"),
+            sample_timeout=cfg_section.get("sample_timeout", 600),
+            disable_speculative_decoding=cfg_section.get("disable_speculative_decoding", True),
+            replica_count=cfg_section.get("replica_count"),
+            extra_values=dict(cfg_section.get("extra_values") or {}) or None,
+        )
+
+    def _init_fireworks_infra(self, **kwargs) -> None:
+        """Create Fireworks TrainerJobManager, DeploymentManager,
+        ReconnectableClient, WeightSyncer, and DeploymentSampler."""
+        cfg = self.full_config
+        api_key = os.environ["FIREWORKS_API_KEY"]
+        base_url = cfg.get("fireworks_base_url", "https://api.fireworks.ai")
+
+        rlor_mgr = TrainerJobManager(api_key=api_key, base_url=base_url)
+        deploy_mgr = DeploymentManager(api_key=api_key, base_url=base_url)
+        self._rlor_mgr = rlor_mgr
+        self._deploy_mgr = deploy_mgr
+        self._cleanup = ResourceCleanup(rlor_mgr, deploy_mgr)
+
+        infra = self._to_infra_config(cfg.training_infra)
+        deploy = self._to_deploy_config(cfg.deployment)
+
+        # Resolve training shape profile and auto-derive config values
+        profile = None
+        if infra.training_shape_id:
+            profile = rlor_mgr.resolve_training_profile(infra.training_shape_id)
+            dep_shape = getattr(profile, "deployment_shape", None) or getattr(profile, "deployment_shape_version", None)
+            if dep_shape and not deploy.deployment_shape:
+                deploy.deployment_shape = dep_shape
+                logger.info("Auto-derived deployment_shape from training shape: %s", dep_shape)
+            if profile.max_supported_context_length and not cfg.training.get("max_length"):
+                cfg.training.max_length = profile.max_supported_context_length
+                logger.info("Auto-derived max_length from training shape: %d", cfg.training.max_length)
+            pp = getattr(profile, "pipeline_parallelism", 1)
+            if pp > 1:
+                raise ValueError(f"Pipeline parallelism (PP={pp}) is not supported. Use a training shape with PP=1.")
+
+        dep_info = setup_deployment(deploy_mgr, deploy, cfg.model.name, infra)
+        deployment_id = deploy.deployment_id
+        self._cleanup.deployment(deployment_id, action="delete")
+
+        kl_beta = cfg.rllm.algorithm.get("kl_beta", 0.0)
+        if kl_beta > 0:
+            raise ValueError(f"kl_beta={kl_beta} is not supported with server-side builtin losses. Set kl_beta=0 in your config.")
+
+        policy_ep = create_trainer_job(
+            rlor_mgr,
+            base_model=cfg.model.name,
+            infra=infra,
+            profile=profile,
+            lora_rank=cfg.model.get("lora_rank", 0),
+            max_seq_len=cfg.training.max_length,
+            learning_rate=cfg.training.learning_rate,
+            display_name=f"rllm-policy-{int(time.time())}",
+            hot_load_deployment_id=deployment_id,
+            cleanup=self._cleanup,
+        )
+
+        self._policy_job_id = policy_ep.job_id
+        self._policy_rc = ReconnectableClient(
+            rlor_mgr,
+            policy_ep.job_id,
+            cfg.model.name,
+            lora_rank=cfg.model.get("lora_rank", 0),
+            default_timeout=cfg.training.get("client_timeout", 600),
+            endpoint=policy_ep,
+        )
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            deploy.tokenizer_model or cfg.model.name,
+            trust_remote_code=True,
+        )
+        inference_model = dep_info.inference_model if dep_info else cfg.model.name
+        self.sampling_client = DeploymentSampler(
+            inference_url=deploy_mgr.inference_url,
+            model=inference_model,
+            api_key=api_key,
+            tokenizer=self.tokenizer,
+        )
+        self.weight_syncer = WeightSyncer(
+            policy_client=self._policy_rc.inner,
+            deploy_mgr=deploy_mgr,
+            deployment_id=deployment_id,
+            base_model=cfg.model.name,
+            hotload_timeout=cfg.hotload.hot_load_timeout,
+            warmup_after_hotload=cfg.hotload.get("warmup_after_hotload", True),
+            warmup_max_retries=cfg.hotload.get("warmup_max_retries", 10),
+            reset_prompt_cache=cfg.hotload.get("reset_prompt_cache", True),
+            lora_rank=cfg.model.get("lora_rank", 0),
+        )
+
+    # ------------------------------------------------------------------
+    # BackendProtocol overrides
+    # ------------------------------------------------------------------
+
+    def init_rollout_engine(self, **kwargs) -> RolloutEngine:
+        self._init_fireworks_infra(**kwargs)
+
+        self.policy_trainer = FireworksPolicyTrainer(
+            config=self.full_config,
+            training_client=self._policy_rc,
+            weight_syncer=self.weight_syncer,
+            cf_config=kwargs.get("cf_config"),
+            transform_config=kwargs.get("transform_config"),
+            algorithm_config=kwargs.get("algorithm_config"),
+            rlor_mgr=self._rlor_mgr,
+            policy_job_id=self._policy_job_id,
+        )
+
+        cfg = self.full_config
+        rollout_extra = dict(cfg.get("rollout_engine", {}))
+        self.rollout_engine = FireworksEngine(
+            tokenizer=self.tokenizer,
+            sampler=self.sampling_client,
+            max_prompt_length=cfg.data.max_prompt_length,
+            max_response_length=cfg.data.max_response_length,
+            max_model_length=cfg.training.max_length,
+            sampling_params=cfg.rllm.rollout,
+            disable_thinking=rollout_extra.pop("disable_thinking", False),
+            accumulate_reasoning=rollout_extra.pop("accumulate_reasoning", False),
+            reasoning_effort=rollout_extra.pop("reasoning_effort", "medium"),
+            sample_timeout=cfg.deployment.get("sample_timeout", 600),
+            router_replay=cfg.rllm.algorithm.get("router_replay", "disabled") == "R3",
+            **rollout_extra,
+        )
+        return self.rollout_engine
+
+    def validate_config(self) -> None:
+        if self.full_config.get("fuse_forward_backward_and_optim_step", False):
+            raise ValueError("fuse_forward_backward_and_optim_step is not supported by the Fireworks backend. Set fuse_forward_backward_and_optim_step: false in your config.")
+
+        rollout_cfg = self.full_config.rllm.rollout
+        for split in ("train", "val"):
+            sp = rollout_cfg.get(split, {}) or {}
+            if sp.get("temperature", 1.0) != 1.0 or sp.get("top_p", 1.0) != 1.0:
+                logger.warning(
+                    "rllm.rollout.%s.{temperature,top_p} are set away from 1.0; this can cause issues with logprobs accuracy.",
+                    split,
+                )
+
+        # --- Algorithm / loss function validation ---
+        # Loss function validation is handled by resolve_builtin_loss() at setup time.
+        alg = self.full_config.rllm.algorithm
+        loss_fn = alg.get("loss_fn", None)
+        loss_agg_mode = alg.get("loss_agg_mode", None)
+        eps_clip_high = alg.get("eps_clip_high", None)
+        rc = alg.get("rollout_correction", {})
+        tis_mode = rc.get("tis_mode", None)
+        bypass_mode = rc.get("bypass_mode", True)
+
+        # eps_clip_high only meaningful for dapo/cispo (asymmetric clipping)
+        if eps_clip_high is not None and loss_fn not in ("dapo", "cispo"):
+            logger.warning(
+                "eps_clip_high is set but loss_fn='%s' does not use asymmetric clipping. eps_clip_high is only used by 'dapo' and 'cispo'.",
+                loss_fn,
+            )
+
+        valid_loss_agg_modes = {None, "token-mean", "seq-mean-token-sum", "seq-mean-token-mean"}
+        if loss_agg_mode not in valid_loss_agg_modes:
+            raise ValueError(f"rllm.algorithm.loss_agg_mode must be null, 'token-mean', 'seq-mean-token-sum', or 'seq-mean-token-mean' for the Fireworks backend, got {loss_agg_mode!r}")
+        logger.info("Fireworks loss aggregation mode: %s", loss_agg_mode or "backend default")
+
+        # rollout_correction.tis_mode validation
+        if tis_mode is not None and tis_mode not in ("token", "sequence"):
+            raise ValueError(f"rollout_correction.tis_mode must be null, 'token', or 'sequence', got '{tis_mode}'")
+
+        # TIS with bypass is a no-op (prox = inf, weight = 1.0)
+        if tis_mode is not None and bypass_mode:
+            logger.warning(
+                "rollout_correction.tis_mode='%s' with bypass_mode=true; TIS weight will be 1.0 (no correction). Set bypass_mode=false for active TIS.",
+                tis_mode,
+            )
+
+        # save_freq must be a multiple of sync interval (save requires a sampler snapshot from sync)
+        save_freq = self.full_config.rllm.trainer.get("save_freq", -1)
+        if save_freq > 0:
+            async_cfg = self.full_config.rllm.get("async_training", {})
+            if async_cfg.get("enable", False):
+                sync_interval = async_cfg.get("trigger_parameter_sync_step", 1)
+                if sync_interval > 0 and save_freq % sync_interval != 0:
+                    raise ValueError(f"save_freq ({save_freq}) must be a multiple of trigger_parameter_sync_step ({sync_interval}). Promotion requires a sampler snapshot created at sync time.")
+
+    # ------------------------------------------------------------------
+    # Policy update (override: no fused path, uses ReconnectableClient)
+    # ------------------------------------------------------------------
+
+    async def process_backend_batch(
+        self,
+        trainer_state: TrainerState,
+        **kwargs,
+    ) -> None:
+        await super().process_backend_batch(trainer_state, **kwargs)
+        trainer_state.extra_info.pop("training_logprobs", None)
+
+    async def update_policy(self, trainer_state: TrainerState, **kwargs) -> None:
+        assert self.policy_trainer is not None, "policy_trainer is not initialized"
+
+        with simple_timer("optim_step", trainer_state.timing_dict):
+            scheduled_lr, optim_metrics = await self.policy_trainer.optim_step(
+                step=trainer_state.global_step,
+                total_steps=trainer_state.total_steps,
+                learning_rate=self.learning_rate,
+                beta1=self.beta1,
+                beta2=self.beta2,
+                eps=self.eps,
+                weight_decay=self.weight_decay,
+                grad_clip_norm=self.grad_clip_norm,
+            )
+            trainer_state.extra_info["scheduled_learning_rate"] = scheduled_lr
+            trainer_state.metrics.update(optim_metrics)
+
+    # ------------------------------------------------------------------
+    # Train lifecycle hooks (overrides)
+    # ------------------------------------------------------------------
+
+    async def on_train_start(self, trainer_state: TrainerState) -> None:
+        assert self.policy_trainer is not None, "policy_trainer is not initialized"
+
+        start_step = await self.policy_trainer.initialize_async(
+            resume_from_checkpoint=True,
+            hot_load_before_training=self.full_config.hotload.get("hot_load_before_training", False),
+        )
+        trainer_state.global_step = start_step
+
+    async def _save_and_sync(
+        self,
+        trainer_state: TrainerState,
+        should_save: bool = False,
+        should_sync: bool = False,
+    ) -> None:
+        """Unified save + sync + promote logic.
+
+        Args:
+            trainer_state: Current trainer state.
+            should_save: Save a DCP checkpoint and promote if sync also happens.
+            should_sync: Sync (hotload) weights to the inference deployment.
+        """
+        global_step = trainer_state.global_step
+
+        if should_save and not should_sync:
+            logger.warning(
+                "save_freq triggered at step %d but no sync; skipping save/promote (save_freq must be a multiple of sync interval)",
+                global_step,
+            )
+
+        if should_sync:
+            checkpoint_type = "base" if should_save else None
+            snapshot_name = await self.policy_trainer.sync_weights(
+                global_step,
+                checkpoint_type=checkpoint_type,
+            )
+
+            if should_save:
+                with simple_timer("save_checkpoint", trainer_state.timing_dict):
+                    await self.policy_trainer.save_dcp_checkpoint(global_step)
+                if snapshot_name:
+                    experiment = self.full_config.rllm.trainer.get("experiment_name", "default")
+                    output_model_id = f"{experiment}-step-{global_step}"
+                    try:
+                        await self.policy_trainer.promote_checkpoint(
+                            snapshot_name,
+                            output_model_id,
+                        )
+                    except Exception as exc:
+                        logger.exception(
+                            "Checkpoint promotion failed for '%s' -> '%s'; continuing because the DCP checkpoint was saved. Error: %s",
+                            snapshot_name,
+                            output_model_id,
+                            exc,
+                        )
+
+    async def on_train_end(self, trainer_state: TrainerState) -> None:
+        assert self.policy_trainer is not None, "policy_trainer is not initialized"
+        logger.info("Saving final checkpoint at step %d", trainer_state.global_step)
+        await self._save_and_sync(trainer_state, should_save=True, should_sync=True)
+
+    async def on_policy_updated(self, trainer_state: TrainerState) -> None:
+        """Called in async mode after optimizer step when coordinator triggers sync."""
+        assert self.policy_trainer is not None
+        self._policy_updated_this_step = True
+        save_freq = self.full_config.rllm.trainer.save_freq
+        step = trainer_state.global_step
+        await self._save_and_sync(
+            trainer_state,
+            should_save=save_freq > 0 and step % save_freq == 0,
+            should_sync=True,
+        )
+
+    async def on_batch_end(self, trainer_state: TrainerState) -> None:
+        assert self.policy_trainer is not None, "policy_trainer is not initialized"
+
+        # In async mode, on_policy_updated already handled save/sync
+        if not self._policy_updated_this_step:
+            step = trainer_state.global_step
+            save_freq = self.full_config.rllm.trainer.save_freq
+            await self._save_and_sync(
+                trainer_state,
+                should_save=save_freq > 0 and step % save_freq == 0,
+                should_sync=True,
+            )
+        self._policy_updated_this_step = False
+
+        learning_rate = trainer_state.extra_info.get("scheduled_learning_rate", self.learning_rate)
+        update_training_metrics(trainer_state, learning_rate, trainer_state.total_steps)
+        if trainer_state.backend_batch:
+            trainer_state.metrics.update(self.policy_trainer._compute_rollout_entropy_metrics(trainer_state.backend_batch))
+
+    def shutdown(self) -> None:
+        """Cleanup Fireworks resources via ResourceCleanup."""
+        if self._cleanup:
+            self._cleanup.__exit__(None, None, None)

--- a/rllm/experimental/fireworks/fireworks_launcher.py
+++ b/rllm/experimental/fireworks/fireworks_launcher.py
@@ -1,0 +1,47 @@
+from omegaconf import DictConfig
+
+from rllm.data import Dataset
+from rllm.experimental.fireworks.fireworks_backend import FireworksBackend
+from rllm.experimental.unified_trainer import TrainerLauncher, UnifiedTrainer
+from rllm.workflows.store import Store
+from rllm.workflows.workflow import Workflow
+
+
+class FireworksTrainerLauncher(TrainerLauncher):
+    """
+    Fireworks trainer launcher that scaffolds the fireworks backend.
+    """
+
+    def __init__(
+        self,
+        config: DictConfig,
+        workflow_class: type[Workflow] | None = None,
+        train_dataset: Dataset | None = None,
+        val_dataset: Dataset | None = None,
+        workflow_args: dict | None = None,
+        store: Store | None = None,
+        **kwargs,
+    ):
+        """Initialize the FireworksTrainerLauncher. Nothing special here, just use the parent class's init."""
+        super().__init__(config, workflow_class, train_dataset, val_dataset, workflow_args, store=store, **kwargs)
+
+    def train(self):
+        trainer = None
+        try:
+            trainer = UnifiedTrainer(
+                backend_cls=FireworksBackend,
+                config=self.config,
+                workflow_class=self.workflow_class,
+                train_dataset=self.train_dataset,
+                val_dataset=self.val_dataset,
+                workflow_args=self.workflow_args,
+                store=self.store,
+                **self.kwargs,
+            )
+            trainer.fit()
+        except Exception as e:
+            print(f"Error training with Fireworks: {e}")
+            raise e
+        finally:
+            if trainer is not None:
+                trainer.shutdown()

--- a/rllm/experimental/fireworks/fireworks_policy_trainer.py
+++ b/rllm/experimental/fireworks/fireworks_policy_trainer.py
@@ -1,0 +1,591 @@
+"""Policy training module for Firetitan-based RL.
+
+Uses ``FiretitanTrainingClient`` / ``ReconnectableClient`` from the
+Fireworks training SDK instead of Tinker's ``ServiceClient``.
+
+This module handles gradient updates, model checkpointing, and data processing.
+It does NOT contain any environment or agent logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import re
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+import tinker
+from fireworks.training.sdk import WeightSyncer
+from tinker.types import AdamParams
+from training.utils.client import ReconnectableClient
+
+from rllm.experimental.common import (
+    AlgorithmConfig,
+    CompactFilteringConfig,
+    TransformConfig,
+)
+from rllm.trainer.tinker.tinker_policy_trainer import (
+    compute_schedule_lr_multiplier,
+    require_training_client,
+)
+from rllm.trainer.tinker.transform import transform_trajectory_groups_to_datums
+from rllm.types import TrajectoryGroup
+
+logger = logging.getLogger(__name__)
+
+
+class FireworksPolicyTrainer:
+    """Handles policy updates via gradient descent using Fireworks Firetitan.
+
+    This class handles:
+    - Training client management (``ReconnectableClient`` with auto-reconnect)
+    - Data processing (filtering, advantages, datum conversion)
+    - Forward-backward passes
+    - Optimizer steps
+    - Checkpoint saving / loading
+    - Weight syncing to an inference deployment (``WeightSyncer``)
+
+    It does NOT handle:
+    - Environment or agent interactions
+    - Trajectory collection
+    - Sampling
+    """
+
+    _METRIC_SKIP_KEYS = {"step_id", "step"}
+    _STEP_CHECKPOINT_RE = re.compile(r"(?:^|/)step-(\d+)$")
+
+    def __init__(
+        self,
+        config,
+        training_client: ReconnectableClient,
+        weight_syncer: WeightSyncer | None = None,
+        cf_config: CompactFilteringConfig | None = None,
+        transform_config: TransformConfig | None = None,
+        algorithm_config: AlgorithmConfig | None = None,
+        rlor_mgr=None,
+        policy_job_id: str | None = None,
+    ):
+        self.config = config
+        self.training_client = training_client
+        self.weight_syncer = weight_syncer
+        self._rlor_mgr = rlor_mgr
+        self._policy_job_id = policy_job_id
+        self._resume_checkpoint_name = self.config.training.get("resume_from_dcp_checkpoint")
+        self._resume_source_job_id = self.config.training.get("resume_from_fireworks_job_id") or policy_job_id
+
+        self.cf_config = cf_config or CompactFilteringConfig.from_config(self.config.rllm.compact_filtering)
+        self.transform_config = transform_config or TransformConfig()
+        self.algorithm_config = algorithm_config or AlgorithmConfig.from_config(self.config.rllm.algorithm)
+        self.resolve_builtin_loss(self.algorithm_config)
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
+    async def initialize_async(
+        self,
+        resume_from_checkpoint: bool = True,
+        hot_load_before_training: bool = False,
+    ) -> int:
+        """Initialize or resume training.
+
+        Handles checkpoint resume via ``FiretitanTrainingClient.list_checkpoints``
+        and ``load_state_with_optimizer``.
+
+        Args:
+            resume_from_checkpoint: If True, attempt to resume from the
+                last DCP checkpoint.
+            hot_load_before_training: If True, push initial weights to the
+                inference deployment before the first training step.
+
+        Returns:
+            The starting global step (0 when training from scratch).
+        """
+        start_step = 0
+
+        if resume_from_checkpoint:
+            start_step = await self._try_resume()
+
+        if start_step == 0:
+            logger.info("Starting training from scratch with model: %s", self.config.model.name)
+            if hot_load_before_training:
+                await self._initial_weight_sync()
+
+        return start_step
+
+    async def _try_resume(self) -> int:
+        """Attempt to resume from a DCP checkpoint.
+
+        Returns:
+            The step to resume from, or 0 if no checkpoint was found.
+        """
+        inner = self.training_client.inner
+        source_job_id = self._resume_source_job_id
+        checkpoint_name = self._resume_checkpoint_name
+
+        if checkpoint_name:
+            spec_source_job_id, checkpoint_name = self._parse_checkpoint_spec(checkpoint_name)
+            source_job_id = spec_source_job_id or source_job_id
+            logger.info(
+                "Resuming from configured DCP checkpoint: %s (source job: %s)",
+                checkpoint_name,
+                source_job_id or self._policy_job_id,
+            )
+        else:
+            checkpoints = self._list_resume_checkpoints(source_job_id)
+            if not checkpoints:
+                logger.info("No existing checkpoints found.")
+                return 0
+
+            checkpoint_name = checkpoints[-1]
+            logger.info("Resuming from latest DCP checkpoint: %s", checkpoint_name)
+
+        checkpoint_ref = inner.resolve_checkpoint_path(checkpoint_name, source_job_id=source_job_id)
+        timeout = self.config.hotload.get("dcp_timeout", 2700)
+        await asyncio.to_thread(self.training_client.load_state_with_optimizer, checkpoint_ref, timeout=timeout)
+
+        step = self._parse_checkpoint_step(checkpoint_name)
+
+        await self._sync_weights(f"resume-{step}")
+        return step
+
+    @staticmethod
+    def _parse_checkpoint_spec(spec: str) -> tuple[str | None, str]:
+        """Parse ``job_id:checkpoint_name`` or a plain checkpoint name."""
+        if ":" in spec and not spec.startswith(("gs://", "/")):
+            source_job_id, checkpoint_name = spec.split(":", 1)
+            return source_job_id, checkpoint_name
+        return None, spec
+
+    def _list_resume_checkpoints(self, source_job_id: str | None) -> list[str]:
+        """List DCP checkpoint names from the source job when available."""
+        if self._rlor_mgr is not None and source_job_id:
+            rows = self._rlor_mgr.list_checkpoints(source_job_id)
+            checkpoints = [(row.get("name") or "").rstrip("/").rsplit("/", 1)[-1] for row in rows if self._is_dcp_checkpoint_row(row)]
+            return sorted(checkpoints, key=self._parse_checkpoint_step)
+
+        checkpoints = self.training_client.inner.list_checkpoints()
+        if isinstance(checkpoints, tuple):
+            checkpoints = checkpoints[0]
+        return list(checkpoints)
+
+    @staticmethod
+    def _is_dcp_checkpoint_row(row: dict) -> bool:
+        checkpoint_type = row.get("checkpointType") or ""
+        return checkpoint_type.endswith("TRAINING") or checkpoint_type.endswith("TRAINING_LORA")
+
+    @classmethod
+    def _parse_checkpoint_step(cls, checkpoint_name: str) -> int:
+        """Parse integer step from DCP names like ``step-50``."""
+        match = cls._STEP_CHECKPOINT_RE.search(checkpoint_name)
+        if not match:
+            logger.warning("Could not parse step from checkpoint name: %s", checkpoint_name)
+            return 0
+        return int(match.group(1))
+
+    async def _initial_weight_sync(self) -> None:
+        """Push initial base weights to the inference deployment."""
+        await self._sync_weights("step-0-base", checkpoint_type="base")
+
+    async def _sync_weights(self, name: str, checkpoint_type: str | None = None) -> str | None:
+        """Save sampler weights and hot-load them into the deployment.
+
+        Returns the snapshot_name on success, None on failure."""
+        if self.weight_syncer is None:
+            return None
+        snapshot_name = await asyncio.to_thread(
+            self.weight_syncer.save_and_hotload,
+            name,
+            checkpoint_type=checkpoint_type,
+        )
+        logger.debug("Weights synced to deployment: %s", name)
+        return snapshot_name
+
+    # ------------------------------------------------------------------
+    # Loss helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _process_datums(
+        raw_datums: list[tinker.Datum],
+    ) -> tuple[list[tinker.Datum], list[float], list[list[float]], list[int], list[int]]:
+        """Extract rollout data and rebuild clean datums matching cookbook format.
+
+        Returns (clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens).
+        """
+        clean_datums: list[tinker.Datum] = []
+        advantages: list[float] = []
+        inf_logprobs: list[list[float]] = []
+        prompt_lens: list[int] = []
+        num_loss_tokens: list[int] = []
+        for datum in raw_datums:
+            # Extract rollout data
+            inf_logprobs.append(list(datum.loss_fn_inputs["logprobs"].data))
+            mask = datum.loss_fn_inputs["mask"].data
+            adv_data = datum.loss_fn_inputs["advantages"].data
+            prompt_len = len(mask) + 1
+            scalar = 0.0
+            for i, m in enumerate(mask):
+                if m != 0:
+                    prompt_len = i + 1
+                    scalar = float(adv_data[i])
+                    break
+            prompt_lens.append(prompt_len)
+            advantages.append(scalar)
+            num_loss_tokens.append(int(sum(mask)))
+
+            # Rebuild clean datum: target_tokens + loss_mask only
+            inputs = {"target_tokens": datum.loss_fn_inputs["target_tokens"]}
+            if "mask" in datum.loss_fn_inputs:
+                inputs["loss_mask"] = datum.loss_fn_inputs["mask"]
+            clean_datums.append(tinker.Datum(model_input=datum.model_input, loss_fn_inputs=inputs))
+
+        return clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens
+
+    async def _compute_proximal_logprobs(
+        self,
+        datums: list[tinker.Datum],
+    ) -> list[list[float]]:
+        """Compute proximal (pi_old) logprobs via policy.forward().
+
+        Only called when ``bypass_mode=False`` (3-policy / decoupled PPO).
+        """
+        prox_fwd = await asyncio.to_thread(
+            self.training_client.forward,
+            datums,
+            "cross_entropy",
+        )
+        return [out["logprobs"].data for out in prox_fwd.loss_fn_outputs]
+
+    @staticmethod
+    def _compute_rollout_entropy_metrics(datums: list[tinker.Datum]) -> dict[str, float]:
+        total_logprob = 0.0
+        total_tokens = 0
+        for datum in datums:
+            logprobs = datum.loss_fn_inputs["logprobs"].data
+            mask = datum.loss_fn_inputs["mask"].data
+            for lp, m in zip(logprobs, mask, strict=True):
+                if m:
+                    total_logprob += float(lp)
+                    total_tokens += 1
+
+        if total_tokens == 0:
+            return {}
+
+        entropy = -total_logprob / total_tokens
+        return {
+            "train/entropy": entropy,
+            "train/perplexity": math.exp(entropy),
+        }
+
+    @staticmethod
+    def _compute_offpolicy_metrics(
+        old_logprobs: list[list[float]],
+        rollout_logprobs: list[list[float]],
+        masks: list[list[int]],
+    ) -> dict[str, float]:
+        import torch
+
+        safety_bound = 20.0
+        training_means = []
+        rollout_means = []
+        log_ratio_sums = []
+        token_old = []
+        token_rollout = []
+
+        for old_lp, rollout_lp, mask in zip(old_logprobs, rollout_logprobs, masks, strict=False):
+            active_old = []
+            active_rollout = []
+            for old, rollout, m in zip(old_lp, rollout_lp, mask, strict=False):
+                if m:
+                    active_old.append(float(old))
+                    active_rollout.append(float(rollout))
+            if not active_old:
+                continue
+
+            old_t = torch.tensor(active_old, dtype=torch.float32)
+            rollout_t = torch.tensor(active_rollout, dtype=torch.float32)
+            training_means.append(old_t.mean())
+            rollout_means.append(rollout_t.mean())
+            log_ratio_sums.append((old_t - rollout_t).sum())
+            token_old.append(old_t)
+            token_rollout.append(rollout_t)
+
+        if not token_old:
+            return {}
+
+        mean_log_prob_training = torch.stack(training_means)
+        mean_log_prob_rollout = torch.stack(rollout_means)
+        old_flat = torch.cat(token_old)
+        rollout_flat = torch.cat(token_rollout)
+        log_ratio = old_flat - rollout_flat
+        logprob_abs_diff = log_ratio.abs()
+        old_prob = torch.exp(old_flat)
+        rollout_prob = torch.exp(rollout_flat)
+        prob_abs_diff = (old_prob - rollout_prob).abs()
+        log_ratio_safe = torch.clamp(log_ratio, min=-safety_bound, max=safety_bound)
+        ratio = torch.exp(log_ratio_safe)
+        log_ppl_diff = mean_log_prob_rollout - mean_log_prob_training
+
+        metrics = {
+            "offpolicy/kl": (rollout_flat - old_flat).mean().item(),
+            "offpolicy/k3_kl": (torch.exp(log_ratio) - log_ratio - 1).mean().item(),
+            "offpolicy/logprob_abs_diff/mean": logprob_abs_diff.mean().item(),
+            "offpolicy/logprob_abs_diff/min": logprob_abs_diff.min().item(),
+            "offpolicy/logprob_abs_diff/max": logprob_abs_diff.max().item(),
+            "offpolicy/prob_abs_diff/mean": prob_abs_diff.mean().item(),
+            "offpolicy/prob_abs_diff/min": prob_abs_diff.min().item(),
+            "offpolicy/prob_abs_diff/max": prob_abs_diff.max().item(),
+            "offpolicy/training_ppl": torch.exp(-mean_log_prob_training).mean().item(),
+            "offpolicy/training_log_ppl": (-mean_log_prob_training).mean().item(),
+            "offpolicy/rollout_ppl": torch.exp(-mean_log_prob_rollout).mean().item(),
+            "offpolicy/rollout_log_ppl": (-mean_log_prob_rollout).mean().item(),
+            "offpolicy/log_ppl_diff": log_ppl_diff.mean().item(),
+            "offpolicy/log_ppl_abs_diff": log_ppl_diff.abs().mean().item(),
+            "offpolicy/log_ppl_diff_min": log_ppl_diff.min().item(),
+            "offpolicy/log_ppl_diff_max": log_ppl_diff.max().item(),
+            "offpolicy/ppl_ratio": torch.exp(log_ppl_diff).mean().item(),
+            "offpolicy/ratio/mean": ratio.mean().item(),
+            "offpolicy/ratio/min": ratio.min().item(),
+            "offpolicy/ratio/max": ratio.max().item(),
+        }
+
+        if old_prob.numel() > 1:
+            old_centered = old_prob - old_prob.mean()
+            rollout_centered = rollout_prob - rollout_prob.mean()
+            denom = torch.sqrt(old_centered.square().sum() * rollout_centered.square().sum())
+            if denom.item() > 0.0:
+                metrics["offpolicy/prob_pearson_corr"] = ((old_centered * rollout_centered).sum() / denom).item()
+
+        metrics["offpolicy/chi2_token"] = (ratio.square().mean() - 1.0).item()
+
+        log_ratio_sum = torch.stack(log_ratio_sums)
+        log_ratio_sum_safe = torch.clamp(log_ratio_sum, min=-safety_bound, max=safety_bound)
+        metrics["offpolicy/chi2_seq"] = (torch.exp(2.0 * log_ratio_sum_safe).mean() - 1.0).item()
+
+        return metrics
+
+    def resolve_builtin_loss(self, algorithm_config: AlgorithmConfig, profile=None):
+        """Resolve the builtin server-side loss kernel at setup time.
+
+        Must be called before the first forward-backward pass.
+        Raises ValueError if the loss has no builtin kernel or PP > 1.
+        """
+        from training.utils.rl.cispo import CISPOConfig
+        from training.utils.rl.dapo import DAPOConfig
+        from training.utils.rl.dro import DROConfig
+        from training.utils.rl.gspo import GSPOConfig
+        from training.utils.rl.losses import resolve_builtin_loss
+
+        eps = algorithm_config.eps_clip
+        eps_high = algorithm_config.eps_clip_high
+        loss_fn_name = algorithm_config.loss_fn or "grpo"
+
+        result = resolve_builtin_loss(
+            loss_fn_name,
+            profile,
+            dapo_config=DAPOConfig(
+                eps_clip=eps,
+                eps_clip_high=eps_high if eps_high is not None else 0.28,
+            ),
+            dro_config=DROConfig(),
+            gspo_config=GSPOConfig(
+                clip_ratio_low=eps,
+                clip_ratio_high=eps_high,
+            ),
+            cispo_config=CISPOConfig(
+                eps_low=eps,
+                eps_high=eps_high if eps_high is not None else 0.28,
+            ),
+            eps_clip=eps,
+            eps_clip_high=eps_high,
+        )
+        if result is None:
+            from training.utils.rl.losses import SUPPORTED_POLICY_LOSSES
+
+            raise ValueError(f"loss_fn='{loss_fn_name}' has no builtin server-side kernel. Supported: {', '.join(SUPPORTED_POLICY_LOSSES)}")
+        self._builtin_loss = result
+        logger.info("Resolved builtin loss: kernel=%s, config=%s", result[0], result[1])
+
+    # ------------------------------------------------------------------
+    # Forward-backward
+    # ------------------------------------------------------------------
+
+    @require_training_client
+    async def forward_backward_from_trajectory_groups(
+        self,
+        trajectory_groups: list[TrajectoryGroup],
+        algorithm_config: AlgorithmConfig | None = None,
+    ) -> tuple[list[tinker.Datum] | dict[str, list[tinker.Datum]], list[torch.Tensor], dict]:
+        """Run forward-backward pass using the builtin server-side loss kernel.
+
+        Args:
+            trajectory_groups: List of TrajectoryGroup objects (already filtered/transformed).
+            algorithm_config: Algorithm config (uses ``self.algorithm_config`` if None).
+
+        Returns:
+            ``(training_datums, training_logprobs, adv_metrics)``
+        """
+        from training.utils.rl.losses import build_builtin_loss_datums
+        from training.utils.rl.tis import TISConfig
+
+        if algorithm_config is None:
+            algorithm_config = self.algorithm_config
+
+        raw_datums, adv_metrics = transform_trajectory_groups_to_datums(
+            trajectory_groups,
+            algorithm_config=algorithm_config,
+        )
+
+        adv_metrics["train/num_sequences"] = len(raw_datums)
+        adv_metrics["train/active_tokens"] = sum(int(sum(datum.loss_fn_inputs["mask"].data)) for datum in raw_datums)
+        adv_metrics.update(self._compute_rollout_entropy_metrics(raw_datums))
+
+        rc = algorithm_config.rollout_correction
+        clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens = self._process_datums(raw_datums)
+
+        # seq-mean-token-mean: normalize advantages by number of loss tokens so that
+        # token-sum within each sequence equals token-mean, then NUM_SEQUENCES
+        # at optim_step gives seq-mean-token-mean overall.
+        if algorithm_config.loss_agg_mode == "seq-mean-token-mean":
+            for i in range(len(advantages)):
+                advantages[i] /= max(1, num_loss_tokens[i])
+
+        # Proximal logprobs
+        t0 = time.perf_counter()
+        if rc.bypass_mode:
+            prox_logprobs = inf_logprobs
+        else:
+            prox_logprobs = await self._compute_proximal_logprobs(clean_datums)
+        adv_metrics.update(
+            self._compute_offpolicy_metrics(
+                old_logprobs=prox_logprobs,
+                rollout_logprobs=inf_logprobs,
+                masks=[list(datum.loss_fn_inputs["mask"].data) for datum in raw_datums],
+            )
+        )
+        adv_metrics["time/proximal_forward"] = time.perf_counter() - t0
+
+        # Build datums for the builtin kernel.
+        tis_config = TISConfig(level=rc.tis_mode or "token", cap=rc.tis_cap) if rc.tis_mode else None
+        builtin_datums = build_builtin_loss_datums(
+            clean_datums,
+            advantages,
+            prox_logprobs,
+            inf_logprobs,
+            prompt_lens,
+            tis_config=tis_config,
+            policy_loss=algorithm_config.loss_fn or "grpo",
+        )
+
+        kernel_loss, kernel_config = self._builtin_loss
+        fwd_bwd_result = await asyncio.to_thread(
+            self.training_client.forward_backward,
+            builtin_datums,
+            kernel_loss,
+            loss_fn_config=kernel_config,
+        )
+
+        # Merge remote fwd/bwd metrics (e.g. loss) into adv_metrics
+        if hasattr(fwd_bwd_result, "metrics") and fwd_bwd_result.metrics:
+            for k, v in fwd_bwd_result.metrics.items():
+                if k not in self._METRIC_SKIP_KEYS:
+                    adv_metrics[f"train/{k}"] = v
+
+        return raw_datums, [], adv_metrics
+
+    # ------------------------------------------------------------------
+    # Optimizer step
+    # ------------------------------------------------------------------
+
+    @require_training_client
+    async def optim_step(
+        self,
+        step: int,
+        total_steps: int,
+        learning_rate: float,
+        beta1: float = 0.9,
+        beta2: float = 0.999,
+        eps: float = 1e-8,
+        weight_decay: float = 0.01,
+        grad_clip_norm: float = 1.0,
+    ) -> tuple[float, dict]:
+        """Run optimizer step. Returns (scheduled_lr, metrics)."""
+        scheduled_lr = learning_rate * compute_schedule_lr_multiplier(
+            lr_schedule=self.algorithm_config.lr_schedule,
+            warmup_steps_ratio=self.algorithm_config.warmup_steps_ratio,
+            step=step,
+            total_steps=total_steps,
+        )
+
+        adam_params = AdamParams(
+            learning_rate=scheduled_lr,
+            beta1=beta1,
+            beta2=beta2,
+            eps=eps,
+            weight_decay=weight_decay,
+            grad_clip_norm=grad_clip_norm,
+        )
+        from fireworks.training.sdk.client import GradAccNormalization
+
+        _LOSS_AGG_MAP = {
+            "token-mean": GradAccNormalization.NUM_LOSS_TOKENS,
+            "seq-mean-token-sum": GradAccNormalization.NUM_SEQUENCES,
+            "seq-mean-token-mean": GradAccNormalization.NUM_SEQUENCES,
+        }
+        grad_norm = _LOSS_AGG_MAP.get(self.algorithm_config.loss_agg_mode)
+        optim_result = await asyncio.to_thread(
+            self.training_client.optim_step,
+            adam_params,
+            grad_accumulation_normalization=grad_norm,
+        )
+
+        metrics = {}
+        if hasattr(optim_result, "metrics") and optim_result.metrics:
+            for k, v in optim_result.metrics.items():
+                if k not in self._METRIC_SKIP_KEYS:
+                    metrics[f"train/{k}"] = v
+
+        return scheduled_lr, metrics
+
+    # ------------------------------------------------------------------
+    # Checkpointing
+    # ------------------------------------------------------------------
+
+    @require_training_client
+    async def sync_weights(self, step: int, checkpoint_type: str | None = None) -> str | None:
+        """Hot-load current weights into the inference deployment.
+
+        Returns the snapshot_name on success, None on failure."""
+        return await self._sync_weights(f"step-{step}", checkpoint_type=checkpoint_type)
+
+    async def promote_checkpoint(self, snapshot_name: str, output_model_id: str) -> None:
+        """Promote a sampler checkpoint to a deployable Fireworks model."""
+        if self._rlor_mgr is None or self._policy_job_id is None:
+            logger.warning("Cannot promote: rlor_mgr or policy_job_id not set")
+            return
+        await asyncio.to_thread(
+            self._rlor_mgr.promote_checkpoint,
+            self._policy_job_id,
+            snapshot_name,
+            output_model_id,
+            self.config.model.name,
+        )
+        logger.info("Promoted checkpoint '%s' -> model '%s'", snapshot_name, output_model_id)
+
+    @require_training_client
+    async def save_dcp_checkpoint(self, step: int) -> None:
+        """Save a DCP checkpoint for resume."""
+        name = f"step-{step}"
+        timeout = self.config.hotload.get("dcp_timeout", 2700)
+        try:
+            await asyncio.to_thread(self.training_client.save_state, name, timeout=timeout)
+            logger.info("DCP checkpoint saved: %s", name)
+        except Exception:
+            logger.exception("Failed to save DCP checkpoint %s", name)
+            raise

--- a/rllm/experimental/rollout/__init__.py
+++ b/rllm/experimental/rollout/__init__.py
@@ -4,12 +4,14 @@ from .rollout_engine import ModelOutput, RolloutEngine
 from .types import TinkerTokenInput, TinkerTokenOutput, TokenInput, Tokenizer, TokenOutput, VerlTokenInput, VerlTokenOutput
 
 if TYPE_CHECKING:
+    from .fireworks_engine import FireworksEngine
     from .tinker_engine import TinkerEngine
     from .verl_engine import VerlEngine
 
 __all__ = [
     "ModelOutput",
     "RolloutEngine",
+    "FireworksEngine",
     "TinkerEngine",
     "VerlEngine",
     # Token types
@@ -24,6 +26,10 @@ __all__ = [
 
 
 def __getattr__(name):
+    if name == "FireworksEngine":
+        from .fireworks_engine import FireworksEngine as _FireworksEngine
+
+        return _FireworksEngine
     if name == "TinkerEngine":
         from .tinker_engine import TinkerEngine as _TinkerEngine
 

--- a/rllm/experimental/rollout/fireworks_engine.py
+++ b/rllm/experimental/rollout/fireworks_engine.py
@@ -1,0 +1,335 @@
+"""RolloutEngine backed by Fireworks ``DeploymentSampler``.
+
+Inherits from ``TinkerEngine``. The only differences are:
+
+1. ``__init__``: creates a ``DeploymentSampler`` instead of requiring a
+   ``tinker.ServiceClient``.  The sampler is stored as ``self.sampling_client``
+   so that the inherited ``set_sampling_client`` / ``generate_episodes`` flow
+   works unchanged.
+2. ``get_token_output_from_token_input``: calls ``DeploymentSampler.completions``
+   (token-in / token-out) and wraps the response in a ``SampledSequence``-compatible
+   adapter so that the inherited ``assemble_model_output`` works unchanged.
+
+Everything else, including ``get_model_response``, ``assemble_model_output``,
+``set_sampling_client``, ``_prepare_max_tokens``, and chat-template rendering,
+is inherited from ``TinkerEngine``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+from typing import Any
+
+from fireworks.training.sdk import DeploymentSampler
+from typing_extensions import override
+
+from rllm.experimental.rollout.rollout_engine import ModelOutput
+from rllm.experimental.rollout.tinker_engine import (
+    TinkerEngine,
+    _flat_token_input_length,
+)
+from rllm.experimental.rollout.types import (
+    TinkerTokenInput,
+    TinkerTokenOutput,
+    Tokenizer,
+)
+from rllm.workflows import TerminationEvent, TerminationReason
+
+logger = logging.getLogger(__name__)
+
+_MAX_SAMPLE_ATTEMPTS = 5
+_TRANSIENT_ERROR_MARKERS = (
+    "502",
+    "503",
+    "425",
+    "Connection",
+    "incomplete chunked read",
+    "_SSETruncationError",
+    "closed the SSE stream mid-generation",
+)
+
+
+class _EmptyCompletionIdsError(RuntimeError):
+    pass
+
+
+class _SampledSequenceAdapter:
+    """Lightweight adapter so that a ``DeploymentSampler.completions`` response
+    exposes the same ``.tokens``, ``.logprobs``, ``.stop_reason`` interface
+    that ``tinker.SampledSequence`` (``TinkerTokenOutput``) provides."""
+
+    __slots__ = ("tokens", "logprobs", "stop_reason", "routing_matrices", "server_metrics")
+
+    def __init__(
+        self,
+        tokens: list[int],
+        logprobs: list[float] | None,
+        stop_reason: str | None,
+        routing_matrices: list[str] | None = None,
+        server_metrics: dict | None = None,
+    ):
+        self.tokens = tokens
+        self.logprobs = logprobs
+        self.stop_reason = stop_reason
+        self.routing_matrices = routing_matrices
+        self.server_metrics = server_metrics
+
+
+class FireworksEngine(TinkerEngine):
+    """``TinkerEngine`` subclass that uses a Fireworks ``DeploymentSampler``
+    for inference instead of a Tinker ``SamplingClient``.
+
+    ``DeploymentSampler`` supports token-in / token-out via the
+    ``/inference/v1/completions`` endpoint, so ``TinkerTokenInput`` and
+    ``TinkerTokenOutput`` are fully supported.
+    """
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        sampler: DeploymentSampler,
+        max_prompt_length: int = 4096,
+        max_response_length: int = 4096,
+        max_model_length: int = 32768,
+        sampling_params: dict | None = None,
+        disable_thinking: bool = False,
+        accumulate_reasoning: bool = False,
+        reasoning_effort: str = "medium",
+        sample_timeout: int = 600,
+        processor=None,
+        router_replay: bool = False,
+        **kwargs,
+    ):
+        """
+        Args:
+            tokenizer: HuggingFace tokenizer for chat-template rendering.
+            sampler: Pre-built ``DeploymentSampler``.
+            max_prompt_length: Hard cap on prompt token length.
+            max_response_length: Default max completion tokens.
+            max_model_length: Total context window.
+            sampling_params: Dict with optional ``"train"`` / ``"val"``
+                sub-dicts for default sampling kwargs.
+            disable_thinking: Suppress thinking tokens in the prompt.
+            accumulate_reasoning: Accumulate reasoning across turns.
+            reasoning_effort: Reasoning effort hint for the parser.
+            sample_timeout: HTTP timeout (seconds) for sampling calls.
+            processor: Optional ``ProcessorMixin`` for multimodal models.
+            router_replay: If True, request and propagate routing matrices
+                for Router Replay (R3) training.
+        """
+        from rllm.experimental.rollout.rollout_engine import RolloutEngine
+        from rllm.parser import ChatTemplateParser
+
+        # Skip TinkerEngine.__init__ (it requires tinker.ServiceClient);
+        # set up the same attributes directly.
+        RolloutEngine.__init__(self)
+
+        self.tokenizer = tokenizer
+        self.max_prompt_length = max_prompt_length
+        self.max_response_length = max_response_length
+        self.max_model_length = max_model_length - 1 if max_model_length is not None else max_prompt_length + max_response_length - 1
+        self.accumulate_reasoning = accumulate_reasoning
+        self.reasoning_effort = reasoning_effort
+
+        self.train_sampling_params = dict((sampling_params or {}).get("train", {}))
+        self.val_sampling_params = dict((sampling_params or {}).get("val", {}))
+
+        # Chat template parser (same setup as TinkerEngine bypass mode)
+        self.bypass_render_with_parser = True
+        self.chat_parser = ChatTemplateParser.get_parser(
+            tokenizer,
+            processor=processor,
+            disable_thinking=disable_thinking,
+        )
+
+        self.sample_timeout = sample_timeout
+        self.router_replay = router_replay
+        self.sampling_client = sampler
+
+    # ------------------------------------------------------------------
+    # Token-in / token-out override
+    # ------------------------------------------------------------------
+
+    @override
+    async def get_model_response(self, messages: list[dict], **kwargs) -> ModelOutput:
+        application_id = kwargs.pop("application_id", None)
+
+        tools = kwargs.pop("tools", [])
+        accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.accumulate_reasoning)
+        reasoning_effort = kwargs.pop("reasoning_effort", self.reasoning_effort)
+
+        prompt = self.chat_parser.parse(
+            messages,
+            add_generation_prompt=True,
+            is_first_msg=True,
+            tools=tools,
+            reasoning_effort=reasoning_effort,
+            accumulate_reasoning=accumulate_reasoning,
+        )
+        token_input = self.tokenizer.encode(prompt, add_special_tokens=False)
+
+        if application_id is not None:
+            kwargs["user"] = application_id
+
+        version = self.weight_version
+        sampled_sequence = await self.get_token_output_from_token_input(token_input=token_input, **kwargs)
+        result = self.assemble_model_output(token_input=token_input, token_output=sampled_sequence)
+        result.weight_version = version
+        result.routing_matrices = sampled_sequence.routing_matrices
+        result.metrics = sampled_sequence.server_metrics
+        return result
+
+    @override
+    async def get_model_response_from_tokens(self, token_input, **kwargs) -> ModelOutput:
+        application_id = kwargs.pop("application_id", None)
+        if application_id is not None:
+            kwargs["user"] = application_id
+
+        version = self.weight_version
+        sampled_sequence = await self.get_token_output_from_token_input(token_input=token_input, **kwargs)
+        result = self.assemble_model_output(token_input=token_input, token_output=sampled_sequence)
+        result.weight_version = version
+        result.routing_matrices = sampled_sequence.routing_matrices
+        result.metrics = sampled_sequence.server_metrics
+        return result
+
+    @property
+    def supports_token_in_token_out(self) -> bool:
+        return True
+
+    async def compute_logprobs(self, ids: list[int]) -> list[float]:
+        raise NotImplementedError("compute_logprobs is not supported by FireworksEngine.")
+
+    @override
+    async def get_token_output_from_token_input(self, token_input: TinkerTokenInput, **kwargs) -> TinkerTokenOutput:
+        """Sample from the Fireworks deployment using pre-tokenized IDs.
+
+        Returns a ``SampledSequence``-compatible object so that the inherited
+        ``assemble_model_output`` works unchanged.
+        """
+        if self.sampling_client is None:
+            raise RuntimeError("Sampling client not set. Call set_sampling_client() first.")
+
+        input_length = _flat_token_input_length(token_input)
+
+        enforce_max_prompt_length = kwargs.pop("enforce_max_prompt_length", True)
+        if enforce_max_prompt_length and (input_length > self.max_prompt_length or input_length >= self.max_model_length):
+            raise TerminationEvent(TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED)
+
+        # Flatten TinkerTokenInput to plain list[int]
+        prompt_ids: list[int] = []
+        for elem in token_input:
+            if isinstance(elem, int):
+                prompt_ids.append(elem)
+            else:
+                # tinker.EncodedTextChunk
+                prompt_ids.extend(elem.tokens)
+
+        sampling_params = self.val_sampling_params.copy() if self.is_validation else self.train_sampling_params.copy()
+        requested_max_tokens = kwargs.pop("max_tokens", kwargs.pop("max_new_tokens", self.max_response_length))
+        requested_max_tokens = sampling_params.pop("max_tokens", requested_max_tokens)
+        max_tokens = self._prepare_max_tokens(requested_max_tokens, input_length)
+
+        for key in ("temperature", "top_p", "top_k", "user"):
+            if key in kwargs:
+                sampling_params[key] = kwargs.pop(key)
+
+        if self.router_replay:
+            sampling_params["include_routing_matrix"] = True
+
+        raw, server_metrics = await self._completions_with_retry(
+            prompt_ids,
+            max_tokens,
+            sampling_params,
+        )
+
+        choice = raw["choices"][0]
+        completion_ids: list[int] = list((choice.get("raw_output") or {}).get("completion_token_ids") or [])
+
+        logprobs: list[float] | None = None
+        content: list[dict] | None = None
+        lp_data = choice.get("logprobs")
+        if lp_data and isinstance(lp_data, dict):
+            content = lp_data.get("content")
+            if isinstance(content, list) and content:
+                logprobs = [tok.get("logprob", 0.0) for tok in content]
+
+        finish_reason = choice.get("finish_reason", "stop")
+
+        routing_matrices = None
+        if self.router_replay and content:
+            matrices = [tok.get("routing_matrix", "") for tok in content]
+            if any(matrices):
+                routing_matrices = matrices
+            else:
+                logger.debug("router_replay enabled but API returned no routing matrices")
+
+        if logprobs is not None and len(logprobs) != len(completion_ids):
+            raise RuntimeError(f"Fireworks response length mismatch: {len(logprobs)} logprobs vs {len(completion_ids)} completion tokens")
+        if routing_matrices is not None and len(routing_matrices) != len(completion_ids):
+            raise RuntimeError(f"Fireworks response length mismatch: {len(routing_matrices)} routing matrices vs {len(completion_ids)} completion tokens")
+
+        return _SampledSequenceAdapter(  # type: ignore[return-value]
+            tokens=completion_ids,
+            logprobs=logprobs,
+            stop_reason=finish_reason,
+            routing_matrices=routing_matrices,
+            server_metrics=server_metrics,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal retry helper
+    # ------------------------------------------------------------------
+
+    async def _completions_with_retry(
+        self,
+        prompt_ids: list[int],
+        max_tokens: int,
+        sampling_kwargs: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict | None]:
+        """Call ``DeploymentSampler.async_completions_stream`` with transient-error retries.
+
+        Returns (response_dict, server_metrics_dict)."""
+
+        for attempt in range(_MAX_SAMPLE_ATTEMPTS):
+            try:
+                result, server_metrics = await self.sampling_client.async_completions_stream(
+                    prompt=prompt_ids,
+                    max_tokens=max_tokens,
+                    raw_output=True,
+                    logprobs=True,
+                    http_timeout=self.sample_timeout,
+                    **sampling_kwargs,
+                )
+                metrics_dict = {k: v for k, v in dataclasses.asdict(server_metrics).items() if v is not None} if server_metrics else None
+                choice = (result.get("choices") or [{}])[0]
+                completion_ids = (choice.get("raw_output") or {}).get("completion_token_ids") or []
+                if not completion_ids:
+                    raise _EmptyCompletionIdsError("Fireworks response included empty completion_token_ids")
+                return result, metrics_dict
+            except Exception as exc:
+                err = str(exc)
+                exc_name = exc.__class__.__name__
+                transient = isinstance(exc, _EmptyCompletionIdsError) or any(marker in err or marker in exc_name for marker in _TRANSIENT_ERROR_MARKERS)
+                if transient and attempt < _MAX_SAMPLE_ATTEMPTS - 1:
+                    wait = 10 * (attempt + 1)
+                    logger.debug(
+                        "Attempt %d/%d failed (%s), retrying in %ds...",
+                        attempt + 1,
+                        _MAX_SAMPLE_ATTEMPTS,
+                        exc,
+                        wait,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                resp_text = getattr(getattr(exc, "response", None), "text", None)
+                logger.error(
+                    "Sampling failed permanently after %d attempts: %s\n%s",
+                    attempt + 1,
+                    exc,
+                    resp_text or "",
+                )
+                raise
+        raise RuntimeError("unreachable")

--- a/rllm/experimental/unified_trainer.py
+++ b/rllm/experimental/unified_trainer.py
@@ -869,7 +869,7 @@ class AgentTrainer:
         train_dataset: Dataset | None = None,
         val_dataset: Dataset | None = None,
         workflow_args: dict | None = None,
-        backend: Literal["verl", "tinker"] = "verl",
+        backend: Literal["verl", "tinker", "fireworks"] = "verl",
         agent_flow: Any = None,
         evaluator: Any = None,
         store: Store | None = None,
@@ -911,6 +911,20 @@ class AgentTrainer:
                 store=store,
                 **kwargs,
             )
+        elif backend == "fireworks":
+            from rllm.experimental.fireworks.fireworks_launcher import FireworksTrainerLauncher
+
+            self.launcher = FireworksTrainerLauncher(
+                config=config,
+                workflow_class=workflow_class,
+                train_dataset=train_dataset,
+                val_dataset=val_dataset,
+                workflow_args=workflow_args,
+                store=store,
+                **kwargs,
+            )
+        else:
+            raise ValueError(f"Unsupported backend: {backend}")
 
     def train(self):
         self.launcher.train()


### PR DESCRIPTION
## Summary

Adds an experimental Fireworks training backend for `UnifiedTrainer`, including Fireworks rollout, policy update, checkpoint, and hotload/sync plumbing. This lets agent/workflow training use Fireworks Firetitan for policy updates and Fireworks deployments for sampling while keeping the integration under `rllm.experimental`.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Added an optional `fireworks` dependency extra with pinned Fireworks SDK and training cookbook versions.
- Added `rllm.experimental.fireworks` backend, launcher, and policy trainer for Fireworks training, checkpoint resume/save, optimizer steps, and deployment weight sync.
- Added `FireworksEngine` rollout support and wired `backend="fireworks"` into `AgentTrainer` / `UnifiedTrainer`.
- Added Fireworks backend config under `rllm/experimental/config/rllm/backend/fireworks.yaml`.

## Validation

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

## Breaking changes / migration notes

- None. This adds a new experimental backend and optional dependency group.

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [x] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

N/A