### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -198,12 +198,11 @@ PROVIDER_REGISTRY: list[ProviderInfo] = [
         label="MiniMax",
         litellm_prefix="minimax",
         env_key="MINIMAX_API_KEY",
-        default_model="MiniMax-M2.7",
+        default_model="MiniMax-M3",
         models=[
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
         ],
     ),
     # --- Custom endpoint (last) ---

--- a/tests/eval/test_eval_config.py
+++ b/tests/eval/test_eval_config.py
@@ -196,40 +196,39 @@ class TestConstants:
         assert info.litellm_prefix == "minimax"
         assert info.env_key == "MINIMAX_API_KEY"
 
-    def test_minimax_default_model_is_m27(self):
-        """MiniMax default model should be the latest M2.7."""
+    def test_minimax_default_model_is_m3(self):
+        """MiniMax default model should be the latest M3."""
         info = get_provider_info("minimax")
         assert info is not None
-        assert info.default_model == "MiniMax-M2.7"
+        assert info.default_model == "MiniMax-M3"
+
+    def test_minimax_models_include_m3(self):
+        """MiniMax model list should include the M3 flagship."""
+        info = get_provider_info("minimax")
+        assert info is not None
+        assert "MiniMax-M3" in info.models
 
     def test_minimax_models_include_m27_family(self):
-        """MiniMax model list should include M2.7 and M2.7-highspeed."""
+        """MiniMax model list should still include M2.7 and M2.7-highspeed for backward compat."""
         info = get_provider_info("minimax")
         assert info is not None
         assert "MiniMax-M2.7" in info.models
         assert "MiniMax-M2.7-highspeed" in info.models
 
-    def test_minimax_models_include_m25_family(self):
-        """MiniMax model list should still include M2.5 models for backward compat."""
+    def test_minimax_m3_is_first_model(self):
+        """M3 should be listed before M2.7 (newest first)."""
         info = get_provider_info("minimax")
         assert info is not None
-        assert "MiniMax-M2.5" in info.models
-        assert "MiniMax-M2.5-highspeed" in info.models
-
-    def test_minimax_m27_is_first_model(self):
-        """M2.7 should be listed before M2.5 (newest first)."""
-        info = get_provider_info("minimax")
-        assert info is not None
+        m3_idx = info.models.index("MiniMax-M3")
         m27_idx = info.models.index("MiniMax-M2.7")
-        m25_idx = info.models.index("MiniMax-M2.5")
-        assert m27_idx < m25_idx
+        assert m3_idx < m27_idx
 
     def test_minimax_config_validates(self):
         """A complete MiniMax config should pass validation."""
         config = RllmConfig(
             provider="minimax",
             api_keys={"minimax": "test-key"},
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
         )
         assert config.is_configured()
         assert config.validate() == []
@@ -237,4 +236,4 @@ class TestConstants:
     def test_minimax_in_default_models(self):
         """MiniMax should have an entry in DEFAULT_MODELS."""
         assert "minimax" in DEFAULT_MODELS
-        assert DEFAULT_MODELS["minimax"] == "MiniMax-M2.7"
+        assert DEFAULT_MODELS["minimax"] == "MiniMax-M3"

--- a/tests/eval/test_eval_proxy.py
+++ b/tests/eval/test_eval_proxy.py
@@ -54,6 +54,19 @@ class TestEvalProxyManager:
         assert pm.proxy_port == 8080
         assert pm.get_proxy_url() == "http://0.0.0.0:8080/v1"
 
+    def test_build_proxy_config_minimax_m3(self):
+        """MiniMax M3 should route through minimax/ LiteLLM prefix."""
+        pm = EvalProxyManager(provider="minimax", model_name="MiniMax-M3", api_key="mm-test-key")
+        config = pm.build_proxy_config()
+
+        assert "model_list" in config
+        assert len(config["model_list"]) == 1
+
+        entry = config["model_list"][0]
+        assert entry["model_name"] == "MiniMax-M3"
+        assert entry["litellm_params"]["model"] == "minimax/MiniMax-M3"
+        assert entry["litellm_params"]["api_key"] == "mm-test-key"
+
     def test_build_proxy_config_minimax_m27(self):
         """MiniMax M2.7 should route through minimax/ LiteLLM prefix."""
         pm = EvalProxyManager(provider="minimax", model_name="MiniMax-M2.7", api_key="mm-test-key")

--- a/tests/integration/test_minimax_integration.py
+++ b/tests/integration/test_minimax_integration.py
@@ -25,16 +25,16 @@ class TestMiniMaxIntegration:
 
     @requires_minimax
     def test_minimax_litellm_config_generation(self):
-        """Verify LiteLLM config is correctly generated for MiniMax M2.7."""
+        """Verify LiteLLM config is correctly generated for MiniMax M3."""
         pm = EvalProxyManager(
             provider="minimax",
-            model_name="MiniMax-M2.7",
+            model_name="MiniMax-M3",
             api_key=MINIMAX_API_KEY,
         )
         config = pm.build_proxy_config()
 
         entry = config["model_list"][0]
-        assert entry["litellm_params"]["model"] == "minimax/MiniMax-M2.7"
+        assert entry["litellm_params"]["model"] == "minimax/MiniMax-M3"
         assert entry["litellm_params"]["api_key"] == MINIMAX_API_KEY
 
     @requires_minimax
@@ -45,24 +45,24 @@ class TestMiniMaxIntegration:
         original = RllmConfig(
             provider="minimax",
             api_keys={"minimax": MINIMAX_API_KEY},
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
         )
         save_config(original)
 
         loaded = load_config()
         assert loaded.provider == "minimax"
-        assert loaded.model == "MiniMax-M2.7"
+        assert loaded.model == "MiniMax-M3"
         assert loaded.api_key == MINIMAX_API_KEY
         assert loaded.is_configured()
         assert loaded.validate() == []
 
     @requires_minimax
     def test_minimax_litellm_completion(self):
-        """Verify MiniMax M2.7 responds via LiteLLM completion (no proxy)."""
+        """Verify MiniMax M3 responds via LiteLLM completion (no proxy)."""
         import litellm
 
         response = litellm.completion(
-            model="minimax/MiniMax-M2.7",
+            model="minimax/MiniMax-M3",
             messages=[{"role": "user", "content": "Say hello in one word."}],
             api_key=MINIMAX_API_KEY,
             max_tokens=16,


### PR DESCRIPTION
## Summary

Upgrade the MiniMax provider configuration in the rLLM eval registry to track MiniMax's latest flagship model, **MiniMax-M3**, while keeping the M2.7 family available for users who want to pin to it.

## Type of change

- [x] Feature

## What changed

- `rllm/eval/config.py`: add `MiniMax-M3` to the `minimax` provider's model list (now first), set it as `default_model`, and remove the deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are kept.
- `tests/eval/test_eval_config.py`: refresh the minimax-specific assertions — default is now `MiniMax-M3`, M3 must be present and ordered before M2.7, drop the M2.5 backward-compat assertion.
- `tests/eval/test_eval_proxy.py`: add an `MiniMax-M3` proxy-config test alongside the existing M2.7 ones to confirm the `minimax/MiniMax-M3` LiteLLM route.
- `tests/integration/test_minimax_integration.py`: switch the live `MINIMAX_API_KEY` integration tests to exercise `MiniMax-M3`.

No changes to LiteLLM prefixes, env keys, or non-minimax providers.

## Validation

- [x] Targeted tests: ran the minimax-related assertions in `tests/eval/test_eval_config.py` and `tests/eval/test_eval_proxy.py` against the modified config — all pass.
- [ ] `pre-commit run --all-files` — not run locally (ruff version mismatch); changes follow the existing 4-space / dataclass / list literal style already used in `config.py`.

## Breaking changes / migration notes

If a user previously pinned `model="MiniMax-M2.5"` or `model="MiniMax-M2.5-highspeed"`, that model id is no longer in the registry's model list. They should switch to `MiniMax-M3` (recommended) or `MiniMax-M2.7` / `MiniMax-M2.7-highspeed`. The default for the `minimax` provider also changes from `MiniMax-M2.7` to `MiniMax-M3`.

## Docs / examples

- [x] Not needed (no public docs reference specific MiniMax model ids)

## Related issues / PRs

- None