### PR TITLE
fix(trainer): handle empty group metrics

### DIFF
--- a/rllm/experimental/common/transform.py
+++ b/rllm/experimental/common/transform.py
@@ -162,9 +162,14 @@ def _get_transform_metrics(episodes: list[Episode], groups: list[TrajectoryGroup
     metrics[f"{prefix}/num_trajs_before_filter"] = group_sizes_before.sum()
     metrics[f"{prefix}/num_trajs_after_filter"] = group_sizes.sum()
     metrics[f"{prefix}/num_groups"] = len(groups)
-    metrics[f"{prefix}/avg_group_size"] = group_sizes.mean()
-    metrics[f"{prefix}/max_group_size"] = group_sizes.max()
-    metrics[f"{prefix}/min_group_size"] = group_sizes.min()
+    if len(group_sizes) == 0:
+        metrics[f"{prefix}/avg_group_size"] = 0.0
+        metrics[f"{prefix}/max_group_size"] = 0
+        metrics[f"{prefix}/min_group_size"] = 0
+    else:
+        metrics[f"{prefix}/avg_group_size"] = group_sizes.mean()
+        metrics[f"{prefix}/max_group_size"] = group_sizes.max()
+        metrics[f"{prefix}/min_group_size"] = group_sizes.min()
     return metrics
 
 

--- a/tests/unified_trainer/test_verl_transform.py
+++ b/tests/unified_trainer/test_verl_transform.py
@@ -11,8 +11,11 @@ from unittest.mock import MagicMock
 import torch
 
 from rllm.agents.agent import Episode, Step, Trajectory
+from rllm.experimental.common.config import CompactFilteringConfig, TransformConfig
+from rllm.experimental.common.transform import transform_episodes_to_trajectory_groups
 from rllm.experimental.rollout import ModelOutput
 from rllm.experimental.verl.transform import transform_episodes_to_dataproto
+from rllm.workflows.workflow import TerminationReason
 
 
 def _make_mock_rollout_engine(pad_token_id: int = 0):
@@ -44,6 +47,24 @@ def _make_episode(
     )
     trajectory = Trajectory(steps=[step], reward=reward)
     return Episode(id=episode_id, trajectories=[trajectory], is_correct=reward > 0)
+
+
+def test_transform_metrics_handle_all_filtered_groups():
+    episodes = [Episode(id=f"task:{i}", trajectories=[], termination_reason=TerminationReason.TIMEOUT) for i in range(2)]
+    cf_config = CompactFilteringConfig(enable=True, mask_timeout=True)
+
+    groups, metrics = transform_episodes_to_trajectory_groups(
+        episodes,
+        TransformConfig(),
+        cf_config,
+    )
+
+    assert groups == []
+    assert metrics["groups/num_groups"] == 0
+    assert metrics["groups/num_trajs_after_filter"] == 0
+    assert metrics["groups/avg_group_size"] == 0.0
+    assert metrics["groups/max_group_size"] == 0
+    assert metrics["groups/min_group_size"] == 0
 
 
 class TestRolloutLogProbsPropagation:


### PR DESCRIPTION
## Summary

This fixes trajectory-group transform metrics when filtering removes all groups. Instead of calling NumPy reductions on an empty array, the transform now reports zero-valued group-size metrics, preventing crashes in filtered batches.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Handle empty trajectory-group outputs in transform metrics.
- Return `0.0` / `0` for average, max, and min group size when no groups remain.
- Added regression coverage in the existing transform test suite.

## Validation

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `./.venv/bin/python -m pytest tests/unified_trainer/test_verl_transform.py::test_transform_metrics_handle_all_filtered_groups`
- Commit hook ran `ruff` and `ruff-format` successfully.

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

N/A
