### PR TITLE
feat(parser): add Harmony tool call support

### DIFF
--- a/rllm/parser/chat_template_parser.py
+++ b/rllm/parser/chat_template_parser.py
@@ -651,6 +651,8 @@ class LlamaChatTemplateParser(ChatTemplateParser):
 
 
 class HarmonyChatTemplateParser(ChatTemplateParser):
+    builtin_tool_prefixes = ("browser", "python")
+
     def __init__(self, tokenizer=None):
         from openai_harmony import (
             HarmonyEncodingName,
@@ -664,8 +666,71 @@ class HarmonyChatTemplateParser(ChatTemplateParser):
     def parse(self, messages, add_generation_prompt=False, is_first_msg=False, **kwargs) -> str:
         return self.parse_prompt_from_messages(messages, add_generation_prompt=add_generation_prompt, is_first_msg=is_first_msg, **kwargs)
 
+    def _tool_name(self, tool) -> str:
+        if isinstance(tool, Tool):
+            return tool.name or ""
+        if isinstance(tool, dict):
+            if "function" in tool:
+                return tool["function"].get("name", "")
+            return tool.get("name", "")
+        return getattr(tool, "name", "")
+
+    def _is_builtin_tool(self, name: str) -> bool:
+        return name.startswith(self.builtin_tool_prefixes)
+
+    def _tool_json(self, tool) -> dict:
+        if isinstance(tool, Tool):
+            return tool.json
+        if isinstance(tool, dict):
+            return tool
+        tool_json = getattr(tool, "json", None)
+        if tool_json is not None:
+            return tool_json
+        return {}
+
+    def _function_tool_description(self, tool):
+        from openai_harmony import ToolDescription
+
+        tool_json = self._tool_json(tool)
+        function_schema = tool_json.get("function", tool_json)
+        return ToolDescription(
+            name=function_schema["name"],
+            description=function_schema.get("description", ""),
+            parameters=function_schema.get("parameters"),
+        )
+
+    def _normalize_tool_call(self, tool_call) -> tuple[str, dict | str]:
+        if isinstance(tool_call, ToolCall):
+            return tool_call.name, tool_call.arguments
+        if isinstance(tool_call, dict) and "function" in tool_call:
+            function_call = tool_call["function"]
+            return function_call.get("name", ""), function_call.get("arguments", {})
+        if isinstance(tool_call, dict):
+            return tool_call.get("name", ""), tool_call.get("arguments", {})
+        return getattr(tool_call, "name", ""), getattr(tool_call, "arguments", {})
+
+    def _normalize_tool_output(self, tool_output) -> ToolOutput:
+        if isinstance(tool_output, ToolOutput):
+            return tool_output
+        if isinstance(tool_output, dict):
+            return ToolOutput(**tool_output)
+        return ToolOutput(name=getattr(tool_output, "name", "tool"), output=str(tool_output))
+
+    def _recipient_for_tool_name(self, name: str) -> str:
+        if self._is_builtin_tool(name) or name.startswith("functions."):
+            return name
+        return f"functions.{name}"
+
+    def _tool_name_from_recipient(self, recipient: str) -> str:
+        if recipient.startswith("functions."):
+            return recipient[len("functions.") :]
+        return recipient
+
+    def _message_text(self, message) -> str:
+        return "".join(getattr(content, "text", "") for content in message.content)
+
     def parse_prompt_from_messages(self, messages, add_generation_prompt=False, is_first_msg=False, **kwargs):
-        from openai_harmony import Conversation, DeveloperContent, Message, ReasoningEffort, RenderConversationConfig, Role, SystemContent
+        from openai_harmony import Author, Conversation, DeveloperContent, Message, ReasoningEffort, RenderConversationConfig, Role, SystemContent
 
         # messages is a list[dict], where each dict is of the following structure:
         # {
@@ -676,17 +741,34 @@ class HarmonyChatTemplateParser(ChatTemplateParser):
 
         messages = deepcopy(messages)
         harmony_messages: list[Message] = []
+        tools = list(kwargs.get("tools") or [])
+        builtin_tools = [tool for tool in tools if self._is_builtin_tool(self._tool_name(tool))]
+        function_tools = [tool for tool in tools if not self._is_builtin_tool(self._tool_name(tool))]
 
         if is_first_msg:
             # 1. system prompt
             reasoning_effort = ReasoningEffort(kwargs.get("reasoning_effort", "medium").capitalize())
             system_message = SystemContent.new().with_reasoning_effort(reasoning_effort)
+            for tool in builtin_tools:
+                tool_name = self._tool_name(tool)
+                if tool_name.startswith("browser"):
+                    system_message = system_message.with_browser_tool()
+                elif tool_name.startswith("python"):
+                    tool_config = getattr(tool, "tool_config", None)
+                    system_message = system_message.with_tools(tool_config) if tool_config is not None else system_message.with_python_tool()
             harmony_messages.append(Message.from_role_and_content(Role.SYSTEM, system_message))
 
             # 2. developer prompt
-            if messages[0]["role"] == "system":
+            developer_message = DeveloperContent.new()
+            has_developer_message = False
+            if messages and messages[0]["role"] == "system":
                 instructions = messages.pop(0).get("content")
-                developer_message = DeveloperContent.new().with_instructions(instructions)
+                developer_message = developer_message.with_instructions(instructions)
+                has_developer_message = True
+            if function_tools:
+                developer_message = developer_message.with_function_tools([self._function_tool_description(tool) for tool in function_tools])
+                has_developer_message = True
+            if has_developer_message:
                 harmony_messages.append(Message.from_role_and_content(Role.DEVELOPER, developer_message))
 
         # 3. the rest of the messages
@@ -696,12 +778,40 @@ class HarmonyChatTemplateParser(ChatTemplateParser):
             elif message["role"] == "assistant":
                 reasoning = message.get("reasoning", None)
                 content = message.get("content", None)
+                tool_calls = message.get("tool_calls", None) or []
                 if reasoning:
                     harmony_messages.append(Message.from_role_and_content(Role.ASSISTANT, reasoning).with_channel("analysis"))
+                for tool_call in tool_calls:
+                    name, arguments = self._normalize_tool_call(tool_call)
+                    if isinstance(arguments, str):
+                        rendered_arguments = arguments
+                    elif name.startswith("python") and isinstance(arguments, dict) and "code" in arguments:
+                        rendered_arguments = arguments["code"]
+                    else:
+                        rendered_arguments = json.dumps(arguments)
+                    channel = "analysis" if self._is_builtin_tool(name) else "commentary"
+                    content_type = "code" if name.startswith("python") else "json"
+                    harmony_messages.append(
+                        Message.from_role_and_content(Role.ASSISTANT, rendered_arguments).with_channel(channel).with_recipient(self._recipient_for_tool_name(name)).with_content_type(content_type)
+                    )
                 if content:
-                    harmony_messages.append(Message.from_role_and_content(Role.ASSISTANT, content).with_channel("final"))
+                    content_channel = "commentary" if tool_calls else "final"
+                    harmony_messages.append(Message.from_role_and_content(Role.ASSISTANT, content).with_channel(content_channel))
             elif message["role"] == "tool":
-                raise NotImplementedError("Tool messages are not supported yet")
+                tool_outputs = message.get("tool_outputs", [])
+                if not tool_outputs and message.get("content") is not None:
+                    tool_outputs = [{"name": message.get("name", "tool"), "output": message["content"]}]
+                for tool_output in tool_outputs:
+                    tool_output = self._normalize_tool_output(tool_output)
+                    channel = "analysis" if self._is_builtin_tool(tool_output.name) else "commentary"
+                    harmony_messages.append(
+                        Message.from_author_and_content(
+                            Author.new(Role.TOOL, self._recipient_for_tool_name(tool_output.name)),
+                            str(tool_output),
+                        )
+                        .with_channel(channel)
+                        .with_recipient("assistant")
+                    )
             else:
                 raise NotImplementedError(f"Unsupported message role: {message['role']}")
 
@@ -729,21 +839,35 @@ class HarmonyChatTemplateParser(ChatTemplateParser):
 
         analysis = ""
         final = ""
+        tool_calls = []
         for message in harmony_messages:
-            content = message.content[0].text
+            content = self._message_text(message)
             channel = message.channel
+            recipient = message.recipient
 
-            if channel == "analysis":
+            if recipient:
+                name = self._tool_name_from_recipient(recipient)
+                if name.startswith("python"):
+                    arguments = {"code": content}
+                else:
+                    try:
+                        arguments = json.loads(content) if content.strip() else {}
+                    except json.JSONDecodeError:
+                        logger.warning("Failed to parse Harmony tool call arguments as JSON: %s", content)
+                        arguments = {}
+                    if not isinstance(arguments, dict):
+                        logger.warning("Harmony tool call arguments parsed to %s, expected dict", type(arguments).__name__)
+                        arguments = {}
+                tool_calls.append(ToolCall(name=name, arguments=arguments))
+            elif channel == "analysis":
                 analysis += content
             elif channel == "final":
                 final += content
 
-        # TODO: handle tool calls
-
         return {
             "content": final,
             "reasoning": analysis,
-            "tool_calls": [],
+            "tool_calls": tool_calls,
         }
 
 

--- a/rllm/tools/tool_base.py
+++ b/rllm/tools/tool_base.py
@@ -22,6 +22,9 @@ class ToolOutput:
     error: str | None = None
     metadata: dict | None = None
 
+    def to_dict(self):
+        return {"name": self.name, "output": self.output, "error": self.error, "metadata": self.metadata}
+
     def __str__(self) -> str:
         """Convert the tool output to a string representation."""
         if self.error:

--- a/tests/parser/test_harmony_chat_parser.py
+++ b/tests/parser/test_harmony_chat_parser.py
@@ -1,0 +1,100 @@
+import pytest
+
+from rllm.parser.chat_template_parser import HarmonyChatTemplateParser
+from rllm.tools.tool_base import Tool, ToolCall, ToolOutput
+
+
+class BuiltinTool:
+    name = "python"
+
+
+@pytest.fixture
+def harmony_parser(tmp_path, monkeypatch):
+    pytest.importorskip("openai_harmony")
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    try:
+        return HarmonyChatTemplateParser()
+    except Exception as exc:
+        pytest.skip(f"Harmony encoding unavailable: {exc}")
+
+
+def lookup(query: str) -> str:
+    """Look up a query."""
+    return query
+
+
+def completion_tokens(parser: HarmonyChatTemplateParser, message) -> list[int]:
+    rendered = parser.enc.decode_utf8(parser.enc.render(message))
+    completion = rendered.removeprefix("<|start|>assistant")
+    return parser.enc.encode(completion, allowed_special="all")
+
+
+def test_harmony_renders_builtin_and_function_tools(harmony_parser):
+    prompt = harmony_parser.parse(
+        [{"role": "user", "content": "use tools"}],
+        is_first_msg=True,
+        tools=[BuiltinTool(), Tool(function=lookup)],
+    )
+
+    assert "## python" in prompt
+    assert "namespace functions" in prompt
+    assert "type lookup" in prompt
+
+
+def test_harmony_renders_assistant_tool_calls_and_tool_messages(harmony_parser):
+    prompt = harmony_parser.parse(
+        [
+            {"role": "user", "content": "look up weather"},
+            {
+                "role": "assistant",
+                "tool_calls": [ToolCall(name="lookup", arguments={"query": "weather"})],
+            },
+            {
+                "role": "tool",
+                "tool_outputs": [ToolOutput(name="lookup", output={"result": "sunny"})],
+            },
+            {"role": "assistant", "content": "It is sunny."},
+        ],
+        is_first_msg=True,
+        tools=[Tool(function=lookup)],
+    )
+
+    assert "to=functions.lookup" in prompt
+    assert '{"query": "weather"}' in prompt
+    assert "<|start|>functions.lookup to=assistant" in prompt
+    assert '{"result": "sunny"}' in prompt
+    assert "It is sunny." in prompt
+
+
+def test_harmony_renders_builtin_python_tool_call(harmony_parser):
+    prompt = harmony_parser.parse(
+        [
+            {"role": "user", "content": "compute"},
+            {
+                "role": "assistant",
+                "tool_calls": [ToolCall(name="python", arguments={"code": "print(1)"})],
+            },
+        ],
+        is_first_msg=True,
+        tools=[BuiltinTool()],
+    )
+
+    assert "to=python" in prompt
+    assert "analysis code" in prompt
+    assert "print(1)" in prompt
+
+
+def test_harmony_parse_completion_tool_calls(harmony_parser):
+    from openai_harmony import Message, Role
+
+    function_message = Message.from_role_and_content(Role.ASSISTANT, '{"query":"weather"}').with_channel("commentary").with_recipient("functions.lookup").with_content_type("json")
+    parsed = harmony_parser.parse_completion(completion_tokens(harmony_parser, function_message))
+
+    assert parsed["content"] == ""
+    assert parsed["reasoning"] == ""
+    assert parsed["tool_calls"] == [ToolCall(name="lookup", arguments={"query": "weather"})]
+
+    python_message = Message.from_role_and_content(Role.ASSISTANT, "print(1)").with_channel("analysis").with_recipient("python").with_content_type("code")
+    parsed = harmony_parser.parse_completion(completion_tokens(harmony_parser, python_message))
+
+    assert parsed["tool_calls"] == [ToolCall(name="python", arguments={"code": "print(1)"})]


### PR DESCRIPTION
## Summary

Adds narrow Harmony tool-call support to the chat template parser. Harmony now renders builtin tools, function tools, assistant tool calls, and tool messages, and can parse tool calls from Harmony completion tokens. This also adds `ToolOutput.to_dict()` so generic trajectory serialization can handle `ToolOutput` objects.

## Type of change

- [x] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Added Harmony rendering for builtin tools and function tools.
- Added Harmony rendering for assistant tool calls and tool-role messages.
- Added Harmony completion parsing for function and builtin Python tool calls.
- Added `ToolOutput.to_dict()` for generic serialization.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Commit hooks passed: `ruff`, `ruff-format`
- `.venv/bin/ruff check rllm/parser/chat_template_parser.py rllm/tools/tool_base.py tests/parser/test_harmony_chat_parser.py`
- `.venv/bin/ruff format --check rllm/parser/chat_template_parser.py rllm/tools/tool_base.py tests/parser/test_harmony_chat_parser.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile rllm/parser/chat_template_parser.py rllm/tools/tool_base.py tests/parser/test_harmony_chat_parser.py`
- `TMPDIR=/data/kyle/rllm/.cache PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q -p no:cacheprovider tests/parser/test_harmony_chat_parser.py`
- Result: `4 passed`

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

N/A