### PR TITLE
feat(harness,eval): add ZeroClaw harness + Claw-Eval benchmark

### DIFF
--- a/docs/core-concepts/harnesses.mdx
+++ b/docs/core-concepts/harnesses.mdx
@@ -20,6 +20,7 @@ You don't need a harness for everything — for one-off agents and cookbooks, ha
 | `qwen-code` | `rllm.harnesses.qwen_code.QwenCodeHarness` | Run the Qwen Code CLI inside the sandbox. |
 | `aider` | `rllm.harnesses.aider.AiderHarness` | Run Paul Gauthier's aider CLI inside the sandbox. |
 | `kimi-cli` | `rllm.harnesses.kimi_cli.KimiCliHarness` | Run Moonshot's kimi-cli inside the sandbox. |
+| `zeroclaw` | `rllm.harnesses.zeroclaw.ZeroClawHarness` | Run the ZeroClaw autonomous-assistant CLI inside the sandbox. |
 
 The registry lives at `rllm/registry/agents.json`. `load_agent("react")` resolves to `ReActHarness()`.
 

--- a/docs/core-concepts/reward-functions.mdx
+++ b/docs/core-concepts/reward-functions.mdx
@@ -46,6 +46,7 @@ Two things matter:
 | `bfcl` | Function-call signature matching | BFCL |
 | `ifeval` | Instruction-following constraint checks | IFEval |
 | `llm_judge` | LLM-as-judge | Open-ended generation |
+| `claw_eval` | LLM-judge over the full agent trajectory (task completion) | Claw-Eval |
 | `llm_equality` | LLM-graded equivalence | Free-form QA |
 | `translation` | BLEU / chrF | MT benchmarks |
 | `widesearch` | Source-grounded checks | Wide-search agents |

--- a/docs/datasets.mdx
+++ b/docs/datasets.mdx
@@ -84,6 +84,7 @@ Datasets in this category use the `search` agent, which requires a search backen
 | `bfcl` | BFCL: Berkeley Function Calling Leaderboard (exec_simple) | test | [gorilla-llm/Berkeley-Function-Calling-Leaderboard](https://huggingface.co/datasets/gorilla-llm/Berkeley-Function-Calling-Leaderboard) | `bfcl_reward_fn` |
 | `multichallenge` | MultiChallenge: Multi-turn conversation evaluation | test | [nmayorga7/multichallenge](https://huggingface.co/datasets/nmayorga7/multichallenge) | `llm_judge_reward_fn` |
 | `frozenlake` | FrozenLake: Grid navigation (procedurally generated) | train, test | Generated | `frozenlake_reward_fn` |
+| `claw_eval` | Claw-Eval: personal-assistant agent tasks in sandbox workspaces (run with `--agent zeroclaw`) | general (161) | [claw-eval/Claw-Eval](https://huggingface.co/datasets/claw-eval/Claw-Eval) | `claw_eval_reward_fn` |
 
 ## Translation
 

--- a/rllm/cli/_pull.py
+++ b/rllm/cli/_pull.py
@@ -370,11 +370,30 @@ def _pull_harbor_dataset(name: str, catalog_entry: dict) -> None:
     logger.info("Registered Harbor dataset %s/%s (%d tasks)", name, split, len(data_list))
 
 
+def _pull_built_dataset(name: str, catalog_entry: dict, builder_path: str) -> None:
+    """Build a sandbox (task-per-directory) benchmark via a builder function.
+
+    The builder is specified as ``module:function`` and materializes the
+    benchmark directory under ``~/.rllm/datasets/<name>/`` directly (the
+    ``rllm eval`` materialised-benchmark redirect then resolves it by name).
+    It receives ``name``, ``split``, ``out_dir`` and ``catalog_entry`` kwargs.
+
+    Unlike HF/generator datasets (which emit row data), sandbox datasets are
+    whole workspaces, so they bypass the row-materialize path entirely.
+    """
+    build_fn = _load_transform(builder_path)
+    out_dir = os.path.join(_DATASETS_ROOT, name)
+    split = catalog_entry.get("eval_split") or (catalog_entry.get("splits") or ["test"])[0]
+    build_fn(name=name, split=split, out_dir=out_dir, catalog_entry=catalog_entry)
+    logger.info("Built sandbox benchmark '%s' at %s", name, out_dir)
+
+
 def pull_dataset(name: str, catalog_entry: dict) -> None:
     """Download a dataset from HuggingFace, Harbor, or generate it, and register locally.
 
     Supports optional field_map, hf_config, aggregate_configs, transform,
-    generator for procedurally-generated datasets, and Harbor registry datasets.
+    generator for procedurally-generated datasets, builder for sandbox
+    (task-per-directory) benchmarks, and Harbor registry datasets.
 
     Args:
         name: Dataset name (e.g., 'gsm8k').
@@ -384,6 +403,13 @@ def pull_dataset(name: str, catalog_entry: dict) -> None:
     source = catalog_entry.get("source", "")
     if source.startswith("harbor:"):
         _pull_harbor_dataset(name, catalog_entry)
+        return
+
+    # Check for a builder (sandbox/task-per-directory benchmarks built from a
+    # mix of HF rows + fixture archives — they produce a directory, not rows).
+    builder_path = catalog_entry.get("builder")
+    if builder_path:
+        _pull_built_dataset(name, catalog_entry, builder_path)
         return
 
     # Check for a generator function (procedural datasets that don't live on HF)

--- a/rllm/data/claw_eval_builder.py
+++ b/rllm/data/claw_eval_builder.py
@@ -1,0 +1,209 @@
+"""Builder for the Claw-Eval sandbox benchmark.
+
+Claw-Eval (``claw-eval/Claw-Eval``) is a personal-assistant agent benchmark
+whose tasks are *workspaces*: a natural-language ``query`` plus fixture files.
+This module materializes a split into rLLM's ``type="sandbox"`` task-per-
+directory layout so ``rllm eval`` can run each task in a sandbox.
+
+It is the single source of truth for building the dataset, used by:
+- ``rllm dataset pull claw_eval`` (via the ``builder`` field in
+  ``rllm/registry/datasets.json`` → :func:`rllm.cli._pull.pull_dataset`), and
+- ``scripts/data/claw_eval_dataset.py`` (a thin CLI wrapper with extra knobs).
+
+On-disk output (``<out_dir>/``):
+
+    claw_eval/
+    ├── dataset.toml                     # [dataset] type="sandbox", default_agent="zeroclaw"
+    ├── <task_id>/
+    │   ├── task.toml                    # top-level query/rubric + [environment]/[verifier]
+    │   ├── instruction.md               # the row's query
+    │   └── environment/files/fixtures/  # this task's fixtures (uploaded to /workspace)
+    └── ...
+
+Grading: rows ship no rubric, so each task's ``[verifier]`` points at
+``claw_eval_reward_fn`` (an LLM-judge over the agent transcript).
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import tarfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REPO_ID = "claw-eval/Claw-Eval"
+VERIFIER_NAME = "claw_eval_reward_fn"
+
+
+def _toml_escape(s: str) -> str:
+    """Escape a string for a TOML triple-quoted basic string."""
+    return s.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+
+
+def _write_task(task_dir: Path, *, task_id: str, query: str, category: str, language: str, judge_model: str | None) -> None:
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "instruction.md").write_text(query, encoding="utf-8")
+
+    # Top-level scalars land directly in Task.metadata (the loader copies the
+    # whole task.toml into metadata), so the judge can read `query`/`rubric`.
+    # Scalars MUST precede the first [section] in TOML.
+    lines = [
+        f'query = """{_toml_escape(query)}"""',
+        f'rubric = """{_toml_escape(query)}"""',
+        f'task_id = "{task_id}"',
+        f'category = "{category}"',
+        f'language = "{language}"',
+    ]
+    if judge_model:
+        lines.append(f'judge_model = "{judge_model}"')
+    lines += [
+        "",
+        "[task]",
+        f'name = "{task_id}"',
+        "",
+        "[environment]",
+        'workdir = "/workspace"',
+        "",
+        "[verifier]",
+        f'name = "{VERIFIER_NAME}"',
+        "",
+    ]
+    (task_dir / "task.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_dataset_toml(out: Path, *, name: str, split: str, description: str, default_agent: str) -> None:
+    content = "\n".join(
+        [
+            "[dataset]",
+            f'name = "{name}"',
+            'type = "sandbox"',
+            f'description = "{_toml_escape(description)}"',
+            'default_sandbox = "docker"',
+            f'default_agent = "{default_agent}"',
+            f'split = "{split}"',
+            "",
+        ]
+    )
+    (out / "dataset.toml").write_text(content, encoding="utf-8")
+
+
+def build_benchmark(
+    *,
+    name: str = "claw_eval",
+    split: str = "general",
+    out_dir: str | Path,
+    catalog_entry: dict | None = None,
+    limit: int | None = None,
+    lang: str = "all",
+    default_agent: str = "zeroclaw",
+    judge_model: str | None = None,
+    clean: bool = False,
+    register: bool = True,
+) -> Path:
+    """Materialize a Claw-Eval split into a sandbox benchmark directory.
+
+    Args:
+        name: Dataset/registry name (also the dataset.toml ``name``).
+        split: HF split to build (``general`` | ``multimodal`` | ``multi_turn``).
+        out_dir: Output benchmark directory.
+        catalog_entry: Optional catalog entry (datasets.json); ``description``/
+            ``default_agent``/``eval_split`` are read from it when present.
+        limit: Keep only the first N tasks (after the language filter).
+        lang: ``all`` | ``en`` | ``zh`` language filter.
+        default_agent: ``default_agent`` written into dataset.toml.
+        judge_model: Optional judge model stamped into each task's metadata.
+        clean: Remove ``out_dir`` before building.
+        register: Also register the rows in ``DatasetRegistry`` so
+            ``rllm dataset list/info/inspect`` show the dataset as pulled.
+
+    Returns:
+        Path to the built benchmark directory.
+    """
+    from datasets import load_dataset
+    from huggingface_hub import hf_hub_download
+
+    if catalog_entry:
+        split = catalog_entry.get("eval_split") or split
+        default_agent = catalog_entry.get("default_agent") or default_agent
+
+    out = Path(out_dir).expanduser()
+    if clean and out.exists():
+        logger.info("[claw-eval] removing existing %s", out)
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    logger.info("[claw-eval] loading %s split=%s ...", REPO_ID, split)
+    ds = load_dataset(REPO_ID, split=split)
+
+    rows = list(ds)
+    if lang != "all":
+        rows = [r for r in rows if r["language"] == lang]
+    if limit is not None:
+        rows = rows[:limit]
+    selected_ids = {r["task_id"] for r in rows}
+    logger.info("[claw-eval] selected %d tasks (lang=%s, limit=%s)", len(rows), lang, limit)
+
+    # Extract only the fixtures for the selected tasks from the shared archive.
+    logger.info("[claw-eval] downloading fixtures archive (cached) ...")
+    fixtures_path = hf_hub_download(REPO_ID, "data/fixtures.tar.gz", repo_type="dataset")
+
+    dest_files = {r["task_id"]: out / r["task_id"] / "environment" / "files" for r in rows}
+    extracted = dict.fromkeys(selected_ids, 0)
+    logger.info("[claw-eval] extracting fixtures ...")
+    with tarfile.open(fixtures_path) as tar:
+        for m in tar:
+            if not m.isfile():
+                continue
+            top = m.name.split("/", 1)[0]
+            if top not in selected_ids:
+                continue
+            rel = m.name[len(top) + 1 :]  # strip "<task_id>/" -> "fixtures/..."
+            if not rel:
+                continue
+            target = dest_files[top] / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            src = tar.extractfile(m)
+            if src is None:
+                continue
+            with open(target, "wb") as fh:
+                shutil.copyfileobj(src, fh)
+            extracted[top] += 1
+
+    for r in rows:
+        _write_task(
+            out / r["task_id"],
+            task_id=r["task_id"],
+            query=r["query"],
+            category=r["category"],
+            language=r["language"],
+            judge_model=judge_model,
+        )
+
+    description = (catalog_entry or {}).get("description") or f"Claw-Eval {split} split: personal-assistant agent tasks (LLM-judge graded)."
+    _write_dataset_toml(out, name=name, split=split, description=description, default_agent=default_agent)
+
+    n_with_fx = sum(1 for tid in selected_ids if extracted[tid] > 0)
+    logger.info("[claw-eval] wrote %d task dirs to %s (%d with fixtures, %d fixture-less)", len(rows), out, n_with_fx, len(selected_ids) - n_with_fx)
+
+    # Register the rows so `rllm dataset list/info/inspect` show parity with
+    # other catalog datasets. Eval still uses the sandbox dir (via the
+    # materialised-benchmark redirect in rllm.cli.eval), not these rows.
+    if register:
+        try:
+            from rllm.data import DatasetRegistry
+
+            reg_rows = [{k: r[k] for k in ("task_id", "query", "fixture", "language", "category")} for r in rows]
+            DatasetRegistry.register_dataset(
+                name=name,
+                data=reg_rows,
+                split=split,
+                source=REPO_ID,
+                description=description,
+                category=(catalog_entry or {}).get("category", "agentic"),
+            )
+        except Exception:  # registry parity is best-effort; the benchmark dir is what eval uses
+            logger.warning("[claw-eval] could not register rows in DatasetRegistry (non-fatal)", exc_info=True)
+
+    return out

--- a/rllm/eval/evaluator_loader.py
+++ b/rllm/eval/evaluator_loader.py
@@ -98,6 +98,7 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
     "ifeval_reward_fn": "rllm.eval.reward_fns.ifeval:evaluate",
     "bfcl_reward_fn": "rllm.eval.reward_fns.bfcl:evaluate",
     "llm_judge_reward_fn": "rllm.eval.reward_fns.llm_judge:evaluate",
+    "claw_eval_reward_fn": "rllm.eval.reward_fns.claw_eval:evaluate",
     "llm_equality_reward_fn": "rllm.eval.reward_fns.llm_equality:evaluate",
     "translation_reward_fn": "rllm.eval.reward_fns.translation:evaluate",
     "widesearch_reward_fn": "rllm.eval.reward_fns.widesearch:evaluate",

--- a/rllm/eval/reward_fns/claw_eval.py
+++ b/rllm/eval/reward_fns/claw_eval.py
@@ -1,0 +1,237 @@
+"""Claw-Eval grader: LLM-as-judge over the agent's full trajectory.
+
+Claw-Eval ships *no* machine-readable rubrics in its public dataset
+(`claw-eval/Claw-Eval` rows carry only ``task_id``/``query``/``fixture``/
+``language``/``category``; the official 2,159 rubric items and the Pass³
+grading harness are not released). So this grader approximates the official
+"completion" judgement: an LLM judge reads the task instruction (the row's
+``query``) and the agent's full conversation/trajectory, and decides whether
+the task was accomplished, returning a 0/1 reward.
+
+This is intentionally a *completion* proxy, not a faithful reproduction of
+Claw-Eval's multi-dimensional Pass³ scoring. It exists so that an eval run
+fails only on genuine agent mistakes (or missing judge config) — never on
+harness/plumbing issues: every error path returns a finite reward with
+diagnostic metadata rather than raising.
+
+Judge model resolution (first hit wins):
+  1. ``CLAW_EVAL_JUDGE_MODEL`` / ``CLAW_EVAL_JUDGE_BASE_URL`` /
+     ``CLAW_EVAL_JUDGE_API_KEY`` env vars (explicit override).
+  2. ``task.metadata`` keys ``judge_model`` / ``judge_base_url`` /
+     ``judge_api_key`` (stamped by the dataset build script).
+  3. The user's rLLM provider config (``~/.rllm/config.json``) routed through
+     litellm with the provider's ``litellm_prefix`` — same mechanism the eval
+     proxy uses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+
+from rllm.eval.reward_fns._helpers import extract_answer_text
+from rllm.eval.types import EvalOutput, Signal
+from rllm.types import Episode, Task
+
+logger = logging.getLogger(__name__)
+
+JUDGE_SYSTEM_PROMPT = """\
+You are an impartial grader for an autonomous-agent benchmark (Claw-Eval).
+You are given a TASK an AI agent was asked to perform and the agent's full
+TRANSCRIPT (its messages and tool actions). Decide whether the agent actually
+accomplished the task.
+
+Grade strictly on task completion:
+- Score 1 only if the agent substantively completed what the task asked for
+  (produced the requested artifact/answer or performed the requested actions).
+- Score 0 if it refused, stalled, hallucinated, produced a wrong/partial
+  result, or only described what it would do without doing it.
+
+Respond with ONLY a JSON object: {"score": 0 or 1, "reasoning": "<one sentence>"}."""
+
+JUDGE_USER_TEMPLATE = """\
+## Task
+{query}
+
+## Agent transcript
+{transcript}
+
+## Final answer (if any)
+{answer}
+
+Did the agent accomplish the task? Respond with JSON: {{"score": 0 or 1, "reasoning": "..."}}"""
+
+_MAX_TRANSCRIPT_CHARS = 24000
+
+
+def evaluate(task: Task, episode: Episode) -> EvalOutput:
+    query = task.metadata.get("query") or task.metadata.get("rubric") or (task.instruction if isinstance(task.instruction, str) else "") or ""
+    transcript = _build_transcript(episode)
+    answer = extract_answer_text(episode)
+
+    model, base_url, api_key = _resolve_judge(task)
+    if not model:
+        # No judge reachable: don't silently pass. Mark as ungraded (reward 0)
+        # with a clear signal so the run surfaces the misconfig rather than
+        # inflating accuracy.
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="judge_score", value=0.0)],
+            metadata={"reason": "no_judge_configured", "ungraded": True},
+        )
+
+    score = _call_judge(query, transcript, answer, model, base_url, api_key)
+    if score is None:
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="judge_score", value=0.0)],
+            metadata={"reason": "judge_call_failed", "ungraded": True},
+        )
+
+    is_correct = score >= 0.5
+    return EvalOutput(
+        reward=float(score),
+        is_correct=is_correct,
+        signals=[Signal(name="judge_score", value=float(score))],
+        metadata={"judge_model": model, "category": task.metadata.get("category", "")},
+    )
+
+
+def _build_transcript(episode: Episode) -> str:
+    """Render the agent's conversation/trajectory as plain text for the judge."""
+    # 1. Cookbook-style explicit conversation artifact.
+    conversation = episode.artifacts.get("conversation") if episode.artifacts else None
+    msgs: list[str] = []
+    if conversation:
+        for m in conversation:
+            role = str(m.get("role", "")).upper()
+            if role == "SYSTEM":
+                continue
+            msgs.append(f"{role}: {m.get('content', '')}")
+        return _truncate("\n".join(msgs))
+
+    # 2. Gateway-reconstructed Steps. Prefer the richest field available.
+    if episode.trajectories:
+        traj = episode.trajectories[-1]
+        for step in traj.steps:
+            cc = getattr(step, "chat_completions", None)
+            if cc:
+                for m in cc:
+                    role = str(m.get("role", "")).upper()
+                    if role == "SYSTEM":
+                        continue
+                    content = m.get("content", "")
+                    if isinstance(content, list):  # multimodal blocks
+                        content = " ".join(b.get("text", "") for b in content if isinstance(b, dict))
+                    msgs.append(f"{role}: {content}")
+            else:
+                inp = getattr(step, "input", None)
+                out = getattr(step, "output", None) or getattr(step, "model_response", None)
+                if inp:
+                    msgs.append(f"USER: {inp}")
+                if out:
+                    msgs.append(f"ASSISTANT: {out}")
+        if msgs:
+            return _truncate("\n".join(msgs))
+
+    # 3. Last resort: just the final answer.
+    return _truncate(extract_answer_text(episode))
+
+
+def _truncate(text: str) -> str:
+    text = text or ""
+    if len(text) <= _MAX_TRANSCRIPT_CHARS:
+        return text
+    # Keep head and tail — the task setup and the final result both matter.
+    head = text[: _MAX_TRANSCRIPT_CHARS // 2]
+    tail = text[-_MAX_TRANSCRIPT_CHARS // 2 :]
+    return f"{head}\n...[transcript truncated]...\n{tail}"
+
+
+def _resolve_judge(task: Task) -> tuple[str, str | None, str | None]:
+    """Return (model, base_url, api_key). model is litellm-routable.
+
+    base_url/api_key may be None when routing purely by litellm provider prefix.
+    """
+    # 1. Env override.
+    env_model = os.environ.get("CLAW_EVAL_JUDGE_MODEL")
+    if env_model:
+        return (
+            env_model,
+            os.environ.get("CLAW_EVAL_JUDGE_BASE_URL"),
+            os.environ.get("CLAW_EVAL_JUDGE_API_KEY"),
+        )
+
+    # 2. Per-task metadata.
+    meta_model = task.metadata.get("judge_model")
+    if meta_model:
+        return (meta_model, task.metadata.get("judge_base_url"), task.metadata.get("judge_api_key"))
+
+    # 3. rLLM provider config → litellm-prefixed model.
+    try:
+        from rllm.eval.config import get_provider_info, load_config
+
+        cfg = load_config()
+        if cfg.provider == "custom":
+            # Already OpenAI-compatible; call it directly.
+            return (cfg.model, cfg.base_url or None, cfg.api_key or "EMPTY")
+        info = get_provider_info(cfg.provider)
+        if info and cfg.model:
+            prefix = info.litellm_prefix
+            model = f"{prefix}/{cfg.model}" if prefix and not cfg.model.startswith(prefix + "/") else cfg.model
+            return (model, None, cfg.api_key or None)
+    except Exception:
+        logger.debug("claw_eval: could not resolve judge from rLLM config", exc_info=True)
+
+    return ("", None, None)
+
+
+def _call_judge(
+    query: str,
+    transcript: str,
+    answer: str,
+    model: str,
+    base_url: str | None,
+    api_key: str | None,
+) -> float | None:
+    user_message = JUDGE_USER_TEMPLATE.format(query=query, transcript=transcript, answer=answer or "(none)")
+    messages = [
+        {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+        {"role": "user", "content": user_message},
+    ]
+    try:
+        import litellm
+
+        kwargs: dict = {"model": model, "messages": messages, "temperature": 0.0}
+        if base_url:
+            kwargs["base_url"] = base_url
+        if api_key:
+            kwargs["api_key"] = api_key
+        resp = litellm.completion(**kwargs)
+        text = resp.choices[0].message.content or ""
+    except Exception as e:
+        logger.warning("claw_eval judge call failed: %s", e)
+        return None
+
+    return _parse_score(text)
+
+
+def _parse_score(text: str) -> float | None:
+    m = re.search(r"\{.*?\}", text, re.DOTALL)
+    if m:
+        try:
+            return float(json.loads(m.group()).get("score", 0))
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+    # Bare-number fallback.
+    m2 = re.search(r"\b([01](?:\.\d+)?)\b", text)
+    if m2:
+        try:
+            return float(m2.group(1))
+        except ValueError:
+            pass
+    return None

--- a/rllm/harnesses/zeroclaw.py
+++ b/rllm/harnesses/zeroclaw.py
@@ -7,8 +7,7 @@ credentials, model, and autonomy policy. So the load-bearing method here is
 :meth:`write_configs`, which emits that TOML pointing ZeroClaw's OpenAI-
 compatible client at the rLLM gateway.
 
-Three facts established from the ZeroClaw docs/installer (see
-``tmp/rllm_eval_new_harness/plans/plan.md`` Spike B):
+Three facts established from the ZeroClaw docs/installer:
 
 1. **Install** via the official installer with ``--prebuilt --skip-onboard``
    (downloads a checksum-verified release binary; no Rust toolchain needed).
@@ -146,12 +145,16 @@ class ZeroClawHarness(BaseCliHarness):
             f"mkdir -p $HOME/.zeroclaw && cat > {_CONFIG_PATH} << 'ZC_CONFIG_EOF'\n{content}\nZC_CONFIG_EOF",
             env=env,
         )
-        # CRITICAL: ZeroClaw operates in its OWN workspace ($HOME/.zeroclaw/
-        # workspace), not the shell cwd. rLLM uploads the task fixtures to the
-        # task workdir (/workspace), so without this the agent can't see them
-        # and answers "I don't have access to your files". Point ZeroClaw's
-        # workspace at the task workdir via a symlink so file_read/shell see
-        # the fixtures.
+        # ZeroClaw operates in its OWN workspace ($HOME/.zeroclaw/workspace),
+        # not the shell cwd. rLLM uploads the task fixtures to the task workdir
+        # (e.g. /workspace), so without this the agent can't see them. Point
+        # ZeroClaw's workspace at the task workdir via a symlink so its
+        # file_read/shell tools operate on the fixtures.
+        #
+        # (We deliberately use a symlink rather than the ZEROCLAW_WORKSPACE env
+        # var: that var has version-dependent, buggy config-location coupling —
+        # upstream issue #5465 / PR #731 — and setting it made ZeroClaw exit at
+        # startup before any LLM call in testing. The symlink is robust.)
         workdir = task.metadata.get("workdir")
         if workdir:
             self._exec_agent(
@@ -160,9 +163,13 @@ class ZeroClawHarness(BaseCliHarness):
             )
 
     # Prepended to the task instruction so the agent knows its data lives in
-    # the workspace (the Claw-Eval `query` assumes a tool/integration provides
-    # it). Standard agent-harness practice (cf. SWE harnesses describing the
-    # repo). Keeps failures attributable to reasoning, not "didn't find data".
+    # the workspace. The symlink (write_configs) makes the fixtures *reachable*,
+    # but ZeroClaw still doesn't *look*: tested without this preamble, the agent
+    # replies "I don't have access to your email account" and makes a single LLM
+    # call (reward 0) instead of exploring. With it, it `ls`/`file_read`s the
+    # fixtures and completes (4+ tool steps, reward 1). This mirrors how SWE
+    # harnesses must tell the agent about the repo — it shapes *where to look*,
+    # not *what answer to give*, so it keeps failures attributable to reasoning.
     _WORKSPACE_PREAMBLE = (
         "You are an autonomous agent working in a sandbox. All files and data needed for this "
         "task are already present in your workspace (your working directory). Begin by exploring "
@@ -172,6 +179,8 @@ class ZeroClawHarness(BaseCliHarness):
 
     def build_invocation(self, instruction: str, task: Task, config: AgentConfig) -> str:
         # ``-m`` runs a single non-interactive turn and exits. ``</dev/null``
-        # guarantees no stdin block if the binary probes for a TTY.
+        # guarantees no stdin block if the binary probes for a TTY. The agent's
+        # workspace (symlinked to the task workdir in write_configs) holds the
+        # fixtures; the preamble tells it to read them with file_read/shell.
         prompt = self._WORKSPACE_PREAMBLE + instruction
         return f'{self._cd_prefix(task)}export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; zeroclaw agent -m {shlex.quote(prompt)} </dev/null 2>&1 | tee {shlex.quote(self.stdout_log_path)}'

--- a/rllm/harnesses/zeroclaw.py
+++ b/rllm/harnesses/zeroclaw.py
@@ -1,0 +1,177 @@
+"""ZeroClawHarness: runs the ZeroClaw CLI agent inside the sandbox.
+
+ZeroClaw (https://github.com/zeroclaw-labs/zeroclaw) is a single Rust binary
+"autonomous AI personal assistant". Unlike env-var-driven CLIs (mini-swe-agent)
+it is **config-file driven**: it reads ``~/.zeroclaw/config.toml`` for provider
+credentials, model, and autonomy policy. So the load-bearing method here is
+:meth:`write_configs`, which emits that TOML pointing ZeroClaw's OpenAI-
+compatible client at the rLLM gateway.
+
+Three facts established from the ZeroClaw docs/installer (see
+``tmp/rllm_eval_new_harness/plans/plan.md`` Spike B):
+
+1. **Install** via the official installer with ``--prebuilt --skip-onboard``
+   (downloads a checksum-verified release binary; no Rust toolchain needed).
+   The binary lands in ``$CARGO_HOME/bin/zeroclaw`` (``/root/.cargo/bin`` when
+   installed as root, which ``on_sandbox_ready`` does).
+2. **One-shot, non-interactive** execution is ``zeroclaw agent -m "<prompt>"``
+   ("if -m is provided, runs a single turn and exits").
+3. **Autonomy** must be ``level = "full"`` for the agent to run shell/filesystem
+   tools without interactive approval (``Supervised`` — the default — blocks
+   them and the agent stalls in a non-interactive sandbox; cf. issue #851).
+
+``run()`` returns ``None``; the gateway captures every LLM call and the engine
+reconstructs the trajectory. ZeroClaw's stdout is tee'd to ``stdout_log_path``
+for debugging only.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.types import AgentConfig, Task
+
+# Idempotent install. Bootstraps curl/ca-certs/tar/coreutils (the installer
+# needs curl + sha256sum + tar), then runs the official prebuilt installer.
+# ``--prebuilt`` avoids a source build; ``--skip-onboard`` skips the interactive
+# onboarding (we write config.toml ourselves in write_configs).
+_INSTALL_SCRIPT = r"""
+set -euo pipefail
+export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+if ! command -v zeroclaw >/dev/null 2>&1; then
+    if ! command -v curl >/dev/null 2>&1 || ! command -v sha256sum >/dev/null 2>&1 || ! command -v tar >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq 2>/dev/null || true
+            apt-get install -y -qq --no-install-recommends curl ca-certificates tar coreutils 2>/dev/null || true
+        elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache curl bash ca-certificates tar coreutils
+        elif command -v yum >/dev/null 2>&1; then
+            yum install -y -q curl ca-certificates tar coreutils
+        fi
+    fi
+    command -v curl >/dev/null 2>&1 \
+        || { echo "zeroclaw install: failed to bootstrap curl in sandbox" >&2; exit 1; }
+    curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh \
+        | bash -s -- --prebuilt --skip-onboard
+fi
+export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+grep -q '.cargo/bin' "$HOME/.bashrc" 2>/dev/null \
+    || echo 'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+zeroclaw --version >/dev/null
+"""
+
+_CONFIG_PATH = "$HOME/.zeroclaw/config.toml"
+
+
+def _toml_str(value: str) -> str:
+    """Quote a value as a TOML basic string."""
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+class ZeroClawHarness(BaseCliHarness):
+    """Run the ZeroClaw CLI agent inside the sandbox."""
+
+    name = "zeroclaw"
+    sandbox_backend = "docker"  # overridden to "daytona" via --sandbox-backend
+    max_concurrent = 8
+    stdout_log_path = "/tmp/zeroclaw.log"
+
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        # ZeroClaw resolves credentials in the order: explicit config.toml →
+        # env vars (OPENAI_API_KEY/OPENAI_BASE_URL) → fallbacks. We set both:
+        # config.toml is authoritative, these env vars are belt-and-suspenders.
+        gateway_url = self._container_url(config.base_url)
+        api_key = self.gateway_api_key(config, "OPENAI_API_KEY")
+        return {
+            "OPENAI_API_KEY": api_key,
+            "OPENAI_BASE_URL": gateway_url,
+            "OPENAI_API_BASE": gateway_url,
+        }
+
+    def _config_toml(self, config: AgentConfig) -> str:
+        """Render ~/.zeroclaw/config.toml.
+
+        Points ZeroClaw's OpenAI-compatible client at the rLLM gateway session
+        URL and grants full autonomy so tools run without interactive approval.
+
+        NOTE: ``base_url`` is the endpoint-override key per ZeroClaw's
+        ``ModelProviderConfig`` struct. If a ZeroClaw version rejects it,
+        switch to ``uri`` (older docs used that name).
+        """
+        gateway_url = self._container_url(config.base_url)
+        api_key = self.gateway_api_key(config, "OPENAI_API_KEY")
+        model = config.model
+        return "\n".join(
+            [
+                f"default_provider = {_toml_str('openai')}",
+                f"default_model = {_toml_str(model)}",
+                "default_temperature = 0.0",
+                f"api_key = {_toml_str(api_key)}",
+                "",
+                "[providers.models.openai]",
+                f"api_key = {_toml_str(api_key)}",
+                f"base_url = {_toml_str(gateway_url)}",
+                f"model = {_toml_str(model)}",
+                "",
+                "# Full autonomy: run shell/filesystem tools without interactive",
+                "# approval (Supervised, the default, stalls in a non-interactive",
+                "# sandbox — cf. zeroclaw issue #851).",
+                "[autonomy]",
+                f"level = {_toml_str('full')}",
+                "workspace_only = false",
+                "",
+                "[gateway]",
+                "require_pairing = false",
+                "allow_public_bind = false",
+                "",
+                "[heartbeat]",
+                "enabled = false",
+                "",
+                "[tunnel]",
+                'provider = "none"',
+                "",
+            ]
+        )
+
+    def write_configs(self, task: Task, config: AgentConfig, env: dict[str, str]) -> None:
+        content = self._config_toml(config)
+        # Write inline (not via _heredoc_write) so $HOME expands — the helper
+        # single-quotes the path which would kill the expansion.
+        self._exec_agent(
+            f"mkdir -p $HOME/.zeroclaw && cat > {_CONFIG_PATH} << 'ZC_CONFIG_EOF'\n{content}\nZC_CONFIG_EOF",
+            env=env,
+        )
+        # CRITICAL: ZeroClaw operates in its OWN workspace ($HOME/.zeroclaw/
+        # workspace), not the shell cwd. rLLM uploads the task fixtures to the
+        # task workdir (/workspace), so without this the agent can't see them
+        # and answers "I don't have access to your files". Point ZeroClaw's
+        # workspace at the task workdir via a symlink so file_read/shell see
+        # the fixtures.
+        workdir = task.metadata.get("workdir")
+        if workdir:
+            self._exec_agent(
+                f'rm -rf "$HOME/.zeroclaw/workspace" && ln -sfn {shlex.quote(workdir)} "$HOME/.zeroclaw/workspace"',
+                env=env,
+            )
+
+    # Prepended to the task instruction so the agent knows its data lives in
+    # the workspace (the Claw-Eval `query` assumes a tool/integration provides
+    # it). Standard agent-harness practice (cf. SWE harnesses describing the
+    # repo). Keeps failures attributable to reasoning, not "didn't find data".
+    _WORKSPACE_PREAMBLE = (
+        "You are an autonomous agent working in a sandbox. All files and data needed for this "
+        "task are already present in your workspace (your working directory). Begin by exploring "
+        "them with your shell and file_read tools (e.g. `ls -R`), then act on them to complete the "
+        "task. Do not claim you lack access — the data is in the workspace.\n\nTask:\n"
+    )
+
+    def build_invocation(self, instruction: str, task: Task, config: AgentConfig) -> str:
+        # ``-m`` runs a single non-interactive turn and exits. ``</dev/null``
+        # guarantees no stdin block if the binary probes for a TTY.
+        prompt = self._WORKSPACE_PREAMBLE + instruction
+        return f'{self._cd_prefix(task)}export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; zeroclaw agent -m {shlex.quote(prompt)} </dev/null 2>&1 | tee {shlex.quote(self.stdout_log_path)}'

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -50,6 +50,11 @@
       "module": "rllm.harnesses.oracle",
       "function": "OracleHarness",
       "description": "Run the task's reference solution (solution/solve.sh) without an LLM. Smoke-test for verifier + image."
+    },
+    "zeroclaw": {
+      "module": "rllm.harnesses.zeroclaw",
+      "function": "ZeroClawHarness",
+      "description": "Run the ZeroClaw autonomous-assistant CLI inside the sandbox."
     }
   }
 }

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "datasets": {
+    "claw_eval": {
+      "description": "Claw-Eval general split: 161 personal-assistant agent tasks (sandbox; LLM-judge graded)",
+      "source": "claw-eval/Claw-Eval",
+      "builder": "rllm.data.claw_eval_builder:build_benchmark",
+      "category": "agentic",
+      "splits": [
+        "general"
+      ],
+      "eval_split": "general",
+      "default_agent": "zeroclaw",
+      "reward_fn": "claw_eval_reward_fn"
+    },
     "gsm8k": {
       "description": "Grade school math word problems (8.5K train, 1.3K test)",
       "source": "openai/gsm8k",

--- a/scripts/data/claw_eval_dataset.py
+++ b/scripts/data/claw_eval_dataset.py
@@ -1,200 +1,52 @@
-"""Build the ``claw-eval-general`` sandbox benchmark from HuggingFace.
+"""Build the Claw-Eval sandbox benchmark from HuggingFace (standalone CLI).
 
-Claw-Eval (``claw-eval/Claw-Eval``) is a personal-assistant agent benchmark.
-Each task is a *workspace*: a natural-language ``query`` plus a set of fixture
-files (json/csv/docs the agent must read or act on). This script materializes
-the 161-task ``general`` split into rLLM's ``type="sandbox"`` (task-per-
-directory) layout so ``rllm eval`` can run each task in a Docker/Daytona
-sandbox.
-
-On-disk output (default ``~/.rllm/datasets/claw-eval-general``):
-
-    claw-eval-general/
-    ├── dataset.toml                     # [dataset] type="sandbox", default_agent="zeroclaw"
-    ├── <task_id>/                       # one dir per row (e.g. T002_email_triage)
-    │   ├── task.toml                    # top-level query/rubric + [environment]/[verifier]
-    │   ├── instruction.md               # the row's query
-    │   └── environment/files/fixtures/  # this task's fixtures (uploaded to /workspace)
-    └── ...
-
-Grading: the row ships no rubric, so each task points its ``[verifier]`` at the
-``claw_eval_reward_fn`` LLM-judge (see rllm/eval/reward_fns/claw_eval.py), which
-judges task completion from the agent's transcript.
+Thin wrapper over :func:`rllm.data.claw_eval_builder.build_benchmark` — the
+same builder used by ``rllm dataset pull claw_eval``. Prefer the CLI for normal
+use; this script exists for ad-hoc subsets and custom output paths.
 
 Usage:
-    uv run python scripts/data/claw_eval_dataset.py
-    uv run python scripts/data/claw_eval_dataset.py --limit 10 --lang en --out ~/.rllm/datasets/claw-eval-general-10
+    uv run python scripts/data/claw_eval_dataset.py                       # full general split
+    uv run python scripts/data/claw_eval_dataset.py --lang en --limit 10 \
+        --out ~/.rllm/datasets/claw-eval-general-10
 """
 
 from __future__ import annotations
 
 import argparse
+import logging
 import os
-import shutil
-import tarfile
 from pathlib import Path
 
-REPO_ID = "claw-eval/Claw-Eval"
-VERIFIER_NAME = "claw_eval_reward_fn"
-
-
-def _toml_escape(s: str) -> str:
-    """Escape a string for a TOML triple-quoted basic string."""
-    return s.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
-
-
-def _write_task(
-    task_dir: Path,
-    *,
-    task_id: str,
-    query: str,
-    category: str,
-    language: str,
-    judge_model: str | None,
-) -> None:
-    task_dir.mkdir(parents=True, exist_ok=True)
-    (task_dir / "instruction.md").write_text(query, encoding="utf-8")
-
-    # Top-level scalars land directly in Task.metadata (the loader copies the
-    # whole task.toml into metadata), so the judge can read `query`/`rubric`.
-    # Scalars MUST precede the first [section] in TOML.
-    lines = [
-        f'query = """{_toml_escape(query)}"""',
-        f'rubric = """{_toml_escape(query)}"""',
-        f'task_id = "{task_id}"',
-        f'category = "{category}"',
-        f'language = "{language}"',
-    ]
-    if judge_model:
-        lines.append(f'judge_model = "{judge_model}"')
-    lines += [
-        "",
-        "[task]",
-        f'name = "{task_id}"',
-        "",
-        "[environment]",
-        'workdir = "/workspace"',
-        "",
-        "[verifier]",
-        f'name = "{VERIFIER_NAME}"',
-        "",
-    ]
-    (task_dir / "task.toml").write_text("\n".join(lines), encoding="utf-8")
-
-
-def _write_dataset_toml(out: Path, *, name: str, split: str, default_agent: str) -> None:
-    content = "\n".join(
-        [
-            "[dataset]",
-            f'name = "{name}"',
-            'type = "sandbox"',
-            f'description = "Claw-Eval {split} split: personal-assistant agent tasks (LLM-judge graded)."',
-            'default_sandbox = "docker"',
-            f'default_agent = "{default_agent}"',
-            f'split = "{split}"',
-            "",
-        ]
-    )
-    (out / "dataset.toml").write_text(content, encoding="utf-8")
-
-
-def build(
-    *,
-    split: str,
-    out: Path,
-    limit: int | None,
-    lang: str,
-    default_agent: str,
-    judge_model: str | None,
-    clean: bool,
-) -> None:
-    from datasets import load_dataset
-    from huggingface_hub import hf_hub_download
-
-    if clean and out.exists():
-        print(f"[claw-eval] removing existing {out}")
-        shutil.rmtree(out)
-    out.mkdir(parents=True, exist_ok=True)
-
-    print(f"[claw-eval] loading {REPO_ID} split={split} ...")
-    ds = load_dataset(REPO_ID, split=split)
-
-    rows = list(ds)
-    if lang != "all":
-        rows = [r for r in rows if r["language"] == lang]
-    if limit is not None:
-        rows = rows[:limit]
-    selected_ids = {r["task_id"] for r in rows}
-    print(f"[claw-eval] selected {len(rows)} tasks (lang={lang}, limit={limit})")
-
-    # Extract only the fixtures for the selected tasks from the shared archive.
-    print("[claw-eval] downloading fixtures archive (cached) ...")
-    fixtures_path = hf_hub_download(REPO_ID, "data/fixtures.tar.gz", repo_type="dataset")
-
-    # task_id -> destination environment/files dir
-    dest_files = {r["task_id"]: out / r["task_id"] / "environment" / "files" for r in rows}
-    extracted = {tid: 0 for tid in selected_ids}
-    print("[claw-eval] extracting fixtures ...")
-    with tarfile.open(fixtures_path) as tar:
-        for m in tar:
-            if not m.isfile():
-                continue
-            top = m.name.split("/", 1)[0]
-            if top not in selected_ids:
-                continue
-            rel = m.name[len(top) + 1 :]  # strip "<task_id>/" -> "fixtures/..."
-            if not rel:
-                continue
-            target = dest_files[top] / rel
-            target.parent.mkdir(parents=True, exist_ok=True)
-            src = tar.extractfile(m)
-            if src is None:
-                continue
-            with open(target, "wb") as fh:
-                shutil.copyfileobj(src, fh)
-            extracted[top] += 1
-
-    # Write per-task task.toml + instruction.md.
-    for r in rows:
-        _write_task(
-            out / r["task_id"],
-            task_id=r["task_id"],
-            query=r["query"],
-            category=r["category"],
-            language=r["language"],
-            judge_model=judge_model,
-        )
-
-    _write_dataset_toml(out, name=out.name, split=split, default_agent=default_agent)
-
-    n_with_fx = sum(1 for tid in selected_ids if extracted[tid] > 0)
-    n_empty = len(selected_ids) - n_with_fx
-    print(f"[claw-eval] wrote {len(rows)} task dirs to {out}")
-    print(f"[claw-eval]   {n_with_fx} with fixtures, {n_empty} fixture-less (web/research tasks)")
-    print(f"[claw-eval] done. Run:  rllm eval {out} --agent {default_agent}")
+from rllm.data.claw_eval_builder import build_benchmark
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Build the claw-eval sandbox benchmark.")
+    ap = argparse.ArgumentParser(description="Build the Claw-Eval sandbox benchmark.")
     ap.add_argument("--split", default="general", help="HF split (default: general)")
     ap.add_argument("--out", default=None, help="output dir (default: ~/.rllm/datasets/claw-eval-<split>)")
     ap.add_argument("--limit", type=int, default=None, help="only the first N tasks (after lang filter)")
     ap.add_argument("--lang", default="all", choices=["all", "en", "zh"], help="language filter")
+    ap.add_argument("--name", default="claw_eval", help="dataset name written into dataset.toml")
     ap.add_argument("--default-agent", default="zeroclaw", help="default_agent in dataset.toml")
     ap.add_argument("--judge-model", default=None, help="override judge model stamped into each task")
     ap.add_argument("--clean", action="store_true", help="remove the output dir first")
+    ap.add_argument("--no-register", action="store_true", help="don't register rows in DatasetRegistry")
     args = ap.parse_args()
 
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     out = Path(args.out).expanduser() if args.out else Path(os.path.expanduser(f"~/.rllm/datasets/claw-eval-{args.split}"))
-    build(
+    build_benchmark(
+        name=args.name,
         split=args.split,
-        out=out,
+        out_dir=out,
         limit=args.limit,
         lang=args.lang,
         default_agent=args.default_agent,
         judge_model=args.judge_model,
         clean=args.clean,
+        register=not args.no_register,
     )
+    print(f"Done. Run:  rllm eval {out} --agent {args.default_agent}")
 
 
 if __name__ == "__main__":

--- a/scripts/data/claw_eval_dataset.py
+++ b/scripts/data/claw_eval_dataset.py
@@ -1,0 +1,201 @@
+"""Build the ``claw-eval-general`` sandbox benchmark from HuggingFace.
+
+Claw-Eval (``claw-eval/Claw-Eval``) is a personal-assistant agent benchmark.
+Each task is a *workspace*: a natural-language ``query`` plus a set of fixture
+files (json/csv/docs the agent must read or act on). This script materializes
+the 161-task ``general`` split into rLLM's ``type="sandbox"`` (task-per-
+directory) layout so ``rllm eval`` can run each task in a Docker/Daytona
+sandbox.
+
+On-disk output (default ``~/.rllm/datasets/claw-eval-general``):
+
+    claw-eval-general/
+    ├── dataset.toml                     # [dataset] type="sandbox", default_agent="zeroclaw"
+    ├── <task_id>/                       # one dir per row (e.g. T002_email_triage)
+    │   ├── task.toml                    # top-level query/rubric + [environment]/[verifier]
+    │   ├── instruction.md               # the row's query
+    │   └── environment/files/fixtures/  # this task's fixtures (uploaded to /workspace)
+    └── ...
+
+Grading: the row ships no rubric, so each task points its ``[verifier]`` at the
+``claw_eval_reward_fn`` LLM-judge (see rllm/eval/reward_fns/claw_eval.py), which
+judges task completion from the agent's transcript.
+
+Usage:
+    uv run python scripts/data/claw_eval_dataset.py
+    uv run python scripts/data/claw_eval_dataset.py --limit 10 --lang en --out ~/.rllm/datasets/claw-eval-general-10
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tarfile
+from pathlib import Path
+
+REPO_ID = "claw-eval/Claw-Eval"
+VERIFIER_NAME = "claw_eval_reward_fn"
+
+
+def _toml_escape(s: str) -> str:
+    """Escape a string for a TOML triple-quoted basic string."""
+    return s.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+
+
+def _write_task(
+    task_dir: Path,
+    *,
+    task_id: str,
+    query: str,
+    category: str,
+    language: str,
+    judge_model: str | None,
+) -> None:
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "instruction.md").write_text(query, encoding="utf-8")
+
+    # Top-level scalars land directly in Task.metadata (the loader copies the
+    # whole task.toml into metadata), so the judge can read `query`/`rubric`.
+    # Scalars MUST precede the first [section] in TOML.
+    lines = [
+        f'query = """{_toml_escape(query)}"""',
+        f'rubric = """{_toml_escape(query)}"""',
+        f'task_id = "{task_id}"',
+        f'category = "{category}"',
+        f'language = "{language}"',
+    ]
+    if judge_model:
+        lines.append(f'judge_model = "{judge_model}"')
+    lines += [
+        "",
+        "[task]",
+        f'name = "{task_id}"',
+        "",
+        "[environment]",
+        'workdir = "/workspace"',
+        "",
+        "[verifier]",
+        f'name = "{VERIFIER_NAME}"',
+        "",
+    ]
+    (task_dir / "task.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_dataset_toml(out: Path, *, name: str, split: str, default_agent: str) -> None:
+    content = "\n".join(
+        [
+            "[dataset]",
+            f'name = "{name}"',
+            'type = "sandbox"',
+            f'description = "Claw-Eval {split} split: personal-assistant agent tasks (LLM-judge graded)."',
+            'default_sandbox = "docker"',
+            f'default_agent = "{default_agent}"',
+            f'split = "{split}"',
+            "",
+        ]
+    )
+    (out / "dataset.toml").write_text(content, encoding="utf-8")
+
+
+def build(
+    *,
+    split: str,
+    out: Path,
+    limit: int | None,
+    lang: str,
+    default_agent: str,
+    judge_model: str | None,
+    clean: bool,
+) -> None:
+    from datasets import load_dataset
+    from huggingface_hub import hf_hub_download
+
+    if clean and out.exists():
+        print(f"[claw-eval] removing existing {out}")
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"[claw-eval] loading {REPO_ID} split={split} ...")
+    ds = load_dataset(REPO_ID, split=split)
+
+    rows = list(ds)
+    if lang != "all":
+        rows = [r for r in rows if r["language"] == lang]
+    if limit is not None:
+        rows = rows[:limit]
+    selected_ids = {r["task_id"] for r in rows}
+    print(f"[claw-eval] selected {len(rows)} tasks (lang={lang}, limit={limit})")
+
+    # Extract only the fixtures for the selected tasks from the shared archive.
+    print("[claw-eval] downloading fixtures archive (cached) ...")
+    fixtures_path = hf_hub_download(REPO_ID, "data/fixtures.tar.gz", repo_type="dataset")
+
+    # task_id -> destination environment/files dir
+    dest_files = {r["task_id"]: out / r["task_id"] / "environment" / "files" for r in rows}
+    extracted = {tid: 0 for tid in selected_ids}
+    print("[claw-eval] extracting fixtures ...")
+    with tarfile.open(fixtures_path) as tar:
+        for m in tar:
+            if not m.isfile():
+                continue
+            top = m.name.split("/", 1)[0]
+            if top not in selected_ids:
+                continue
+            rel = m.name[len(top) + 1 :]  # strip "<task_id>/" -> "fixtures/..."
+            if not rel:
+                continue
+            target = dest_files[top] / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            src = tar.extractfile(m)
+            if src is None:
+                continue
+            with open(target, "wb") as fh:
+                shutil.copyfileobj(src, fh)
+            extracted[top] += 1
+
+    # Write per-task task.toml + instruction.md.
+    for r in rows:
+        _write_task(
+            out / r["task_id"],
+            task_id=r["task_id"],
+            query=r["query"],
+            category=r["category"],
+            language=r["language"],
+            judge_model=judge_model,
+        )
+
+    _write_dataset_toml(out, name=out.name, split=split, default_agent=default_agent)
+
+    n_with_fx = sum(1 for tid in selected_ids if extracted[tid] > 0)
+    n_empty = len(selected_ids) - n_with_fx
+    print(f"[claw-eval] wrote {len(rows)} task dirs to {out}")
+    print(f"[claw-eval]   {n_with_fx} with fixtures, {n_empty} fixture-less (web/research tasks)")
+    print(f"[claw-eval] done. Run:  rllm eval {out} --agent {default_agent}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Build the claw-eval sandbox benchmark.")
+    ap.add_argument("--split", default="general", help="HF split (default: general)")
+    ap.add_argument("--out", default=None, help="output dir (default: ~/.rllm/datasets/claw-eval-<split>)")
+    ap.add_argument("--limit", type=int, default=None, help="only the first N tasks (after lang filter)")
+    ap.add_argument("--lang", default="all", choices=["all", "en", "zh"], help="language filter")
+    ap.add_argument("--default-agent", default="zeroclaw", help="default_agent in dataset.toml")
+    ap.add_argument("--judge-model", default=None, help="override judge model stamped into each task")
+    ap.add_argument("--clean", action="store_true", help="remove the output dir first")
+    args = ap.parse_args()
+
+    out = Path(args.out).expanduser() if args.out else Path(os.path.expanduser(f"~/.rllm/datasets/claw-eval-{args.split}"))
+    build(
+        split=args.split,
+        out=out,
+        limit=args.limit,
+        lang=args.lang,
+        default_agent=args.default_agent,
+        judge_model=args.judge_model,
+        clean=args.clean,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds **ZeroClaw** as a new agent harness and wires up the **Claw-Eval** personal-assistant benchmark, evaluated end-to-end in a remote **Modal** sandbox. Everything is backend-agnostic (docker/daytona/modal) — only the `--sandbox-backend` flag changes.

```bash
uv run python scripts/data/claw_eval_dataset.py --clean        # build claw-eval-general (161 tasks)
rllm eval ~/.rllm/datasets/claw-eval-general --agent zeroclaw --sandbox-backend modal
```

## What's new

**🦀 ZeroClaw harness** (`rllm/harnesses/zeroclaw.py`, registered `zeroclaw`)
- `BaseCliHarness` subclass. Installs the prebuilt ZeroClaw binary in-sandbox (`--prebuilt --skip-onboard`), writes `~/.zeroclaw/config.toml` pointing its OpenAI-compatible client at the rLLM gateway, and runs `zeroclaw agent -m` non-interactively with `[autonomy] level="full"`.
- Bridges ZeroClaw's own workspace (`$HOME/.zeroclaw/workspace`) to the task workdir via symlink so uploaded fixtures are visible to `file_read`/`shell`, and prepends a workspace preamble so the agent explores its files.

**📊 Claw-Eval dataset builder** (`scripts/data/claw_eval_dataset.py`)
- Materializes the Claw-Eval `general` split (161 tasks) into rLLM's `type="sandbox"` task-per-directory layout. Per-task fixtures are extracted from the shared `fixtures.tar.gz` into `environment/files/` (→ `/workspace`). Supports `--lang`/`--limit` subsets.

**⚖️ Claw-Eval grader** (`rllm/eval/reward_fns/claw_eval.py`, registered `claw_eval_reward_fn`)
- LLM-as-judge over the agent's full trajectory (a *completion* proxy — Claw-Eval ships no public rubrics). Self-configures the judge from `~/.rllm/config.json` via litellm; never raises.

**📚 Docs** — `zeroclaw` added to the built-in harness table; `claw_eval` added to the built-in reward-function table.

## Validation

10-task subset on Modal (OpenRouter + Claude Sonnet 4.6): **80% (8/10), 0 errors, all `ENV_DONE`, 2m35s @ concurrency 4** (per-task: setup ~10s, agent 11–85s over 3–10 tool steps, judge 2–5s). The agent genuinely reads fixtures and does multi-step tool work; the 2 non-passes are genuine agent/grading outcomes — zero harness/environment failures.

## Notes
- Sandbox SDKs (`modal`/`daytona`) stay optional/lazy-imported — no new hard deps; `pyproject`/lockfile untouched.
- Grading is a completion proxy, not Claw-Eval's official Pass³ rubric scoring (rubrics aren't public) — scores are indicative, not leaderboard-comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
