### PR TITLE
fix(data): serialize extra_info as JSON string in verl postprocessing

### DIFF
--- a/rllm/data/dataset.py
+++ b/rllm/data/dataset.py
@@ -730,7 +730,7 @@ class DatasetRegistry:
                     "style": "rule",
                     "ground_truth": None,
                 },
-                "extra_info": entry,
+                "extra_info": json.dumps(entry, default=str),
             }
             processed_data.append(processed_entry)
         return processed_data


### PR DESCRIPTION
Fixes #364.\n\nThis PR serializes `extra_info` with `json.dumps(..., default=str)` during Verl postprocessing.\n\nPreviously, `extra_info` was stored as a Python dict when generating the `_verl.parquet` companion dataset. Explicitly serializing it keeps the data format consistent with Verl's expected JSON-string handling in `verl.utils.dataset.rl_dataset.py`.