### PR TITLE
fix(engine): add flush timeout and graceful session delete handling

### DIFF
--- a/rllm/experimental/engine/gateway_manager.py
+++ b/rllm/experimental/engine/gateway_manager.py
@@ -276,7 +276,7 @@ class GatewayManager:
 
     async def adelete_session(self, session_id: str) -> int:
         """Delete a session and all its accumulated traces. Returns count removed."""
-        await self.async_client.flush()
+        await self.async_client.flush(timeout=_TRACE_API_TIMEOUT)
         return await self.async_client.delete_session(session_id)
 
     async def adelete_sessions(self, session_ids: list[str]) -> int:

--- a/rllm/experimental/engine/remote_agent_flow_engine.py
+++ b/rllm/experimental/engine/remote_agent_flow_engine.py
@@ -140,7 +140,10 @@ class RemoteAgentFlowEngine:
                 episode.metadata["error"] = error_info
 
             # Delete traces from gateway DB to prevent unbounded growth
-            await self.gateway.adelete_session(session_id)
+            try:
+                await self.gateway.adelete_session(session_id)
+            except Exception as e:
+                logger.warning("[%s] Failed to delete session (non-fatal): %s", uid, e)
 
             return task_id, rollout_idx, result_idx, episode
 


### PR DESCRIPTION


## Summary

<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Add timeout parameter to flush() call in adelete_session to prevent hangs
- Wrap adelete_session in try-except to handle failures gracefully
- Log warning on session delete failure rather than crashing

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [x] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
