### PR TITLE
Skip none batch

### DIFF
--- a/rllm/experimental/verl/verl_backend.py
+++ b/rllm/experimental/verl/verl_backend.py
@@ -703,14 +703,15 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             await self.checkpoint_manager.update_weights(trainer_state.global_step)
 
         # Update metrics
-        batch: DataProto = trainer_state.backend_batch  # type: ignore[attr-defined]
-        metrics = trainer_state.metrics
-        metrics.update({"training/global_step": trainer_state.global_step, "training/epoch": trainer_state.epoch})
-        metrics.update(compute_data_metrics(batch=batch, use_critic=False))
-        metrics.update(compute_timing_metrics(batch=batch, timing_raw=trainer_state.timing_dict))
+        if trainer_state.has_backend_batch:
+            batch: DataProto = trainer_state.backend_batch  # type: ignore[attr-defined]
+            metrics = trainer_state.metrics
+            metrics.update({"training/global_step": trainer_state.global_step, "training/epoch": trainer_state.epoch})
+            metrics.update(compute_data_metrics(batch=batch, use_critic=False))
+            metrics.update(compute_timing_metrics(batch=batch, timing_raw=trainer_state.timing_dict))
 
-        n_gpus = self.resource_pool_manager.get_n_gpus()
-        metrics.update(compute_throughout_metrics(batch=batch, timing_raw=trainer_state.timing_dict, n_gpus=n_gpus))
+            n_gpus = self.resource_pool_manager.get_n_gpus()
+            metrics.update(compute_throughout_metrics(batch=batch, timing_raw=trainer_state.timing_dict, n_gpus=n_gpus))
 
     async def on_validation_start(self, trainer_state: TrainerState) -> bool:
         """Called at the start of validation."""


### PR DESCRIPTION
## Summary

When `trainer_state` has no valid batch, `metrics.update(compute_data_metrics(batch=batch, use_critic=False))` will throw exception:
```
  File "/fsx/linbol/linbo-projects/rllm/rllm/experimental/verl/verl_backend.py", line 697, in on_batch_end
    metrics.update(compute_data_metrics(batch=batch, use_critic=False))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx/linbol/linbo-projects/rllm/.venv/lib/python3.12/site-packages/verl/trainer/ppo/metric_utils.py", line 105, in compute_data_metrics
    sequence_score = batch.batch["token_level_scores"].sum(-1)
                     ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'batch'. Did you mean: '_return_value'?
```
This fix skips logging for empty batch.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- 
- 
- 

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [x] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
