### PR TITLE
feat(gateway): add a cumulative mode, if input OpenAI message list of one agent session is kept cumulative, user could choose to make model gateway construct cumulative input prompt token id sequence and directly input it to vllm server completion API

### DIFF
--- a/rllm-model-gateway/pyproject.toml
+++ b/rllm-model-gateway/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "pydantic>=2.0.0",
     "aiosqlite>=0.19.0",
     "PyYAML>=6.0",
+    "renderers>=0.1.7",
+    "transformers>=4.50.0",
 ]
 
 [project.optional-dependencies]

--- a/rllm-model-gateway/src/rllm_model_gateway/data_process.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/data_process.py
@@ -21,11 +21,17 @@ logger = logging.getLogger(__name__)
 
 
 def extract_prompt_token_ids(response: dict[str, Any]) -> list[int]:
-    """Extract ``prompt_token_ids`` from the root of a vLLM response."""
+    """Extract ``prompt_token_ids`` from a vLLM response.
+
+    Checks root level first (chat/completions format), then falls back to
+    choices[0].prompt_token_ids (completions format).
+    """
     ids = response.get("prompt_token_ids")
     if ids is None:
-        return []
-    return list(ids)
+        choices = response.get("choices")
+        if choices:
+            ids = choices[0].get("prompt_token_ids")
+    return list(ids) if ids is not None else []
 
 
 def extract_completion_token_ids(response: dict[str, Any]) -> list[int]:
@@ -40,7 +46,12 @@ def extract_completion_token_ids(response: dict[str, Any]) -> list[int]:
 
 
 def extract_logprobs(response: dict[str, Any]) -> list[float]:
-    """Extract per-token logprobs from ``choices[0].logprobs.content``."""
+    """Extract per-token logprobs from a vLLM response.
+
+    Handles both formats:
+    - chat/completions: choices[0].logprobs.content[].logprob
+    - completions: choices[0].logprobs.token_logprobs (flat list)
+    """
     choices = response.get("choices")
     if not choices:
         return []
@@ -48,10 +59,18 @@ def extract_logprobs(response: dict[str, Any]) -> list[float]:
     lp_obj = choices[0].get("logprobs")
     if lp_obj is None:
         return []
+
+    # Chat/completions format: logprobs.content[].logprob
     content = lp_obj.get("content")
-    if content is None:
-        return []
-    return [float(entry["logprob"]) for entry in content if entry and entry.get("logprob") is not None]
+    if content is not None:
+        return [float(entry["logprob"]) for entry in content if entry and entry.get("logprob") is not None]
+
+    # Completions format: logprobs.token_logprobs (flat list of floats)
+    token_logprobs = lp_obj.get("token_logprobs")
+    if token_logprobs is not None:
+        return [float(lp) for lp in token_logprobs if lp is not None]
+
+    return []
 
 
 # ------------------------------------------------------------------
@@ -76,7 +95,12 @@ def extract_delta_token_ids(chunk: dict[str, Any]) -> list[int]:
 
 
 def extract_delta_logprobs(chunk: dict[str, Any]) -> list[float]:
-    """Extract logprobs from a single SSE chunk's ``choices[0].logprobs.content``."""
+    """Extract logprobs from a single SSE chunk.
+
+    Handles both formats:
+    - chat/completions streaming: choices[0].logprobs.content[].logprob
+    - completions streaming: choices[0].logprobs.token_logprobs (flat list)
+    """
     choices = chunk.get("choices")
     if not choices:
         return []
@@ -84,9 +108,12 @@ def extract_delta_logprobs(chunk: dict[str, Any]) -> list[float]:
     if not lp:
         return []
     content = lp.get("content")
-    if not content:
-        return []
-    return [float(e["logprob"]) for e in content if e and e.get("logprob") is not None]
+    if content:
+        return [float(e["logprob"]) for e in content if e and e.get("logprob") is not None]
+    token_logprobs = lp.get("token_logprobs")
+    if token_logprobs:
+        return [float(v) for v in token_logprobs if v is not None]
+    return []
 
 
 # ------------------------------------------------------------------

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -121,3 +121,5 @@ class GatewayConfig(BaseModel):
     sync_traces: bool = False
     sampling_params_priority: str = "client"
     model: str | None = None  # When set, overrides ``body.model``
+    cumulative_token_mode: bool = False
+    tokenizer_path: str | None = None  # Path to the model folder with tokenizer json files

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -122,4 +122,6 @@ class GatewayConfig(BaseModel):
     sampling_params_priority: str = "client"
     model: str | None = None  # When set, overrides ``body.model``
     cumulative_token_mode: bool = False
-    tokenizer_path: str | None = None  # Path to the model folder with tokenizer json files
+    # renderers family for the cumulative-mode bridge. Check supported model families
+    # in MODEL_RENDERER_MAP of https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
+    renderer_family: str = "auto"

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -18,11 +18,17 @@ from starlette.responses import Response, StreamingResponse
 from rllm_model_gateway.data_process import (
     build_trace_record,
     build_trace_record_from_chunks,
+    extract_completion_token_ids,
+    extract_prompt_token_ids,
     strip_vllm_fields,
 )
 from rllm_model_gateway.models import TraceRecord
 from rllm_model_gateway.session_router import SessionRouter
 from rllm_model_gateway.store.base import TraceStore
+from rllm_model_gateway.token_accumulator import (
+    TokenAccumulator,
+    extract_new_user_content,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +85,8 @@ class ReverseProxy:
         sync_traces: bool = False,
         max_retries: int = 2,
         local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+        cumulative_token_mode: bool = False,
+        tokenizer: Any = None,
     ) -> None:
         self.router = router
         self.store = store
@@ -86,8 +94,17 @@ class ReverseProxy:
         self.sync_traces = sync_traces
         self.max_retries = max_retries
         self.local_handler = local_handler
+        self.cumulative_token_mode = cumulative_token_mode
+        self.tokenizer = tokenizer
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
+        self._accumulators: dict[str, TokenAccumulator] = {}
+
+    def _get_accumulator(self, session_id: str) -> TokenAccumulator:
+        """Return the TokenAccumulator for *session_id*, creating if needed."""
+        if session_id not in self._accumulators:
+            self._accumulators[session_id] = TokenAccumulator(self.tokenizer)
+        return self._accumulators[session_id]
 
     async def start(self) -> None:
         self._http = httpx.AsyncClient(
@@ -127,6 +144,28 @@ class ReverseProxy:
             request_body = {}
 
         is_stream = request_body.get("stream", False)
+
+        # Cumulative token mode interception: if enabled and past first turn,
+        # rewrite to /v1/completions with pre-tokenized prompt to avoid drift.
+        if self.cumulative_token_mode and session_id and request.url.path.endswith("/chat/completions"):
+            acc = self._get_accumulator(session_id)
+            if acc.should_rewrite():
+                messages = request_body.get("messages", [])
+                if not acc.is_cumulative(messages):
+                    # Message history diverged — reset and fall through to
+                    # normal chat path (treated as fresh turn-0).
+                    acc.reset()
+                else:
+                    user_content = extract_new_user_content(messages, acc.message_count)
+                    if user_content is not None:
+                        return await self._handle_cumulative_turn(
+                            request,
+                            request_body,
+                            session_id,
+                            acc,
+                            user_content,
+                            originally_requested_logprobs,
+                        )
 
         if is_stream:
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)
@@ -180,6 +219,16 @@ class ReverseProxy:
             trace = build_trace_record(session_id, request_body, response_body, latency_ms)
             await self._persist(trace)
 
+            # Ingest first turn into accumulator for cumulative token mode
+            if self.cumulative_token_mode and request.url.path.endswith("/chat/completions"):
+                acc = self._get_accumulator(session_id)
+                if acc.turn_count == 0:
+                    prompt_ids = extract_prompt_token_ids(response_body)
+                    completion_ids = extract_completion_token_ids(response_body)
+                    if prompt_ids or completion_ids:
+                        acc.ingest_turn(prompt_ids, completion_ids)
+                        acc.update_prefix(request_body.get("messages", []))
+
         # Sanitise response
         needs_strip_vllm = self.strip_vllm
         needs_strip_logprobs = not originally_requested_logprobs
@@ -195,6 +244,250 @@ class ReverseProxy:
             content=json.dumps(sanitized),
             status_code=status_code,
             media_type="application/json",
+        )
+
+    # ------------------------------------------------------------------
+    # Cumulative token mode
+    # ------------------------------------------------------------------
+
+    async def _handle_cumulative_turn(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        user_content: str,
+        originally_requested_logprobs: bool = False,
+    ) -> Response:
+        """Rewrite chat/completions to /v1/completions with pre-tokenized prompt.
+
+        Respects the original stream setting: if the client requested streaming,
+        we stream from vLLM and translate completions chunks to chat format in
+        real-time.
+        """
+        is_stream = request_body.get("stream", False)
+
+        # Build prompt from cumulative token state
+        token_ids = acc.build_next_prompt(user_content)
+
+        # Construct completions request: forward everything except chat-specific fields
+        completions_body = {k: v for k, v in request_body.items() if k not in ("messages", "stream", "stream_options")}
+        completions_body["prompt"] = token_ids
+        completions_body["add_special_tokens"] = False
+
+        if is_stream:
+            return await self._handle_cumulative_streaming(request, request_body, completions_body, session_id, acc, token_ids)
+        return await self._handle_cumulative_non_streaming(
+            request,
+            request_body,
+            completions_body,
+            session_id,
+            acc,
+            token_ids,
+            originally_requested_logprobs,
+        )
+
+    async def _handle_cumulative_non_streaming(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        completions_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        token_ids: list[int],
+        originally_requested_logprobs: bool = False,
+    ) -> Response:
+        """Non-streaming cumulative turn: send non-streaming to vLLM, return JSON."""
+        t0 = time.perf_counter()
+
+        worker = self.router.route(session_id)
+        url = self._build_url(worker.api_url, "/v1/completions", "")
+        headers = self._forward_headers(request)
+        raw_body = json.dumps(completions_body).encode()
+        try:
+            resp = await self._send_with_retry(
+                method="POST",
+                url=url,
+                content=raw_body,
+                headers=headers,
+            )
+            content = resp.content
+            status_code = resp.status_code
+        finally:
+            self.router.release(worker.url)
+
+        try:
+            response_body = json.loads(content)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            response_body = {}
+
+        latency_ms = (time.perf_counter() - t0) * 1000
+
+        prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
+        completion_token_ids = extract_completion_token_ids(response_body)
+
+        acc.ingest_turn(prompt_token_ids, completion_token_ids)
+        acc.update_prefix(request_body.get("messages", []))
+
+        # Translate to chat format
+        choices = response_body.get("choices") or []
+        if choices:
+            first_choice = choices[0]
+            first_choice["message"] = {"role": "assistant", "content": first_choice.pop("text", "")}
+        response_body["object"] = "chat.completion"
+
+        if session_id and response_body:
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms)
+            await self._persist(trace)
+
+        sanitized = response_body
+        if isinstance(response_body, dict) and response_body:
+            if self.strip_vllm:
+                sanitized = strip_vllm_fields(response_body)
+            if not originally_requested_logprobs:
+                sanitized = _strip_logprobs(sanitized)
+
+        return Response(
+            content=json.dumps(sanitized),
+            status_code=status_code,
+            media_type="application/json",
+        )
+
+    async def _handle_cumulative_streaming(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        completions_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        token_ids: list[int],
+    ) -> StreamingResponse:
+        """Streaming cumulative turn: stream from vLLM, translate chunks to chat format."""
+        completions_body["stream"] = True
+
+        worker = self.router.route(session_id)
+        url = self._build_url(worker.api_url, "/v1/completions", "")
+        headers = self._forward_headers(request)
+        raw_body = json.dumps(completions_body).encode()
+
+        assert self._http is not None
+        upstream = self._http.stream(
+            method="POST",
+            url=url,
+            content=raw_body,
+            headers=headers,
+        )
+        retry_client: httpx.AsyncClient | None = None
+        try:
+            resp = await upstream.__aenter__()
+        except (httpx.ReadError, httpx.ConnectError, httpx.RemoteProtocolError, httpx.TimeoutException) as first_exc:
+            logger.warning(
+                "Cumulative streaming connection error to %s (type=%s). Retrying.",
+                url,
+                type(first_exc).__name__,
+            )
+            retry_client = httpx.AsyncClient(
+                timeout=httpx.Timeout(timeout=None),
+                limits=httpx.Limits(max_connections=1, max_keepalive_connections=0),
+                follow_redirects=True,
+            )
+            retry_upstream = retry_client.stream(
+                method="POST",
+                url=url,
+                content=raw_body,
+                headers=headers,
+            )
+            try:
+                resp = await retry_upstream.__aenter__()
+                upstream = retry_upstream
+            except Exception:
+                await retry_client.aclose()
+                self.router.release(worker.url)
+                raise
+
+        t0 = time.perf_counter()
+        chunks: list[dict[str, Any]] = []
+
+        async def event_generator():
+            try:
+                first_chunk_sent = False
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data: "):
+                        if line:
+                            yield line + "\n"
+                        continue
+
+                    data_str = line[6:].strip()
+                    if data_str == "[DONE]":
+                        yield "data: [DONE]\n\n"
+                        continue
+
+                    try:
+                        chunk = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    chunks.append(chunk)
+
+                    # Translate completions chunk → chat chunk
+                    choices = chunk.get("choices", [])
+                    chat_chunk: dict[str, Any] = {
+                        "id": chunk.get("id", ""),
+                        "object": "chat.completion.chunk",
+                        "created": chunk.get("created", 0),
+                        "model": chunk.get("model", ""),
+                        "choices": [],
+                    }
+                    if choices:
+                        c = choices[0]
+                        delta: dict[str, Any] = {}
+                        if not first_chunk_sent:
+                            delta["role"] = "assistant"
+                            first_chunk_sent = True
+                        text = c.get("text", "")
+                        if text:
+                            delta["content"] = text
+                        chat_chunk["choices"] = [
+                            {
+                                "index": 0,
+                                "delta": delta,
+                                "finish_reason": c.get("finish_reason"),
+                            }
+                        ]
+                    elif not chunk.get("usage"):
+                        # Empty chunk with no usage either — nothing to forward
+                        continue
+
+                    if chunk.get("usage"):
+                        chat_chunk["usage"] = chunk["usage"]
+
+                    sanitized = strip_vllm_fields(chat_chunk) if self.strip_vllm else chat_chunk
+                    yield f"data: {json.dumps(sanitized)}\n\n"
+
+            finally:
+                await upstream.__aexit__(None, None, None)
+                if retry_client is not None:
+                    await retry_client.aclose()
+                self.router.release(worker.url)
+
+                # Ingest accumulated token data
+                if chunks:
+                    latency_ms = (time.perf_counter() - t0) * 1000
+                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms)
+                    prompt_ids = trace.prompt_token_ids or token_ids
+                    completion_ids = trace.completion_token_ids
+
+                    acc.ingest_turn(prompt_ids, completion_ids)
+                    acc.update_prefix(request_body.get("messages", []))
+
+                    task = asyncio.create_task(self._safe_store(trace.trace_id, trace.session_id, trace.model_dump()))
+                    self._pending_traces.add(task)
+                    task.add_done_callback(self._pending_traces.discard)
+
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            status_code=resp.status_code,
         )
 
     # ------------------------------------------------------------------
@@ -316,6 +609,16 @@ class ReverseProxy:
                     )
                     self._pending_traces.add(task)
                     task.add_done_callback(self._pending_traces.discard)
+
+                    # Ingest first turn into accumulator for cumulative token mode
+                    if self.cumulative_token_mode:
+                        acc = self._get_accumulator(session_id)
+                        if acc.turn_count == 0:
+                            prompt_ids = trace.prompt_token_ids
+                            completion_ids = trace.completion_token_ids
+                            if prompt_ids or completion_ids:
+                                acc.ingest_turn(prompt_ids, completion_ids)
+                                acc.update_prefix(request_body.get("messages", []))
 
         return StreamingResponse(
             event_generator(),

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -171,8 +171,11 @@ class ReverseProxy:
                         )
                     # No new messages, or the renderer couldn't prove the
                     # prefix-extension contract (e.g. DefaultRenderer, or an
-                    # assistant message in the new slice). Fall through to the
-                    # normal chat path.
+                    # assistant message in the new slice). Reset so this turn is
+                    # re-ingested as a fresh turn-0 on the chat path; otherwise
+                    # the stale prefix would drop this turn's completion tokens
+                    # from the next cumulative prompt and break prefix-extension.
+                    acc.reset()
 
         if is_stream:
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -27,7 +27,7 @@ from rllm_model_gateway.session_router import SessionRouter
 from rllm_model_gateway.store.base import TraceStore
 from rllm_model_gateway.token_accumulator import (
     TokenAccumulator,
-    extract_new_user_content,
+    extract_new_messages,
 )
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class ReverseProxy:
         max_retries: int = 2,
         local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
         cumulative_token_mode: bool = False,
-        tokenizer: Any = None,
+        renderer: Any = None,
     ) -> None:
         self.router = router
         self.store = store
@@ -95,7 +95,7 @@ class ReverseProxy:
         self.max_retries = max_retries
         self.local_handler = local_handler
         self.cumulative_token_mode = cumulative_token_mode
-        self.tokenizer = tokenizer
+        self.renderer = renderer
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
         self._accumulators: dict[str, TokenAccumulator] = {}
@@ -103,7 +103,7 @@ class ReverseProxy:
     def _get_accumulator(self, session_id: str) -> TokenAccumulator:
         """Return the TokenAccumulator for *session_id*, creating if needed."""
         if session_id not in self._accumulators:
-            self._accumulators[session_id] = TokenAccumulator(self.tokenizer)
+            self._accumulators[session_id] = TokenAccumulator(self.renderer)
         return self._accumulators[session_id]
 
     async def start(self) -> None:
@@ -156,16 +156,23 @@ class ReverseProxy:
                     # normal chat path (treated as fresh turn-0).
                     acc.reset()
                 else:
-                    user_content = extract_new_user_content(messages, acc.message_count)
-                    if user_content is not None:
+                    new_messages = extract_new_messages(messages, acc.message_count)
+                    token_ids = None
+                    if new_messages:
+                        token_ids = acc.build_next_prompt(new_messages, tools=request_body.get("tools"))
+                    if token_ids is not None:
                         return await self._handle_cumulative_turn(
                             request,
                             request_body,
                             session_id,
                             acc,
-                            user_content,
+                            token_ids,
                             originally_requested_logprobs,
                         )
+                    # No new messages, or the renderer couldn't prove the
+                    # prefix-extension contract (e.g. DefaultRenderer, or an
+                    # assistant message in the new slice). Fall through to the
+                    # normal chat path.
 
         if is_stream:
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)
@@ -256,10 +263,13 @@ class ReverseProxy:
         request_body: dict[str, Any],
         session_id: str,
         acc: TokenAccumulator,
-        user_content: str,
+        token_ids: list[int],
         originally_requested_logprobs: bool = False,
     ) -> Response:
         """Rewrite chat/completions to /v1/completions with pre-tokenized prompt.
+
+        ``token_ids`` is the full bridge-extended prompt for this turn, built
+        by ``acc.build_next_prompt`` in ``handle()``.
 
         Respects the original stream setting: if the client requested streaming,
         we stream from vLLM and translate completions chunks to chat format in
@@ -267,11 +277,8 @@ class ReverseProxy:
         """
         is_stream = request_body.get("stream", False)
 
-        # Build prompt from cumulative token state
-        token_ids = acc.build_next_prompt(user_content)
-
         # Construct completions request: forward everything except chat-specific fields
-        completions_body = {k: v for k, v in request_body.items() if k not in ("messages", "stream", "stream_options")}
+        completions_body = {k: v for k, v in request_body.items() if k not in ("messages", "stream", "stream_options", "tools", "tool_choice")}
         completions_body["prompt"] = token_ids
         completions_body["add_special_tokens"] = False
 

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -148,18 +148,51 @@ def create_app(
             )
         )
 
-    # Load tokenizer for cumulative token mode
-    tokenizer = None
+    # Build the renderer for cumulative token mode. The renderer owns
+    # message↔token conversion and the cross-turn bridge (see
+    # token_accumulator.TokenAccumulator). The tokenizer is loaded from the
+    # served model path (``config.model``), which we assume is a complete,
+    # unmodified HuggingFace checkpoint.
+    renderer = None
     if config.cumulative_token_mode:
-        if not config.tokenizer_path:
-            raise ValueError("cumulative_token_mode=True requires tokenizer_path to be set in GatewayConfig (path to a HuggingFace tokenizer).")
+        if not config.model:
+            raise ValueError("cumulative_token_mode=True requires 'model' to be set in GatewayConfig (path to the served HuggingFace checkpoint).")
         try:
+            from renderers import create_renderer
             from transformers import AutoTokenizer
-
-            tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_path)
-            logger.info("Loaded tokenizer from %s for cumulative token mode", config.tokenizer_path)
         except ImportError as err:
-            raise ImportError("cumulative_token_mode requires the 'transformers' package. Install it with: pip install transformers") from err
+            raise ImportError("cumulative_token_mode requires the 'renderers' and 'transformers' packages. Install them with: pip install renderers transformers") from err
+
+        tokenizer = AutoTokenizer.from_pretrained(config.model)
+
+        # renderer_family="auto" lets renderers resolve the family by matching the
+        # tokenizer's name_or_path against its MODEL_RENDERER_MAP. This succeeds
+        # when ``model`` is a canonical HF id (e.g. "Qwen/Qwen3-8B") but misses for
+        # a local/custom checkpoint path, which falls back to DefaultRenderer (whose
+        # bridge_to_next_turn always returns None, disabling drift protection). When
+        # serving from a path, set renderer_family explicitly. Supported families /
+        # MODEL_RENDERER_MAP:
+        #   https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
+        renderer = create_renderer(tokenizer, renderer=config.renderer_family)
+        logger.info(
+            "Built %s (family=%r) from %s for cumulative token mode",
+            type(renderer).__name__,
+            config.renderer_family,
+            config.model,
+        )
+        if type(renderer).__name__ == "DefaultRenderer":
+            raise ValueError(
+                f"Cumulative token mode resolved to DefaultRenderer for renderer_family="
+                f"{config.renderer_family!r} (model={config.model!r}). DefaultRenderer "
+                "provides no cross-turn bridge, so drift-free token forwarding is disabled. "
+                "renderer_family='auto' only resolves when 'model' is a canonical HuggingFace "
+                "id present in renderers' MODEL_RENDERER_MAP; a local/custom checkpoint path "
+                "will not match. Either pass a recognized HF id as 'model', or set "
+                "renderer_family explicitly to match your model (e.g. 'qwen3', 'qwen3.5', "
+                "'qwen3.6', 'glm-5', 'deepseek-v3', 'gpt-oss'). Check supported families in "
+                "MODEL_RENDERER_MAP of: https://github.com/PrimeIntellect-ai/renderers/blob/"
+                "main/renderers/base.py"
+            )
 
     proxy = ReverseProxy(
         router=router,
@@ -168,7 +201,7 @@ def create_app(
         sync_traces=config.sync_traces,
         local_handler=local_handler,
         cumulative_token_mode=config.cumulative_token_mode,
-        tokenizer=tokenizer,
+        renderer=renderer,
     )
     sessions = SessionManager(store)
 
@@ -447,8 +480,8 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["model"] = args.model
     if getattr(args, "cumulative_token_mode", False):
         data["cumulative_token_mode"] = True
-    if getattr(args, "tokenizer_path", None) is not None:
-        data["tokenizer_path"] = args.tokenizer_path
+    if getattr(args, "renderer_family", None) is not None:
+        data["renderer_family"] = args.renderer_family
 
     # Workers from CLI --worker flags (WorkerConfig validator auto-splits URLs)
     worker_urls = getattr(args, "worker", None) or []
@@ -494,13 +527,17 @@ def main() -> None:
         "--cumulative-token-mode",
         action="store_true",
         default=False,
-        help="Enable cumulative token mode for drift-free multi-turn RL training.",
+        help="Enable cumulative token mode for drift-free multi-turn RL training. Loads the tokenizer from --model (the served HuggingFace checkpoint).",
     )
     parser.add_argument(
-        "--tokenizer-path",
+        "--renderer-family",
         type=str,
         default=None,
-        help="HuggingFace model name or path for tokenizer (required with --cumulative-token-mode).",
+        help="renderers family for the cumulative-mode bridge (e.g. 'qwen3', 'qwen3.5', "
+        "'qwen3.6', 'glm-5', 'deepseek-v3', 'gpt-oss'). Renderers can auto infer it if --model "
+        "is a huggingface model id, but if --model is a local path, you must explicitly set it. "
+        "Check the supported model families in MODEL_RENDERER_MAP of "
+        "https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py",
     )
 
     args = parser.parse_args()

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -148,12 +148,27 @@ def create_app(
             )
         )
 
+    # Load tokenizer for cumulative token mode
+    tokenizer = None
+    if config.cumulative_token_mode:
+        if not config.tokenizer_path:
+            raise ValueError("cumulative_token_mode=True requires tokenizer_path to be set in GatewayConfig (path to a HuggingFace tokenizer).")
+        try:
+            from transformers import AutoTokenizer
+
+            tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_path)
+            logger.info("Loaded tokenizer from %s for cumulative token mode", config.tokenizer_path)
+        except ImportError as err:
+            raise ImportError("cumulative_token_mode requires the 'transformers' package. Install it with: pip install transformers") from err
+
     proxy = ReverseProxy(
         router=router,
         store=store,
         strip_vllm=config.strip_vllm_fields,
         sync_traces=config.sync_traces,
         local_handler=local_handler,
+        cumulative_token_mode=config.cumulative_token_mode,
+        tokenizer=tokenizer,
     )
     sessions = SessionManager(store)
 
@@ -241,6 +256,7 @@ def create_app(
 
     @app.delete("/sessions/{session_id}")
     async def delete_session(session_id: str):
+        proxy._accumulators.pop(session_id, None)
         count = await sessions.delete_session(session_id)
         return {"deleted": count}
 
@@ -250,6 +266,7 @@ def create_app(
         session_ids = body.get("session_ids", [])
         total = 0
         for sid in session_ids:
+            proxy._accumulators.pop(sid, None)
             total += await sessions.delete_session(sid)
         return {"deleted": total}
 
@@ -428,6 +445,10 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["sampling_params_priority"] = args.sampling_params_priority
     if getattr(args, "model", None) is not None:
         data["model"] = args.model
+    if getattr(args, "cumulative_token_mode", False):
+        data["cumulative_token_mode"] = True
+    if getattr(args, "tokenizer_path", None) is not None:
+        data["tokenizer_path"] = args.tokenizer_path
 
     # Workers from CLI --worker flags (WorkerConfig validator auto-splits URLs)
     worker_urls = getattr(args, "worker", None) or []
@@ -468,6 +489,18 @@ def main() -> None:
         type=str,
         default=None,
         help="If set, the gateway rewrites every request body's 'model' field to this value before forwarding.",
+    )
+    parser.add_argument(
+        "--cumulative-token-mode",
+        action="store_true",
+        default=False,
+        help="Enable cumulative token mode for drift-free multi-turn RL training.",
+    )
+    parser.add_argument(
+        "--tokenizer-path",
+        type=str,
+        default=None,
+        help="HuggingFace model name or path for tokenizer (required with --cumulative-token-mode).",
     )
 
     args = parser.parse_args()

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -3,6 +3,13 @@
 Prevents tokenization drift (decode→re-encode producing different token IDs)
 by maintaining raw token ID sequences across turns and using /v1/completions
 with pre-tokenized prompts instead of re-tokenizing from text each turn.
+
+The cross-turn "bridge" (end-of-assistant-turn + new user/tool messages +
+start-of-next-generation) is delegated to the ``renderers`` package
+(https://github.com/PrimeIntellect-ai/renderers), whose per-model
+``bridge_to_next_turn`` guarantees the returned sequence starts byte-for-byte
+with ``previous_prompt + previous_completion`` — exactly the prefix-extension
+invariant the training-side merger relies on.
 """
 
 from __future__ import annotations
@@ -24,74 +31,52 @@ def _messages_fingerprint(messages: list[dict[str, Any]]) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-def compute_bridge(tokenizer: Any, user_content: str) -> list[int]:
-    """Compute bridge token IDs between an assistant completion and next generation.
-
-    Uses the tokenizer's own apply_chat_template to determine the exact tokens
-    for: end-of-assistant-turn + user-turn-with-content + start-of-next-generation.
-
-    This is template-agnostic: works for Qwen, Llama-3, Mistral, etc. as long as
-    the template uses special tokens at message boundaries (preventing BPE merges).
-
-    Args:
-        tokenizer: A HuggingFace tokenizer with apply_chat_template support.
-        user_content: The new user message content for this turn.
-
-    Returns:
-        List of token IDs representing the bridge between turns.
-    """
-    prefix_msgs = [
-        {"role": "user", "content": "X"},
-        {"role": "assistant", "content": "Y"},
-    ]
-    full_msgs = prefix_msgs + [{"role": "user", "content": user_content}]
-
-    prefix_ids = tokenizer.apply_chat_template(prefix_msgs, tokenize=True, continue_final_message=True)
-    full_ids = tokenizer.apply_chat_template(full_msgs, tokenize=True, add_generation_prompt=True)
-
-    if full_ids[: len(prefix_ids)] != prefix_ids:
-        raise ValueError(
-            "Chat template prefix mismatch — template may not use special tokens at message boundaries. Cumulative token mode requires templates where BPE merges cannot cross message boundaries."
-        )
-
-    return full_ids[len(prefix_ids) :]
-
-
-def extract_new_user_content(messages: list[dict[str, Any]], prev_message_count: int) -> str | None:
-    """Extract the content of the new user message added since last turn.
+def extract_new_messages(messages: list[dict[str, Any]], prev_message_count: int) -> list[dict[str, Any]]:
+    """Return the messages added since the last processed turn, minus assistants.
 
     The agent sends a cumulative message list. We already processed
-    `prev_message_count` messages. The new messages should be:
-    [assistant_response, new_user_message] — we return the user content.
+    ``prev_message_count`` messages. The genuinely new messages are
+    ``messages[prev_message_count:]`` — but the first of these is typically the
+    assistant turn the model just sampled, which is already captured as
+    completion token IDs. ``bridge_to_next_turn`` refuses assistant content
+    (re-tokenizing sampled tokens would corrupt training), so we drop every
+    assistant message from the slice.
 
-    Returns None if no new user message is found.
+    Returns an empty list if there are no new non-assistant messages.
     """
     if len(messages) <= prev_message_count:
-        return None
-
-    new_messages = messages[prev_message_count:]
-    for msg in reversed(new_messages):
-        if msg.get("role") == "user":
-            return msg.get("content", "")
-    return None
+        return []
+    new = messages[prev_message_count:]
+    return [m for m in new if m.get("role") != "assistant"]
 
 
 class TokenAccumulator:
     """Maintains per-session cumulative token state for drift-free generation.
 
-    Tracks the exact token IDs across turns so that the next turn's prompt
-    can be constructed by concatenation rather than re-tokenization from text.
+    Tracks the exact token IDs of the most recent turn so the next turn's
+    prompt can be built by ``renderers.bridge_to_next_turn`` (concatenation +
+    new-message rendering) rather than re-tokenization from text.
 
     Detects non-cumulative message list changes (prefix divergence) and
     automatically resets, so the training-side merger sees a segment break.
     """
 
-    def __init__(self, tokenizer: Any) -> None:
-        self.tokenizer = tokenizer
-        self.cumulative_ids: list[int] = []
+    def __init__(self, renderer: Any) -> None:
+        self.renderer = renderer
+        self.prev_prompt_ids: list[int] = []
+        self.prev_completion_ids: list[int] = []
         self.turn_count: int = 0
         self.message_count: int = 0
         self._prefix_fingerprint: str = ""
+
+    @property
+    def cumulative_ids(self) -> list[int]:
+        """Full token sequence through the most recent completion.
+
+        After turn N this is ``prev_prompt_ids + prev_completion_ids`` — the
+        prompt the last turn was sampled from plus the tokens it produced.
+        """
+        return self.prev_prompt_ids + self.prev_completion_ids
 
     def should_rewrite(self) -> bool:
         """Return True if this session should use /v1/completions rewriting."""
@@ -120,7 +105,8 @@ class TokenAccumulator:
             self.turn_count,
             self.message_count,
         )
-        self.cumulative_ids = []
+        self.prev_prompt_ids = []
+        self.prev_completion_ids = []
         self.turn_count = 0
         self.message_count = 0
         self._prefix_fingerprint = ""
@@ -128,13 +114,13 @@ class TokenAccumulator:
     def ingest_turn(self, prompt_token_ids: list[int], completion_token_ids: list[int]) -> None:
         """Record the token IDs from a completed turn.
 
-        On the first turn, sets cumulative_ids = prompt + completion.
-        On subsequent turns, appends the completion (prompt was already built by us).
+        ``prompt_token_ids`` is the full prompt the turn was sampled from (turn
+        1: the chat-rendered prompt; later turns: the bridge output we built).
+        ``completion_token_ids`` is what the model produced. Together they form
+        ``previous_prompt`` / ``previous_completion`` for the next bridge call.
         """
-        if self.turn_count == 0:
-            self.cumulative_ids = list(prompt_token_ids) + list(completion_token_ids)
-        else:
-            self.cumulative_ids.extend(completion_token_ids)
+        self.prev_prompt_ids = list(prompt_token_ids)
+        self.prev_completion_ids = list(completion_token_ids)
         self.turn_count += 1
 
     def update_prefix(self, messages: list[dict[str, Any]]) -> None:
@@ -142,20 +128,26 @@ class TokenAccumulator:
         self.message_count = len(messages)
         self._prefix_fingerprint = _messages_fingerprint(messages)
 
-    def build_next_prompt(self, user_content: str) -> list[int]:
+    def build_next_prompt(
+        self,
+        new_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int] | None:
         """Construct the full prompt token IDs for the next turn.
 
-        Appends bridge tokens (end-of-turn + user message + generation prompt)
-        to the cumulative sequence.
-
-        If the last completion token is the same as the bridge's first token
-        (typically <|im_end|>), the bridge is trimmed to avoid duplication.
-        This handles the common case where the model generates the end-of-turn
-        token as its natural stop.
+        Delegates to ``renderers.bridge_to_next_turn``, which extends the prior
+        ``prev_prompt_ids + prev_completion_ids`` with the rendered new messages
+        plus the next generation prompt. Returns the full token-ID sequence, or
+        ``None`` if the renderer cannot prove the prefix-extension contract (in
+        which case the caller falls back to the normal chat path).
         """
-        bridge = compute_bridge(self.tokenizer, user_content)
-        if self.cumulative_ids and bridge and self.cumulative_ids[-1] == bridge[0]:
-            bridge = bridge[1:]
-        prompt_ids = self.cumulative_ids + bridge
-        self.cumulative_ids = list(prompt_ids)
-        return prompt_ids
+        rendered = self.renderer.bridge_to_next_turn(
+            self.prev_prompt_ids,
+            self.prev_completion_ids,
+            new_messages,
+            tools=tools,
+        )
+        if rendered is None:
+            return None
+        return list(rendered.token_ids)

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -1,0 +1,161 @@
+"""Per-session cumulative token state for drift-free multi-turn RL training.
+
+Prevents tokenization drift (decode→re-encode producing different token IDs)
+by maintaining raw token ID sequences across turns and using /v1/completions
+with pre-tokenized prompts instead of re-tokenizing from text each turn.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _messages_fingerprint(messages: list[dict[str, Any]]) -> str:
+    """Compute a stable fingerprint for a message list prefix.
+
+    Uses JSON serialization + SHA-256 to detect any content/role changes.
+    """
+    raw = json.dumps(messages, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def compute_bridge(tokenizer: Any, user_content: str) -> list[int]:
+    """Compute bridge token IDs between an assistant completion and next generation.
+
+    Uses the tokenizer's own apply_chat_template to determine the exact tokens
+    for: end-of-assistant-turn + user-turn-with-content + start-of-next-generation.
+
+    This is template-agnostic: works for Qwen, Llama-3, Mistral, etc. as long as
+    the template uses special tokens at message boundaries (preventing BPE merges).
+
+    Args:
+        tokenizer: A HuggingFace tokenizer with apply_chat_template support.
+        user_content: The new user message content for this turn.
+
+    Returns:
+        List of token IDs representing the bridge between turns.
+    """
+    prefix_msgs = [
+        {"role": "user", "content": "X"},
+        {"role": "assistant", "content": "Y"},
+    ]
+    full_msgs = prefix_msgs + [{"role": "user", "content": user_content}]
+
+    prefix_ids = tokenizer.apply_chat_template(prefix_msgs, tokenize=True, continue_final_message=True)
+    full_ids = tokenizer.apply_chat_template(full_msgs, tokenize=True, add_generation_prompt=True)
+
+    if full_ids[: len(prefix_ids)] != prefix_ids:
+        raise ValueError(
+            "Chat template prefix mismatch — template may not use special tokens at message boundaries. Cumulative token mode requires templates where BPE merges cannot cross message boundaries."
+        )
+
+    return full_ids[len(prefix_ids) :]
+
+
+def extract_new_user_content(messages: list[dict[str, Any]], prev_message_count: int) -> str | None:
+    """Extract the content of the new user message added since last turn.
+
+    The agent sends a cumulative message list. We already processed
+    `prev_message_count` messages. The new messages should be:
+    [assistant_response, new_user_message] — we return the user content.
+
+    Returns None if no new user message is found.
+    """
+    if len(messages) <= prev_message_count:
+        return None
+
+    new_messages = messages[prev_message_count:]
+    for msg in reversed(new_messages):
+        if msg.get("role") == "user":
+            return msg.get("content", "")
+    return None
+
+
+class TokenAccumulator:
+    """Maintains per-session cumulative token state for drift-free generation.
+
+    Tracks the exact token IDs across turns so that the next turn's prompt
+    can be constructed by concatenation rather than re-tokenization from text.
+
+    Detects non-cumulative message list changes (prefix divergence) and
+    automatically resets, so the training-side merger sees a segment break.
+    """
+
+    def __init__(self, tokenizer: Any) -> None:
+        self.tokenizer = tokenizer
+        self.cumulative_ids: list[int] = []
+        self.turn_count: int = 0
+        self.message_count: int = 0
+        self._prefix_fingerprint: str = ""
+
+    def should_rewrite(self) -> bool:
+        """Return True if this session should use /v1/completions rewriting."""
+        return self.turn_count > 0
+
+    def is_cumulative(self, messages: list[dict[str, Any]]) -> bool:
+        """Check if *messages* is a cumulative extension of the tracked prefix.
+
+        Returns True if the first `message_count` messages in the new list
+        match the fingerprint of the messages we already processed.
+        Returns False (and the caller should reset) if:
+          - The new list has fewer messages than what we've processed.
+          - The prefix (first `message_count` msgs) differs from what we saw.
+        """
+        if self.turn_count == 0:
+            return True
+        if len(messages) <= self.message_count:
+            return False
+        prefix = messages[: self.message_count]
+        return _messages_fingerprint(prefix) == self._prefix_fingerprint
+
+    def reset(self) -> None:
+        """Clear all accumulated state, restarting this session's history."""
+        logger.info(
+            "Resetting TokenAccumulator (was at turn %d, %d messages)",
+            self.turn_count,
+            self.message_count,
+        )
+        self.cumulative_ids = []
+        self.turn_count = 0
+        self.message_count = 0
+        self._prefix_fingerprint = ""
+
+    def ingest_turn(self, prompt_token_ids: list[int], completion_token_ids: list[int]) -> None:
+        """Record the token IDs from a completed turn.
+
+        On the first turn, sets cumulative_ids = prompt + completion.
+        On subsequent turns, appends the completion (prompt was already built by us).
+        """
+        if self.turn_count == 0:
+            self.cumulative_ids = list(prompt_token_ids) + list(completion_token_ids)
+        else:
+            self.cumulative_ids.extend(completion_token_ids)
+        self.turn_count += 1
+
+    def update_prefix(self, messages: list[dict[str, Any]]) -> None:
+        """Snapshot the current message list as the verified prefix."""
+        self.message_count = len(messages)
+        self._prefix_fingerprint = _messages_fingerprint(messages)
+
+    def build_next_prompt(self, user_content: str) -> list[int]:
+        """Construct the full prompt token IDs for the next turn.
+
+        Appends bridge tokens (end-of-turn + user message + generation prompt)
+        to the cumulative sequence.
+
+        If the last completion token is the same as the bridge's first token
+        (typically <|im_end|>), the bridge is trimmed to avoid duplication.
+        This handles the common case where the model generates the end-of-turn
+        token as its natural stop.
+        """
+        bridge = compute_bridge(self.tokenizer, user_content)
+        if self.cumulative_ids and bridge and self.cumulative_ids[-1] == bridge[0]:
+            bridge = bridge[1:]
+        prompt_ids = self.cumulative_ids + bridge
+        self.cumulative_ids = list(prompt_ids)
+        return prompt_ids

--- a/rllm-model-gateway/tests/helpers/mock_vllm.py
+++ b/rllm-model-gateway/tests/helpers/mock_vllm.py
@@ -113,6 +113,72 @@ def stream_chunks():
     yield "data: [DONE]\n\n"
 
 
+def completions_stream_chunks(prompt_token_ids: list[int]):
+    """Yield SSE chunks for /v1/completions streaming format."""
+    chunks = [
+        {
+            "id": "cmpl-mock",
+            "object": "text_completion",
+            "model": "mock-model",
+            "prompt_token_ids": prompt_token_ids,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "Hello",
+                    "finish_reason": None,
+                    "stop_reason": None,
+                    "token_ids": [10],
+                    "logprobs": {
+                        "tokens": ["Hello"],
+                        "token_logprobs": [-0.5],
+                        "token_ids": [10],
+                    },
+                }
+            ],
+        },
+        {
+            "id": "cmpl-mock",
+            "object": "text_completion",
+            "model": "mock-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": " from mock!",
+                    "finish_reason": None,
+                    "stop_reason": None,
+                    "token_ids": [11, 12],
+                    "logprobs": {
+                        "tokens": [" from", " mock!"],
+                        "token_logprobs": [-0.3, -0.1],
+                        "token_ids": [11, 12],
+                    },
+                }
+            ],
+        },
+        {
+            "id": "cmpl-mock",
+            "object": "text_completion",
+            "model": "mock-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "",
+                    "finish_reason": "stop",
+                    "stop_reason": None,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": len(prompt_token_ids),
+                "completion_tokens": 3,
+                "total_tokens": len(prompt_token_ids) + 3,
+            },
+        },
+    ]
+    for chunk in chunks:
+        yield f"data: {json.dumps(chunk)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
 def build_mock_vllm_app() -> FastAPI:
     """Create a minimal mock vLLM server that returns canned responses."""
     app = FastAPI()
@@ -142,7 +208,45 @@ def build_mock_vllm_app() -> FastAPI:
         body = await request.json()
         with app.state._log_lock:
             app.state.request_log.append(body)
-        return JSONResponse(content=MOCK_RESPONSE)
+
+        prompt = body.get("prompt", "")
+        if isinstance(prompt, list):
+            prompt_token_ids = prompt
+        else:
+            prompt_token_ids = [1, 2, 3, 4, 5]
+
+        if body.get("stream"):
+            return StreamingResponse(
+                completions_stream_chunks(prompt_token_ids),
+                media_type="text/event-stream",
+            )
+
+        completion_response = {
+            "id": "cmpl-mock",
+            "object": "text_completion",
+            "model": "mock-model",
+            "prompt_token_ids": prompt_token_ids,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "Hello from mock!",
+                    "finish_reason": "stop",
+                    "stop_reason": None,
+                    "token_ids": [10, 11, 12],
+                    "logprobs": {
+                        "tokens": ["Hello", " from", " mock!"],
+                        "token_logprobs": [-0.5, -0.3, -0.1],
+                        "token_ids": [10, 11, 12],
+                    },
+                }
+            ],
+            "usage": {
+                "prompt_tokens": len(prompt_token_ids),
+                "completion_tokens": 3,
+                "total_tokens": len(prompt_token_ids) + 3,
+            },
+        }
+        return JSONResponse(content=completion_response)
 
     return app
 

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
@@ -1,0 +1,386 @@
+"""Tests for cumulative token mode.
+
+Verifies that when cumulative_token_mode=True, the gateway:
+1. Forwards turn 1 to /v1/chat/completions normally
+2. Rewrites turn 2+ to /v1/completions with raw token IDs
+3. Translates the response back to chat/completions format
+4. Stores traces with correct prompt_token_ids and completion_token_ids
+"""
+
+from unittest.mock import MagicMock
+
+import openai
+import pytest
+from rllm_model_gateway import GatewayClient, GatewayConfig, create_app
+
+from tests.helpers.gateway_server import GatewayServer
+from tests.helpers.mock_vllm import MockVLLMServer
+
+
+def _make_test_tokenizer():
+    """Create a mock tokenizer for testing cumulative mode without loading a real model.
+
+    Uses the same scheme as test_token_accumulator.py:
+    - Special tokens: <|im_end|>=100, <|im_start|>=101, newline=10
+    - apply_chat_template with continue_final_message=True returns [101, 1, 10, 101, 2, 10, 50, 51]
+    - apply_chat_template with add_generation_prompt=True returns prefix + bridge + content
+    """
+    tokenizer = MagicMock()
+
+    def _apply_chat_template(conversation, tokenize=False, **kwargs):
+        if kwargs.get("continue_final_message"):
+            return [101, 1, 10, 101, 2, 10, 50, 51]
+
+        if kwargs.get("add_generation_prompt"):
+            user_content = conversation[-1]["content"]
+            prefix = [101, 1, 10, 101, 2, 10, 50, 51]
+            content_ids = [ord(c) for c in user_content[:3]]
+            bridge = [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
+            return prefix + bridge
+
+        return []
+
+    tokenizer.apply_chat_template = _apply_chat_template
+    return tokenizer
+
+
+@pytest.fixture
+def cumulative_gateway(mock_vllm: MockVLLMServer):
+    """Gateway with cumulative_token_mode enabled using a mock tokenizer.
+
+    Creates the app with cumulative_token_mode=False to avoid AutoTokenizer.from_pretrained,
+    then manually injects the mock tokenizer and enables cumulative mode on the proxy.
+    """
+    config = GatewayConfig(
+        store_worker="memory",
+        workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
+        health_check_interval=999,
+        sync_traces=True,
+        cumulative_token_mode=False,  # Don't try to load real tokenizer
+    )
+    app = create_app(config)
+    # Inject mock tokenizer and enable cumulative mode
+    mock_tokenizer = _make_test_tokenizer()
+    app.state.proxy.tokenizer = mock_tokenizer
+    app.state.proxy.cumulative_token_mode = True
+
+    server = GatewayServer(app, port=0)
+    server.start()
+    yield server, mock_vllm
+    server.stop()
+
+
+class TestCumulativeTokenMode:
+    def test_turn1_uses_chat_completions(self, cumulative_gateway):
+        """First turn goes to /v1/chat/completions normally."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-test/v1", api_key="dummy")
+        resp = oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        assert resp.choices[0].message.content == "Hello from mock!"
+
+        # Verify the request went to chat/completions (has messages field)
+        assert len(mock_vllm.request_log) == 1
+        req = mock_vllm.request_log[0]
+        assert "messages" in req
+
+    def test_turn2_uses_completions_with_token_ids(self, cumulative_gateway):
+        """Second turn rewrites to /v1/completions with raw token IDs."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-test2/v1", api_key="dummy")
+
+        # Turn 1
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        # Turn 2
+        resp = oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "How are you?"},
+            ],
+        )
+        assert resp.choices[0].message.content == "Hello from mock!"
+
+        # Verify second request used /v1/completions with prompt as token IDs
+        assert len(mock_vllm.request_log) == 2
+        second_req = mock_vllm.request_log[1]
+        assert "prompt" in second_req
+        assert isinstance(second_req["prompt"], list)
+        assert all(isinstance(t, int) for t in second_req["prompt"])
+        assert "messages" not in second_req
+
+    def test_turn2_prompt_extends_turn1(self, cumulative_gateway):
+        """Turn 2 prompt token IDs are cumulative (extend turn 1's prompt + completion)."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-extend/v1", api_key="dummy")
+
+        # Turn 1
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        # Turn 2
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "More"},
+            ],
+        )
+
+        # The turn 2 prompt should START with turn 1's prompt_token_ids + completion_token_ids
+        second_req = mock_vllm.request_log[1]
+        prompt = second_req["prompt"]
+        # Turn 1 returned prompt_token_ids=[1,2,3,4,5] and completion_token_ids=[10,11,12]
+        # So turn 2 prompt should start with [1,2,3,4,5,10,11,12] + bridge
+        assert prompt[:8] == [1, 2, 3, 4, 5, 10, 11, 12]
+
+    def test_traces_have_correct_token_ids(self, cumulative_gateway):
+        """Both turns produce traces with prompt_token_ids and completion_token_ids."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        client = GatewayClient(gw_url)
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-traces/v1", api_key="dummy")
+
+        # Turn 1
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        # Turn 2
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "Tell me more"},
+            ],
+        )
+
+        traces = client.get_session_traces("cum-traces")
+        assert len(traces) == 2
+
+        # Both traces have token IDs
+        for trace in traces:
+            assert len(trace.prompt_token_ids) > 0
+            assert len(trace.completion_token_ids) > 0
+
+        # Turn 2 prompt should be longer (cumulative)
+        assert len(traces[1].prompt_token_ids) > len(traces[0].prompt_token_ids)
+        client.close()
+
+    def test_sampling_params_forwarded(self, cumulative_gateway):
+        """Sampling params from the original request are forwarded to /v1/completions."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-params/v1", api_key="dummy")
+
+        # Turn 1
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            temperature=0.7,
+            max_tokens=100,
+        )
+
+        # Turn 2 with sampling params
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "More"},
+            ],
+            temperature=0.7,
+            max_tokens=100,
+        )
+
+        second_req = mock_vllm.request_log[1]
+        assert second_req.get("temperature") == 0.7
+        assert second_req.get("max_tokens") == 100
+
+    def test_reset_on_non_cumulative_messages(self, cumulative_gateway):
+        """When message list diverges from accumulated prefix, gateway resets and uses chat path."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-reset/v1", api_key="dummy")
+
+        # Turn 1 — normal chat path, seeds accumulator
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        assert len(mock_vllm.request_log) == 1
+        assert "messages" in mock_vllm.request_log[0]  # chat/completions
+
+        # Turn 2 — cumulative extension, uses /v1/completions
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "Follow up"},
+            ],
+        )
+        assert len(mock_vllm.request_log) == 2
+        assert "prompt" in mock_vllm.request_log[1]  # completions (token IDs)
+
+        # Turn 3 — NON-CUMULATIVE: different prefix (divergent history)
+        # This should trigger a reset and use the chat path
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Completely different start"},
+                {"role": "assistant", "content": "Different response"},
+                {"role": "user", "content": "New question"},
+            ],
+        )
+        assert len(mock_vllm.request_log) == 3
+        # After reset, it goes back to chat/completions (turn-0 behavior)
+        assert "messages" in mock_vllm.request_log[2]
+        assert "prompt" not in mock_vllm.request_log[2]
+
+    def test_reset_then_resume_cumulative(self, cumulative_gateway):
+        """After a reset, the next cumulative extension works normally again."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-resume/v1", api_key="dummy")
+
+        # Turn 1 — seeds accumulator
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        # Turn 2 — divergent (reset)
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Fresh start"}],
+        )
+        # is_cumulative returns False when len(messages) <= message_count, triggering reset
+        assert "messages" in mock_vllm.request_log[1]  # went through chat path
+
+        # Turn 3 — cumulative extension of the new history
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Fresh start"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "Continue from fresh"},
+            ],
+        )
+        # Should now use cumulative path again (turn-1 was re-seeded after reset)
+        assert "prompt" in mock_vllm.request_log[2]
+        assert isinstance(mock_vllm.request_log[2]["prompt"], list)
+
+
+class TestCumulativeStreaming:
+    """Streaming-specific tests for the cumulative path (turn 2+ rewritten
+    to /v1/completions streaming).
+
+    Only covers behavior that is unique to the cumulative-streaming path.
+    Generic streaming behavior (vLLM field stripping, content delivery,
+    trace capture mechanics) is shared with _handle_streaming and covered
+    by TestStreamingProxy in test_server.py.
+    """
+
+    def test_turn2_stream_uses_completions_with_token_ids(self, cumulative_gateway):
+        """Streaming second turn rewrites to /v1/completions with raw token IDs
+        and translates chunks back to chat-format for the client."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-stream-1/v1", api_key="dummy")
+
+        # Turn 1 — seed the accumulator.
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        # Turn 2 — streaming.
+        stream = oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "How are you?"},
+            ],
+            stream=True,
+        )
+        content_parts = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                content_parts.append(chunk.choices[0].delta.content)
+
+        # Client received chat-format content end-to-end.
+        assert "".join(content_parts) == "Hello from mock!"
+
+        # Upstream got a /v1/completions streaming request with token-IDs prompt.
+        assert len(mock_vllm.request_log) == 2
+        second_req = mock_vllm.request_log[1]
+        assert "prompt" in second_req
+        assert isinstance(second_req["prompt"], list)
+        assert all(isinstance(t, int) for t in second_req["prompt"])
+        assert "messages" not in second_req
+        assert second_req.get("stream") is True
+
+    def test_streaming_forwards_usage(self, cumulative_gateway):
+        """Final usage-only chunk from /v1/completions should reach the client.
+
+        Regression test: cumulative streaming used to drop chunks where
+        choices was empty, dropping vLLM's trailing usage-only chunk.
+        """
+        import httpx as _httpx
+
+        server, _ = cumulative_gateway
+        gw_url = server.url
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-stream-usage/v1", api_key="dummy")
+
+        # Turn 1 — seed.
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        # Turn 2 — read SSE directly so we can inspect the usage chunk.
+        with _httpx.Client(timeout=10.0) as c:
+            resp = c.post(
+                f"{gw_url}/sessions/cum-stream-usage/v1/chat/completions",
+                json={
+                    "model": "mock-model",
+                    "messages": [
+                        {"role": "user", "content": "Hello"},
+                        {"role": "assistant", "content": "Hello from mock!"},
+                        {"role": "user", "content": "More"},
+                    ],
+                    "stream": True,
+                },
+            )
+            import json as _json
+
+            chunks = [_json.loads(line[6:]) for line in resp.text.strip().split("\n") if line.startswith("data: ") and line.strip() != "data: [DONE]"]
+
+        usage_chunks = [c for c in chunks if c.get("usage")]
+        assert len(usage_chunks) >= 1
+        usage = usage_chunks[-1]["usage"]
+        assert "prompt_tokens" in usage
+        assert "completion_tokens" in usage

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
@@ -260,6 +260,69 @@ class TestCumulativeTokenMode:
         assert "messages" in mock_vllm.request_log[2]
         assert "prompt" not in mock_vllm.request_log[2]
 
+    def test_declined_bridge_resets_and_reingests(self, cumulative_gateway):
+        """When the renderer declines a cumulative (non-divergent) turn, the
+        accumulator must reset so that turn is re-ingested on the chat path.
+
+        Regression: without the reset, the stale prefix drops the declined
+        turn's completion tokens from the next cumulative prompt, breaking the
+        prefix-extension invariant. A bridge can return None even when the
+        message prefix is cumulative (e.g. DefaultRenderer, or a slice the
+        renderer can't bridge).
+        """
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+
+        class _DecliningRenderer(_MockRenderer):
+            """Declines (returns None) when the new user message is 'DECLINE'."""
+
+            def bridge_to_next_turn(self, prev_prompt_ids, prev_completion_ids, new_messages, *, tools=None):
+                for m in reversed(new_messages):
+                    if m.get("role") == "user":
+                        if m.get("content") == "DECLINE":
+                            return None
+                        break
+                return super().bridge_to_next_turn(prev_prompt_ids, prev_completion_ids, new_messages, tools=tools)
+
+        server.app.state.proxy.renderer = _DecliningRenderer()
+        acc_store = server.app.state.proxy._accumulators
+
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/cum-decline/v1", api_key="dummy")
+
+        # Turn 1 — seeds accumulator (prompt [1,2,3,4,5] + completion [10,11,12]).
+        oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "Hello"}])
+
+        # Turn 2 — cumulative prefix, but the renderer declines the bridge.
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "DECLINE"},
+            ],
+        )
+        # Declined -> chat path (not /v1/completions).
+        assert "messages" in mock_vllm.request_log[1]
+        assert "prompt" not in mock_vllm.request_log[1]
+        # Reset + re-ingest: prefix snapshot now reflects turn-2's 3 messages,
+        # not turn-1's single message (the bug leaves this at 1).
+        assert acc_store["cum-decline"].message_count == 3
+
+        # Turn 3 — cumulative extension resumes from the re-ingested turn-2 state.
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "DECLINE"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "More"},
+            ],
+        )
+        assert "prompt" in mock_vllm.request_log[2]
+        # Prompt extends the re-ingested turn-2 full sequence [1,2,3,4,5,10,11,12].
+        assert mock_vllm.request_log[2]["prompt"][:8] == [1, 2, 3, 4, 5, 10, 11, 12]
+
     def test_reset_then_resume_cumulative(self, cumulative_gateway):
         """After a reset, the next cumulative extension works normally again."""
         server, mock_vllm = cumulative_gateway

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
@@ -7,8 +7,6 @@ Verifies that when cumulative_token_mode=True, the gateway:
 4. Stores traces with correct prompt_token_ids and completion_token_ids
 """
 
-from unittest.mock import MagicMock
-
 import openai
 import pytest
 from rllm_model_gateway import GatewayClient, GatewayConfig, create_app
@@ -17,51 +15,55 @@ from tests.helpers.gateway_server import GatewayServer
 from tests.helpers.mock_vllm import MockVLLMServer
 
 
-def _make_test_tokenizer():
-    """Create a mock tokenizer for testing cumulative mode without loading a real model.
+class _MockRendered:
+    """Stand-in for renderers.RenderedTokens (only .token_ids is consumed)."""
 
-    Uses the same scheme as test_token_accumulator.py:
-    - Special tokens: <|im_end|>=100, <|im_start|>=101, newline=10
-    - apply_chat_template with continue_final_message=True returns [101, 1, 10, 101, 2, 10, 50, 51]
-    - apply_chat_template with add_generation_prompt=True returns prefix + bridge + content
+    def __init__(self, token_ids):
+        self.token_ids = token_ids
+
+
+class _MockRenderer:
+    """Mimics renderers.Renderer.bridge_to_next_turn without loading a real model.
+
+    Bridge output = prev_prompt + prev_completion + deterministic extension:
+        [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
+    where content_ids = ord() of the first 3 chars of the last user message.
+
+    Returns None when new_messages is empty or contains an assistant turn —
+    mirroring renderers' reject_assistant_in_extension contract.
     """
-    tokenizer = MagicMock()
 
-    def _apply_chat_template(conversation, tokenize=False, **kwargs):
-        if kwargs.get("continue_final_message"):
-            return [101, 1, 10, 101, 2, 10, 50, 51]
-
-        if kwargs.get("add_generation_prompt"):
-            user_content = conversation[-1]["content"]
-            prefix = [101, 1, 10, 101, 2, 10, 50, 51]
-            content_ids = [ord(c) for c in user_content[:3]]
-            bridge = [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
-            return prefix + bridge
-
-        return []
-
-    tokenizer.apply_chat_template = _apply_chat_template
-    return tokenizer
+    def bridge_to_next_turn(self, prev_prompt_ids, prev_completion_ids, new_messages, *, tools=None):
+        if not new_messages or any(m.get("role") == "assistant" for m in new_messages):
+            return None
+        content = ""
+        for m in reversed(new_messages):
+            if m.get("role") == "user":
+                content = m.get("content", "")
+                break
+        content_ids = [ord(c) for c in content[:3]]
+        bridge = [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
+        return _MockRendered(list(prev_prompt_ids) + list(prev_completion_ids) + bridge)
 
 
 @pytest.fixture
 def cumulative_gateway(mock_vllm: MockVLLMServer):
-    """Gateway with cumulative_token_mode enabled using a mock tokenizer.
+    """Gateway with cumulative_token_mode enabled using a mock renderer.
 
-    Creates the app with cumulative_token_mode=False to avoid AutoTokenizer.from_pretrained,
-    then manually injects the mock tokenizer and enables cumulative mode on the proxy.
+    Creates the app with cumulative_token_mode=False to avoid building a real
+    renderer (which would load AutoTokenizer), then injects the mock renderer
+    and enables cumulative mode on the proxy.
     """
     config = GatewayConfig(
         store_worker="memory",
         workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
         health_check_interval=999,
         sync_traces=True,
-        cumulative_token_mode=False,  # Don't try to load real tokenizer
+        cumulative_token_mode=False,  # Don't try to build a real renderer
     )
     app = create_app(config)
-    # Inject mock tokenizer and enable cumulative mode
-    mock_tokenizer = _make_test_tokenizer()
-    app.state.proxy.tokenizer = mock_tokenizer
+    # Inject mock renderer and enable cumulative mode
+    app.state.proxy.renderer = _MockRenderer()
     app.state.proxy.cumulative_token_mode = True
 
     server = GatewayServer(app, port=0)

--- a/rllm-model-gateway/tests/unit/test_token_accumulator.py
+++ b/rllm-model-gateway/tests/unit/test_token_accumulator.py
@@ -1,127 +1,127 @@
 """Tests for token_accumulator module."""
 
-from unittest.mock import MagicMock
 
-import pytest
+class _MockRendered:
+    """Stand-in for renderers.RenderedTokens (only .token_ids is used)."""
+
+    def __init__(self, token_ids):
+        self.token_ids = token_ids
 
 
-def _make_mock_tokenizer():
-    """Create a mock tokenizer that simulates apply_chat_template behavior.
+class _MockRenderer:
+    """Mimics renderers.Renderer.bridge_to_next_turn for tests.
 
-    Uses a simple scheme:
-    - Special tokens: <|im_end|>=100, <|im_start|>=101, newline=10
-    - apply_chat_template with continue_final_message=True returns [101, 1, 10, 101, 2, 10, 50, 51]
-    - apply_chat_template with add_generation_prompt=True returns above + bridge + content
+    Bridge output = prev_prompt + prev_completion + a deterministic extension:
+        [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
+    where content_ids = ord() of the first 3 chars of the last user message.
+
+    Returns None when any new message is an assistant turn (mirroring
+    renderers' reject_assistant_in_extension) or when new_messages is empty.
     """
-    tokenizer = MagicMock()
 
-    def _apply_chat_template(conversation, tokenize=False, **kwargs):
-        if kwargs.get("continue_final_message"):
-            return [101, 1, 10, 101, 2, 10, 50, 51]
-
-        if kwargs.get("add_generation_prompt"):
-            user_content = conversation[-1]["content"]
-            content_ids = [ord(c) for c in user_content[:3]]
-            prefix = [101, 1, 10, 101, 2, 10, 50, 51]
-            bridge = [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
-            return prefix + bridge
-
-        return []
-
-    tokenizer.apply_chat_template = _apply_chat_template
-    return tokenizer
-
-
-class TestComputeBridge:
-    def test_bridge_returns_correct_ids(self):
-        from rllm_model_gateway.token_accumulator import compute_bridge
-
-        tokenizer = _make_mock_tokenizer()
-        bridge = compute_bridge(tokenizer, "hi!")
-        expected = [100, 10, 101, 1, 10, ord("h"), ord("i"), ord("!"), 100, 10, 101, 2, 10]
-        assert bridge == expected
-
-    def test_bridge_empty_content(self):
-        from rllm_model_gateway.token_accumulator import compute_bridge
-
-        tokenizer = _make_mock_tokenizer()
-        bridge = compute_bridge(tokenizer, "")
-        expected = [100, 10, 101, 1, 10, 100, 10, 101, 2, 10]
-        assert bridge == expected
-
-    def test_bridge_raises_on_prefix_mismatch(self):
-        from rllm_model_gateway.token_accumulator import compute_bridge
-
-        tokenizer = MagicMock()
-        tokenizer.apply_chat_template = lambda *a, **kw: ([1, 2, 3] if kw.get("continue_final_message") else [9, 9, 9, 4, 5])
-        with pytest.raises(ValueError, match="prefix mismatch"):
-            compute_bridge(tokenizer, "test")
+    def bridge_to_next_turn(self, prev_prompt_ids, prev_completion_ids, new_messages, *, tools=None):
+        if not new_messages or any(m.get("role") == "assistant" for m in new_messages):
+            return None
+        content = ""
+        for m in reversed(new_messages):
+            if m.get("role") == "user":
+                content = m.get("content", "")
+                break
+        content_ids = [ord(c) for c in content[:3]]
+        bridge = [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
+        return _MockRendered(list(prev_prompt_ids) + list(prev_completion_ids) + bridge)
 
 
 class TestTokenAccumulator:
     def test_initial_state(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         assert acc.turn_count == 0
         assert acc.cumulative_ids == []
 
     def test_ingest_first_turn(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
         assert acc.turn_count == 1
         assert acc.cumulative_ids == [1, 2, 3, 10, 11]
+        assert acc.prev_prompt_ids == [1, 2, 3]
+        assert acc.prev_completion_ids == [10, 11]
 
     def test_should_rewrite_false_on_first_turn(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         assert acc.should_rewrite() is False
 
     def test_should_rewrite_true_after_first_turn(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
         assert acc.should_rewrite() is True
 
     def test_build_prompt_ids(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
-        prompt_ids = acc.build_next_prompt("hello")
+        prompt_ids = acc.build_next_prompt([{"role": "user", "content": "hello"}])
         bridge = [100, 10, 101, 1, 10, ord("h"), ord("e"), ord("l"), 100, 10, 101, 2, 10]
         expected = [1, 2, 3, 10, 11] + bridge
         assert prompt_ids == expected
 
-    def test_ingest_second_turn_extends_cumulative(self):
+    def test_build_prompt_returns_none_on_assistant_in_new_messages(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
-        # Build prompt for turn 2 (this extends cumulative_ids with bridge)
-        prompt_ids = acc.build_next_prompt("hi!")
-        # Now ingest turn 2's completion
+        # An assistant message in the new slice must make the bridge bail out.
+        result = acc.build_next_prompt([{"role": "assistant", "content": "sampled"}, {"role": "user", "content": "x"}])
+        assert result is None
+
+    def test_ingest_second_turn_replaces_state(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(renderer=_MockRenderer())
+        acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
+        # Build prompt for turn 2.
+        prompt_ids = acc.build_next_prompt([{"role": "user", "content": "hi!"}])
+        # Ingest turn 2's completion: prev_prompt becomes the bridge prompt,
+        # prev_completion becomes the new completion.
         acc.ingest_turn(prompt_token_ids=prompt_ids, completion_token_ids=[20, 21])
         assert acc.turn_count == 2
+        assert acc.prev_prompt_ids == prompt_ids
+        assert acc.prev_completion_ids == [20, 21]
         assert acc.cumulative_ids == prompt_ids + [20, 21]
+
+    def test_turn3_prompt_extends_turn2(self):
+        """The bridge contract: each turn's prompt starts with the prior full sequence."""
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(renderer=_MockRenderer())
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        p2 = acc.build_next_prompt([{"role": "user", "content": "abc"}])
+        acc.ingest_turn(p2, [20, 21])
+        p3 = acc.build_next_prompt([{"role": "user", "content": "def"}])
+        # p3 must start with the full turn-2 sequence (p2 + completion2).
+        assert p3[: len(p2) + 2] == p2 + [20, 21]
 
 
 class TestCumulativeVerification:
     def test_is_cumulative_true_on_first_turn(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         messages = [{"role": "user", "content": "Hello"}]
         assert acc.is_cumulative(messages) is True
 
     def test_is_cumulative_true_when_prefix_matches(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         messages_t1 = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi"},
@@ -135,7 +135,7 @@ class TestCumulativeVerification:
     def test_is_cumulative_false_when_prefix_changes(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         messages_t1 = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi"},
@@ -154,7 +154,7 @@ class TestCumulativeVerification:
     def test_is_cumulative_false_when_message_count_shrinks(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         messages_t1 = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi"},
@@ -169,7 +169,7 @@ class TestCumulativeVerification:
     def test_reset_clears_state(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         acc.ingest_turn([1, 2, 3], [10, 11])
         acc.update_prefix([{"role": "user", "content": "Hello"}])
         assert acc.turn_count == 1
@@ -177,13 +177,15 @@ class TestCumulativeVerification:
         acc.reset()
         assert acc.turn_count == 0
         assert acc.cumulative_ids == []
+        assert acc.prev_prompt_ids == []
+        assert acc.prev_completion_ids == []
         assert acc.message_count == 0
         assert acc.should_rewrite() is False
 
     def test_reset_allows_fresh_ingestion(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
-        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc = TokenAccumulator(renderer=_MockRenderer())
         acc.ingest_turn([1, 2, 3], [10, 11])
         acc.update_prefix([{"role": "user", "content": "Hello"}])
 
@@ -193,9 +195,9 @@ class TestCumulativeVerification:
         assert acc.cumulative_ids == [5, 6, 7, 20, 21]
 
 
-class TestExtractNewUserContent:
-    def test_extract_last_user_message(self):
-        from rllm_model_gateway.token_accumulator import extract_new_user_content
+class TestExtractNewMessages:
+    def test_extract_new_user_message(self):
+        from rllm_model_gateway.token_accumulator import extract_new_messages
 
         messages = [
             {"role": "system", "content": "You are helpful."},
@@ -203,25 +205,41 @@ class TestExtractNewUserContent:
             {"role": "assistant", "content": "Hi there!"},
             {"role": "user", "content": "How are you?"},
         ]
-        assert extract_new_user_content(messages, prev_message_count=3) == "How are you?"
+        # prev_message_count=3 means [system, user, assistant] already processed.
+        # The new slice is [user "How are you?"]; no assistant to drop.
+        assert extract_new_messages(messages, prev_message_count=3) == [{"role": "user", "content": "How are you?"}]
+
+    def test_extract_drops_assistant_from_new_slice(self):
+        from rllm_model_gateway.token_accumulator import extract_new_messages
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+            {"role": "user", "content": "Next"},
+        ]
+        # prev_message_count=1 → new slice is [assistant, user]; assistant dropped.
+        assert extract_new_messages(messages, prev_message_count=1) == [{"role": "user", "content": "Next"}]
 
     def test_extract_handles_no_new_messages(self):
-        from rllm_model_gateway.token_accumulator import extract_new_user_content
+        from rllm_model_gateway.token_accumulator import extract_new_messages
 
         messages = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi"},
         ]
-        result = extract_new_user_content(messages, prev_message_count=2)
-        assert result is None
+        assert extract_new_messages(messages, prev_message_count=2) == []
 
-    def test_extract_with_multiple_new_messages(self):
-        from rllm_model_gateway.token_accumulator import extract_new_user_content
+    def test_extract_keeps_tool_and_user_messages(self):
+        from rllm_model_gateway.token_accumulator import extract_new_messages
 
         messages = [
             {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi"},
-            {"role": "user", "content": "Second question"},
+            {"role": "assistant", "content": "use tool"},
+            {"role": "tool", "content": "result"},
+            {"role": "user", "content": "thanks"},
         ]
-        result = extract_new_user_content(messages, prev_message_count=1)
-        assert result == "Second question"
+        # prev=2 → slice [tool, user]; both kept (only assistants dropped).
+        assert extract_new_messages(messages, prev_message_count=2) == [
+            {"role": "tool", "content": "result"},
+            {"role": "user", "content": "thanks"},
+        ]

--- a/rllm-model-gateway/tests/unit/test_token_accumulator.py
+++ b/rllm-model-gateway/tests/unit/test_token_accumulator.py
@@ -1,0 +1,227 @@
+"""Tests for token_accumulator module."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_mock_tokenizer():
+    """Create a mock tokenizer that simulates apply_chat_template behavior.
+
+    Uses a simple scheme:
+    - Special tokens: <|im_end|>=100, <|im_start|>=101, newline=10
+    - apply_chat_template with continue_final_message=True returns [101, 1, 10, 101, 2, 10, 50, 51]
+    - apply_chat_template with add_generation_prompt=True returns above + bridge + content
+    """
+    tokenizer = MagicMock()
+
+    def _apply_chat_template(conversation, tokenize=False, **kwargs):
+        if kwargs.get("continue_final_message"):
+            return [101, 1, 10, 101, 2, 10, 50, 51]
+
+        if kwargs.get("add_generation_prompt"):
+            user_content = conversation[-1]["content"]
+            content_ids = [ord(c) for c in user_content[:3]]
+            prefix = [101, 1, 10, 101, 2, 10, 50, 51]
+            bridge = [100, 10, 101, 1, 10] + content_ids + [100, 10, 101, 2, 10]
+            return prefix + bridge
+
+        return []
+
+    tokenizer.apply_chat_template = _apply_chat_template
+    return tokenizer
+
+
+class TestComputeBridge:
+    def test_bridge_returns_correct_ids(self):
+        from rllm_model_gateway.token_accumulator import compute_bridge
+
+        tokenizer = _make_mock_tokenizer()
+        bridge = compute_bridge(tokenizer, "hi!")
+        expected = [100, 10, 101, 1, 10, ord("h"), ord("i"), ord("!"), 100, 10, 101, 2, 10]
+        assert bridge == expected
+
+    def test_bridge_empty_content(self):
+        from rllm_model_gateway.token_accumulator import compute_bridge
+
+        tokenizer = _make_mock_tokenizer()
+        bridge = compute_bridge(tokenizer, "")
+        expected = [100, 10, 101, 1, 10, 100, 10, 101, 2, 10]
+        assert bridge == expected
+
+    def test_bridge_raises_on_prefix_mismatch(self):
+        from rllm_model_gateway.token_accumulator import compute_bridge
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template = lambda *a, **kw: ([1, 2, 3] if kw.get("continue_final_message") else [9, 9, 9, 4, 5])
+        with pytest.raises(ValueError, match="prefix mismatch"):
+            compute_bridge(tokenizer, "test")
+
+
+class TestTokenAccumulator:
+    def test_initial_state(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        assert acc.turn_count == 0
+        assert acc.cumulative_ids == []
+
+    def test_ingest_first_turn(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
+        assert acc.turn_count == 1
+        assert acc.cumulative_ids == [1, 2, 3, 10, 11]
+
+    def test_should_rewrite_false_on_first_turn(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        assert acc.should_rewrite() is False
+
+    def test_should_rewrite_true_after_first_turn(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
+        assert acc.should_rewrite() is True
+
+    def test_build_prompt_ids(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
+        prompt_ids = acc.build_next_prompt("hello")
+        bridge = [100, 10, 101, 1, 10, ord("h"), ord("e"), ord("l"), 100, 10, 101, 2, 10]
+        expected = [1, 2, 3, 10, 11] + bridge
+        assert prompt_ids == expected
+
+    def test_ingest_second_turn_extends_cumulative(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc.ingest_turn(prompt_token_ids=[1, 2, 3], completion_token_ids=[10, 11])
+        # Build prompt for turn 2 (this extends cumulative_ids with bridge)
+        prompt_ids = acc.build_next_prompt("hi!")
+        # Now ingest turn 2's completion
+        acc.ingest_turn(prompt_token_ids=prompt_ids, completion_token_ids=[20, 21])
+        assert acc.turn_count == 2
+        assert acc.cumulative_ids == prompt_ids + [20, 21]
+
+
+class TestCumulativeVerification:
+    def test_is_cumulative_true_on_first_turn(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        messages = [{"role": "user", "content": "Hello"}]
+        assert acc.is_cumulative(messages) is True
+
+    def test_is_cumulative_true_when_prefix_matches(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        messages_t1 = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        acc.update_prefix(messages_t1)
+
+        messages_t2 = messages_t1 + [{"role": "user", "content": "How are you?"}]
+        assert acc.is_cumulative(messages_t2) is True
+
+    def test_is_cumulative_false_when_prefix_changes(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        messages_t1 = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        acc.update_prefix(messages_t1)
+
+        # Divergent: earlier message content changed
+        messages_t2 = [
+            {"role": "user", "content": "Different start"},
+            {"role": "assistant", "content": "Hi"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        assert acc.is_cumulative(messages_t2) is False
+
+    def test_is_cumulative_false_when_message_count_shrinks(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        messages_t1 = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        acc.update_prefix(messages_t1)
+
+        # Fewer messages than what was ingested
+        messages_t2 = [{"role": "user", "content": "Fresh start"}]
+        assert acc.is_cumulative(messages_t2) is False
+
+    def test_reset_clears_state(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        acc.update_prefix([{"role": "user", "content": "Hello"}])
+        assert acc.turn_count == 1
+
+        acc.reset()
+        assert acc.turn_count == 0
+        assert acc.cumulative_ids == []
+        assert acc.message_count == 0
+        assert acc.should_rewrite() is False
+
+    def test_reset_allows_fresh_ingestion(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(tokenizer=_make_mock_tokenizer())
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        acc.update_prefix([{"role": "user", "content": "Hello"}])
+
+        acc.reset()
+        acc.ingest_turn([5, 6, 7], [20, 21])
+        assert acc.turn_count == 1
+        assert acc.cumulative_ids == [5, 6, 7, 20, 21]
+
+
+class TestExtractNewUserContent:
+    def test_extract_last_user_message(self):
+        from rllm_model_gateway.token_accumulator import extract_new_user_content
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        assert extract_new_user_content(messages, prev_message_count=3) == "How are you?"
+
+    def test_extract_handles_no_new_messages(self):
+        from rllm_model_gateway.token_accumulator import extract_new_user_content
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        result = extract_new_user_content(messages, prev_message_count=2)
+        assert result is None
+
+    def test_extract_with_multiple_new_messages(self):
+        from rllm_model_gateway.token_accumulator import extract_new_user_content
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+            {"role": "user", "content": "Second question"},
+        ]
+        result = extract_new_user_content(messages, prev_message_count=1)
+        assert result == "Second question"

--- a/rllm/experimental/config/rllm/base.yaml
+++ b/rllm/experimental/config/rllm/base.yaml
@@ -148,6 +148,14 @@ gateway:
   store: memory       # "memory" (non-persistent) | "sqlite" (writes traces to disk)
   db_path: null       # Only used when store=sqlite; null → auto-resolved path (logged at startup)
   sampling_params_priority: session   # "session" | "client" — who wins when both set the same key
+  cumulative_token_mode: false   # Drift-free multi-turn token forwarding: rewrites turn 2+ to
+                                 # /v1/completions with cumulative raw token IDs built by the renderer.
+                                 # The tokenizer is loaded from the served model path (model.name).
+  renderer_family: auto  # renderers family for the cumulative-mode bridge. Renderers can auto infer it
+                         # if your input model.name is a huggingface model it. If model.name is a local
+                         # path, you must set this explicitly (e.g. qwen3, qwen3.5, qwen3.6, glm-5, 
+                         # deepseek-v3, gpt-oss). Check supported model families in MODEL_RENDERER_MAP of 
+                         # https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
 
 # Async Training Configuration
 async_training:

--- a/rllm/experimental/engine/gateway_manager.py
+++ b/rllm/experimental/engine/gateway_manager.py
@@ -139,6 +139,14 @@ class GatewayManager:
         self.sampling_params_priority: str = gw_cfg.get("sampling_params_priority", "client")
         # The gateway always pins ``body.model`` to whatever the trainer is serving
         self.model: str | None = config.get("model", {}).get("name", None)
+
+        # Cumulative token mode: drift-free multi-turn token forwarding. The
+        # gateway loads the tokenizer from the served model path. renderers
+        # cannot infer the family from a local checkpoint path, so
+        # renderer_family must be set explicitly (e.g. "qwen3", "glm-5").
+        self.cumulative_token_mode: bool = gw_cfg.get("cumulative_token_mode", False)
+        self.renderer_family: str = gw_cfg.get("renderer_family", "auto")
+
         self.mode = mode
 
         self._process: subprocess.Popen | None = None
@@ -313,6 +321,10 @@ class GatewayManager:
             cmd.extend(["--sampling-params-priority", self.sampling_params_priority])
         if self.model:
             cmd.extend(["--model", self.model])
+        if self.cumulative_token_mode:
+            cmd.append("--cumulative-token-mode")
+            if self.renderer_family != "auto":
+                cmd.extend(["--renderer-family", self.renderer_family])
 
         logger.info("Starting gateway subprocess: %s", " ".join(cmd))
         # Inherit parent's stdout/stderr so gateway logs are visible for debugging.
@@ -351,6 +363,8 @@ class GatewayManager:
             model=self.model,
             add_logprobs=self.add_logprobs,
             add_return_token_ids=self.add_return_token_ids,
+            cumulative_token_mode=self.cumulative_token_mode,
+            renderer_family=self.renderer_family,
         )
         app = create_app(config=gw_config, local_handler=local_handler)
 


### PR DESCRIPTION
## Summary

Adds optional `cumulative_token_mode` to the gateway. When enabled, the gateway will monitor per-session input OpenAI message text list, if it grows cumulatively (no context break like context compression happens), it will construct cumulative prompt token id sequence (by the [`renderers`](https://github.com/PrimeIntellect-ai/renderers) package) from turn 2, and directly send it to vllm completion API. This avoids retokenization drift --- in default mode, OpenAI message text list is directly input to vllm chat API, they are retokenized to prompt token id sequence every time.

If the message-list prefix diverges from the accumulated state at a turn, the accumulator resets and the request falls back to the normal chat path at that turn, and cumulation monitoring restarts at next turn.

Note that this mode is transparent to upstream agent framework. No need to change any code in agent framework. Agent framework could still send OpenAI chat request and receive OpenAI chat response normally. Input and output format transformation all happen within gateway.

## Why

Multi-turn RL training is sensitive to tokenization drift: re-tokenizing the message list each turn can produce a token sequence different from what the model originally generated. If users do not like it, they can choose to avoid it by using this mode.

## Changes

- **`token_accumulator.py`** — `TokenAccumulator` tracks per-session cumulative
    token state and delegates cross-turn bridging to the renderer's
    `bridge_to_next_turn(prev_prompt_ids, prev_completion_ids, new_messages, *, tools=None)`.
    `extract_new_messages` slices the unseen tail of the message list and drops
    assistant turns (the model re-samples those). Truncated completions are closed
    with a synthesized end token by the renderer; assistant messages in the new slice
    cause the bridge to bail out (falling back to the chat path).
- **`proxy.py`** — `ReverseProxy` gains `cumulative_token_mode` and `renderer`. In
    `handle()`, chat-completions requests on an established session are rewritten to
    `/v1/completions` with the cumulative prompt; if the bridge returns `None`, it
    falls back to the normal chat path.
- **`data_process.py`** — extractors handle the `/v1/completions` response shape
    (root-level `prompt_token_ids`, flat `token_logprobs`).
- **`server.py`** — when `cumulative_token_mode=True`, loads the tokenizer from
    `config.model` and builds a renderer via `create_renderer(tokenizer, renderer=config.renderer_family)`.
    Raises a hard startup error if this resolves to `DefaultRenderer` (which provides
    no cross-turn bridge). New CLI flags: `--cumulative-token-mode`, `--renderer-family`.
- **`models.py`** — `GatewayConfig` gains `cumulative_token_mode: bool` and
    `renderer_family: str = "auto"`.
- **`pyproject.toml`** — adds `renderers>=0.1.7` and `transformers>=4.50.0`.

## Example usage

```bash
python -m rllm_model_gateway.server \
    --worker http://localhost:8000/v1 \
    --model Qwen/Qwen3-8B \
    --cumulative-token-mode \
    --renderer-family qwen3
```
In RL training, set in `gateway:` config:

```yaml
gateway:
  cumulative_token_mode: true
  renderer_family: qwen3   # or "auto" if model is a canonical HF id
```

## Tests

- [x] pytest rllm-model-gateway/tests/unit/
- [x] Multi-turn rollout vs real vLLM; verify turn-N prompt id sequence prefix equal turn-(N-1) prompt + completion + environment observation.
- [x] Verify reset path triggers on context compression.
- [x] cumulative_token_mode=False (default) behavior unchanged.
- [x] Test it in a real agentic RL experiment (on AppWorld) agent and ensure cumulative input token sequence is maintained.