### PR TITLE
fix(gateway): disable client keepalive to avoid idle-connection race with uvicorn

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/client.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/client.py
@@ -20,7 +20,13 @@ class GatewayClient:
         timeout: float = 30.0,
     ) -> None:
         self.gateway_url = gateway_url.rstrip("/")
-        self._http = httpx.Client(timeout=timeout)
+        # max_keepalive_connections=0 disables idle connection reuse so every
+        # request opens a fresh TCP connection. Avoids the keepalive race where
+        # client and uvicorn both expire idle connections at ~5s and the next
+        # request hits a half-closed socket → httpx.ReadError. Per-request
+        # handshake cost is negligible for the control-plane JSON calls this
+        # client makes.
+        self._http = httpx.Client(timeout=timeout, limits=httpx.Limits(max_keepalive_connections=0))
 
     def close(self) -> None:
         self._http.close()
@@ -146,7 +152,8 @@ class AsyncGatewayClient:
         timeout: float = 30.0,
     ) -> None:
         self.gateway_url = gateway_url.rstrip("/")
-        self._http = httpx.AsyncClient(timeout=timeout)
+        # See GatewayClient.__init__ for why keepalive is disabled.
+        self._http = httpx.AsyncClient(timeout=timeout, limits=httpx.Limits(max_keepalive_connections=0))
 
     async def close(self) -> None:
         await self._http.aclose()


### PR DESCRIPTION
## Summary

The trainer-side `GatewayClient` / `AsyncGatewayClient` periodically crashed with `httpx.ReadError` on otherwise-healthy gateway calls (`flush`, `delete_session`, `get_session_traces`). Root cause is a TCP keepalive race between httpx and uvicorn, independent of trace-store backend or gateway health.

This PR disables idle-connection reuse on both clients by passing `httpx.Limits(max_keepalive_connections=0)`.

## The race

- httpx default `keepalive_expiry`: **5.0s**
- uvicorn default `timeout_keep_alive`: **5s**

Both ends expire idle sockets at the same instant. When the trainer pauses between calls for ~5s (slow validation task, GC pause, scheduler stall) and then issues another call, this can happen:

```
t=0.0   trainer call returns        → socket goes idle in httpx pool
t=5.0   server fires keepalive timer → sends FIN
t=5.001 trainer issues next call    → httpx dequeues the same socket
t=5.001 trainer writes request  → server returns RST → httpx.ReadError, fatal (no client-side retry)
```

Observed in one of the long-horizon training runs (migrationbench) on the val rollout long tail (task 233/299 took longer
than 5s; the next `flush()` hit a half-closed socket and crashed training).

## Fix

```python
self._http = httpx.Client(
    timeout=timeout,
    limits=httpx.Limits(max_keepalive_connections=0),
)
```

Every request opens a fresh TCP connection, so there is no idle pooled socket to race against the server's FIN. Per-request handshake cost is negligible for the few control-plane JSON calls this client makes (`create_session`, `get_session_traces`, `flush`, `health`, etc.). The hot inference path in `proxy.py` keeps pooling — only the trainer-side control client is affected.

## Relationship to #590

#590 (memory trace store default) and this PR are orthogonal:

| Failure mode | #590 | This PR |
|---|---|---|
| sqlite `database is locked` → 500 | fixed | — |
| Slow `flush()` triggers server-side close | fixed (memory flush is fast) | — |
| Trainer-side stale-socket race | still present with memory store | fixed |

Both are needed; each fixes real crashes seen in production.

## Test plan

- [x] Test suites pass (`pytest rllm-model-gateway/tests/`)
- [x] Long-running training run no longer hits `httpx.ReadError` on control-plane calls after >5s idle gaps
