### PR TITLE
feat(eval): add Tinker as an OpenAI-compatible eval provider

### DIFF
--- a/docs/quickstart-cli.mdx
+++ b/docs/quickstart-cli.mdx
@@ -31,6 +31,10 @@ You'll be prompted to:
 Your configuration is saved to `~/.rllm/config.json`. You can switch providers later with `rllm model swap`.
 </Info>
 
+<Tip>
+Selecting **Tinker (Thinking Machines)** evaluates against Tinker's (beta) OpenAI-compatible endpoint using your `TINKER_API_KEY`. The model list is fetched live from the Tinker server — pick any base model (e.g. `Qwen/Qwen3-8B`, no checkpoint needed) or paste a `tinker://…` sampler checkpoint path to evaluate a fine-tune.
+</Tip>
+
 ## Step 2: Explore available datasets
 
 Browse the full catalog of 50+ benchmarks:

--- a/rllm/cli/_ui.py
+++ b/rllm/cli/_ui.py
@@ -103,9 +103,24 @@ def _select_provider(existing: RllmConfig) -> str:
     return provider_ids[idx]
 
 
-def _select_model(provider: str, existing: RllmConfig) -> str:
-    """Interactive model selection with option to enter a custom model."""
+def _select_model(provider: str, existing: RllmConfig, api_key: str | None = None) -> str:
+    """Interactive model selection with option to enter a custom model.
+
+    For Tinker, the model list is pulled live from the server's capabilities
+    (``api_key`` lets the fetch authenticate); the curated list is the fallback.
+    """
     models = PROVIDER_MODELS.get(provider, [])
+
+    if provider == "tinker":
+        from rllm.eval.config import fetch_tinker_models
+
+        with console.status("[dim]Fetching Tinker model catalog...[/]"):
+            live = fetch_tinker_models(api_key)
+        if live:
+            models = live
+            console.print(f"  [success]Loaded {len(live)} Tinker models[/] [dim](base IDs; you can also paste a tinker:// checkpoint path)[/]")
+        else:
+            console.print("  [dim]Could not fetch live catalog — showing curated list (or enter a tinker:// path manually).[/]")
 
     # For custom provider or providers with no curated list, prompt for free-text
     if provider == "custom" or not models:

--- a/rllm/cli/model_cmd.py
+++ b/rllm/cli/model_cmd.py
@@ -8,6 +8,8 @@ Subcommands:
 
 from __future__ import annotations
 
+import os
+
 import click
 from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
@@ -29,12 +31,43 @@ from rllm.eval.config import (
 )
 
 
+def _env_key_value(env_key: str) -> str:
+    """Resolve an API key from the environment, falling back to a ``.env`` file.
+
+    Checks ``os.environ`` first, then a ``.env`` in the current directory so the
+    user can just press Enter at the prompt instead of re-typing the key.
+    """
+    if not env_key:
+        return ""
+    val = os.environ.get(env_key, "")
+    if val:
+        return val
+    env_path = os.path.join(os.getcwd(), ".env")
+    if os.path.isfile(env_path):
+        try:
+            with open(env_path) as f:
+                for raw in f:
+                    line = raw.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, _, value = line.partition("=")
+                    if key.strip() == env_key:
+                        return value.strip().strip('"').strip("'")
+        except OSError:
+            pass
+    return ""
+
+
 def _prompt_api_key(provider: str) -> str:
-    """Prompt for an API key, showing env var tip."""
+    """Prompt for an API key, defaulting to the provider's env var if present."""
     env_key = PROVIDER_ENV_KEYS.get(provider, "")
-    if env_key:
+    env_val = _env_key_value(env_key)
+    if env_val:
+        console.print(f"  [dim]Found {env_key} in your environment — press Enter to use it.[/]")
+    elif env_key:
         console.print(f"  [dim]Tip: you can also set {env_key} in your environment[/]")
-    api_key = Prompt.ask("  [label]API key[/]", password=True, console=console).strip()
+    api_key = Prompt.ask("  [label]API key[/]", password=True, default=env_val or None, show_default=False, console=console)
+    api_key = (api_key or "").strip()
     if not api_key:
         console.print("  [error]API key is required.[/]")
         raise SystemExit(1)

--- a/rllm/cli/model_cmd.py
+++ b/rllm/cli/model_cmd.py
@@ -129,7 +129,7 @@ def _do_swap(existing: RllmConfig) -> None:
 
     # Model — pre-select current if same provider
     model_existing = RllmConfig(provider=provider, model=existing.model if existing.provider == provider else "")
-    model = _select_model(provider, model_existing)
+    model = _select_model(provider, model_existing, api_key=api_keys.get(provider))
     console.print()
 
     config = RllmConfig(provider=provider, model=model, api_keys=api_keys, base_url=base_url)
@@ -184,7 +184,7 @@ def model_setup():
         api_key = _prompt_api_key(provider)
     console.print()
 
-    model_name = _select_model(provider, existing)
+    model_name = _select_model(provider, existing, api_key=api_key)
     console.print()
 
     api_keys = {}

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -9,6 +9,12 @@ import json
 import os
 from dataclasses import dataclass, field
 
+# Tinker's (beta) OpenAI-compatible inference endpoint. Used as a fixed
+# ``api_base`` so the Tinker provider routes through LiteLLM's OpenAI adapter
+# exactly like any other provider. See
+# https://tinker-docs.thinkingmachines.ai/tinker/compatible-apis/openai/
+TINKER_OAI_BASE_URL = "https://tinker.thinkingmachines.dev/services/tinker-prod/oai/api/v1"
+
 
 @dataclass
 class ProviderInfo:
@@ -20,6 +26,7 @@ class ProviderInfo:
     env_key: str  # Environment variable for API key, e.g. "OPENAI_API_KEY"
     default_model: str  # Default model name
     models: list[str] = field(default_factory=list)  # Curated model list
+    base_url: str = ""  # Fixed OpenAI-compatible api_base (e.g. Tinker); blank = use provider default
 
 
 PROVIDER_REGISTRY: list[ProviderInfo] = [
@@ -226,6 +233,31 @@ PROVIDER_REGISTRY: list[ProviderInfo] = [
             "MiniMax-M2.7-highspeed",
         ],
     ),
+    # --- Tinker (Thinking Machines) — beta OpenAI-compatible endpoint ---
+    ProviderInfo(
+        id="tinker",
+        label="Tinker (Thinking Machines)",
+        # Route through LiteLLM's OpenAI-compatible adapter pointed at the
+        # Tinker endpoint (``base_url`` below). The OAI endpoint accepts both
+        # base model IDs (below) and ``tinker://`` sampler checkpoint paths.
+        litellm_prefix="openai",
+        env_key="TINKER_API_KEY",
+        default_model="Qwen/Qwen3-8B",
+        # Curated fallback shown when the live catalog can't be fetched
+        # (offline / no key). ``rllm model setup`` pulls the full, live list
+        # from ``ServiceClient.get_server_capabilities()`` when possible.
+        models=[
+            "Qwen/Qwen3-8B",
+            "Qwen/Qwen3-32B",
+            "Qwen/Qwen3-4B-Instruct-2507",
+            "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "meta-llama/Llama-3.3-70B-Instruct",
+            "deepseek-ai/DeepSeek-V3.1",
+            "openai/gpt-oss-20b",
+        ],
+        base_url=TINKER_OAI_BASE_URL,
+    ),
     # --- Custom endpoint (last) ---
     ProviderInfo(
         id="custom",
@@ -243,6 +275,9 @@ DEFAULT_MODELS: dict[str, str] = {p.id: p.default_model for p in PROVIDER_REGIST
 PROVIDER_MODELS: dict[str, list[str]] = {p.id: p.models for p in PROVIDER_REGISTRY if p.models}
 PROVIDER_ENV_KEYS: dict[str, str] = {p.id: p.env_key for p in PROVIDER_REGISTRY if p.env_key}
 
+# Fixed OpenAI-compatible api_base per provider (only set for e.g. Tinker)
+PROVIDER_BASE_URLS: dict[str, str] = {p.id: p.base_url for p in PROVIDER_REGISTRY if p.base_url}
+
 # Index for fast lookup
 _PROVIDER_INDEX: dict[str, ProviderInfo] = {p.id: p for p in PROVIDER_REGISTRY}
 
@@ -250,6 +285,39 @@ _PROVIDER_INDEX: dict[str, ProviderInfo] = {p.id: p for p in PROVIDER_REGISTRY}
 def get_provider_info(provider_id: str) -> ProviderInfo | None:
     """Look up a provider by ID. Returns None if not found."""
     return _PROVIDER_INDEX.get(provider_id)
+
+
+def fetch_tinker_models(api_key: str | None = None) -> list[str]:
+    """Return Tinker's live base-model catalog (best-effort).
+
+    Queries ``ServiceClient.get_server_capabilities()`` for the models the
+    Tinker server currently exposes. Any base model here can be sampled via
+    the OpenAI-compatible endpoint without training (a ``tinker://`` sampler
+    checkpoint path also works, but isn't enumerable here).
+
+    Returns an empty list on any failure (tinker not installed, no API key,
+    network error) so callers can fall back to the curated static list.
+    """
+    key = api_key or os.environ.get("TINKER_API_KEY", "")
+    if not key:
+        return []
+    # ServiceClient reads TINKER_API_KEY from the environment; set it for the
+    # duration of the call without clobbering any pre-existing value.
+    prev = os.environ.get("TINKER_API_KEY")
+    os.environ["TINKER_API_KEY"] = key
+    try:
+        import tinker
+
+        caps = tinker.ServiceClient().get_server_capabilities()
+        names = [m.model_name for m in caps.supported_models if m.model_name]
+        return sorted(names)
+    except Exception:
+        return []
+    finally:
+        if prev is None:
+            os.environ.pop("TINKER_API_KEY", None)
+        else:
+            os.environ["TINKER_API_KEY"] = prev
 
 
 def _rllm_home() -> str:

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -128,14 +128,20 @@ class EvalProxyManager(_ProxyManagerBase):
         prefix = info.litellm_prefix if info else self.provider
         litellm_model = f"{prefix}/{self.model_name}"
 
+        litellm_params: dict[str, Any] = {
+            "model": litellm_model,
+            "api_key": self.api_key,
+        }
+        # Providers with a fixed OpenAI-compatible endpoint (e.g. Tinker) route
+        # through the ``openai/`` adapter pinned to their ``api_base``.
+        if info and info.base_url:
+            litellm_params["api_base"] = info.base_url
+
         return {
             "model_list": [
                 {
                     "model_name": self.model_name,
-                    "litellm_params": {
-                        "model": litellm_model,
-                        "api_key": self.api_key,
-                    },
+                    "litellm_params": litellm_params,
                 }
             ],
             "litellm_settings": {


### PR DESCRIPTION
## Why

[Tinker](https://thinkingmachines.ai/) (Thinking Machines) is one of rLLM's two training backends — but until now you could only *train* with it, not *evaluate* against it through the standard `rllm eval` CLI. Tinker recently shipped a (beta) **OpenAI-compatible inference endpoint**, which lets us treat it as just another provider — no native `SamplingClient`, no bespoke plumbing. This closes the loop: configure Tinker once and use the same `rllm model setup` → `rllm eval` flow you use for OpenAI/Anthropic/Together/etc.

## What's supported

- **First-class `tinker` provider** in `rllm model setup` / `swap` / `show`, authenticated with `TINKER_API_KEY`.
- **Live model catalog** — `setup` pulls the server's supported models from `ServiceClient.get_server_capabilities()` (41 models today: Qwen3, Llama, DeepSeek, Kimi, Nemotron, gpt-oss, …), with a curated static fallback when offline / unkeyed.
- **Base models *and* fine-tunes** — the OAI endpoint accepts:
  - a **base model ID** like `Qwen/Qwen3-8B` (no checkpoint / training required), or
  - a **`tinker://…/sampler_weights/…` checkpoint path** (pasted via "Other (enter manually)") to eval a fine-tune.
- **Consistent routing** — goes through the existing LiteLLM proxy → gateway path like every other provider; Tinker just pins LiteLLM's `openai/` adapter to a fixed `api_base`.

## How it works

`ProviderInfo` gains an optional `base_url`. `EvalProxyManager` injects that as the LiteLLM `api_base` only for providers that declare one (so OpenAI/Together/etc. are byte-for-byte unchanged). Generated LiteLLM params for Tinker:

```yaml
model: openai/Qwen/Qwen3-8B
api_base: https://tinker.thinkingmachines.dev/services/tinker-prod/oai/api/v1
api_key: $TINKER_API_KEY
```

## Testing

End-to-end through the real endpoint:

```
rllm eval gsm8k --split test --max-examples 3   # Qwen/Qwen3-4B-Instruct-2507
→ Accuracy 100.0% (3/3), 0 errors
```

Also verified: live catalog fetch returns 41 models; `api_base` is injected for Tinker only (no regression for other providers); `ruff` clean.

## Files

- `rllm/eval/config.py` — `tinker` provider, `ProviderInfo.base_url`, `fetch_tinker_models()` live-catalog helper.
- `rllm/eval/proxy.py` — inject `api_base` for fixed-URL providers.
- `rllm/cli/_ui.py`, `rllm/cli/model_cmd.py` — live catalog in model picker; thread API key through.
- `docs/quickstart-cli.mdx` — Tinker setup note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)