### PR TITLE
fix(eval): run harbor SWE-bench via the native mini-swe-agent harness on remote sandboxes

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -37,13 +37,15 @@ def _suggest_benchmarks(name: str, catalog_names: list[str], max_suggestions: in
 def _dict_rows_to_tasks(rows: list[dict]) -> list:
     """Wrap dict-rows from a catalog dataset as Task objects.
 
-    Harbor rows carry ``task_path`` pointing at their own Harbor task
-    directory; we root the Task there so HarborRuntime and per-task
-    verifier resolution find ``task.toml`` / ``tests/`` natively. Other
-    rows get ``dataset_dir=Path(".")`` and rely on ``evaluator_override``.
+    Harbor rows carry ``task_path``; we root the Task there and merge the task's
+    ``task.toml`` + ``environment/Dockerfile`` metadata (workdir, verifier
+    timeout, per-task image) so per-task verifier resolution and an rllm-native
+    harness get the right sandbox. Other rows get ``dataset_dir=Path(".")`` and
+    rely on ``evaluator_override``.
     """
     from pathlib import Path
 
+    from rllm.tasks.loader import _merge_task_toml_metadata
     from rllm.types import Task
 
     tasks: list[Task] = []
@@ -52,11 +54,14 @@ def _dict_rows_to_tasks(rows: list[dict]) -> list:
         task_id = str(row.get("id") or row.get("task_id") or idx)
         task_path = row.get("task_path")
         dataset_dir = Path(task_path) if task_path else Path(".")
+        metadata = dict(row)
+        if task_path:
+            metadata = _merge_task_toml_metadata(dataset_dir, metadata)
         tasks.append(
             Task(
                 id=task_id,
                 instruction=str(instruction),
-                metadata=dict(row),
+                metadata=metadata,
                 dataset_dir=dataset_dir,
                 sub_dir=None,
             )
@@ -219,8 +224,14 @@ def _run_eval(
             else:
                 split = "test"
 
-        # Docker check for Harbor tasks
-        if (agent_name and agent_name.startswith("harbor:")) or (catalog_entry and catalog_entry.get("source", "").startswith("harbor:")):
+        _is_harbor_agent = bool(agent_name) and agent_name.startswith("harbor:")
+        _is_harbor_source = bool(catalog_entry) and catalog_entry.get("source", "").startswith("harbor:")
+
+        # Require Docker only when execution lands on the local daemon; a remote
+        # backend (modal/daytona) pulls the task's image in the cloud.
+        _eff_backend = (agent_metadata or {}).get("sandbox_backend")
+        _runs_on_local_docker = _eff_backend in (None, "docker")
+        if (_is_harbor_agent or _is_harbor_source) and _runs_on_local_docker:
             from rllm.integrations.harbor.utils import diagnose_docker
 
             ok, reason, hint = diagnose_docker()
@@ -228,9 +239,8 @@ def _run_eval(
                 console.print(f"  [error]Harbor tasks require Docker — {reason}.[/]")
                 if hint:
                     console.print(f"  [dim]{hint}[/]")
+                console.print("  [dim]Or run on a remote backend, e.g. [bold]--sandbox-backend modal[/].[/]")
                 raise SystemExit(1)
-
-        _is_harbor_agent = bool(agent_name) and agent_name.startswith("harbor:")
 
         # Load the agent. Catalog covers built-in flows (react/bash/claude-code)
         # plus user-registered + plugin agents; ``harbor:<scaffold>`` resolves
@@ -303,12 +313,12 @@ def _run_eval(
             console.print(f"  [error]Could not load dataset '{benchmark}' split '{split}'.[/]")
             raise SystemExit(1)
 
-        # Prefer a materialised local dir for non-harbor catalog datasets so
-        # each Task carries its per-task verifier from dataset.toml. Harbor
-        # datasets carry their verifier inside the harbor task dir (read via
-        # task.metadata["task_path"]), so we wrap rows directly.
+        # Materialise non-harbor catalog datasets so each Task carries its
+        # per-task verifier from dataset.toml. Harbor datasets are
+        # task-per-directory; materialising would drop their tests/ +
+        # environment/, so wrap their rows directly instead.
         bench_result = None
-        if not _is_harbor_agent:
+        if not _is_harbor_agent and not _is_harbor_source:
             _materialised = os.path.expanduser(os.path.join(os.environ.get("RLLM_HOME", "~/.rllm"), "datasets", benchmark))
             if not os.path.isfile(os.path.join(_materialised, "dataset.toml")):
                 try:
@@ -327,8 +337,10 @@ def _run_eval(
                 dataset = Dataset(data=list(bench_result.tasks), name=bench_result.name, split=bench_result.split or split)
 
         if bench_result is None:
-            # Wrap dict-rows as Tasks; rely on evaluator_override for scoring.
-            if evaluator is None:
+            # Harbor rows root at their task dir, so SandboxTaskHooks resolves
+            # each task's own tests/test.sh — no dataset-wide evaluator needed.
+            # Non-harbor rows carry no per-task verifier, so still require one.
+            if evaluator is None and not _is_harbor_source:
                 console.print(f"  [error]No evaluator found for '{benchmark}'. Specify --evaluator explicitly.[/]")
                 raise SystemExit(1)
             from rllm.data.dataset import Dataset

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -196,7 +196,7 @@ def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox
 
     safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
     name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
-    sandbox = create_sandbox(backend, name=name, image=image)
+    sandbox = create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend))
 
     # Non-docker backends pull the Dockerfile's FROM base instead of building
     # it, so replay its RUN steps (e.g. swebench's `uv`, needed by the grader).
@@ -205,6 +205,32 @@ def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox
         for cmd in _dockerfile_run_commands(task):
             _safe_exec(sandbox, cmd, timeout=900)
     return sandbox
+
+
+def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
+    """Map a harbor task's declared ``[environment]`` resources to backend kwargs.
+
+    Harbor task.toml declares ``cpus`` / ``memory_mb`` / ``storage_mb``; without
+    these a remote sandbox runs at the backend default (Daytona: 1 GiB), which
+    OOM-kills compile-heavy graders (e.g. ``go test ./...``). Modal takes memory
+    in MB; Daytona takes memory/disk in GB. Docker/local ignore the values.
+    """
+    env = task.metadata.get("environment", {}) or {}
+    cpus, mem_mb, disk_mb = env.get("cpus"), env.get("memory_mb"), env.get("storage_mb")
+    kw: dict = {}
+    if backend == "modal":
+        if cpus:
+            kw["cpu"] = float(cpus)
+        if mem_mb:
+            kw["memory"] = int(mem_mb)
+    elif backend == "daytona":
+        if cpus:
+            kw["cpu"] = int(cpus)
+        if mem_mb:
+            kw["memory"] = max(1, round(mem_mb / 1024))
+        if disk_mb:
+            kw["disk"] = max(1, round(disk_mb / 1024))
+    return kw
 
 
 def _dockerfile_run_commands(task: Task) -> list[str]:

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -196,7 +196,49 @@ def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox
 
     safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
     name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
-    return create_sandbox(backend, name=name, image=image)
+    sandbox = create_sandbox(backend, name=name, image=image)
+
+    # Non-docker backends pull the Dockerfile's FROM base instead of building
+    # it, so replay its RUN steps (e.g. swebench's `uv`, needed by the grader).
+    # Best-effort: a failed step shouldn't abort the task.
+    if backend != "docker":
+        for cmd in _dockerfile_run_commands(task):
+            _safe_exec(sandbox, cmd, timeout=900)
+    return sandbox
+
+
+def _dockerfile_run_commands(task: Task) -> list[str]:
+    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps (joining
+    ``\\``-continuations). Non-``RUN`` directives — ``COPY``/``ADD`` etc. — are
+    skipped; only ``RUN`` is replayable on a live sandbox.
+    """
+    dockerfile = task.task_dir / "environment" / "Dockerfile"
+    if not dockerfile.exists():
+        dockerfile = task.dataset_dir / "environment" / "Dockerfile"
+    if not dockerfile.exists():
+        return []
+    try:
+        lines = dockerfile.read_text().splitlines()
+    except OSError:
+        return []
+
+    commands: list[str] = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.upper().startswith("RUN "):
+            parts = [stripped[4:]]
+            while parts[-1].rstrip().endswith("\\"):
+                parts[-1] = parts[-1].rstrip()[:-1]
+                i += 1
+                if i >= len(lines):
+                    break
+                parts.append(lines[i])
+            cmd = "\n".join(parts).strip()
+            if cmd:
+                commands.append(cmd)
+        i += 1
+    return commands
 
 
 def _resolve_image(task: Task, backend: str) -> str:

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -232,7 +232,10 @@ class DaytonaSandbox:
         try:
             remote_tar = f"/tmp/_upload_{self.name}_{int(time.time() * 1000)}.tar.gz"
             self._sandbox.fs.upload_file(tmp_path, remote_tar)
-            self.exec(f"tar xzf {remote_tar} -C {remote_parent} && rm -f {remote_tar}")
+            # --no-same-owner: don't restore the host's uid/gid (root extraction
+            # would otherwise chown to nonexistent ids and fail). Permissions are
+            # kept, so executables stay +x.
+            self.exec(f"tar xzf {remote_tar} --no-same-owner -C {remote_parent} && rm -f {remote_tar}")
         finally:
             try:
                 os.unlink(tmp_path)

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -189,8 +189,10 @@ class ModalSandbox:
 
         b64 = base64.b64encode(tar_buf.read()).decode("ascii")
 
-        # Write tar to sandbox and extract
-        self._exec_unchecked(f"echo '{b64}' | base64 -d | tar xzf - -C {remote_parent}")
+        # Write tar to sandbox and extract. --no-same-owner: don't restore the
+        # host's uid/gid (root extraction would otherwise chown to nonexistent
+        # ids and error); permissions are kept so executables stay +x.
+        self._exec_unchecked(f"echo '{b64}' | base64 -d | tar xzf - --no-same-owner -C {remote_parent}")
         logger.debug("Uploaded dir %s -> %s in sandbox %s", local_path, remote_path, self.name)
 
     def start_agent_process(self, command: str, port: int) -> None:

--- a/rllm/sandbox/sandboxed_flow.py
+++ b/rllm/sandbox/sandboxed_flow.py
@@ -135,7 +135,7 @@ def create_sandbox(backend: str, name: str, image: str, **kwargs) -> Sandbox:
     elif backend == "modal":
         from rllm.sandbox.backends.modal_backend import ModalSandbox
 
-        return ModalSandbox(name=name, **kwargs)
+        return ModalSandbox(name=name, image=image, **kwargs)
     elif backend == "daytona":
         from rllm.sandbox.backends.daytona import DaytonaSandbox
 

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -163,6 +163,31 @@ def _load_data_dataset(
     )
 
 
+def _parse_dockerfile_image_workdir(dockerfile: Path) -> tuple[str | None, str | None]:
+    """Return ``(base_image, workdir)`` from a Dockerfile's last ``FROM`` (``AS``
+    alias / platform flags stripped) and last ``WORKDIR``. Either is ``None`` if
+    absent/unreadable. Lets backends that pull a named image (rather than
+    building the Dockerfile) still get a harbor task's image + cwd.
+    """
+    if not dockerfile.exists():
+        return None, None
+    base_image: str | None = None
+    workdir: str | None = None
+    try:
+        for raw_line in dockerfile.read_text().splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            upper = line.upper()
+            if upper.startswith("FROM "):
+                base_image = line[5:].strip().split()[0]  # drop "AS <alias>" / flags
+            elif upper.startswith("WORKDIR "):
+                workdir = line[8:].strip()
+    except OSError:
+        return None, None
+    return base_image, workdir
+
+
 def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     """Merge per-task ``task.toml`` metadata into *base*.
 
@@ -182,14 +207,20 @@ def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     except Exception:
         return base
     merged = {**base, **raw}
-    env_section = raw.get("environment", {}) or {}
-    # Only set workdir when the task explicitly declares one. Otherwise
-    # downstream (``_setup_task_environment`` / ``ShellScriptEvaluator``
-    # / ``BaseCliHarness._cd_prefix``) leaves cwd alone and the
-    # Dockerfile's WORKDIR wins — required for harbor task families
-    # like swesmith whose base image expects ``/testbed`` and whose
-    # test.sh + pytest break when forced into ``/workspace``.
-    declared_workdir = env_section.get("workdir") or merged.get("workdir")
+    env_section = dict(raw.get("environment", {}) or {})
+    # Harbor tasks declare image + workdir in environment/Dockerfile, not
+    # task.toml. Surface both as fallbacks so a non-docker backend (which pulls
+    # a named image rather than building the Dockerfile) still gets them; docker
+    # backends rebuild the Dockerfile in _resolve_image and ignore these.
+    base_image, dockerfile_workdir = _parse_dockerfile_image_workdir(task_dir / "environment" / "Dockerfile")
+    if base_image and not env_section.get("docker_image"):
+        env_section["docker_image"] = base_image
+    if env_section:
+        merged["environment"] = env_section
+    # Set workdir only when declared (task.toml or Dockerfile WORKDIR); else
+    # leave cwd alone so the image's WORKDIR wins — swesmith-style tasks expect
+    # /testbed and break if forced into /workspace.
+    declared_workdir = env_section.get("workdir") or merged.get("workdir") or dockerfile_workdir
     if declared_workdir is not None:
         merged["workdir"] = declared_workdir
     merged["env_vars"] = env_section.get("env", {}) or merged.get("env_vars", {}) or {}


### PR DESCRIPTION
## What

Makes this work end-to-end:

```bash
rllm eval harbor:swebench-verified --agent mini-swe-agent --sandbox-backend modal
rllm eval harbor:swebenchpro      --agent mini-swe-agent --sandbox-backend daytona
# provider: rllm model show → OpenRouter / anthropic/claude-sonnet-4-6
```

i.e. evaluate a Harbor SWE-bench dataset with a **built-in** rLLM harness on a **remote** cloud sandbox (Modal/Daytona), scored by rLLM's own per-task verifier — no Harbor `swerex`/trial runtime, no bespoke SWE module.

## Why it didn't work before

A Harbor task-per-directory dataset already ships everything rLLM needs (`environment/Dockerfile` + `tests/test.sh`), and `ShellScriptEvaluator` is already Harbor-convention-aware (`/tests`, `/logs/verifier/reward.txt`). Harbor's own `harbor_reward_fn` only reads a reward that `HarborRuntime` pre-computes, so a **native** agent needs the per-task `tests/test.sh` verifier instead — which rLLM already falls back to. The missing piece was wiring each task's **image / workdir / verifier / resources** through to a remote sandbox.

**Resolution wiring (image / workdir / verifier):**

- **Per-task image never reached the sandbox.** The SWE-bench image is declared as `FROM <registry>/<instance>` in the task's `environment/Dockerfile`; it wasn't surfaced anywhere, so non-docker backends fell back to `python:3.11-slim` (no repo). → parse the Dockerfile `FROM`/`WORKDIR` into task metadata (`docker_image` + workdir).
- **Eval flattened Harbor task-dirs.** For a non-Harbor agent, eval tried to materialise the rows into a flat "simple" benchmark (dropping `tests/` + `environment/`) and required an explicit evaluator. → Harbor-source datasets now skip materialise, wrap rows with `task.toml` merge, and allow the per-task `tests/test.sh` verifier (no dataset-wide evaluator).
- **Docker precondition blocked Modal.** A working local Docker daemon was required for *any* Harbor dataset, even with `--sandbox-backend modal`. → gate only when the effective backend is local docker.
- **`create_sandbox` dropped the image for Modal (latent bug).** It passed `image=` to docker/daytona but not Modal, so **every** Modal sandbox silently used `python:3.11-slim`. → pass it through.
- **Base image lacks the verifier's toolchain.** Pulling the Dockerfile's `FROM` base (instead of building it) skips its `RUN` steps — including `install uv`, which the swebench grader needs. Without it the tests ran but the grader didn't, so even a golden patch scored 0. → replay the Dockerfile's `RUN` steps on non-docker sandboxes.

**Sandbox plumbing (backend-generic; surfaced live on Daytona, latent on Modal):**

- **Uploaded dirs carried host uid/gid.** `upload_dir` tarred with the host's uid/gid; root extraction in the sandbox tried to `chown` to nonexistent ids and exited 2 — a hard crash on Daytona (raising `exec`), silently swallowed on Modal. → extract with `tar --no-same-owner` (permissions kept, so `test.sh` stays +x).
- **Declared task resources were ignored.** `_create_sandbox_for_task` never passed the `[environment]` resources task.toml declares (`memory_mb`, `cpus`, …), so remote sandboxes ran at the backend default (Daytona: **1 GiB**). Compile-heavy graders (`go test ./...`, Go not cgroup-CPU-aware → 64 parallel compiles) OOM-killed the build → 0 tests pass → even the golden patch scored 0. → honor declared cpus/memory/storage per backend (Modal MB, Daytona GB).

All changes live in the shared eval/sandbox path; no SWE-specific module.

## Validation (real cloud runs, OpenRouter / Sonnet 4.6)

- **Modal · swebench-verified · oracle** (golden patch + verifier, no LLM): **2/3 reward 1.0**. The miss returns FAILED from Harbor's *verbatim* `parser.py` with all 242 tests passing — a benchmark grading quirk for that instance, reproducible independent of rLLM.
- **Modal · swebench-verified · mini-swe-agent**: **2/2 = 100%** on the gradeable tasks — the agent genuinely fixed both real GitHub issues (31 / 55 LLM steps).
- **Daytona · swebenchpro** (different backend *and* dataset — generality check): before the two sandbox fixes, both tasks errored (tar/chown crash). After: **Errors=0** with real verifier verdicts (`setup=8s evaluator=32s`), and the Go-grader oracle that OOM'd at the 1 GiB default runs cleanly at the honored 4 GiB (`oom_kill 0`).

So failures are attributable to genuine agent mistakes or the benchmark's own grading — not harness/environment plumbing — across two backends and two datasets.

## Files

- `rllm/tasks/loader.py` — `_parse_dockerfile_image_workdir` + Dockerfile parsing in `_merge_task_toml_metadata`.
- `rllm/cli/eval.py` — `_dict_rows_to_tasks` merges `task.toml`; Harbor-source skips materialise + allows per-task verifier; docker gate scoped to local-docker.
- `rllm/sandbox/sandboxed_flow.py` — pass `image` to the Modal backend.
- `rllm/eval/_resolution.py` — `_dockerfile_run_commands` replay on non-docker sandboxes; `_sandbox_resource_kwargs` honors task.toml resources.
- `rllm/sandbox/backends/{daytona,modal_backend}.py` — `tar --no-same-owner` on `upload_dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
