### PR TITLE
feat(logging): add default logger and RLLM_LOG_LEVEL

### DIFF
--- a/rllm/__init__.py
+++ b/rllm/__init__.py
@@ -5,7 +5,11 @@ Main package for the rLLM framework.
 
 import sys
 
+from rllm.utils.logging import configure_logging_from_env
+
 __all__ = ["BaseAgent", "Action", "Step", "Trajectory", "Episode", "rollout", "evaluator", "Task", "Runner"]
+
+configure_logging_from_env()
 
 
 def __getattr__(name: str):

--- a/rllm/utils/logging.py
+++ b/rllm/utils/logging.py
@@ -1,4 +1,21 @@
 import logging
+import os
+
+
+def get_log_level_from_env(env_var: str = "RLLM_LOG_LEVEL", default: str = "INFO") -> int:
+    default_level = getattr(logging, default.upper(), logging.INFO)
+    level_name = os.getenv(env_var, default).upper()
+    return getattr(logging, level_name, default_level)
+
+
+def configure_logging_from_env(
+    env_var: str = "RLLM_LOG_LEVEL",
+    default: str = "INFO",
+) -> int:
+    """Set the rLLM logger level from RLLM_LOG_LEVEL."""
+    level = get_log_level_from_env(env_var, default)
+    logging.getLogger("rllm").setLevel(level)
+    return level
 
 
 class DuplicateLoggingFilter(logging.Filter):

--- a/rllm/utils/logging.py
+++ b/rllm/utils/logging.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 
-def get_log_level_from_env(env_var: str = "RLLM_LOG_LEVEL", default: str = "INFO") -> int:
+def get_log_level_from_env(env_var: str = "RLLM_LOG_LEVEL", default: str = "WARNING") -> int:
     default_level = getattr(logging, default.upper(), logging.INFO)
     level_name = os.getenv(env_var, default).upper()
     return getattr(logging, level_name, default_level)
@@ -10,10 +10,11 @@ def get_log_level_from_env(env_var: str = "RLLM_LOG_LEVEL", default: str = "INFO
 
 def configure_logging_from_env(
     env_var: str = "RLLM_LOG_LEVEL",
-    default: str = "INFO",
+    default: str = "WARNING",
 ) -> int:
-    """Set the rLLM logger level from RLLM_LOG_LEVEL."""
+    """Configure logging from RLLM_LOG_LEVEL."""
     level = get_log_level_from_env(env_var, default)
+    logging.basicConfig(format="%(levelname)s:%(asctime)s:%(message)s", level=level)
     logging.getLogger("rllm").setLevel(level)
     return level
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,13 +1,34 @@
 import importlib
 import logging
 
+import pytest
+
 import rllm
 from rllm.utils.logging import configure_logging_from_env, get_log_level_from_env
+
+
+@pytest.fixture(autouse=True)
+def restore_logging_state():
+    root = logging.getLogger()
+    logger = logging.getLogger("rllm")
+    root_handlers = list(root.handlers)
+    root_level = root.level
+    logger_level = logger.level
+
+    yield
+
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    for handler in root_handlers:
+        root.addHandler(handler)
+    root.setLevel(root_level)
+    logger.setLevel(logger_level)
 
 
 def test_get_log_level_from_env_uses_default(monkeypatch):
     monkeypatch.delenv("RLLM_LOG_LEVEL", raising=False)
 
+    assert get_log_level_from_env() == logging.WARNING
     assert get_log_level_from_env(default="WARNING") == logging.WARNING
 
 
@@ -25,24 +46,29 @@ def test_get_log_level_from_env_falls_back_for_invalid_level(monkeypatch):
 
 def test_configure_logging_from_env_sets_rllm_logger(monkeypatch):
     logger = logging.getLogger("rllm")
-    original_level = logger.level
     monkeypatch.setenv("RLLM_LOG_LEVEL", "ERROR")
 
-    try:
-        assert configure_logging_from_env() == logging.ERROR
-        assert logger.level == logging.ERROR
-    finally:
-        logger.setLevel(original_level)
+    assert configure_logging_from_env() == logging.ERROR
+    assert logger.level == logging.ERROR
+
+
+def test_configure_logging_from_env_initializes_basic_logging(monkeypatch):
+    root = logging.getLogger()
+    logger = logging.getLogger("rllm")
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    monkeypatch.setenv("RLLM_LOG_LEVEL", "WARNING")
+
+    assert configure_logging_from_env() == logging.WARNING
+    assert root.handlers
+    assert root.level == logging.WARNING
+    assert logger.level == logging.WARNING
 
 
 def test_import_configures_rllm_logger_from_env(monkeypatch):
     logger = logging.getLogger("rllm")
-    original_level = logger.level
     monkeypatch.setenv("RLLM_LOG_LEVEL", "CRITICAL")
 
-    try:
-        importlib.reload(rllm)
+    importlib.reload(rllm)
 
-        assert logger.level == logging.CRITICAL
-    finally:
-        logger.setLevel(original_level)
+    assert logger.level == logging.CRITICAL

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,48 @@
+import importlib
+import logging
+
+import rllm
+from rllm.utils.logging import configure_logging_from_env, get_log_level_from_env
+
+
+def test_get_log_level_from_env_uses_default(monkeypatch):
+    monkeypatch.delenv("RLLM_LOG_LEVEL", raising=False)
+
+    assert get_log_level_from_env(default="WARNING") == logging.WARNING
+
+
+def test_get_log_level_from_env_reads_level(monkeypatch):
+    monkeypatch.setenv("RLLM_LOG_LEVEL", "debug")
+
+    assert get_log_level_from_env() == logging.DEBUG
+
+
+def test_get_log_level_from_env_falls_back_for_invalid_level(monkeypatch):
+    monkeypatch.setenv("RLLM_LOG_LEVEL", "not-a-level")
+
+    assert get_log_level_from_env(default="ERROR") == logging.ERROR
+
+
+def test_configure_logging_from_env_sets_rllm_logger(monkeypatch):
+    logger = logging.getLogger("rllm")
+    original_level = logger.level
+    monkeypatch.setenv("RLLM_LOG_LEVEL", "ERROR")
+
+    try:
+        assert configure_logging_from_env() == logging.ERROR
+        assert logger.level == logging.ERROR
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_import_configures_rllm_logger_from_env(monkeypatch):
+    logger = logging.getLogger("rllm")
+    original_level = logger.level
+    monkeypatch.setenv("RLLM_LOG_LEVEL", "CRITICAL")
+
+    try:
+        importlib.reload(rllm)
+
+        assert logger.level == logging.CRITICAL
+    finally:
+        logger.setLevel(original_level)


### PR DESCRIPTION
## Summary

Adds runtime control over rLLM logging verbosity via `RLLM_LOG_LEVEL`. rLLM now initializes a default Python logging handler when no logging has already been configured, so warnings and errors are not silently dropped in CLI, training, or Ray worker paths. The default rLLM log level is `WARNING`, and users can opt into more verbosity with values like `RLLM_LOG_LEVEL=INFO` or `RLLM_LOG_LEVEL=DEBUG`.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Added `RLLM_LOG_LEVEL` helpers for parsing and applying runtime log levels.
- Configured rLLM logging on package import with a default `WARNING` level.
- Added basic logging initialization so rLLM warnings/errors are emitted when no other logging setup exists.
- Added focused tests for default level behavior, env-var overrides, invalid level fallback, and import-time setup.

## Validation

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `uv run pytest tests/test_logging.py`
- `uv run ruff check rllm/__init__.py rllm/utils/logging.py tests/test_logging.py`
- `uv run ruff format --check rllm/__init__.py rllm/utils/logging.py tests/test_logging.py`
- Commit hooks ran `ruff` and `ruff-format`.

## Breaking changes / migration notes

- Default rLLM logging is now initialized at `WARNING` on package import when no logging has already been configured.
- Set `RLLM_LOG_LEVEL=INFO` or `RLLM_LOG_LEVEL=DEBUG` to increase rLLM verbosity.

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

N/A