### PR TITLE
perf(cli): lazy-load rllm.eval re-exports to speed up fast CLI commands

### DIFF
--- a/rllm/eval/__init__.py
+++ b/rllm/eval/__init__.py
@@ -1,27 +1,44 @@
-from rllm.eval.agent_loader import load_agent
-from rllm.eval.config import RllmConfig, load_config, save_config
-from rllm.eval.evaluator_loader import load_evaluator, resolve_evaluator_from_catalog
-from rllm.eval.proxy import EvalProxyManager
-from rllm.eval.results import EvalItem, EvalResult
-from rllm.eval.runner import run_dataset
-from rllm.eval.types import EvalOutput, Signal
-from rllm.types import AgentConfig, AgentFlow, Evaluator, run_agent_flow
+"""rLLM evaluation package.
 
-__all__ = [
-    "load_agent",
-    "load_evaluator",
-    "resolve_evaluator_from_catalog",
-    "run_dataset",
-    "EvalResult",
-    "EvalItem",
-    "RllmConfig",
-    "load_config",
-    "save_config",
-    "EvalProxyManager",
-    "AgentConfig",
-    "AgentFlow",
-    "Evaluator",
-    "EvalOutput",
-    "Signal",
-    "run_agent_flow",
-]
+Re-exports the public eval API. Imports are lazy (PEP 562): heavy submodules
+(``runner``, ``proxy``, ``rllm.types`` and their transitive torch/verl deps) are
+only loaded when the corresponding name is first accessed. This keeps lightweight
+consumers — e.g. the ``rllm model`` CLI, which only needs ``config`` — fast.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+# name -> submodule that defines it
+_EXPORTS = {
+    "load_agent": "rllm.eval.agent_loader",
+    "load_evaluator": "rllm.eval.evaluator_loader",
+    "resolve_evaluator_from_catalog": "rllm.eval.evaluator_loader",
+    "run_dataset": "rllm.eval.runner",
+    "EvalResult": "rllm.eval.results",
+    "EvalItem": "rllm.eval.results",
+    "RllmConfig": "rllm.eval.config",
+    "load_config": "rllm.eval.config",
+    "save_config": "rllm.eval.config",
+    "EvalProxyManager": "rllm.eval.proxy",
+    "AgentConfig": "rllm.types",
+    "AgentFlow": "rllm.types",
+    "Evaluator": "rllm.types",
+    "EvalOutput": "rllm.eval.types",
+    "Signal": "rllm.eval.types",
+    "run_agent_flow": "rllm.types",
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str):
+    module_path = _EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_path), name)
+
+
+def __dir__() -> list[str]:
+    return __all__


### PR DESCRIPTION
## Problem

Read-only CLI commands that should be instant were taking ~10–13s. The worst offenders just read `.rllm/` config or list local scaffolds.

Profiling with `python -X importtime` traced it to a single import chain:

```
rllm model show
  → cli/model_cmd.py: from rllm.eval.config import load_config, ...
  → importing rllm.eval.config first executes rllm/eval/__init__.py
  → __init__.py eagerly imports runner → workflows → engine.rollout → verl.workers + torch
```

`rllm/eval/config.py` itself only needs `json`/`os`/`dataclasses`, but importing the submodule forces the package `__init__.py` to run first — and that `__init__.py` eagerly re-exported `runner`/`proxy`/`rllm.types`, pulling in the **entire verl + torch stack (~8.6s)** for a config lookup.

## Fix

Convert `rllm/eval/__init__.py` to **lazy re-exports via PEP 562** (`module __getattr__`). The public API is unchanged — `from rllm.eval import load_config, run_dataset, ...` still works — but each name is imported from its source submodule only on first access. Commands that genuinely need `run_dataset` load verl/torch lazily, exactly as before.

Single-file change, no API break, no new abstractions.

## Benchmarks (best of 3 runs)

| Command | Before | After |
|---|---|---|
| `rllm model show` | 9.89s | 0.27s |
| `rllm agent list` | 9.89s | 0.30s |
| `rllm dataset list` | 0.30s | 0.29s (already fast) |
| `rllm --help` | 0.26s | 0.27s |
| `rllm --version` | 0.27s | 0.26s |

`model` and `agent` import `rllm.eval`, so they benefit directly; `dataset`/`--help`/`--version` never went through that path and are unchanged.

Direct import check: `import rllm.eval.config` went **8.73s → 0.18s** with no `verl`/`torch` loaded.

## Verification

- `tests/eval/test_eval_config.py` + `tests/cli/test_eval_command.py`: **43 passed**
- `from rllm.eval import *` and all heavy re-exports (`run_dataset`, `EvalProxyManager`, `AgentConfig`, …) still resolve
- `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)