### PR TITLE
fix(remote-agent-flow-engine): make correct criteria reward >=1 to allow reward shaping

### DIFF
--- a/rllm/experimental/engine/remote_agent_flow_engine.py
+++ b/rllm/experimental/engine/remote_agent_flow_engine.py
@@ -192,7 +192,7 @@ def _build_episode(
     metrics["empty"] = int(len(traces) == 0)
     metrics["steps_collected"] = len(traces)
 
-    is_correct = bool(result.reward and result.reward > 0)
+    is_correct = bool(result.reward and result.reward >= 1.0)
 
     return Episode(
         id=uid,


### PR DESCRIPTION
## Summary

- This is a simple one-liner PR that makes the correct criteria `reward >= 1` instead of `reward > 0` for the remote-agent-flow-engine, which is currently only used by agentcore runtime. This will allow pass@1 to compute correctly while also supporting reward shaping/progress reward.