### PR TITLE
feat(agentcore): distinguish timeouts and propagate session_id to episode logs

### DIFF
--- a/.github/workflows/test-remote-runtime.yml
+++ b/.github/workflows/test-remote-runtime.yml
@@ -1,0 +1,46 @@
+name: Test remote runtime
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rllm/experimental/engine/remote_runtime/**"
+      - "rllm/experimental/engine/remote_agent_flow_engine.py"
+      - "rllm/experimental/engine/gateway_manager.py"
+      - "rllm/experimental/engine/trace_converter.py"
+      - "rllm/utils/episode_logger.py"
+      - "rllm/types.py"
+      - "tests/engine/test_remote_runtime.py"
+      - ".github/workflows/test-remote-runtime.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "rllm/experimental/engine/remote_runtime/**"
+      - "rllm/experimental/engine/remote_agent_flow_engine.py"
+      - "rllm/experimental/engine/gateway_manager.py"
+      - "rllm/experimental/engine/trace_converter.py"
+      - "rllm/utils/episode_logger.py"
+      - "rllm/types.py"
+      - "tests/engine/test_remote_runtime.py"
+      - ".github/workflows/test-remote-runtime.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra agentcore --extra dev
+
+      - name: Run remote runtime tests
+        run: uv run pytest tests/engine/test_remote_runtime.py -v

--- a/rllm/experimental/engine/remote_agent_flow_engine.py
+++ b/rllm/experimental/engine/remote_agent_flow_engine.py
@@ -121,7 +121,7 @@ class RemoteAgentFlowEngine:
             result = results[0]
 
             if not result.finished:
-                logger.warning("[%s] Remote task failed (assigning reward=0): %s", uid, result.error)
+                logger.warning("Remote task failed (session=%s, assigning reward=0): %s", result.session_id, result.error)
                 result.reward = 0.0
 
             traces = await self.gateway.aget_traces(session_id)
@@ -129,7 +129,15 @@ class RemoteAgentFlowEngine:
             if result.metadata:
                 episode.metadata.update(result.metadata)
             if not result.finished:
-                episode.metadata["error"] = {"message": result.error or "Unknown error"}
+                error_info: dict = {
+                    "error_message": result.error or "Unknown error",
+                    "elapsed": result.elapsed,
+                }
+                if result.raw_result:
+                    for k in ("stop_reason", "traceback", "status_code"):
+                        if k in result.raw_result:
+                            error_info[k] = result.raw_result[k]
+                episode.metadata["error"] = error_info
 
             # Delete traces from gateway DB to prevent unbounded growth
             await self.gateway.adelete_session(session_id)
@@ -190,6 +198,7 @@ def _build_episode(
         id=uid,
         task=task,
         is_correct=is_correct,
+        session_id=result.session_id,
         trajectories=trajectories,
         metrics=metrics,
         termination_reason=result.termination_reason or TerminationReason.UNKNOWN,

--- a/rllm/experimental/engine/remote_runtime/agentcore_runtime.py
+++ b/rllm/experimental/engine/remote_runtime/agentcore_runtime.py
@@ -57,12 +57,7 @@ class AgentCoreRuntime(RemoteAgentRuntime):
         )
 
     async def _run_one(self, sub: TaskSubmission, timeout: float) -> RemoteTaskResult:
-        """Submit a single task and poll for its result.
-
-        Handles two failure modes:
-        - Transport-level: invoke_async or result_async raises (network, timeout)
-        - Application-level: @rollout_entrypoint returns status_code != 200
-        """
+        """Submit a single task and poll S3 for the result."""
         try:
             future = await self._client.invoke_async(
                 payload=sub.task,
@@ -71,22 +66,47 @@ class AgentCoreRuntime(RemoteAgentRuntime):
                 base_url=sub.inference_url,
                 model_id=self._model_id,
             )
-            result = await future.result_async(timeout=timeout)
         except Exception as e:
-            logger.error("Task %s failed: %s", sub.session_id, e)
+            logger.error("Task %s submission failed: %s", sub.session_id, e)
             return RemoteTaskResult(
                 finished=False,
                 session_id=sub.session_id,
                 task_id=sub.task_id,
                 error=str(e),
                 termination_reason=TerminationReason.ERROR,
+                elapsed=0.0,
+            )
+
+        try:
+            result = await future.result_async(timeout=timeout)
+        except asyncio.TimeoutError:
+            elapsed = future.elapsed()
+            logger.error("Task %s timed out after %.1fs", sub.session_id, elapsed)
+            return RemoteTaskResult(
+                finished=False,
+                session_id=sub.session_id,
+                task_id=sub.task_id,
+                error=f"Timeout after {elapsed:.1f}s",
+                termination_reason=TerminationReason.TIMEOUT,
+                elapsed=elapsed,
+            )
+        except Exception as e:
+            elapsed = future.elapsed()
+            logger.error("Task %s polling failed: %s", sub.session_id, e)
+            return RemoteTaskResult(
+                finished=False,
+                session_id=sub.session_id,
+                task_id=sub.task_id,
+                error=str(e),
+                termination_reason=TerminationReason.ERROR,
+                elapsed=elapsed,
             )
 
         # Check for application-level errors from @rollout_entrypoint in ART
         status_code = result.get("status_code")
         if status_code is not None and status_code != 200:
-            error_msg = result.get("stop_reason", "Unknown remote error")
-            logger.warning(
+            error_msg = result.get("stop_reason", "unknown remote error")
+            logger.error(
                 "Task %s returned status_code=%s: %s",
                 sub.session_id,
                 status_code,

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -322,6 +322,7 @@ class Episode(BaseModel):
     task: Any = None
     termination_reason: Any | None = None
     is_correct: bool = False
+    session_id: str | None = None
     trajectories: list[Trajectory] = Field(default_factory=list)
     artifacts: dict[str, Any] = Field(default_factory=dict)
     metrics: dict = Field(default_factory=dict)
@@ -357,6 +358,7 @@ class Episode(BaseModel):
             "task": _sanitize_task(self.task),
             "termination_reason": self.termination_reason.value if self.termination_reason is not None else None,
             "is_correct": bool(self.is_correct),
+            "session_id": self.session_id,
             "trajectories": [trajectory.to_dict() for trajectory in self.trajectories],
             "metrics": self.metrics,
             "info": self.info,

--- a/rllm/utils/episode_logger.py
+++ b/rllm/utils/episode_logger.py
@@ -89,11 +89,13 @@ class EpisodeLogger:
             "training_step": step,
             "epoch": epoch,
             "episode_id": episode.id,
+            "session_id": episode.session_id,
             "task": episode.task,
             "task_hash": self.compute_task_hash(episode.task),
             "is_correct": episode.is_correct,
             "termination_reason": (episode.termination_reason.value if episode.termination_reason else None),
             "metrics": episode.metrics,
+            "metadata": episode.metadata,
             "timing": episode.info.get("timing", {}),
             "trajectories": [],
         }

--- a/tests/engine/test_remote_runtime.py
+++ b/tests/engine/test_remote_runtime.py
@@ -5,9 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from omegaconf import OmegaConf
 
-from rllm.agents.agent import Step, Trajectory
 from rllm.experimental.engine.gateway_manager import GatewayManager, _get_routable_ip
-from rllm.experimental.engine.remote_agent_flow_engine import _build_episode, _error_episode
+from rllm.experimental.engine.remote_agent_flow_engine import _build_episode
 from rllm.experimental.engine.remote_runtime.agentcore_runtime import AgentCoreRuntime
 from rllm.experimental.engine.remote_runtime.protocol import (
     RemoteRuntimeConfig,
@@ -15,6 +14,7 @@ from rllm.experimental.engine.remote_runtime.protocol import (
     TaskSubmission,
 )
 from rllm.experimental.engine.trace_converter import compute_step_metrics
+from rllm.types import Step, Trajectory
 from rllm.workflows.workflow import TerminationReason
 
 # ---------------------------------------------------------------------------
@@ -69,7 +69,7 @@ def _make_step(prompt_len: int = 10, response_len: int = 20) -> Step:
 
 class TestRunOneSuccess:
     def test_success_with_reward(self):
-        """status_code=200 result -> RemoteTaskResult(success=True, reward=1.0)."""
+        """status_code=200 result -> RemoteTaskResult(finished=True, reward=1.0)."""
         runtime = _make_runtime()
         sub = _make_submission()
         future = _make_future(
@@ -80,11 +80,12 @@ class TestRunOneSuccess:
 
         result = asyncio.run(runtime._run_one(sub, timeout=300.0))
 
-        assert result.success is True
+        assert result.finished is True
         assert result.reward == 1.0
         assert result.session_id == "sess-1"
         assert result.task_id == "task-1"
         assert result.elapsed == 2.3
+        assert result.raw_result is not None
         assert result.raw_result["status_code"] == 200
 
     def test_success_reward_scalar(self):
@@ -96,13 +97,13 @@ class TestRunOneSuccess:
 
         result = asyncio.run(runtime._run_one(sub, timeout=300.0))
 
-        assert result.success is True
+        assert result.finished is True
         assert result.reward is None
 
 
 class TestRunOneErrorStatus:
     def test_error_status_500(self):
-        """status_code=500 result -> RemoteTaskResult(success=False, error=...)."""
+        """status_code=500 result -> RemoteTaskResult(finished=False, error=...)."""
         runtime = _make_runtime()
         sub = _make_submission()
         future = _make_future(
@@ -117,9 +118,10 @@ class TestRunOneErrorStatus:
 
         result = asyncio.run(runtime._run_one(sub, timeout=300.0))
 
-        assert result.success is False
-        assert "ZeroDivisionError" in result.error
+        assert result.finished is False
+        assert "ZeroDivisionError" in (result.error or "")
         assert result.elapsed == 3.0
+        assert result.raw_result is not None
         assert result.raw_result["status_code"] == 500
 
     def test_error_status_no_stop_reason(self):
@@ -131,34 +133,53 @@ class TestRunOneErrorStatus:
 
         result = asyncio.run(runtime._run_one(sub, timeout=300.0))
 
-        assert result.success is False
-        assert result.error == "Unknown remote error"
+        assert result.finished is False
+        assert result.error == "unknown remote error"
 
 
 class TestRunOneTransportError:
     def test_invoke_raises(self):
-        """invoke_async raising -> RemoteTaskResult(success=False)."""
+        """invoke_async raising -> RemoteTaskResult(finished=False)."""
         runtime = _make_runtime()
         sub = _make_submission()
         runtime._client.invoke_async = AsyncMock(side_effect=ConnectionError("network down"))
 
         result = asyncio.run(runtime._run_one(sub, timeout=300.0))
 
-        assert result.success is False
-        assert "network down" in result.error
+        assert result.finished is False
+        assert "network down" in (result.error or "")
 
-    def test_result_async_raises(self):
-        """result_async raising (timeout) -> RemoteTaskResult(success=False)."""
+    def test_result_async_timeout(self):
+        """asyncio.TimeoutError -> termination_reason=TIMEOUT."""
         runtime = _make_runtime()
         sub = _make_submission()
         future = AsyncMock()
-        future.result_async = AsyncMock(side_effect=TimeoutError("timed out"))
+        future.result_async = AsyncMock(side_effect=asyncio.TimeoutError())
+        future.elapsed = MagicMock(return_value=1.7)
         runtime._client.invoke_async = AsyncMock(return_value=future)
 
         result = asyncio.run(runtime._run_one(sub, timeout=1.0))
 
-        assert result.success is False
-        assert "timed out" in result.error
+        assert result.finished is False
+        assert result.termination_reason == TerminationReason.TIMEOUT
+        assert result.elapsed == 1.7
+        assert "Timeout after 1.7s" in (result.error or "")
+
+    def test_result_async_other_error(self):
+        """Non-timeout polling error -> termination_reason=ERROR."""
+        runtime = _make_runtime()
+        sub = _make_submission()
+        future = AsyncMock()
+        future.result_async = AsyncMock(side_effect=RuntimeError("S3 unreachable"))
+        future.elapsed = MagicMock(return_value=2.4)
+        runtime._client.invoke_async = AsyncMock(return_value=future)
+
+        result = asyncio.run(runtime._run_one(sub, timeout=1.0))
+
+        assert result.finished is False
+        assert result.termination_reason == TerminationReason.ERROR
+        assert result.elapsed == 2.4
+        assert "S3 unreachable" in (result.error or "")
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +205,7 @@ class TestBuildEpisodeWithTraces:
             traces.append(trace)
 
         result = RemoteTaskResult(
-            success=True,
+            finished=True,
             session_id="sess-1",
             task_id="task-1",
             reward=1.0,
@@ -200,6 +221,7 @@ class TestBuildEpisodeWithTraces:
         assert len(episode.trajectories[0].steps) == 3
         assert episode.trajectories[0].reward == 1.0
         assert episode.is_correct is True
+        assert episode.session_id == "sess-1"
         assert episode.metrics["num_trajectories"] == 1
         assert episode.metrics["steps_used"] == 3
         assert episode.metrics["steps_collected"] == 3
@@ -210,7 +232,7 @@ class TestBuildEpisodeNoTraces:
     def test_no_traces_with_reward(self):
         """No traces + reward -> empty-steps trajectory."""
         result = RemoteTaskResult(
-            success=True,
+            finished=True,
             session_id="sess-1",
             task_id="task-1",
             reward=0.5,
@@ -227,7 +249,7 @@ class TestBuildEpisodeNoTraces:
     def test_no_traces_no_reward(self):
         """No traces + no reward -> no trajectories."""
         result = RemoteTaskResult(
-            success=True,
+            finished=True,
             session_id="sess-1",
             task_id="task-1",
             reward=None,
@@ -237,16 +259,6 @@ class TestBuildEpisodeNoTraces:
 
         assert len(episode.trajectories) == 0
         assert episode.metrics["empty"] == 1
-
-
-class TestErrorEpisode:
-    def test_error_episode_fields(self):
-        """Error episode has termination_reason=ERROR."""
-        episode = _error_episode("task-1:0", {"prompt": "test"}, "something broke")
-
-        assert episode.is_correct is False
-        assert episode.termination_reason == TerminationReason.ERROR
-        assert episode.metadata["error"]["message"] == "something broke"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Issue

When training with agentcore (e.g. `examples/agentcore_math/train_agentcore_math_verl.sh`), the wandb
`batch/*` panels and per-episode logs were missing key debugging information:

- `asyncio.TimeoutError` from `RolloutFuture.result_async` was conflated with every other transport failure, so `batch/termination_reason/timeout` stayed at 0 and all failures landed under `error`.
- `future.elapsed()` was only captured on the success path; transport errors recorded `elapsed=0.0`.
- Application-error detail (status_code, stop_reason, traceback from `@rollout_entrypoint`) was truncated.
- The AgentCore `session_id` (the only handle that resolves to a CloudWatch trace) was never written to the per-episode JSON, so `/check-agentcore-session-logs` could not link a failed episode back to its session.

# Summary

- Split `_run_one` so `asyncio.TimeoutError` produces `TerminationReason.TIMEOUT`, and capture `future.elapsed()` on every failure path.
- Preserve `status_code` / `stop_reason` / `traceback` from AgentCore application errors via `RemoteTaskResult.raw_result`, surface them in `episode.metadata.error`.
- Add typed `Episode.session_id` and write it to the per-episode JSON so `/check-agentcore-session-logs` can resolve a failed episode to its CloudWatch trace. Harbor's `metadata` use is unchanged.
- Restore `tests/engine/test_remote_runtime.py` (had bit-rotted: stale field names,missing imports) and add `.github/workflows/test-remote-runtime.yml` so it stays green.

# Changes

- `rllm/experimental/engine/remote_runtime/agentcore_runtime.py` — split submission vs polling exception handling; emit `TerminationReason.TIMEOUT` for`asyncio.TimeoutError`; ERROR-level logs for transport failures so they survive
  megatron's WARNING filter.
- `rllm/experimental/engine/remote_agent_flow_engine.py` — populate `episode.metadata["error"]` with `error_message`, `elapsed`, plus `stop_reason`/`traceback`/`status_code` from `result.raw_result` when available; reference the AgentCore `session_id` in the per-episode failure log line.
- `rllm/types.py` — add `Episode.session_id: str | None = None`; include in `Episode.to_dict()`.
- `rllm/experimental/engine/remote_agent_flow_engine.py` (`_build_episode`) — set `session_id` from `RemoteTaskResult.session_id`.
- `rllm/utils/episode_logger.py` — write top-level `session_id` and the full `metadata` dict to per-episode JSON.
- `tests/engine/test_remote_runtime.py` — fix imports/field renames; replace the single `result_async_raises` test with separate `TIMEOUT` and `ERROR` cases; assert `episode.session_id`.
- `.github/workflows/test-remote-runtime.yml` — new CI workflow guarding the test file and its production deps.

# Test plan

- [x] CI: `pytest tests/engine/test_remote_runtime.py` (16 tests) passes via `test-remote-runtime.yml`.
- [x] E2E `bash examples/agentcore_math/train_agentcore_math_verl.sh` with default `session_timeout=300`: wandb shows `batch/termination_reason/env_done ≈ 1`, `timeout ≈ 0`; per-episode JSON has top-level `session_id`, empty `metadata.error`.
- [x] E2E with override `rllm.remote_runtime.session_timeout=10`: `batch/termination_reason/timeout` populates; driver log shows `ERROR: Task <session> timed out after Ys` lines; per-episode JSON for timeout episodes carries `metadata.error.error_message="Timeout after Ys"`, `elapsed`, `termination_reason="timeout"`.
