### PR TITLE
feat(sandbox): environment snapshots for cold-start acceleration

### DIFF
--- a/docs/core-concepts/running-evaluations.mdx
+++ b/docs/core-concepts/running-evaluations.mdx
@@ -1,0 +1,275 @@
+---
+title: Running evaluations
+description: A practical walkthrough of rllm eval — choosing a dataset, picking an agent harness, and tuning every flag that shapes a run
+---
+
+`rllm eval` runs a model against a benchmark and reports how well it did. A single command pulls the dataset, spins up the agent, routes model calls, scores each result, and prints accuracy:
+
+```bash
+rllm eval gsm8k
+```
+
+This guide walks through the whole workflow — from picking *what* to evaluate to controlling *how* the run executes — without assuming any knowledge of rLLM's internals.
+
+<Note>
+New to the CLI? Start with the [Quick start](/quickstart-cli) to configure a model provider (`rllm model setup`). Everything below assumes you've done that once.
+</Note>
+
+## The shape of a command
+
+```bash
+rllm eval <benchmark> [--agent <harness>] [--model <name>] [options]
+```
+
+Only the benchmark is required. When you omit the rest, rLLM fills in sensible defaults: the dataset's default agent, your configured model, and the benchmark's built-in scorer.
+
+<Steps>
+  <Step title="Choose a dataset">
+    What you want to measure — math, coding, QA, agentic tasks.
+  </Step>
+  <Step title="Choose an agent harness">
+    How the model attempts each task — a single call, a tool loop, or a full coding CLI in a sandbox.
+  </Step>
+  <Step title="Point at a model">
+    Your configured provider, or any OpenAI-compatible endpoint.
+  </Step>
+  <Step title="Tune the run">
+    Limit examples, set concurrency, save outputs.
+  </Step>
+</Steps>
+
+## Step 1 — Choose a dataset
+
+rLLM ships a catalog of 50+ benchmarks across math, code, QA, instruction-following, search, vision-language, and agentic tasks. Browse and preview them before committing to a run.
+
+```bash
+rllm dataset list --all          # the full catalog
+rllm dataset list --category code # filter by category
+rllm dataset info swebench-verified  # splits, size, default agent
+rllm dataset inspect gsm8k -n 3      # peek at a few real rows
+```
+
+<Tip>
+The [Supported datasets](/datasets) page lists every benchmark with its size, source, and default evaluator. Use it to find the exact name to pass to `rllm eval`.
+</Tip>
+
+You can evaluate three kinds of dataset sources:
+
+<Tabs>
+  <Tab title="Catalog benchmark">
+    A name from the built-in catalog. Auto-pulled from HuggingFace on first use.
+
+    ```bash
+    rllm eval gsm8k
+    rllm eval humaneval
+    ```
+  </Tab>
+  <Tab title="Harbor (agentic) dataset">
+    Sandboxed SWE-style tasks (each task ships its own environment + verifier). Use the `harbor:` prefix.
+
+    ```bash
+    rllm eval harbor:swebench-verified --sandbox-backend modal
+    ```
+  </Tab>
+  <Tab title="Local directory">
+    Your own benchmark folder (`dataset.toml` / `task.toml`).
+
+    ```bash
+    rllm eval ./my-benchmark --agent react
+    ```
+  </Tab>
+</Tabs>
+
+## Step 2 — Choose an agent harness
+
+The **agent harness** decides how the model actually attempts each task. Pass it with `--agent`; if you omit it, the dataset's default is used (`react` for most data benchmarks).
+
+```bash
+rllm agent list   # see every built-in harness
+```
+
+| Harness | What it does | Good for |
+|---------|--------------|----------|
+| `react` | One-shot LLM call | Math, multiple-choice, QA — the default for data tasks |
+| `bash` | Multi-turn ReAct bash loop in a sandbox | General agentic / shell tasks |
+| `mini-swe-agent` | Lightweight SWE agent in a sandbox | SWE-bench-style code repair |
+| `claude-code`, `codex`, `aider`, `opencode`, `qwen-code`, `kimi-cli`, `zeroclaw` | Run a real coding-agent CLI inside the sandbox | Benchmarking coding agents on repo tasks |
+| `oracle` | Runs the task's reference solution (no LLM) | Smoke-testing that an environment + verifier work before spending tokens |
+
+```bash
+# Evaluate a coding agent on a sandboxed benchmark
+rllm eval harbor:swebench-verified --agent mini-swe-agent --sandbox-backend modal
+
+# Sanity-check the environment with no model calls
+rllm eval harbor:swebench-verified --agent oracle --sandbox-backend modal
+```
+
+<Tip>
+`--agent oracle` is the cheapest way to confirm a sandboxed benchmark is wired correctly: it runs the gold solution and should score ~100%. If it doesn't, the problem is the environment, not your model.
+</Tip>
+
+You can also point `--agent` at your own scaffold — a registry name (`rllm init my-agent`) or a `module:object` import path.
+
+## Step 3 — Point at a model
+
+By default, `eval` uses the model from `rllm model setup` and starts a local LiteLLM proxy to route requests. Override either piece:
+
+<Tabs>
+  <Tab title="Configured provider">
+    ```bash
+    rllm eval gsm8k --model gpt-4o
+    ```
+    Uses your saved provider + API key; the proxy is started for you.
+  </Tab>
+  <Tab title="Your own endpoint">
+    ```bash
+    rllm eval gsm8k \
+      --base-url http://localhost:30000/v1 \
+      --model Qwen/Qwen3-4B
+    ```
+    Any OpenAI-compatible server (vLLM, SGLang, etc.). `--model` is required here.
+  </Tab>
+</Tabs>
+
+## Step 4 — Tune the run
+
+These flags shape how the evaluation executes and what it leaves behind.
+
+<ParamField path="--max-examples" type="int">
+  Evaluate only the first N examples. Ideal for a quick smoke test before a full run.
+</ParamField>
+
+<ParamField path="--task-indices" type="string">
+  Run specific rows only: `'0'`, `'3,7,12'`, or a range `'0-9'`. Great for re-running a handful of failures.
+</ParamField>
+
+<ParamField path="--split" type="string">
+  Which dataset split to use (defaults to the benchmark's eval split, usually `test`).
+</ParamField>
+
+<ParamField path="--concurrency" type="int" default="64">
+  How many tasks run in parallel. Lower it if you hit provider rate limits; raise it for throughput.
+</ParamField>
+
+<ParamField path="--evaluator" type="string">
+  Override the scorer for every task (a registry name or `module:class`). By default each benchmark brings its own.
+</ParamField>
+
+<ParamField path="--output" type="string">
+  Where to write the results JSON. Defaults to a timestamped run directory under `~/.rllm/eval_results/`.
+</ParamField>
+
+<ParamField path="--save-episodes / --no-save-episodes" default="enabled">
+  Save each task's full trajectory as JSON for later inspection with `rllm view`.
+</ParamField>
+
+```bash
+# A fast, reproducible dev loop
+rllm eval gsm8k --max-examples 20 --concurrency 16
+
+# Re-run just three rows and save results to a known path
+rllm eval gsm8k --task-indices 4,11,27 --output runs/retry.json
+```
+
+When the run finishes, rLLM prints accuracy, an error count, and per-signal metrics, and tells you how to browse the saved episodes:
+
+```bash
+rllm view <run-id>
+```
+
+## Sandboxed (agentic) evaluations
+
+Coding agents and Harbor tasks run inside an isolated **sandbox** — a container with the task's repo, dependencies, and test suite. Pick where those sandboxes run with `--sandbox-backend`:
+
+| Backend | Where it runs | Notes |
+|---------|---------------|-------|
+| `docker` | Your local Docker daemon | Default; requires Docker installed |
+| `local` | The host machine directly | No isolation; fastest |
+| `modal`, `daytona`, `e2b`, `runloop`, `gke` | Cloud | No local Docker needed; scales out |
+
+```bash
+rllm eval harbor:swebench-verified \
+  --agent mini-swe-agent \
+  --sandbox-backend modal \
+  --sandbox-concurrency 8
+```
+
+<Note>
+`--sandbox-concurrency` caps how many sandboxes exist at once, independent of `--concurrency`. Use it to stay within a cloud backend's limits.
+</Note>
+
+## Accelerating cold start with snapshots
+
+Every sandboxed task pays a **cold start** before any real work happens: the backend pulls a (often multi-gigabyte) image and replays the environment's setup steps. For large or repeated evaluations this can dominate wall-clock time. A **snapshot** bakes that one-time work into a reusable backend artifact, so tasks boot from a warmed environment in roughly a second.
+
+Snapshots are managed like datasets — you create them once, they persist, and `rllm eval` uses them automatically:
+
+<Steps>
+  <Step title="Create snapshots for a dataset (or a slice)">
+    ```bash
+    # Build snapshots for the whole benchmark, or just the slice you'll evaluate
+    rllm snapshot create harbor:swebench-verified --sandbox-backend modal
+    rllm snapshot create harbor:swebench-verified --sandbox-backend modal --max-examples 5
+    ```
+  </Step>
+  <Step title="Evaluate — snapshots are used transparently">
+    ```bash
+    # Boots from a snapshot whenever one exists; falls back to cold otherwise
+    rllm eval harbor:swebench-verified --sandbox-backend modal
+    ```
+  </Step>
+  <Step title="Inspect or remove them">
+    ```bash
+    rllm snapshot list                                            # what you have, by dataset
+    rllm snapshot destroy harbor:swebench-verified --sandbox-backend modal
+    ```
+  </Step>
+</Steps>
+
+### What a snapshot is
+
+<AccordionGroup>
+  <Accordion title="A per-environment artifact, shared widely">
+    A snapshot is keyed by the **environment** — its base image plus Dockerfile setup steps — not by an individual task. So every task that shares an environment uses the same snapshot, and one set of snapshots is reused by **eval and training alike** (including all the group copies a training run makes of a task). The agent harness is *not* part of the key, so the same snapshots serve any harness.
+  </Accordion>
+  <Accordion title="Persistent and user-managed, unlike a sandbox">
+    A **sandbox** is ephemeral — created for one rollout and torn down right after. A **snapshot** persists until you remove it, like a dataset. Evaluation never creates or destroys snapshots; it only reads them. Building and removing them is always an explicit `rllm snapshot create` / `destroy`.
+  </Accordion>
+  <Accordion title="Storage, not running compute">
+    Snapshots are stored as image diffs, so they cost almost nothing while idle (no sandbox is running). Each carries a local **time-to-live** (`--ttl-hours`, default 7 days): past it, rLLM stops trusting the local entry and falls back to cold rather than risk a stale boot.
+  </Accordion>
+</AccordionGroup>
+
+| | Cold (default fallback) | Snapshot |
+|---|:---:|:---:|
+| Setup re-paid per task | Yes | No — boots from the warmed environment |
+| Idle cost | None | Negligible (storage only) |
+| Reused across runs | — | Yes, by eval **and** training |
+| Created by | — | `rllm snapshot create` (never by a run) |
+
+Snapshots are available only on cloud backends with a snapshot mechanism (`modal`, `daytona`); `docker` / `local` always take the cold path (their local image cache already amortizes it). To force the cold path on a backend that has snapshots — for A/B timing, say — pass `--no-snapshot`:
+
+```bash
+rllm eval harbor:swebench-verified --sandbox-backend modal --no-snapshot
+```
+
+<Note>
+If a snapshot was removed on the backend out of band, the eval notices on boot and transparently falls back to cold for that task — a run never fails because a snapshot went missing.
+</Note>
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Supported datasets" icon="database" href="/datasets">
+    Every benchmark with its size, source, and evaluator
+  </Card>
+  <Card title="CLI reference" icon="terminal" href="/core-concepts/cli-and-ui">
+    All commands, flags, and the web UI
+  </Card>
+  <Card title="Agent harnesses" icon="robot" href="/core-concepts/harnesses">
+    How harnesses drive the model through a task
+  </Card>
+  <Card title="Evaluators" icon="check" href="/core-concepts/agentflow-evaluator">
+    How results are scored
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,8 +56,9 @@
             "group": "rLLM CLI & UI",
             "pages": [
               "core-concepts/cli-and-ui",
-              "experimental/ui",
-              "datasets"
+              "core-concepts/running-evaluations",
+              "datasets",
+              "experimental/ui"
             ]
           },
           {

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -84,6 +84,7 @@ def _run_eval(
     enable_ui: bool = False,
     save_episodes: bool = True,
     episodes_dir: str | None = None,
+    use_snapshot: bool = True,
 ):
     """Core eval logic, extracted for clean proxy lifecycle management."""
     from rllm.data import DatasetRegistry
@@ -378,6 +379,8 @@ def _run_eval(
         agent_text += f"  [dim]{agent_desc}[/]"
     table.add_row("Agent", agent_text)
     table.add_row("Evaluator", f"[dim]{evaluator_display}[/]")
+    if not use_snapshot:
+        table.add_row("Snapshots", "[dim]disabled (--no-snapshot, cold start)[/]")
     console.print()
     console.print(Panel(table, border_style="cyan", expand=False))
     console.print()
@@ -479,6 +482,7 @@ def _run_eval(
             model=model,
             concurrency=concurrency,
             sandbox_backend=(agent_metadata or {}).get("sandbox_backend"),
+            use_snapshot=use_snapshot,
             agent_name=agent_name,
             dataset_name=getattr(dataset, "name", benchmark) or benchmark,
             on_episode_complete=on_episode_complete,
@@ -565,6 +569,12 @@ def _run_eval(
     help="Sandbox/environment backend. For Harbor agents: docker, daytona, modal, e2b, etc. For sandboxed agents: docker, local, modal.",
 )
 @click.option("--sandbox-concurrency", "sandbox_concurrency", default=None, type=int, help="Override max concurrent sandboxes (default: agent's max_concurrent).")
+@click.option(
+    "--snapshot/--no-snapshot",
+    "use_snapshot",
+    default=True,
+    help="Boot each task from a pre-built environment snapshot when one exists (default). Use --no-snapshot to force the cold path (e.g. A/B timing). Build snapshots with 'rllm snapshot create'.",
+)
 @click.option("--ui/--no-ui", "enable_ui", default=None, help="Enable/disable live UI logging. Default: auto-enabled when logged in (see 'rllm login').")
 @click.option("--save-episodes/--no-save-episodes", "save_episodes", default=True, help="Save each Episode as its own JSON file for later visualization (default: enabled).")
 @click.option("--episodes-dir", "episodes_dir", default=None, help="Directory to write the episode JSONs into. Default: ~/.rllm/eval_results/<bench>_<model>_<timestamp>/.")
@@ -582,6 +592,7 @@ def eval_cmd(
     search_backend: str | None,
     sandbox_backend: str | None,
     sandbox_concurrency: int | None,
+    use_snapshot: bool,
     enable_ui: bool | None,
     save_episodes: bool,
     episodes_dir: str | None,
@@ -686,6 +697,7 @@ def eval_cmd(
             enable_ui=enable_ui,
             save_episodes=save_episodes,
             episodes_dir=episodes_dir,
+            use_snapshot=use_snapshot,
         )
     finally:
         if proxy_manager is not None:

--- a/rllm/cli/main.py
+++ b/rllm/cli/main.py
@@ -22,6 +22,7 @@ _COMMAND_ICONS = {
     "init": "🚀",
     "model": "⚙️ ",
     "login": "🔑",
+    "snapshot": "📸",
     "train": "🏋️",
     "view": "🔍",
 }
@@ -44,6 +45,7 @@ class _LazyGroup(click.Group):
         "eval": ("rllm.cli.eval", "eval_cmd", "Evaluate a model on a benchmark dataset."),
         "init": ("rllm.cli.init", "init_cmd", "Scaffold a new agent project."),
         "model": ("rllm.cli.model_cmd", "model", "Manage provider and model configuration."),
+        "snapshot": ("rllm.cli.snapshot_cmd", "snapshot", "Manage sandbox environment snapshots."),
         "train": ("rllm.cli.train", "train_cmd", "Train a model on a benchmark dataset using RL."),
         "view": ("rllm.cli.view", "view_cmd", "Browse saved eval episodes in a Gradio viewer."),
         "login": ("rllm.cli.login", "login_cmd", "Log in to rLLM UI."),

--- a/rllm/cli/snapshot_cmd.py
+++ b/rllm/cli/snapshot_cmd.py
@@ -1,0 +1,211 @@
+"""``rllm snapshot``: manage sandbox environment snapshots like datasets.
+
+A snapshot bakes a dataset's environments (base image + Dockerfile RUN steps)
+into backend artifacts, so ``rllm eval`` / ``rllm train`` boot from them instead
+of paying cold start every rollout. Snapshots persist and are user-managed:
+
+    rllm snapshot create harbor:swebench-verified --sandbox-backend modal --max-examples 5
+    rllm snapshot list
+    rllm snapshot destroy harbor:swebench-verified --sandbox-backend modal
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import click
+from rich.console import Console
+from rich.table import Table
+from rich.theme import Theme
+
+theme = Theme({"label": "dim", "success": "bold green", "error": "bold red", "val": "bold", "key": "yellow"})
+console = Console(theme=theme)
+
+_MAX_BUILD_WORKERS = 4  # snapshot builds are network/IO-bound; a few in parallel is a real win
+
+
+def _resolve_dataset_tasks(benchmark: str, agent_name: str | None, sandbox_backend: str | None, split: str | None) -> list:
+    """Resolve a benchmark to a list of Tasks carrying environment metadata.
+
+    Mirrors the sandboxed branches of ``rllm eval`` (local benchmark dir +
+    harbor catalog) — the only datasets that have environments to snapshot.
+    """
+    from rllm.cli._pull import load_dataset_catalog, pull_dataset
+    from rllm.cli.eval import _dict_rows_to_tasks
+    from rllm.data import DatasetRegistry
+    from rllm.tasks.loader import BenchmarkLoader
+
+    if BenchmarkLoader.is_local_benchmark(benchmark):
+        bench = BenchmarkLoader.load(benchmark, sandbox_backend=sandbox_backend, harness_name=agent_name)
+        return list(bench.tasks)
+
+    catalog = load_dataset_catalog()
+    catalog_entry = catalog.get("datasets", {}).get(benchmark)
+    if catalog_entry is None and benchmark.startswith("harbor:"):
+        from rllm.cli._pull import resolve_harbor_catalog_entry
+
+        harbor_name = benchmark.removeprefix("harbor:")
+        catalog_entry = resolve_harbor_catalog_entry(harbor_name)
+        benchmark = harbor_name
+
+    if catalog_entry is None:
+        raise click.ClickException(f"Benchmark '{benchmark}' not found in catalog and is not a local benchmark directory.")
+
+    split = split or catalog_entry.get("eval_split", "test")
+    dataset = DatasetRegistry.load_dataset(benchmark, split)
+    if dataset is None:
+        pull_dataset(benchmark, catalog_entry)
+        dataset = DatasetRegistry.load_dataset(benchmark, split)
+    if dataset is None:
+        raise click.ClickException(f"Could not load dataset '{benchmark}' split '{split}'.")
+
+    return _dict_rows_to_tasks(list(dataset.data))
+
+
+def _slice_tasks(tasks: list, max_examples: int | None, task_indices: str | None) -> list:
+    """Apply a ``--task-indices`` (e.g. '0,3-5') or ``--max-examples`` slice."""
+    if task_indices is not None:
+        idx: list[int] = []
+        for part in task_indices.split(","):
+            part = part.strip()
+            if "-" in part:
+                lo, hi = part.split("-", 1)
+                idx.extend(range(int(lo), int(hi) + 1))
+            else:
+                idx.append(int(part))
+        return [tasks[i] for i in idx if 0 <= i < len(tasks)]
+    if max_examples is not None:
+        return tasks[:max_examples]
+    return tasks
+
+
+def _humanize_expiry(iso: str | None) -> str:
+    from datetime import datetime, timezone
+
+    if not iso:
+        return "-"
+    dt = datetime.fromisoformat(iso)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = dt - datetime.now(tz=timezone.utc)
+    if delta.total_seconds() <= 0:
+        return "[error]expired[/]"
+    days, hours = delta.days, delta.seconds // 3600
+    return f"in {days}d" if days else f"in {hours}h"
+
+
+@click.group("snapshot")
+def snapshot():
+    """Manage sandbox environment snapshots."""
+
+
+@snapshot.command("create")
+@click.argument("benchmark")
+@click.option(
+    "--sandbox-backend",
+    "sandbox_backend",
+    required=True,
+    type=click.Choice(["modal", "daytona"], case_sensitive=False),
+    help="Backend to build snapshots on (only modal/daytona have snapshots).",
+)
+@click.option("--agent", "agent_name", default=None, help="Agent scaffold (only affects local-benchmark resolution).")
+@click.option("--split", default=None, help="Dataset split (default: from catalog eval_split).")
+@click.option("--max-examples", default=None, type=int, help="Snapshot only the first N tasks (e.g. the slice you'll eval).")
+@click.option("--task-indices", default=None, type=str, help="Snapshot only these task indices (e.g. '0', '3,7,12', '0-9').")
+@click.option("--ttl-hours", default=168.0, type=float, help="Local trust horizon in hours (default: 168 = 7 days).")
+def create_snapshots(benchmark: str, sandbox_backend: str, agent_name: str | None, split: str | None, max_examples: int | None, task_indices: str | None, ttl_hours: float):
+    """Build environment snapshots for a benchmark (or a slice of it)."""
+    from rllm.eval._resolution import _resolve_image
+    from rllm.sandbox.sandboxed_flow import build_snapshot
+    from rllm.sandbox.snapshot import SnapshotRegistry, keys_for_tasks
+
+    tasks = _slice_tasks(_resolve_dataset_tasks(benchmark, agent_name, sandbox_backend, split), max_examples, task_indices)
+    by_key = keys_for_tasks(tasks, sandbox_backend)
+    if not by_key:
+        console.print(f"  [dim]No snapshottable environments for '{benchmark}' on {sandbox_backend}.[/]")
+        return
+
+    console.print(f"\n  Building [val]{len(by_key)}[/] snapshot(s) from [val]{len(tasks)}[/] task(s) on [val]{sandbox_backend}[/]\n")
+    registry = SnapshotRegistry.load()
+
+    def _build(item: tuple[str, object]) -> tuple[str, str, float]:
+        key, task = item
+        t0 = time.monotonic()
+        try:
+            ref = build_snapshot(sandbox_backend, task, key)
+            if ref is not None:
+                registry.record_env(key, sandbox_backend, ref, _resolve_image(task, sandbox_backend), benchmark, ttl_hours=ttl_hours)
+            status = "[success]ok[/]" if ref is not None else "[error]no-snapshot[/]"
+        except Exception as e:  # noqa: BLE001
+            status = f"[error]failed[/] [dim]{e}[/]"
+        return key, status, time.monotonic() - t0
+
+    with ThreadPoolExecutor(max_workers=min(_MAX_BUILD_WORKERS, len(by_key))) as pool:
+        results = list(pool.map(_build, by_key.items()))
+
+    table = Table(box=None, padding=(0, 2))
+    table.add_column("env_key", style="key")
+    table.add_column("status", style="val")
+    table.add_column("elapsed", style="dim", justify="right")
+    for key, status, elapsed in results:
+        table.add_row(key, status, f"{elapsed:.1f}s")
+    console.print(table)
+    console.print(f"\n  [dim]Registry: ~/.rllm/snapshots.json — reuse with[/] [bold]rllm eval {benchmark} --sandbox-backend {sandbox_backend}[/]\n")
+
+
+@snapshot.command("list")
+@click.option("--sandbox-backend", "sandbox_backend", default=None, type=click.Choice(["modal", "daytona"], case_sensitive=False), help="Filter to one backend.")
+@click.option("--verbose", is_flag=True, help="Expand to one row per environment.")
+def list_snapshots(sandbox_backend: str | None, verbose: bool):
+    """List snapshots by dataset (local registry view)."""
+    from rllm.sandbox.snapshot import SnapshotRegistry
+
+    registry = SnapshotRegistry.load()
+
+    if verbose:
+        entries = {k: e for k, e in registry.env_entries().items() if sandbox_backend is None or e.get("backend") == sandbox_backend}
+        if not entries:
+            console.print("  [dim]No snapshots.[/]")
+            return
+        table = Table(box=None, padding=(0, 2))
+        for col in ("env_key", "backend", "ref", "base image", "datasets", "expires"):
+            table.add_column(col, style="key" if col == "env_key" else "dim")
+        for key, e in entries.items():
+            table.add_row(key, e.get("backend", "?"), str(e.get("ref", "?")), e.get("base_image", "?"), ", ".join(e.get("datasets", [])), _humanize_expiry(e.get("expires_at")))
+        console.print(table)
+        return
+
+    rows = [c for c in registry.collections() if sandbox_backend is None or c["backend"] == sandbox_backend]
+    if not rows:
+        console.print("  [dim]No snapshots. Build some with[/] [bold]rllm snapshot create <dataset> --sandbox-backend <b>[/]")
+        return
+    table = Table(box=None, padding=(0, 2))
+    table.add_column("dataset", style="val")
+    table.add_column("backend", style="key")
+    table.add_column("envs", style="dim", justify="right")
+    table.add_column("expires", style="dim")
+    for c in rows:
+        table.add_row(c["dataset"], c["backend"], str(c["envs"]), _humanize_expiry(c["expires_at"]))
+    console.print(table)
+
+
+@snapshot.command("destroy")
+@click.argument("benchmark")
+@click.option(
+    "--sandbox-backend",
+    "sandbox_backend",
+    default=None,
+    type=click.Choice(["modal", "daytona"], case_sensitive=False),
+    help="Restrict to one backend (default: all backends for this dataset).",
+)
+def destroy_snapshots(benchmark: str, sandbox_backend: str | None):
+    """Delete a dataset's snapshots from their backend and the registry."""
+    from rllm.sandbox.snapshot import SnapshotRegistry
+
+    detached, deleted = SnapshotRegistry.load().destroy(benchmark, sandbox_backend)
+    if detached == 0:
+        scope = f" on {sandbox_backend}" if sandbox_backend else ""
+        console.print(f"  [dim]No snapshots recorded for '{benchmark}'{scope}.[/]")
+        return
+    console.print(f"  [success]Removed[/] {deleted} backend snapshot(s); detached '{benchmark}' from {detached} environment(s).")

--- a/rllm/cli/snapshot_cmd.py
+++ b/rllm/cli/snapshot_cmd.py
@@ -1,12 +1,18 @@
 """``rllm snapshot``: manage sandbox environment snapshots like datasets.
 
-A snapshot bakes a dataset's environments (base image + Dockerfile RUN steps)
-into backend artifacts, so ``rllm eval`` / ``rllm train`` boot from them instead
-of paying cold start every rollout. Snapshots persist and are user-managed:
+A snapshot bakes a task's environment (base image + Dockerfile RUN steps) into a
+backend artifact, so ``rllm eval`` / ``rllm train`` boot from it instead of paying
+cold start every rollout. Each ``create`` records a named *group*: a thin manifest
+of the exact tasks it covered and the env_keys they resolved to. Groups are what a
+human names, lists, inspects, and destroys; snapshots are shared freely between them.
 
     rllm snapshot create harbor:swebench-verified --sandbox-backend modal --max-examples 5
     rllm snapshot list
-    rllm snapshot destroy harbor:swebench-verified --sandbox-backend modal
+    rllm snapshot info    swebench-verified-first5-a17c3d9e
+    rllm snapshot inspect swebench-verified-first5-a17c3d9e
+    rllm snapshot destroy swebench-verified-first5-a17c3d9e
+    rllm snapshot renew   swebench-verified-first5-a17c3d9e --ttl-hours 168
+    rllm snapshot sync --sandbox-backend modal
 """
 
 from __future__ import annotations
@@ -16,6 +22,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import click
 from rich.console import Console
+from rich.panel import Panel
 from rich.table import Table
 from rich.theme import Theme
 
@@ -80,6 +87,25 @@ def _slice_tasks(tasks: list, max_examples: int | None, task_indices: str | None
     return tasks
 
 
+def _slice_spec(max_examples: int | None, task_indices: str | None) -> dict:
+    """The slice descriptor stored on the group (``kind`` + raw ``value`` for display)."""
+    if task_indices is not None:
+        return {"kind": "task_indices", "value": task_indices}
+    if max_examples is not None:
+        return {"kind": "max_examples", "value": max_examples}
+    return {"kind": "all", "value": None}
+
+
+def _slice_display(slice_spec: dict) -> str:
+    """Render a slice spec for the ``list``/``info`` columns."""
+    kind, value = slice_spec.get("kind"), slice_spec.get("value")
+    if kind == "max_examples":
+        return f"first {value}"
+    if kind == "task_indices":
+        return f"idx {value}"
+    return "all"
+
+
 def _humanize_expiry(iso: str | None) -> str:
     from datetime import datetime, timezone
 
@@ -93,6 +119,13 @@ def _humanize_expiry(iso: str | None) -> str:
         return "[error]expired[/]"
     days, hours = delta.days, delta.seconds // 3600
     return f"in {days}d" if days else f"in {hours}h"
+
+
+def _is_live(iso: str | None) -> bool:
+    """True if an env's expiry is in the future."""
+    from rllm.sandbox.snapshot import _expired
+
+    return bool(iso) and not _expired(iso)
 
 
 @click.group("snapshot")
@@ -114,11 +147,12 @@ def snapshot():
 @click.option("--max-examples", default=None, type=int, help="Snapshot only the first N tasks (e.g. the slice you'll eval).")
 @click.option("--task-indices", default=None, type=str, help="Snapshot only these task indices (e.g. '0', '3,7,12', '0-9').")
 @click.option("--ttl-hours", default=168.0, type=float, help="Local trust horizon in hours (default: 168 = 7 days).")
-def create_snapshots(benchmark: str, sandbox_backend: str, agent_name: str | None, split: str | None, max_examples: int | None, task_indices: str | None, ttl_hours: float):
-    """Build environment snapshots for a benchmark (or a slice of it)."""
+@click.option("--force", is_flag=True, help="Rebuild even when a live snapshot exists, and refresh its TTL.")
+def create_snapshots(benchmark: str, sandbox_backend: str, agent_name: str | None, split: str | None, max_examples: int | None, task_indices: str | None, ttl_hours: float, force: bool):
+    """Build environment snapshots for a benchmark (or a slice of it) and record a group."""
     from rllm.eval._resolution import _resolve_image
     from rllm.sandbox.sandboxed_flow import build_snapshot
-    from rllm.sandbox.snapshot import SnapshotRegistry, keys_for_tasks
+    from rllm.sandbox.snapshot import SnapshotRegistry, env_key_for, keys_for_tasks
 
     tasks = _slice_tasks(_resolve_dataset_tasks(benchmark, agent_name, sandbox_backend, split), max_examples, task_indices)
     by_key = keys_for_tasks(tasks, sandbox_backend)
@@ -129,83 +163,215 @@ def create_snapshots(benchmark: str, sandbox_backend: str, agent_name: str | Non
     console.print(f"\n  Building [val]{len(by_key)}[/] snapshot(s) from [val]{len(tasks)}[/] task(s) on [val]{sandbox_backend}[/]\n")
     registry = SnapshotRegistry.load()
 
-    def _build(item: tuple[str, object]) -> tuple[str, str, float]:
+    def _build(item: tuple[str, object]) -> tuple[str, str | None, str, float]:
         key, task = item
         t0 = time.monotonic()
         try:
-            ref = build_snapshot(sandbox_backend, task, key)
-            if ref is not None:
-                registry.record_env(key, sandbox_backend, ref, _resolve_image(task, sandbox_backend), benchmark, ttl_hours=ttl_hours)
-            status = "[success]ok[/]" if ref is not None else "[error]no-snapshot[/]"
+            prior_ref = registry.lookup_env(key, sandbox_backend)  # a live local ref to reuse when not forced
+            ref = build_snapshot(sandbox_backend, task, key, prior_ref, force=force)
+            reused = ref is not None and not force and prior_ref == ref
+            status = "[dim]reused[/]" if reused else "[success]ok[/]" if ref is not None else "[error]no-snapshot[/]"
         except Exception as e:  # noqa: BLE001
-            status = f"[error]failed[/] [dim]{e}[/]"
-        return key, status, time.monotonic() - t0
+            ref, status = None, f"[error]failed[/] [dim]{e}[/]"
+        return key, ref, status, time.monotonic() - t0
 
     with ThreadPoolExecutor(max_workers=min(_MAX_BUILD_WORKERS, len(by_key))) as pool:
-        results = list(pool.map(_build, by_key.items()))
+        results = {key: (ref, status, elapsed) for key, ref, status, elapsed in pool.map(_build, by_key.items())}
+
+    # the group's tasks: the exact sliced tasks whose env actually built
+    built_tasks = []
+    for task in tasks:
+        key = env_key_for(task, sandbox_backend)
+        ref = results.get(key, (None,))[0]
+        if ref is not None:
+            built_tasks.append({"id": task.id, "env_key": key, "ref": ref, "base_image": _resolve_image(task, sandbox_backend)})
+
+    group_id = None
+    if built_tasks:
+        group_id = registry.record_group(benchmark, sandbox_backend, _slice_spec(max_examples, task_indices), built_tasks, ttl_hours=ttl_hours, force=force)
 
     table = Table(box=None, padding=(0, 2))
     table.add_column("env_key", style="key")
     table.add_column("status", style="val")
     table.add_column("elapsed", style="dim", justify="right")
-    for key, status, elapsed in results:
+    for key, (ref, status, elapsed) in results.items():
         table.add_row(key, status, f"{elapsed:.1f}s")
     console.print(table)
+    if group_id:
+        console.print(f"\n  group [val]{group_id}[/]")
     console.print(f"\n  [dim]Registry: ~/.rllm/snapshots.json — reuse with[/] [bold]rllm eval {benchmark} --sandbox-backend {sandbox_backend}[/]\n")
 
 
 @snapshot.command("list")
 @click.option("--sandbox-backend", "sandbox_backend", default=None, type=click.Choice(["modal", "daytona"], case_sensitive=False), help="Filter to one backend.")
-@click.option("--verbose", is_flag=True, help="Expand to one row per environment.")
+@click.option("--verbose", is_flag=True, help="Also expand each group to one row per env_key.")
 def list_snapshots(sandbox_backend: str | None, verbose: bool):
-    """List snapshots by dataset (local registry view)."""
+    """List snapshot groups (one row per create invocation)."""
     from rllm.sandbox.snapshot import SnapshotRegistry
 
     registry = SnapshotRegistry.load()
+    envs = registry.env_entries()
+    groups = {gid: g for gid, g in registry.groups().items() if sandbox_backend is None or g.get("backend") == sandbox_backend}
+    if not groups:
+        console.print("  [dim]No snapshot groups. Build some with[/] [bold]rllm snapshot create <dataset> --sandbox-backend <b>[/]")
+        return
+
+    table = Table(box=None, padding=(0, 2))
+    table.add_column("group", style="val")
+    table.add_column("dataset", style="dim")
+    table.add_column("backend", style="key")
+    table.add_column("slice", style="dim")
+    table.add_column("envs", style="dim", justify="right")
+    table.add_column("live", style="dim", justify="right")
+    table.add_column("expires", style="dim")
+    for gid, g in sorted(groups.items()):
+        members = registry.group_members(gid)
+        live = sum(1 for k in members if _is_live(envs.get(k, {}).get("expires_at")))
+        expiries = [envs[k]["expires_at"] for k in members if k in envs and envs[k].get("expires_at")]
+        soonest = min(expiries) if expiries else None
+        table.add_row(gid, g.get("dataset", "?"), g.get("backend", "?"), _slice_display(g.get("slice", {})), str(len(members)), str(live), _humanize_expiry(soonest))
+    console.print(table)
 
     if verbose:
-        entries = {k: e for k, e in registry.env_entries().items() if sandbox_backend is None or e.get("backend") == sandbox_backend}
-        if not entries:
-            console.print("  [dim]No snapshots.[/]")
-            return
+        for gid in sorted(groups):
+            console.print(f"\n  [val]{gid}[/]")
+            sub = Table(box=None, padding=(0, 2))
+            for col in ("env_key", "ref", "base image", "expires"):
+                sub.add_column(col, style="key" if col == "env_key" else "dim")
+            for k in registry.group_members(gid):
+                e = envs.get(k, {})
+                sub.add_row(k, str(e.get("ref", "?")), e.get("base_image", "?"), _humanize_expiry(e.get("expires_at")))
+            console.print(sub)
+
+
+@snapshot.command("info")
+@click.argument("group_id")
+def info_snapshot(group_id: str):
+    """Show one group's metadata (dataset, backend, slice, members, sharing)."""
+    from rllm.sandbox.snapshot import SnapshotRegistry
+
+    registry = SnapshotRegistry.load()
+    group = registry.groups().get(group_id)
+    if group is None:
+        console.print(f"  [error]No group '{group_id}'.[/] [dim]See[/] [bold]rllm snapshot list[/]")
+        raise SystemExit(1)
+
+    envs = registry.env_entries()
+    members = registry.group_members(group_id)
+    live = sum(1 for k in members if _is_live(envs.get(k, {}).get("expires_at")))
+    shared = sorted({g for k in members for g in registry.groups_referencing(k) if g != group_id})
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column(style="label", width=12)
+    table.add_column()
+    table.add_row("Dataset", group.get("dataset", "?"))
+    table.add_row("Backend", f"[key]{group.get('backend', '?')}[/]")
+    table.add_row("Slice", _slice_display(group.get("slice", {})))
+    table.add_row("Created", str(group.get("created_at", "?")))
+    table.add_row("TTL", f"{group.get('ttl_hours', '?')}h")
+    table.add_row("Members", f"{len(members)} env(s), [success]{live} live[/] / {len(members) - live} expired")
+    table.add_row("Shared with", ", ".join(shared) if shared else "[dim]none[/]")
+    console.print(Panel(table, title=f"[val]{group_id}[/]", border_style="cyan", expand=False))
+
+
+@snapshot.command("inspect")
+@click.argument("group_or_env_key")
+def inspect_snapshot(group_or_env_key: str):
+    """Drill into a group's exact tasks, or a single env_key's groups.
+
+    For a group: the precise tasks it was created from (task id + env_key +
+    base image + live status). For a bare env_key: its row plus which groups
+    reference it.
+    """
+    from rllm.sandbox.snapshot import SnapshotRegistry
+
+    registry = SnapshotRegistry.load()
+    envs = registry.env_entries()
+    group = registry.groups().get(group_or_env_key)
+
+    if group is not None:
+        console.print(f"\n  [val]{group_or_env_key}[/]  [dim]{group.get('dataset', '?')} · {group.get('backend', '?')} · {_slice_display(group.get('slice', {}))}[/]\n")
         table = Table(box=None, padding=(0, 2))
-        for col in ("env_key", "backend", "ref", "base image", "datasets", "expires"):
-            table.add_column(col, style="key" if col == "env_key" else "dim")
-        for key, e in entries.items():
-            table.add_row(key, e.get("backend", "?"), str(e.get("ref", "?")), e.get("base_image", "?"), ", ".join(e.get("datasets", [])), _humanize_expiry(e.get("expires_at")))
+        table.add_column("task", style="val")
+        table.add_column("env_key", style="key")
+        table.add_column("base image", style="dim")
+        table.add_column("status", style="dim")
+        for t in group.get("tasks", []):
+            e = envs.get(t["env_key"], {})
+            status = "[success]live[/]" if _is_live(e.get("expires_at")) else "[error]expired/gone[/]"
+            table.add_row(str(t.get("id")), t["env_key"], e.get("base_image", "?"), status)
         console.print(table)
+        console.print()
         return
 
-    rows = [c for c in registry.collections() if sandbox_backend is None or c["backend"] == sandbox_backend]
-    if not rows:
-        console.print("  [dim]No snapshots. Build some with[/] [bold]rllm snapshot create <dataset> --sandbox-backend <b>[/]")
+    if group_or_env_key in envs:
+        e = envs[group_or_env_key]
+        in_groups = sorted(registry.groups_referencing(group_or_env_key))
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column(style="label", width=12)
+        table.add_column()
+        table.add_row("env_key", f"[key]{group_or_env_key}[/]")
+        table.add_row("Backend", e.get("backend", "?"))
+        table.add_row("Ref", str(e.get("ref", "?")))
+        table.add_row("Base image", e.get("base_image", "?"))
+        table.add_row("Expires", _humanize_expiry(e.get("expires_at")))
+        table.add_row("In groups", ", ".join(in_groups) if in_groups else "[dim]none[/]")
+        console.print(Panel(table, title=f"[val]{group_or_env_key}[/]", border_style="cyan", expand=False))
         return
-    table = Table(box=None, padding=(0, 2))
-    table.add_column("dataset", style="val")
-    table.add_column("backend", style="key")
-    table.add_column("envs", style="dim", justify="right")
-    table.add_column("expires", style="dim")
-    for c in rows:
-        table.add_row(c["dataset"], c["backend"], str(c["envs"]), _humanize_expiry(c["expires_at"]))
-    console.print(table)
+
+    console.print(f"  [error]No group or env_key '{group_or_env_key}'.[/] [dim]See[/] [bold]rllm snapshot list[/]")
+    raise SystemExit(1)
 
 
 @snapshot.command("destroy")
-@click.argument("benchmark")
+@click.argument("group_id")
+def destroy_snapshot(group_id: str):
+    """Delete a group; backend snapshots survive while another group still uses them."""
+    from rllm.sandbox.snapshot import SnapshotRegistry
+
+    result = SnapshotRegistry.load().destroy_group(group_id)
+    if not result["found"]:
+        console.print(f"  [error]No group '{group_id}'.[/] [dim]See[/] [bold]rllm snapshot list[/]")
+        raise SystemExit(1)
+
+    console.print(f"  [success]Removed group[/] {group_id}")
+    if result["deleted"]:
+        console.print(f"  Deleted {len(result['deleted'])} backend snapshot(s) no longer referenced.")
+    if result["shared"]:
+        console.print(f"  [dim]Kept {len(result['shared'])} snapshot(s) still used by other groups.[/]")
+    if result["kept"]:
+        console.print(f"  [error]Kept {len(result['kept'])} snapshot(s) locally[/] [dim]— backend delete couldn't be confirmed; retry later.[/]")
+
+
+@snapshot.command("renew")
+@click.argument("group_id")
+@click.option("--ttl-hours", default=168.0, type=float, help="New trust horizon in hours (default: 168 = 7 days).")
+def renew_snapshot(group_id: str, ttl_hours: float):
+    """Refresh a group's members' TTL without rebuilding."""
+    from rllm.sandbox.snapshot import SnapshotRegistry
+
+    registry = SnapshotRegistry.load()
+    if group_id not in registry.groups():
+        console.print(f"  [error]No group '{group_id}'.[/] [dim]See[/] [bold]rllm snapshot list[/]")
+        raise SystemExit(1)
+    renewed = registry.renew(group_id, ttl_hours)
+    console.print(f"  [success]Renewed[/] {renewed} env(s) of {group_id} to +{ttl_hours}h.")
+
+
+@snapshot.command("sync")
 @click.option(
     "--sandbox-backend",
     "sandbox_backend",
-    default=None,
+    required=True,
     type=click.Choice(["modal", "daytona"], case_sensitive=False),
-    help="Restrict to one backend (default: all backends for this dataset).",
+    help="Backend to reconcile local records against.",
 )
-def destroy_snapshots(benchmark: str, sandbox_backend: str | None):
-    """Delete a dataset's snapshots from their backend and the registry."""
+def sync_snapshots(sandbox_backend: str):
+    """Reconcile local records against the backend — drop only verified-absent envs."""
     from rllm.sandbox.snapshot import SnapshotRegistry
 
-    detached, deleted = SnapshotRegistry.load().destroy(benchmark, sandbox_backend)
-    if detached == 0:
-        scope = f" on {sandbox_backend}" if sandbox_backend else ""
-        console.print(f"  [dim]No snapshots recorded for '{benchmark}'{scope}.[/]")
-        return
-    console.print(f"  [success]Removed[/] {deleted} backend snapshot(s); detached '{benchmark}' from {detached} environment(s).")
+    result = SnapshotRegistry.load().sync(sandbox_backend)
+    pruned = result["pruned"]
+    if pruned:
+        console.print(f"  [success]Pruned[/] {len(pruned)} absent env(s) on {sandbox_backend}: [dim]{', '.join(pruned)}[/]")
+    console.print(f"  [dim]Kept {result['kept']} env(s) (present or unconfirmed).[/]")

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -188,22 +188,45 @@ def _needs_sandbox(task: Task, verifier_kind: str) -> bool:
     return False
 
 
-def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox:
+def _resolve_backend(task: Task, sandbox_backend: str | None) -> str:
+    """Resolve the effective sandbox backend for a task."""
+    return sandbox_backend or task.metadata.get("sandbox_backend") or "docker"
+
+
+def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, name: str | None = None) -> Sandbox:
+    """Create a sandbox from a base ``image`` — no Dockerfile RUN replay.
+
+    ``image`` defaults to the task's resolved base image; pass a snapshot
+    ref to boot from a pre-warmed environment instead.
+    """
     from rllm.sandbox.sandboxed_flow import create_sandbox
 
-    backend = sandbox_backend or task.metadata.get("sandbox_backend") or "docker"
-    image = _resolve_image(task, backend)
+    image = image if image is not None else _resolve_image(task, backend)
+    if name is None:
+        safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
+        name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
+    return create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend))
 
-    safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
-    name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
-    sandbox = create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend))
 
-    # Non-docker backends pull the Dockerfile's FROM base instead of building
-    # it, so replay its RUN steps (e.g. swebench's `uv`, needed by the grader).
-    # Best-effort: a failed step shouldn't abort the task.
-    if backend != "docker":
-        for cmd in _dockerfile_run_commands(task):
-            _safe_exec(sandbox, cmd, timeout=900)
+def _replay_dockerfile(task: Task, sandbox: Sandbox, backend: str) -> None:
+    """Replay the Dockerfile RUN steps on a live sandbox (stage C).
+
+    Non-docker backends pull the Dockerfile's FROM base instead of building
+    it, so the RUN steps (e.g. swebench's ``uv``, needed by the grader) must
+    be replayed. Best-effort: a failed step shouldn't abort the task. Docker
+    builds the image, so its RUN steps already ran — skip.
+    """
+    if backend == "docker":
+        return
+    for cmd in _dockerfile_run_commands(task):
+        _safe_exec(sandbox, cmd, timeout=900)
+
+
+def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox:
+    """Cold-path sandbox creation: base image + RUN replay (today's behavior)."""
+    backend = _resolve_backend(task, sandbox_backend)
+    sandbox = _create_base_sandbox(task, backend)
+    _replay_dockerfile(task, sandbox, backend)
     return sandbox
 
 

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -34,6 +34,7 @@ async def run_dataset(
     *,
     concurrency: int = 64,
     sandbox_backend: str | None = None,
+    use_snapshot: bool = True,
     agent_name: str = "",
     dataset_name: str = "unknown",
     on_episode_complete=None,
@@ -82,7 +83,7 @@ async def run_dataset(
         gateway = EvalGatewayManager(upstream_url=base_url, model=model, tunnel=gateway_tunnel)
         gateway.start()
 
-    hooks = SandboxTaskHooks(evaluator_override=evaluator_override, sandbox_backend=sandbox_backend)
+    hooks = SandboxTaskHooks(evaluator_override=evaluator_override, sandbox_backend=sandbox_backend, use_snapshot=use_snapshot)
 
     engine = AgentFlowEngine(
         agent_flow=agent_flow,

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -49,6 +49,14 @@ class SandboxTaskHooks:
         # Read-only registry, loaded once and shared across this run's tasks
         # (None disables snapshots, e.g. eval --no-snapshot).
         self._registry = SnapshotRegistry.load() if use_snapshot else None
+        if self._registry is not None and sandbox_backend:
+            # Best-effort run-start reconcile: drop only verified-absent local
+            # records so a stale ref doesn't cost an optimistic boot. A sync
+            # failure must never crash the run.
+            try:
+                self._registry.sync(sandbox_backend)
+            except Exception:
+                logger.debug("snapshot sync at run start failed — continuing", exc_info=True)
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:
         from rllm.engine.agentflow_engine import TaskContext

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -31,21 +31,29 @@ class SandboxTaskHooks:
         sandbox_backend: Override for the sandbox backend
             (``"docker"``, ``"local"``, ``"modal"``, ...). Falls back to
             per-task ``metadata['sandbox_backend']`` then ``"docker"``.
+        use_snapshot: When True (default), boot each task from a pre-built
+            environment snapshot if the local registry has one (transparent
+            cold-start acceleration); otherwise always take the cold path.
     """
 
     def __init__(
         self,
         evaluator_override: Evaluator | None = None,
         sandbox_backend: str | None = None,
+        use_snapshot: bool = True,
     ) -> None:
+        from rllm.sandbox.snapshot import SnapshotRegistry
+
         self.evaluator_override = evaluator_override
         self.sandbox_backend = sandbox_backend
+        # Read-only registry, loaded once and shared across this run's tasks
+        # (None disables snapshots, e.g. eval --no-snapshot).
+        self._registry = SnapshotRegistry.load() if use_snapshot else None
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:
         from rllm.engine.agentflow_engine import TaskContext
         from rllm.eval._resolution import (
             _adapt_legacy_evaluator,
-            _create_sandbox_for_task,
             _detect_verifier,
             _needs_sandbox,
             _resolve_evaluator,
@@ -67,7 +75,9 @@ class SandboxTaskHooks:
 
         sandbox = None
         if needs_sandbox:
-            sandbox = _create_sandbox_for_task(task, self.sandbox_backend)
+            from rllm.sandbox.snapshot import get_sandbox
+
+            sandbox = get_sandbox(task, self.sandbox_backend, self._registry)
             _setup_task_environment(task, sandbox)
             if isinstance(task_flow, SandboxedAgentFlow):
                 task_flow.set_sandbox(sandbox)
@@ -79,16 +89,17 @@ class SandboxTaskHooks:
             evaluator = _resolve_evaluator(task, sandbox, verifier_kind, verifier_config)
 
         def teardown() -> None:
-            # The hook created the sandbox, so it owns the lifecycle.
-            # Going through ``task_flow.teardown_sandbox()`` would no-op
-            # because ``set_sandbox()`` marks it externally-managed, leaking
-            # cloud sandboxes (Daytona/Modal/e2b) that bill by duration.
+            # Sandboxes are ephemeral — the hook owns this one's lifecycle and
+            # closes it directly (the #616 fix). Going through
+            # ``task_flow.teardown_sandbox()`` would no-op because
+            # ``set_sandbox()`` marks it externally-managed, leaking cloud
+            # sandboxes (Daytona/Modal/e2b) that bill by duration.
             if sandbox is None:
                 return
             try:
                 sandbox.close()
             except Exception:
-                logger.exception("sandbox close failed")
+                logger.exception("sandbox.close failed")
             if isinstance(task_flow, SandboxedAgentFlow):
                 task_flow._sandbox = None  # noqa: SLF001
 

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -24,6 +24,8 @@ import time
 import weakref
 from pathlib import Path
 
+from rllm.sandbox.protocol import SnapshotNotFound
+
 logger = logging.getLogger(__name__)
 
 # Default auto-stop interval (minutes). 0 disables auto-stop entirely;
@@ -97,6 +99,8 @@ class DaytonaSandbox:
                 CreateSandboxFromImageParams,
                 CreateSandboxFromSnapshotParams,
                 Daytona,
+                DaytonaNotFoundError,
+                DaytonaValidationError,
                 Image,
                 Resources,
             )
@@ -147,14 +151,23 @@ class DaytonaSandbox:
             self._sandbox = self._client.create(params, timeout=self._create_timeout)
             image_label = image
         else:
-            # Treat as Daytona snapshot name
+            # Treat as Daytona snapshot name. Resources are baked into the
+            # snapshot at build time, so any re-passed here are ignored (debug,
+            # not a warning — booting from a snapshot is the expected path).
             if resources is not None:
-                logger.warning(
-                    "Resources are ignored when creating from a snapshot (%s); snapshot resources win.",
-                    image,
-                )
+                logger.debug("Resources ignored when creating from snapshot %s; snapshot resources win.", image)
             params = CreateSandboxFromSnapshotParams(snapshot=image, **base_kwargs)
-            self._sandbox = self._client.create(params, timeout=self._create_timeout)
+            try:
+                self._sandbox = self._client.create(params, timeout=self._create_timeout)
+            except (DaytonaNotFoundError, DaytonaValidationError) as e:
+                # A gone/removing snapshot surfaces as 404 (NotFound) or 400
+                # (Validation, e.g. "Snapshot <name> is removing") — both mean
+                # cold fallback. Validation errors that don't name this snapshot
+                # (bad resources, etc.) are real and must propagate.
+                msg = str(e).lower()
+                if isinstance(e, DaytonaNotFoundError) or image.lower() in msg or any(w in msg for w in ("not found", "does not exist", "removing", "removed")):
+                    raise SnapshotNotFound(f"daytona snapshot {image} unavailable: {e}") from e
+                raise
             image_label = f"snapshot:{image}"
 
         self._sandbox_id = getattr(self._sandbox, "id", None) or getattr(self._sandbox, "sandbox_id", None)
@@ -346,3 +359,45 @@ def _shell_quote(s: str) -> str:
 def create_daytona_sandbox(name: str, image: str = "python:3.11-slim", **kwargs) -> DaytonaSandbox:
     """Factory function for creating a DaytonaSandbox."""
     return DaytonaSandbox(name=name, image=image, **kwargs)
+
+
+def build_daytona_snapshot(task, key: str) -> str | None:
+    """Declaratively bake ``task``'s base image + RUN steps into a named snapshot; return the name."""
+    from daytona import CreateSnapshotParams, Daytona, DaytonaNotFoundError, Image, Resources
+
+    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
+
+    client = Daytona()
+    try:
+        client.snapshot.get(key)
+        logger.info("daytona snapshot %s already registered", key)
+        return key
+    except DaytonaNotFoundError:
+        pass
+
+    img = Image.base(_resolve_image(task, "daytona"))
+    run_commands = _dockerfile_run_commands(task)
+    if run_commands:
+        img = img.run_commands(*run_commands)
+
+    res_kw = _sandbox_resource_kwargs(task, "daytona")
+    resources = Resources(**res_kw) if res_kw else None
+    client.snapshot.create(
+        CreateSnapshotParams(name=key, image=img, resources=resources),
+        on_logs=lambda chunk: logger.debug("daytona build[%s]: %s", key, chunk.rstrip()),
+    )
+    logger.info("daytona snapshot built: %s", key)
+    return key
+
+
+def delete_daytona_snapshot(ref: str) -> bool:
+    """Delete a Daytona snapshot by name."""
+    try:
+        from daytona import Daytona
+
+        client = Daytona()
+        client.snapshot.delete(client.snapshot.get(ref))
+        return True
+    except Exception:
+        logger.warning("failed to delete daytona snapshot %s", ref, exc_info=True)
+        return False

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -361,17 +361,24 @@ def create_daytona_sandbox(name: str, image: str = "python:3.11-slim", **kwargs)
     return DaytonaSandbox(name=name, image=image, **kwargs)
 
 
-def build_daytona_snapshot(task, key: str) -> str | None:
-    """Declaratively bake ``task``'s base image + RUN steps into a named snapshot; return the name."""
+def build_daytona_snapshot(task, key: str, *, force: bool = False) -> str | None:
+    """Declaratively bake ``task``'s base image + RUN steps into a named snapshot; return the name.
+
+    Idempotent: an already-registered snapshot is reused unless ``force``, which
+    deletes the existing snapshot first so the rebuild replaces it.
+    """
     from daytona import CreateSnapshotParams, Daytona, DaytonaNotFoundError, Image, Resources
 
     from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
 
     client = Daytona()
     try:
-        client.snapshot.get(key)
-        logger.info("daytona snapshot %s already registered", key)
-        return key
+        existing = client.snapshot.get(key)
+        if not force:
+            logger.info("daytona snapshot %s already registered", key)
+            return key
+        client.snapshot.delete(existing)  # force: replace the existing snapshot
+        logger.info("daytona snapshot %s deleted for forced rebuild", key)
     except DaytonaNotFoundError:
         pass
 
@@ -390,14 +397,49 @@ def build_daytona_snapshot(task, key: str) -> str | None:
     return key
 
 
-def delete_daytona_snapshot(ref: str) -> bool:
-    """Delete a Daytona snapshot by name."""
-    try:
-        from daytona import Daytona
+def _daytona_ref_absent(ref: str) -> bool:
+    """True only when the snapshot is verifiably gone (NotFound / terminal state); ``False`` (keep) on any unconfirmed error."""
+    from daytona import (
+        Daytona,
+        DaytonaAuthenticationError,
+        DaytonaAuthorizationError,
+        DaytonaNotFoundError,
+        DaytonaRateLimitError,
+    )
 
+    try:
+        snapshot = Daytona().snapshot.get(ref)
+        state = getattr(snapshot, "state", None)
+        name = str(getattr(state, "value", state) or "").lower()  # state is a SnapshotState enum
+        return name in {"error", "build_failed", "removing", "removed"}
+    except DaytonaNotFoundError:
+        return True  # confirmed gone
+    except (DaytonaAuthenticationError, DaytonaAuthorizationError, DaytonaRateLimitError):
+        return False  # cannot confirm — keep
+    except Exception:
+        logger.debug("daytona ref probe failed for %s — treating as unknown", ref, exc_info=True)
+        return False
+
+
+def delete_daytona_snapshot(ref: str) -> bool:
+    """Delete a Daytona snapshot by name; ``True`` only when confirmed gone, ``False`` (keep the local record) otherwise."""
+    from daytona import (
+        Daytona,
+        DaytonaAuthenticationError,
+        DaytonaAuthorizationError,
+        DaytonaNotFoundError,
+        DaytonaRateLimitError,
+    )
+
+    try:
         client = Daytona()
         client.snapshot.delete(client.snapshot.get(ref))
         return True
+    except DaytonaNotFoundError:
+        return True  # already gone — safe to drop
+    except (DaytonaAuthenticationError, DaytonaAuthorizationError, DaytonaRateLimitError):
+        logger.warning("no permission to delete daytona snapshot %s — keeping local record", ref)
+        return False
     except Exception:
-        logger.warning("failed to delete daytona snapshot %s", ref, exc_info=True)
+        logger.warning("failed to delete daytona snapshot %s — keeping local record", ref, exc_info=True)
         return False

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -22,6 +22,8 @@ import threading
 import time
 import weakref
 
+from rllm.sandbox.protocol import SnapshotNotFound
+
 logger = logging.getLogger(__name__)
 
 # Default sandbox timeout: 30 minutes (Modal default is 5 min).
@@ -80,29 +82,33 @@ class ModalSandbox:
         self._timeout = kwargs.pop("timeout", _DEFAULT_TIMEOUT)
         self._app_name = kwargs.pop("app_name", "rllm-sandbox")
 
-        # Resolve image
-        if isinstance(image, str):
-            modal_image = modal.Image.from_registry(image)
-        else:
-            # Assume it's already a modal.Image
-            modal_image = image
-
-        # Resolve app
+        # A stored snapshot ref is a bare Modal image id ("im-…", no registry/tag);
+        # the ":" / "/" guard keeps real docker images off the from_id path.
+        from_snapshot = isinstance(image, str) and image.startswith("im-") and ":" not in image and "/" not in image
         self._app = modal.App.lookup(self._app_name, create_if_missing=True)
 
-        # Build create kwargs
-        create_kwargs: dict = {
-            "app": self._app,
-            "image": modal_image,
-            "timeout": self._timeout,
-        }
+        # A missing snapshot surfaces as NotFoundError either at from_id (if it
+        # ever resolves eagerly) or at create; translate both so get_sandbox can
+        # fall back to cold. A registry-image NotFoundError is a genuine bad
+        # image — let it raise.
+        try:
+            if from_snapshot:
+                modal_image = modal.Image.from_id(image)
+            elif isinstance(image, str):
+                modal_image = modal.Image.from_registry(image)
+            else:
+                modal_image = image  # already a modal.Image
 
-        # Optional params
-        for key in ("secrets", "volumes", "workdir", "gpu", "cpu", "memory"):
-            if key in kwargs:
-                create_kwargs[key] = kwargs.pop(key)
+            create_kwargs: dict = {"app": self._app, "image": modal_image, "timeout": self._timeout}
+            for key in ("secrets", "volumes", "workdir", "gpu", "cpu", "memory"):
+                if key in kwargs:
+                    create_kwargs[key] = kwargs.pop(key)
 
-        self._sandbox = modal.Sandbox.create(**create_kwargs)
+            self._sandbox = modal.Sandbox.create(**create_kwargs)
+        except modal.exception.NotFoundError as e:
+            if from_snapshot:
+                raise SnapshotNotFound(f"modal snapshot {image} no longer exists") from e
+            raise
         self._sandbox_id = self._sandbox.object_id
 
         with _LIVE_LOCK:
@@ -259,3 +265,36 @@ class ModalSandbox:
 def create_modal_sandbox(name: str, image: str = "python:3.11-slim", **kwargs) -> ModalSandbox:
     """Factory function for creating a ModalSandbox."""
     return ModalSandbox(name=name, image=image, **kwargs)
+
+
+def build_modal_snapshot(task, key: str) -> str | None:
+    """Build a Modal filesystem snapshot of ``task``'s environment; return its image id.
+
+    Create a base sandbox, replay the Dockerfile RUN steps, then capture the
+    live filesystem as a ``modal.Image`` (stored as a diff from the base).
+    """
+    from rllm.eval._resolution import _create_base_sandbox, _replay_dockerfile
+
+    sb = _create_base_sandbox(task, "modal", name=f"{key}-build")
+    try:
+        _replay_dockerfile(task, sb, "modal")
+        image = sb._sandbox.snapshot_filesystem()  # noqa: SLF001 — modal.Image
+        logger.info("modal snapshot built: %s -> %s", key, image.object_id)
+        return image.object_id
+    finally:
+        try:
+            sb.close()
+        except Exception:
+            logger.debug("build sandbox close failed", exc_info=True)
+
+
+def delete_modal_snapshot(ref: str) -> bool:
+    """Delete a Modal filesystem snapshot by image id."""
+    try:
+        from modal.experimental import image_delete
+
+        image_delete(ref)
+        return True
+    except Exception:
+        logger.warning("failed to delete modal snapshot %s", ref, exc_info=True)
+        return False

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -267,13 +267,61 @@ def create_modal_sandbox(name: str, image: str = "python:3.11-slim", **kwargs) -
     return ModalSandbox(name=name, image=image, **kwargs)
 
 
-def build_modal_snapshot(task, key: str) -> str | None:
+def _modal_ref_alive(ref: str) -> bool:
+    """True only when the image is confirmed present, for build reuse (one no-boot ``ImageFromId`` RPC).
+
+    ``hydrate()`` resolves the id without creating a sandbox. Unsure (auth/unknown)
+    returns ``False`` so the caller rebuilds rather than reuse a ref it cannot confirm.
+    """
+    import modal
+    from modal.exception import NotFoundError
+
+    try:
+        modal.Image.from_id(ref).hydrate()
+        return True
+    except NotFoundError:
+        return False
+    except Exception:
+        logger.debug("modal ref probe failed for %s — treating as unknown", ref, exc_info=True)
+        return False
+
+
+def _modal_ref_absent(ref: str) -> bool:
+    """True only when the image is confirmed gone, for sync prune.
+
+    Not the inverse of :func:`_modal_ref_alive`: both default to ``False`` when unsure,
+    for opposite-safe reasons — here unsure (auth/unknown) means keep the local record
+    rather than prune one we cannot confirm is absent.
+    """
+    import modal
+    from modal.exception import NotFoundError
+
+    try:
+        modal.Image.from_id(ref).hydrate()
+        return False  # present
+    except NotFoundError:
+        return True  # confirmed gone
+    except Exception:
+        logger.debug("modal ref probe failed for %s — treating as unknown (keep)", ref, exc_info=True)
+        return False
+
+
+def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force: bool = False) -> str | None:
     """Build a Modal filesystem snapshot of ``task``'s environment; return its image id.
+
+    Mirrors Daytona's idempotency: when a ``prior_ref`` is known and still live
+    (probed via :func:`_modal_ref_alive`), reuse it instead of capturing a fresh
+    filesystem — every fresh capture orphans the old image forever. ``force``
+    bypasses reuse and always rebuilds.
 
     Create a base sandbox, replay the Dockerfile RUN steps, then capture the
     live filesystem as a ``modal.Image`` (stored as a diff from the base).
     """
     from rllm.eval._resolution import _create_base_sandbox, _replay_dockerfile
+
+    if prior_ref and not force and _modal_ref_alive(prior_ref):
+        logger.info("modal snapshot %s already live (%s) — reusing", key, prior_ref)
+        return prior_ref
 
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build")
     try:
@@ -289,12 +337,18 @@ def build_modal_snapshot(task, key: str) -> str | None:
 
 
 def delete_modal_snapshot(ref: str) -> bool:
-    """Delete a Modal filesystem snapshot by image id."""
-    try:
-        from modal.experimental import image_delete
+    """Delete a Modal snapshot by image id; ``True`` only when confirmed gone, ``False`` (keep) otherwise."""
+    from modal.exception import AuthError, NotFoundError, PermissionDeniedError
+    from modal.experimental import image_delete
 
+    try:
         image_delete(ref)
         return True
+    except NotFoundError:
+        return True  # already gone — safe to drop
+    except (AuthError, PermissionDeniedError):
+        logger.warning("no permission to delete modal snapshot %s — keeping local record", ref)
+        return False
     except Exception:
-        logger.warning("failed to delete modal snapshot %s", ref, exc_info=True)
+        logger.warning("failed to delete modal snapshot %s — keeping local record", ref, exc_info=True)
         return False

--- a/rllm/sandbox/protocol.py
+++ b/rllm/sandbox/protocol.py
@@ -7,6 +7,13 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
 
+class SnapshotNotFound(Exception):
+    """Raised by ``create_sandbox(image=ref)`` when a snapshot ref no longer
+    resolves on its backend, signalling :func:`rllm.sandbox.snapshot.get_sandbox`
+    to fall back to the cold path. Transient/auth errors propagate instead.
+    """
+
+
 @dataclass
 class SandboxConfig:
     """Configuration for sandboxed agent execution."""

--- a/rllm/sandbox/sandboxed_flow.py
+++ b/rllm/sandbox/sandboxed_flow.py
@@ -142,3 +142,33 @@ def create_sandbox(backend: str, name: str, image: str, **kwargs) -> Sandbox:
         return DaytonaSandbox(name=name, image=image, **kwargs)
     else:
         raise ValueError(f"Unknown sandbox backend: {backend}. Available: docker, local, modal, daytona")
+
+
+def build_snapshot(backend: str, task: Task, key: str) -> str | None:
+    """Build a snapshot of ``task``'s environment; return a backend ref, or ``None``.
+
+    Each backend owns its mechanism (Modal: live-FS capture; Daytona:
+    declarative bake). Backends without snapshots (docker/local) return ``None``.
+    """
+    if backend == "modal":
+        from rllm.sandbox.backends.modal_backend import build_modal_snapshot
+
+        return build_modal_snapshot(task, key)
+    elif backend == "daytona":
+        from rllm.sandbox.backends.daytona import build_daytona_snapshot
+
+        return build_daytona_snapshot(task, key)
+    return None
+
+
+def delete_snapshot(backend: str, ref: str) -> bool:
+    """Delete a snapshot from its backend. Returns ``True`` on success."""
+    if backend == "modal":
+        from rllm.sandbox.backends.modal_backend import delete_modal_snapshot
+
+        return delete_modal_snapshot(ref)
+    elif backend == "daytona":
+        from rllm.sandbox.backends.daytona import delete_daytona_snapshot
+
+        return delete_daytona_snapshot(ref)
+    return False

--- a/rllm/sandbox/sandboxed_flow.py
+++ b/rllm/sandbox/sandboxed_flow.py
@@ -144,20 +144,21 @@ def create_sandbox(backend: str, name: str, image: str, **kwargs) -> Sandbox:
         raise ValueError(f"Unknown sandbox backend: {backend}. Available: docker, local, modal, daytona")
 
 
-def build_snapshot(backend: str, task: Task, key: str) -> str | None:
+def build_snapshot(backend: str, task: Task, key: str, prior_ref: str | None = None, *, force: bool = False) -> str | None:
     """Build a snapshot of ``task``'s environment; return a backend ref, or ``None``.
 
     Each backend owns its mechanism (Modal: live-FS capture; Daytona:
     declarative bake). Backends without snapshots (docker/local) return ``None``.
+    A known-live ``prior_ref`` is reused unless ``force``, which always rebuilds.
     """
     if backend == "modal":
         from rllm.sandbox.backends.modal_backend import build_modal_snapshot
 
-        return build_modal_snapshot(task, key)
+        return build_modal_snapshot(task, key, prior_ref, force=force)
     elif backend == "daytona":
         from rllm.sandbox.backends.daytona import build_daytona_snapshot
 
-        return build_daytona_snapshot(task, key)
+        return build_daytona_snapshot(task, key, force=force)
     return None
 
 
@@ -171,4 +172,21 @@ def delete_snapshot(backend: str, ref: str) -> bool:
         from rllm.sandbox.backends.daytona import delete_daytona_snapshot
 
         return delete_daytona_snapshot(ref)
+    return False
+
+
+def snapshot_absent(backend: str, ref: str) -> bool:
+    """No-boot probe for ``registry.sync``: ``True`` only when ``ref`` is verifiably gone.
+
+    Conservative by construction — auth/permission/rate-limit/unknown errors return
+    ``False`` so sync never prunes a record it cannot confirm is absent.
+    """
+    if backend == "modal":
+        from rllm.sandbox.backends.modal_backend import _modal_ref_absent
+
+        return _modal_ref_absent(ref)
+    elif backend == "daytona":
+        from rllm.sandbox.backends.daytona import _daytona_ref_absent
+
+        return _daytona_ref_absent(ref)
     return False

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -1,0 +1,224 @@
+"""Environment snapshots for cold-start acceleration.
+
+A snapshot bakes a task's base image + Dockerfile ``RUN`` steps into a backend
+artifact keyed by :func:`env_key`. :func:`get_sandbox` boots from one when present
+(fast) or creates a cold sandbox otherwise; snapshots are built/destroyed only by
+``rllm snapshot``, never by a run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rllm.sandbox.protocol import Sandbox
+    from rllm.types import Task
+
+logger = logging.getLogger(__name__)
+
+# Backends with no snapshot mechanism — get_sandbox always takes the cold path.
+_NO_SNAPSHOT_BACKENDS = {"docker", "local"}
+
+# Default local trust horizon for a snapshot entry (7 days).
+_DEFAULT_TTL_HOURS = 168.0
+
+
+def _registry_path() -> str:
+    rllm_home = os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))
+    return os.path.join(rllm_home, "snapshots.json")
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _expired(iso: str | None) -> bool:
+    """True if the ISO timestamp is in the past. Coerces a naive value to UTC."""
+    if not iso:
+        return False
+    dt = datetime.fromisoformat(iso)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return _now() >= dt
+
+
+def env_key(backend: str, base_image: str, run_commands: list[str]) -> str:
+    """Content-hash fingerprint of an environment: ``rllm-env-<hash12>``.
+
+    Hashes only ``(backend, base_image, RUN block)`` — never ``task.id`` — so
+    GRPO group copies share one key and any image/RUN change yields a new key
+    (a clean miss, never a stale hit). Lowercase + dashes: a legal Daytona
+    snapshot name, Modal/Docker-safe.
+    """
+    payload = "\n".join([backend, base_image, *run_commands])
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+    return f"rllm-env-{digest}"
+
+
+def env_key_for(task: Task, backend: str) -> str:
+    """Fingerprint a task's environment via the shared image/RUN resolution."""
+    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image
+
+    return env_key(backend, _resolve_image(task, backend), _dockerfile_run_commands(task))
+
+
+def keys_for_tasks(tasks: list[Task], backend: str | None) -> dict[str, Task]:
+    """Map distinct env_keys to a representative task (used by ``rllm snapshot create``)."""
+    from rllm.eval._resolution import _resolve_backend
+
+    out: dict[str, Task] = {}
+    for task in tasks:
+        eff = _resolve_backend(task, backend)
+        if eff in _NO_SNAPSHOT_BACKENDS:
+            continue
+        out.setdefault(env_key_for(task, eff), task)
+    return out
+
+
+def get_sandbox(task: Task, backend: str | None, registry: SnapshotRegistry | None = None) -> Sandbox:
+    """Return a ready sandbox for ``task`` — from a snapshot when available, else cold.
+
+    Snapshots are used iff ``registry`` is given. Two cheap gates before the cold
+    path: a local registry lookup (no network; an absent or expired entry goes
+    straight to cold), then an optimistic boot from the stored ref. If that ref
+    vanished backend-side the boot raises :class:`SnapshotNotFound` and we fall back
+    to cold. Read-only w.r.t. snapshots — building is ``rllm snapshot``'s job.
+    """
+    from rllm.eval._resolution import _create_base_sandbox, _create_sandbox_for_task, _resolve_backend
+    from rllm.sandbox.protocol import SnapshotNotFound
+
+    backend = _resolve_backend(task, backend)
+    if registry is not None and backend not in _NO_SNAPSHOT_BACKENDS:
+        key = env_key_for(task, backend)
+        ref = registry.lookup_env(key, backend)
+        if ref is not None:
+            try:
+                return _create_base_sandbox(task, backend, image=ref)  # snapshot has RUN baked — no replay
+            except SnapshotNotFound:
+                logger.info("snapshot %s gone on %s — cold fallback", ref, backend)
+                registry.discard(key)  # so sibling tasks this run skip the doomed boot
+    return _create_sandbox_for_task(task, backend)
+
+
+class SnapshotRegistry:
+    """Local index of built snapshots at ``~/.rllm/snapshots.json``.
+
+    One flat ``env_key -> {backend, ref, base_image, expires_at, datasets}``
+    table; ``datasets`` back-references the collections that requested each env
+    so the CLI can list/destroy by dataset. The backend is the source of truth —
+    :meth:`lookup_env` is pure-local (a miss or expired entry means cold, no
+    network call).
+    """
+
+    def __init__(self, path: str | None = None, envs: dict | None = None) -> None:
+        self.path = path or _registry_path()
+        self._envs: dict[str, dict] = envs if envs is not None else {}
+        self._lock = threading.Lock()
+
+    @classmethod
+    def load(cls) -> SnapshotRegistry:
+        path = _registry_path()
+        return cls(path, envs=cls._read(path).get("envs", {}))
+
+    # -- hot path (read-only, no live calls) ------------------------------
+
+    def lookup_env(self, key: str, backend: str) -> str | None:
+        """Return a locally-trusted snapshot ref, or ``None`` (→ cold path)."""
+        entry = self._envs.get(key)
+        if entry is None or entry.get("backend") != backend:
+            return None
+        if _expired(entry.get("expires_at")):
+            return None
+        return entry.get("ref")
+
+    def discard(self, key: str) -> None:
+        """Drop an env from the in-memory view (after a self-healed cold fallback)."""
+        with self._lock:
+            self._envs.pop(key, None)
+
+    # -- mutation (CLI only) ----------------------------------------------
+
+    def record_env(self, key: str, backend: str, ref: str, base_image: str, dataset: str | None, *, ttl_hours: float = _DEFAULT_TTL_HOURS) -> None:
+        """Add or refresh an env entry and attach ``dataset`` to its back-reference."""
+        with self._lock:
+            self._envs = self._read(self.path).get("envs", {})  # re-read to merge with on-disk writes since load
+            datasets = set(self._envs.get(key, {}).get("datasets", []))
+            if dataset:
+                datasets.add(dataset)
+            self._envs[key] = {
+                "backend": backend,
+                "ref": ref,
+                "base_image": base_image,
+                "expires_at": (_now() + timedelta(hours=ttl_hours)).isoformat(),
+                "datasets": sorted(datasets),
+            }
+            self._save()
+
+    def destroy(self, dataset: str, backend: str | None = None) -> tuple[int, int]:
+        """Detach ``dataset`` from its envs, deleting backend refs that become orphaned.
+
+        Returns ``(envs_detached, backend_refs_deleted)``.
+        """
+        from rllm.sandbox.sandboxed_flow import delete_snapshot
+
+        detached = deleted = 0
+        with self._lock:
+            self._envs = self._read(self.path).get("envs", {})
+            for key in list(self._envs):
+                entry = self._envs[key]
+                if backend and entry.get("backend") != backend:
+                    continue
+                datasets = [d for d in entry.get("datasets", []) if d != dataset]
+                if len(datasets) == len(entry.get("datasets", [])):
+                    continue
+                detached += 1
+                if datasets:
+                    entry["datasets"] = datasets
+                else:
+                    if delete_snapshot(entry["backend"], entry["ref"]):
+                        deleted += 1
+                    del self._envs[key]
+            self._save()
+        return detached, deleted
+
+    def collections(self) -> list[dict]:
+        """Group envs by ``(dataset, backend)`` for the ``list`` view."""
+        groups: dict[tuple[str, str], list[dict]] = {}
+        for entry in self._envs.values():
+            for dataset in entry.get("datasets", []) or ["(detached)"]:
+                groups.setdefault((dataset, entry["backend"]), []).append(entry)
+        out = []
+        for (dataset, backend), entries in sorted(groups.items()):
+            expiries = [e["expires_at"] for e in entries if e.get("expires_at")]
+            out.append({"dataset": dataset, "backend": backend, "envs": len(entries), "expires_at": min(expiries) if expiries else None})
+        return out
+
+    def env_entries(self) -> dict[str, dict]:
+        """The raw ``env_key -> metadata`` table (``list --verbose``)."""
+        return dict(self._envs)
+
+    # -- persistence ------------------------------------------------------
+
+    @staticmethod
+    def _read(path: str) -> dict:
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    def _save(self) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        tmp = f"{self.path}.tmp"
+        with open(tmp, "w") as f:
+            json.dump({"version": 1, "envs": self._envs}, f, indent=2)
+        os.replace(tmp, self.path)
+
+
+__all__ = ["env_key", "env_key_for", "keys_for_tasks", "get_sandbox", "SnapshotRegistry"]

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import threading
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
@@ -81,6 +82,26 @@ def keys_for_tasks(tasks: list[Task], backend: str | None) -> dict[str, Task]:
     return out
 
 
+def _slug(dataset: str) -> str:
+    """Lowercase a dataset name with non-alphanumeric runs collapsed to dashes."""
+    return re.sub(r"[^a-z0-9]+", "-", dataset.lower()).strip("-") or "dataset"
+
+
+def _slice_id_token(slice_spec: dict, task_count: int) -> str:
+    """The id fragment that disambiguates a group: ``first{N}`` / ``idx{count}`` / ``all``."""
+    kind = slice_spec.get("kind")
+    if kind == "max_examples":
+        return f"first{slice_spec.get('value')}"
+    if kind == "task_indices":
+        return f"idx{task_count}"  # number of indices; the raw expression lives in slice["value"]
+    return "all"
+
+
+def _make_group_id(dataset: str, slice_spec: dict, task_count: int) -> str:
+    """``slug(dataset)-<slice token>-rand8``. The rand8 is per-invocation, never a content hash."""
+    return f"{_slug(dataset)}-{_slice_id_token(slice_spec, task_count)}-{os.urandom(4).hex()}"
+
+
 def get_sandbox(task: Task, backend: str | None, registry: SnapshotRegistry | None = None) -> Sandbox:
     """Return a ready sandbox for ``task`` — from a snapshot when available, else cold.
 
@@ -107,24 +128,30 @@ def get_sandbox(task: Task, backend: str | None, registry: SnapshotRegistry | No
 
 
 class SnapshotRegistry:
-    """Local index of built snapshots at ``~/.rllm/snapshots.json``.
+    """Local index of built snapshots at ``~/.rllm/snapshots.json`` (envelope v2).
 
-    One flat ``env_key -> {backend, ref, base_image, expires_at, datasets}``
-    table; ``datasets`` back-references the collections that requested each env
-    so the CLI can list/destroy by dataset. The backend is the source of truth —
-    :meth:`lookup_env` is pure-local (a miss or expired entry means cold, no
-    network call).
+    Two tables. ``envs[env_key] -> {backend, ref, base_image, created_at, expires_at}``
+    is the content layer: one content-addressed, TTL-mortal built artifact per key
+    (the backend is the source of truth — :meth:`lookup_env` is pure-local, a miss
+    or expired entry means cold with no network call). ``groups[group_id] ->
+    {dataset, backend, slice, tasks, created_at, ttl_hours}`` is a thin named pointer
+    manifest of one ``create`` invocation; ``tasks`` is the single source of
+    membership and a group's env_keys are the unique set over ``tasks[].env_key``.
+    Liveness and refcounts are always *derived* by scanning groups over envs, never
+    stored.
     """
 
-    def __init__(self, path: str | None = None, envs: dict | None = None) -> None:
+    def __init__(self, path: str | None = None, envs: dict | None = None, groups: dict | None = None) -> None:
         self.path = path or _registry_path()
         self._envs: dict[str, dict] = envs if envs is not None else {}
+        self._groups: dict[str, dict] = groups if groups is not None else {}
         self._lock = threading.Lock()
 
     @classmethod
     def load(cls) -> SnapshotRegistry:
         path = _registry_path()
-        return cls(path, envs=cls._read(path).get("envs", {}))
+        data = cls._read(path)
+        return cls(path, envs=data.get("envs", {}), groups=data.get("groups", {}))
 
     # -- hot path (read-only, no live calls) ------------------------------
 
@@ -138,87 +165,222 @@ class SnapshotRegistry:
         return entry.get("ref")
 
     def discard(self, key: str) -> None:
-        """Drop an env from the in-memory view (after a self-healed cold fallback)."""
+        """Drop a dead env and persist the prune so the next process skips the doomed boot."""
         with self._lock:
-            self._envs.pop(key, None)
+            self._reload_locked()  # merge with on-disk writes before pruning
+            if self._envs.pop(key, None) is not None:
+                self._save()
 
-    # -- mutation (CLI only) ----------------------------------------------
-
-    def record_env(self, key: str, backend: str, ref: str, base_image: str, dataset: str | None, *, ttl_hours: float = _DEFAULT_TTL_HOURS) -> None:
-        """Add or refresh an env entry and attach ``dataset`` to its back-reference."""
-        with self._lock:
-            self._envs = self._read(self.path).get("envs", {})  # re-read to merge with on-disk writes since load
-            datasets = set(self._envs.get(key, {}).get("datasets", []))
-            if dataset:
-                datasets.add(dataset)
-            self._envs[key] = {
-                "backend": backend,
-                "ref": ref,
-                "base_image": base_image,
-                "expires_at": (_now() + timedelta(hours=ttl_hours)).isoformat(),
-                "datasets": sorted(datasets),
-            }
-            self._save()
-
-    def destroy(self, dataset: str, backend: str | None = None) -> tuple[int, int]:
-        """Detach ``dataset`` from its envs, deleting backend refs that become orphaned.
-
-        Returns ``(envs_detached, backend_refs_deleted)``.
-        """
-        from rllm.sandbox.sandboxed_flow import delete_snapshot
-
-        detached = deleted = 0
-        with self._lock:
-            self._envs = self._read(self.path).get("envs", {})
-            for key in list(self._envs):
-                entry = self._envs[key]
-                if backend and entry.get("backend") != backend:
-                    continue
-                datasets = [d for d in entry.get("datasets", []) if d != dataset]
-                if len(datasets) == len(entry.get("datasets", [])):
-                    continue
-                detached += 1
-                if datasets:
-                    entry["datasets"] = datasets
-                else:
-                    if delete_snapshot(entry["backend"], entry["ref"]):
-                        deleted += 1
-                    del self._envs[key]
-            self._save()
-        return detached, deleted
-
-    def collections(self) -> list[dict]:
-        """Group envs by ``(dataset, backend)`` for the ``list`` view."""
-        groups: dict[tuple[str, str], list[dict]] = {}
-        for entry in self._envs.values():
-            for dataset in entry.get("datasets", []) or ["(detached)"]:
-                groups.setdefault((dataset, entry["backend"]), []).append(entry)
-        out = []
-        for (dataset, backend), entries in sorted(groups.items()):
-            expiries = [e["expires_at"] for e in entries if e.get("expires_at")]
-            out.append({"dataset": dataset, "backend": backend, "envs": len(entries), "expires_at": min(expiries) if expiries else None})
-        return out
+    # -- read helpers (pure-local, no live calls) -------------------------
 
     def env_entries(self) -> dict[str, dict]:
         """The raw ``env_key -> metadata`` table (``list --verbose``)."""
         return dict(self._envs)
 
+    def groups(self) -> dict[str, dict]:
+        """The raw ``group_id -> manifest`` table."""
+        return dict(self._groups)
+
+    def group_members(self, group_id: str) -> list[str]:
+        """The distinct env_keys a group points at (derived from its ``tasks``)."""
+        group = self._groups.get(group_id)
+        if group is None:
+            return []
+        return list(dict.fromkeys(t["env_key"] for t in group.get("tasks", [])))
+
+    def groups_referencing(self, env_key: str) -> list[str]:
+        """Group ids whose membership includes ``env_key`` (a plain scan)."""
+        return [gid for gid in self._groups if env_key in self.group_members(gid)]
+
+    def refcount(self, env_key: str, exclude_group: str | None = None) -> int:
+        """How many groups (optionally excluding one) still point at ``env_key``."""
+        return sum(gid != exclude_group for gid in self.groups_referencing(env_key))
+
+    # -- mutation (CLI only) ----------------------------------------------
+
+    def record_group(self, dataset: str, backend: str, slice_spec: dict, tasks: list[dict], *, ttl_hours: float = _DEFAULT_TTL_HOURS, force: bool = False) -> str:
+        """Record each env once (force-aware) and write a group manifest; return its new id.
+
+        ``tasks`` is a list of ``{id, env_key, ref, base_image}`` for the exact tasks
+        this creation covered; the stored group keeps only ``{id, env_key}`` (the
+        env layer holds ref/base_image). A fresh random ``group_id`` is minted per
+        invocation, so re-running ``create`` honestly records a new creation.
+        """
+        with self._lock:
+            self._reload_locked()
+            for t in tasks:
+                self._envs[t["env_key"]] = self._env_entry(t["env_key"], backend, t["ref"], t["base_image"], ttl_hours, force)
+            group_id = _make_group_id(dataset, slice_spec, len(tasks))
+            self._groups[group_id] = {
+                "dataset": dataset,
+                "backend": backend,
+                "slice": slice_spec,
+                "tasks": [{"id": t["id"], "env_key": t["env_key"]} for t in tasks],
+                "created_at": _now().isoformat(),
+                "ttl_hours": ttl_hours,
+            }
+            self._save()
+            return group_id
+
+    def renew(self, group_id: str, ttl_hours: float = _DEFAULT_TTL_HOURS) -> int:
+        """Refresh the expiry of a group's members without rebuilding. Returns members renewed."""
+        with self._lock:
+            self._reload_locked()
+            members = self.group_members(group_id)
+            renewed = 0
+            new_expiry = (_now() + timedelta(hours=ttl_hours)).isoformat()
+            for key in members:
+                entry = self._envs.get(key)
+                if entry is None:
+                    continue
+                entry["expires_at"] = new_expiry  # explicit refresh — the only non-force path that moves TTL
+                renewed += 1
+            self._save()
+            return renewed
+
+    def destroy_group(self, group_id: str) -> dict:
+        """Remove a group, deleting backend refs that no other group still references.
+
+        For each of the group's env_keys: if a *derived* refcount (other groups
+        still listing it) is 0, call the backend delete and drop the local env
+        only when it returned ``True`` (verified gone). Returns a summary dict.
+        """
+        from rllm.sandbox.sandboxed_flow import delete_snapshot
+
+        with self._lock:
+            self._reload_locked()
+            group = self._groups.pop(group_id, None)
+            if group is None:
+                return {"found": False, "shared": [], "deleted": [], "kept": []}
+            members = list(dict.fromkeys(t["env_key"] for t in group.get("tasks", [])))
+            backend = group.get("backend")
+            shared, deleted, kept = [], [], []
+            for key in members:
+                entry = self._envs.get(key)
+                if entry is None:
+                    continue
+                if self.refcount(key, exclude_group=group_id) > 0:
+                    shared.append(key)  # another group still needs it — leave it be
+                elif delete_snapshot(entry.get("backend", backend), entry["ref"]):
+                    deleted.append(key)
+                    del self._envs[key]  # drop only on confirmed backend deletion
+                else:
+                    kept.append(key)  # delete unconfirmed — keep so a later run can retry
+            self._save()
+            return {"found": True, "shared": shared, "deleted": deleted, "kept": kept}
+
+    def sync(self, backend: str) -> dict:
+        """Reconcile this backend's local envs against reality — drop only verified-absent ones.
+
+        Per-backend, no-boot probe (Daytona ``snapshot.get``, Modal ``from_id.hydrate``):
+        a local env is pruned ONLY on verified backend absence (typed NotFound /
+        terminal state), NEVER on auth/permission/rate-limit/timeout. Persisted.
+        Returns ``{pruned: [...], kept: <int>}``.
+        """
+        from rllm.sandbox.sandboxed_flow import snapshot_absent
+
+        with self._lock:
+            self._reload_locked()
+            keys = [k for k, e in self._envs.items() if e.get("backend") == backend]
+            pruned = []
+            for key in keys:
+                ref = self._envs[key].get("ref")
+                if ref and snapshot_absent(backend, ref):
+                    del self._envs[key]
+                    pruned.append(key)
+            self._save()
+        return {"pruned": pruned, "kept": len(keys) - len(pruned)}
+
+    # -- internals --------------------------------------------------------
+
+    def _reload_locked(self) -> None:
+        """Re-read both tables from disk (call under ``self._lock``)."""
+        data = self._read(self.path)
+        self._envs = data.get("envs", {})
+        self._groups = data.get("groups", {})
+
+    def _env_entry(self, key: str, backend: str, ref: str, base_image: str, ttl_hours: float, force: bool) -> dict:
+        """Build an env entry; a non-force reuse keeps the prior expiry so re-creates never renew TTL."""
+        prior = self._envs.get(key, {})
+        prior_expiry = prior.get("expires_at")
+        if force or prior_expiry is None:
+            expires_at = (_now() + timedelta(hours=ttl_hours)).isoformat()
+        else:
+            expires_at = prior_expiry  # reuse: only --force or `renew` moves a horizon forward
+        return {
+            "backend": backend,
+            "ref": ref,
+            "base_image": base_image,
+            "created_at": prior.get("created_at") or _now().isoformat(),
+            "expires_at": expires_at,
+        }
+
     # -- persistence ------------------------------------------------------
 
-    @staticmethod
-    def _read(path: str) -> dict:
+    @classmethod
+    def _read(cls, path: str) -> dict:
+        """Read the registry envelope, migrating v1 in place. Empty on missing/corrupt."""
         try:
             with open(path) as f:
-                return json.load(f)
+                data = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError):
-            return {}
+            return {"version": 2, "envs": {}, "groups": {}}
+        if data.get("version") == 2:
+            data.setdefault("envs", {})
+            data.setdefault("groups", {})
+            return data
+        v2 = cls._migrate_v1_to_v2(data)
+        cls._write(path, v2)
+        return v2
+
+    @staticmethod
+    def _migrate_v1_to_v2(v1: dict) -> dict:
+        """Split the v1 flat ``envs[key].datasets[]`` into v2 ``envs`` + ``groups``.
+
+        Each v1 env becomes an ``envs`` entry (created_at backfilled to now). For
+        each distinct dataset name across the old ``datasets[]`` lists, synthesize
+        one ``slug(dataset)-all-rand8`` group whose tasks carry ``id="(migrated)"``
+        — v1 never stored real task ids, so exact provenance is unrecoverable.
+        """
+        now = _now().isoformat()
+        v1_envs = v1.get("envs", {})
+        envs: dict[str, dict] = {}
+        by_dataset: dict[tuple[str, str], list[str]] = {}
+        for key, entry in v1_envs.items():
+            backend = entry.get("backend")
+            envs[key] = {
+                "backend": backend,
+                "ref": entry.get("ref"),
+                "base_image": entry.get("base_image"),
+                "created_at": entry.get("created_at") or now,
+                "expires_at": entry.get("expires_at"),
+            }
+            for dataset in entry.get("datasets", []):
+                by_dataset.setdefault((dataset, backend), []).append(key)
+        groups: dict[str, dict] = {}
+        for (dataset, backend), keys in by_dataset.items():
+            slice_spec = {"kind": "all", "value": None}
+            groups[_make_group_id(dataset, slice_spec, len(keys))] = {
+                "dataset": dataset,
+                "backend": backend,
+                "slice": slice_spec,
+                "tasks": [{"id": "(migrated)", "env_key": k} for k in keys],
+                "created_at": "(migrated)",
+                "ttl_hours": _DEFAULT_TTL_HOURS,
+            }
+        logger.info("Migrated snapshot registry from v1 to v2 (%d envs, %d groups).", len(envs), len(groups))
+        return {"version": 2, "envs": envs, "groups": groups}
+
+    @staticmethod
+    def _write(path: str, data: dict) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = f"{path}.tmp"
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)
 
     def _save(self) -> None:
-        os.makedirs(os.path.dirname(self.path), exist_ok=True)
-        tmp = f"{self.path}.tmp"
-        with open(tmp, "w") as f:
-            json.dump({"version": 1, "envs": self._envs}, f, indent=2)
-        os.replace(tmp, self.path)
+        self._write(self.path, {"version": 2, "envs": self._envs, "groups": self._groups})
 
 
 __all__ = ["env_key", "env_key_for", "keys_for_tasks", "get_sandbox", "SnapshotRegistry"]

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -1,0 +1,191 @@
+"""Offline tests for the snapshot system (env_key, get_sandbox, SnapshotRegistry).
+
+No cloud backend is touched: sandbox creation is monkeypatched so the *logic* —
+env_key/GRPO invariance, the two-gate get_sandbox (local lookup → optimistic
+boot → cold self-heal), the no-live-call-on-miss rule, and the flat registry's
+persistence / dataset collections / refcount destroy — is exercised
+deterministically.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from rllm.sandbox.protocol import SnapshotNotFound
+from rllm.sandbox.snapshot import SnapshotRegistry, env_key, env_key_for, get_sandbox, keys_for_tasks
+from rllm.types import Task
+
+
+def _task(id="task-1", image="swebench/sweb.eval.x86_64.foo:latest", backend="modal"):
+    return Task(
+        id=id,
+        instruction="do the thing",
+        metadata={"environment": {"docker_image": image}, "sandbox_backend": backend},
+        dataset_dir=Path("/nonexistent"),
+        sub_dir=None,
+    )
+
+
+def _future() -> str:
+    return (datetime.now(tz=timezone.utc) + timedelta(hours=1)).isoformat()
+
+
+def _past() -> str:
+    return (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat()
+
+
+class _FakeSandbox:
+    def close(self):
+        pass
+
+
+# --------------------------------------------------------------------------
+# env_key — identity / GRPO invariance / sensitivity
+# --------------------------------------------------------------------------
+
+
+def test_env_key_sensitive_and_legal_name():
+    base = env_key("modal", "img:tag", ["run a"])
+    assert env_key("daytona", "img:tag", ["run a"]) != base  # backend
+    assert env_key("modal", "img:other", ["run a"]) != base  # base image
+    assert env_key("modal", "img:tag", ["run b"]) != base  # RUN block
+    # Legal Daytona snapshot name: lowercase + dashes only.
+    assert base.startswith("rllm-env-") and base.replace("-", "").isalnum() and base.islower()
+
+
+def test_env_key_independent_of_task_id():
+    """GRPO guarantee: group copies differing only by id share one snapshot."""
+    a = _task(id="uuid-aaaa")
+    b = _task(id="uuid-bbbb")
+    assert env_key_for(a, "modal") == env_key_for(b, "modal")
+
+
+def test_keys_for_tasks_dedups_envs_and_skips_local_backends():
+    same_a, same_b = _task(id="1", image="img:a"), _task(id="2", image="img:a")
+    other = _task(id="3", image="img:b")
+    assert len(keys_for_tasks([same_a, same_b, other], "modal")) == 2  # a/b collapse
+    assert keys_for_tasks([_task(backend="docker")], "docker") == {}  # no snapshots for docker
+
+
+# --------------------------------------------------------------------------
+# get_sandbox — two gates + self-heal + no-live-call-on-miss
+# --------------------------------------------------------------------------
+
+
+def test_get_sandbox_local_hit_boots_from_snapshot(monkeypatch, tmp_path):
+    import rllm.eval._resolution as res
+
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))
+    reg._envs[env_key_for(_task(), "modal")] = {"backend": "modal", "ref": "im-abc", "expires_at": _future()}
+
+    booted = {}
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda task, backend, *, image=None, name=None: booted.update(image=image) or _FakeSandbox())
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: pytest.fail("cold path taken on a local hit"))
+
+    sb = get_sandbox(_task(), "modal", reg)
+    assert isinstance(sb, _FakeSandbox)
+    assert booted["image"] == "im-abc"  # booted from the ref, no replay
+
+
+def test_get_sandbox_snapshot_gone_self_heals_to_cold(monkeypatch, tmp_path):
+    import rllm.eval._resolution as res
+
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))
+    key = env_key_for(_task(), "modal")
+    reg._envs[key] = {"backend": "modal", "ref": "im-gone", "expires_at": _future()}
+
+    def _gone(task, backend, *, image=None, name=None):
+        raise SnapshotNotFound("gone")
+
+    cold = {}
+    monkeypatch.setattr(res, "_create_base_sandbox", _gone)
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: cold.update(cold=True) or _FakeSandbox())
+
+    assert isinstance(get_sandbox(_task(), "modal", reg), _FakeSandbox)
+    assert cold["cold"]
+    assert reg.lookup_env(key, "modal") is None  # dead entry pruned so siblings skip the doomed boot
+
+
+def test_get_sandbox_local_miss_is_cold_with_no_live_call(monkeypatch, tmp_path):
+    import rllm.eval._resolution as res
+
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))  # empty → miss
+    cold = {}
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda *a, **k: pytest.fail("snapshot boot attempted on a local miss"))
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: cold.update(cold=True) or _FakeSandbox())
+
+    assert isinstance(get_sandbox(_task(), "modal", reg), _FakeSandbox)
+    assert cold["cold"]
+
+
+def test_get_sandbox_no_snapshot_backend_never_consults_registry(monkeypatch, tmp_path):
+    import rllm.eval._resolution as res
+
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda *a, **k: pytest.fail("docker has no snapshot path"))
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: _FakeSandbox())
+    assert isinstance(get_sandbox(_task(backend="docker"), "docker", reg), _FakeSandbox)
+
+
+def test_get_sandbox_no_registry_forces_cold(monkeypatch):
+    import rllm.eval._resolution as res
+
+    # registry=None (what --no-snapshot passes) must never touch the snapshot path.
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda *a, **k: pytest.fail("no registry must not boot from snapshot"))
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: _FakeSandbox())
+    assert isinstance(get_sandbox(_task(), "modal", None), _FakeSandbox)
+
+
+# --------------------------------------------------------------------------
+# SnapshotRegistry — lookup expiry, persistence, collections, refcount destroy
+# --------------------------------------------------------------------------
+
+
+def test_lookup_env_absent_expired_mismatch_live(tmp_path):
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))
+    assert reg.lookup_env("missing", "modal") is None  # absent
+    reg._envs["k"] = {"backend": "modal", "ref": "im-1", "expires_at": _past()}
+    assert reg.lookup_env("k", "modal") is None  # expired → no live call
+    assert reg.lookup_env("k", "daytona") is None  # backend mismatch
+    reg._envs["k"]["expires_at"] = _future()
+    assert reg.lookup_env("k", "modal") == "im-1"  # live
+
+
+def test_record_persists_and_groups_by_dataset(monkeypatch, tmp_path):
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    reg.record_env("rllm-env-a", "modal", "im-1", "python:3.11", "swebench")
+    reg.record_env("rllm-env-b", "modal", "im-2", "python:3.11", "swebench")
+    reg.record_env("rllm-env-a", "modal", "im-1", "python:3.11", "gsm8k")  # env shared by 2 datasets
+
+    assert Path(tmp_path / "snapshots.json").exists()
+    cols = {(c["dataset"], c["backend"]): c for c in SnapshotRegistry.load().collections()}
+    assert cols[("swebench", "modal")]["envs"] == 2
+    assert cols[("gsm8k", "modal")]["envs"] == 1
+    # round-trip: a fresh load can boot from a recorded ref.
+    assert SnapshotRegistry.load().lookup_env("rllm-env-a", "modal") == "im-1"
+
+
+def test_destroy_refcounts_shared_envs(monkeypatch, tmp_path):
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    reg.record_env("rllm-env-a", "modal", "im-1", "img", "swebench")
+    reg.record_env("rllm-env-b", "modal", "im-2", "img", "swebench")
+    reg.record_env("rllm-env-a", "modal", "im-1", "img", "gsm8k")
+
+    import rllm.sandbox.sandboxed_flow as sf
+
+    deleted: list[str] = []
+    monkeypatch.setattr(sf, "delete_snapshot", lambda backend, ref: deleted.append(ref) or True)
+
+    # gsm8k goes away but env-a is still referenced by swebench → not deleted.
+    detached, n = SnapshotRegistry.load().destroy("gsm8k")
+    assert (detached, n) == (1, 0) and deleted == []
+
+    # swebench goes away → env-b orphaned, env-a now orphaned → both deleted.
+    detached, n = SnapshotRegistry.load().destroy("swebench")
+    assert detached == 2 and n == 2 and sorted(deleted) == ["im-1", "im-2"]
+    assert SnapshotRegistry.load().collections() == []

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -1,14 +1,15 @@
-"""Offline tests for the snapshot system (env_key, get_sandbox, SnapshotRegistry).
+"""Offline tests for the snapshot system (env_key, get_sandbox, SnapshotRegistry v2).
 
-No cloud backend is touched: sandbox creation is monkeypatched so the *logic* —
-env_key/GRPO invariance, the two-gate get_sandbox (local lookup → optimistic
-boot → cold self-heal), the no-live-call-on-miss rule, and the flat registry's
-persistence / dataset collections / refcount destroy — is exercised
-deterministically.
+No cloud backend is touched: sandbox creation and the backend probes/deletes are
+monkeypatched so the *logic* — env_key/GRPO invariance, the two-gate get_sandbox
+(local lookup → optimistic boot → cold self-heal), the no-live-call-on-miss rule,
+and the v2 registry's persistence / v1→v2 migration / derived-refcount destroy /
+verified-absence sync — is exercised deterministically.
 """
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -35,6 +36,17 @@ def _future() -> str:
 
 def _past() -> str:
     return (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat()
+
+
+def make_task_env(env_key: str, ref: str, *, base_image="img") -> dict:
+    """Build one per-task env descriptor (the shape record_group consumes per task)."""
+    return {"id": f"task-{env_key}", "env_key": env_key, "ref": ref, "base_image": base_image}
+
+
+def make_group(reg: SnapshotRegistry, dataset: str, task_envs: list[dict], *, backend="modal", slice_spec=None, ttl_hours=168.0, force=False) -> str:
+    """Record a v2 group through the real record_group path; return its group_id."""
+    spec = slice_spec or {"kind": "all", "value": None}
+    return reg.record_group(dataset, backend, spec, task_envs, ttl_hours=ttl_hours, force=force)
 
 
 class _FakeSandbox:
@@ -140,7 +152,7 @@ def test_get_sandbox_no_registry_forces_cold(monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# SnapshotRegistry — lookup expiry, persistence, collections, refcount destroy
+# SnapshotRegistry v2 — lookup expiry, persistence, groups, derived-refcount destroy
 # --------------------------------------------------------------------------
 
 
@@ -154,38 +166,299 @@ def test_lookup_env_absent_expired_mismatch_live(tmp_path):
     assert reg.lookup_env("k", "modal") == "im-1"  # live
 
 
-def test_record_persists_and_groups_by_dataset(monkeypatch, tmp_path):
+def test_record_group_persists_and_derives_membership(monkeypatch, tmp_path):
     monkeypatch.setenv("RLLM_HOME", str(tmp_path))
     reg = SnapshotRegistry.load()
-    reg.record_env("rllm-env-a", "modal", "im-1", "python:3.11", "swebench")
-    reg.record_env("rllm-env-b", "modal", "im-2", "python:3.11", "swebench")
-    reg.record_env("rllm-env-a", "modal", "im-1", "python:3.11", "gsm8k")  # env shared by 2 datasets
+    gid = make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1"), make_task_env("rllm-env-b", "im-2")])
 
     assert Path(tmp_path / "snapshots.json").exists()
-    cols = {(c["dataset"], c["backend"]): c for c in SnapshotRegistry.load().collections()}
-    assert cols[("swebench", "modal")]["envs"] == 2
-    assert cols[("gsm8k", "modal")]["envs"] == 1
+    reloaded = SnapshotRegistry.load()
+    assert sorted(reloaded.group_members(gid)) == ["rllm-env-a", "rllm-env-b"]
     # round-trip: a fresh load can boot from a recorded ref.
-    assert SnapshotRegistry.load().lookup_env("rllm-env-a", "modal") == "im-1"
+    assert reloaded.lookup_env("rllm-env-a", "modal") == "im-1"
+    # the group records the exact tasks it was created from (D3).
+    tasks = reloaded.groups()[gid]["tasks"]
+    assert {t["env_key"] for t in tasks} == {"rllm-env-a", "rllm-env-b"}
 
 
-def test_destroy_refcounts_shared_envs(monkeypatch, tmp_path):
+def test_group_id_shape_and_randomness(monkeypatch, tmp_path):
+    """slug-slicelabel-rand8; re-running create mints a NEW id (rand8 is per-invocation)."""
     monkeypatch.setenv("RLLM_HOME", str(tmp_path))
     reg = SnapshotRegistry.load()
-    reg.record_env("rllm-env-a", "modal", "im-1", "img", "swebench")
-    reg.record_env("rllm-env-b", "modal", "im-2", "img", "swebench")
-    reg.record_env("rllm-env-a", "modal", "im-1", "img", "gsm8k")
+    a = make_group(reg, "harbor:swebench-verified", [make_task_env("rllm-env-a", "im-1")], slice_spec={"kind": "max_examples", "value": 5})
+    b = make_group(reg, "harbor:swebench-verified", [make_task_env("rllm-env-a", "im-1")], slice_spec={"kind": "max_examples", "value": 5})
+    assert a.startswith("harbor-swebench-verified-first5-") and b.startswith("harbor-swebench-verified-first5-")
+    assert a != b  # same request content, different creation → distinct ids
+
+
+def test_refcount_and_destroy_group_shared_survives(monkeypatch, tmp_path):
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    g1 = make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1"), make_task_env("rllm-env-b", "im-2")])
+    g2 = make_group(reg, "gsm8k", [make_task_env("rllm-env-a", "im-1")])  # shares env-a
 
     import rllm.sandbox.sandboxed_flow as sf
 
     deleted: list[str] = []
     monkeypatch.setattr(sf, "delete_snapshot", lambda backend, ref: deleted.append(ref) or True)
 
-    # gsm8k goes away but env-a is still referenced by swebench → not deleted.
-    detached, n = SnapshotRegistry.load().destroy("gsm8k")
-    assert (detached, n) == (1, 0) and deleted == []
+    # destroy g1: env-b is unshared → deleted; env-a still in g2 → survives.
+    res = SnapshotRegistry.load().destroy_group(g1)
+    assert res["found"] and res["deleted"] == ["rllm-env-b"] and res["shared"] == ["rllm-env-a"]
+    assert deleted == ["im-2"]
+    reloaded = SnapshotRegistry.load()
+    assert "rllm-env-a" in reloaded.env_entries() and "rllm-env-b" not in reloaded.env_entries()
+    assert g1 not in reloaded.groups() and g2 in reloaded.groups()
 
-    # swebench goes away → env-b orphaned, env-a now orphaned → both deleted.
-    detached, n = SnapshotRegistry.load().destroy("swebench")
-    assert detached == 2 and n == 2 and sorted(deleted) == ["im-1", "im-2"]
-    assert SnapshotRegistry.load().collections() == []
+    # now destroy g2: env-a is unshared → deleted.
+    res = SnapshotRegistry.load().destroy_group(g2)
+    assert res["deleted"] == ["rllm-env-a"] and sorted(deleted) == ["im-1", "im-2"]
+    assert SnapshotRegistry.load().env_entries() == {}
+
+
+def test_destroy_group_keeps_env_when_delete_unconfirmed(monkeypatch, tmp_path):
+    """An unconfirmed backend delete (auth-scoped key) must KEEP the local env for retry."""
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    g = make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")])
+
+    import rllm.sandbox.sandboxed_flow as sf
+
+    monkeypatch.setattr(sf, "delete_snapshot", lambda backend, ref: False)  # keep
+    res = SnapshotRegistry.load().destroy_group(g)
+    assert res["found"] and res["kept"] == ["rllm-env-a"] and res["deleted"] == []
+    reloaded = SnapshotRegistry.load()
+    assert g not in reloaded.groups()  # group removed
+    assert reloaded.env_entries()["rllm-env-a"]["ref"] == "im-1"  # env kept — ref didn't leak silently
+
+
+def test_sync_drops_only_verified_absent(monkeypatch, tmp_path):
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1"), make_task_env("rllm-env-b", "im-2")])
+
+    import rllm.sandbox.sandboxed_flow as sf
+
+    # im-1 verifiably gone, im-2 present.
+    monkeypatch.setattr(sf, "snapshot_absent", lambda backend, ref: ref == "im-1")
+    res = SnapshotRegistry.load().sync("modal")
+    assert res["pruned"] == ["rllm-env-a"] and res["kept"] == 1
+    assert "rllm-env-a" not in SnapshotRegistry.load().env_entries()
+
+
+def test_sync_keeps_all_on_auth_failure(monkeypatch, tmp_path):
+    """A sync that can't confirm absence (auth/permission → snapshot_absent False) prunes nothing."""
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1"), make_task_env("rllm-env-b", "im-2")])
+
+    import rllm.sandbox.sandboxed_flow as sf
+
+    monkeypatch.setattr(sf, "snapshot_absent", lambda backend, ref: False)  # never confirmed gone
+    res = SnapshotRegistry.load().sync("modal")
+    assert res["pruned"] == [] and res["kept"] == 2
+    assert set(SnapshotRegistry.load().env_entries()) == {"rllm-env-a", "rllm-env-b"}
+
+
+def test_discard_persists_across_processes(monkeypatch, tmp_path):
+    """discard must rewrite the file so the next process doesn't reload the dead entry."""
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")])
+
+    reg.discard("rllm-env-a")
+    assert SnapshotRegistry.load().lookup_env("rllm-env-a", "modal") is None  # gone from disk too
+
+
+def test_reuse_does_not_renew_ttl(monkeypatch, tmp_path):
+    """A non-force re-create reuses the env and keeps its horizon — even with a longer ttl (no immortality)."""
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")], ttl_hours=1.0)
+    first = SnapshotRegistry.load().env_entries()["rllm-env-a"]["expires_at"]
+
+    # re-create non-force with the DEFAULT (longer) ttl must NOT push the horizon out.
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")], ttl_hours=168.0)
+    assert SnapshotRegistry.load().env_entries()["rllm-env-a"]["expires_at"] == first
+
+
+def test_force_refreshes_ttl(monkeypatch, tmp_path):
+    """--force is the explicit rebuild path that moves the horizon forward."""
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")], ttl_hours=1.0)
+    short = SnapshotRegistry.load().env_entries()["rllm-env-a"]["expires_at"]
+
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")], ttl_hours=168.0, force=True)
+    assert SnapshotRegistry.load().env_entries()["rllm-env-a"]["expires_at"] > short  # horizon moved forward
+
+
+def test_renew_refreshes_member_ttls_without_rebuild(monkeypatch, tmp_path):
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    reg._envs = {"rllm-env-a": {"backend": "modal", "ref": "im-1", "base_image": "img", "created_at": _past(), "expires_at": _past()}}
+    reg._groups = {
+        "swebench-all-deadbeef": {
+            "dataset": "swebench",
+            "backend": "modal",
+            "slice": {"kind": "all", "value": None},
+            "tasks": [{"id": "t", "env_key": "rllm-env-a"}],
+            "created_at": _past(),
+            "ttl_hours": 168.0,
+        }
+    }
+    reg._save()
+
+    renewed = reg.renew("swebench-all-deadbeef", 168.0)
+    assert renewed == 1
+    assert datetime.fromisoformat(SnapshotRegistry.load().env_entries()["rllm-env-a"]["expires_at"]) > datetime.now(tz=timezone.utc)
+
+
+def test_created_at_set_once_and_preserved(monkeypatch, tmp_path):
+    """created_at is stamped on first build and preserved across reuse and force rebuild."""
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    reg = SnapshotRegistry.load()
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")])
+    created = SnapshotRegistry.load().env_entries()["rllm-env-a"]["created_at"]
+    assert created  # set on first build
+
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-1")])  # reuse
+    make_group(reg, "swebench", [make_task_env("rllm-env-a", "im-2")], force=True)  # force rebuild
+    assert SnapshotRegistry.load().env_entries()["rllm-env-a"]["created_at"] == created
+
+
+def test_migrate_v1_to_v2_splits_envs_and_synthesizes_groups(monkeypatch, tmp_path):
+    """A v1 flat datasets[] registry migrates in place to envs + per-dataset (migrated) groups."""
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path))
+    path = tmp_path / "snapshots.json"
+    v1 = {
+        "version": 1,
+        "envs": {
+            "rllm-env-a": {"backend": "modal", "ref": "im-1", "base_image": "img", "expires_at": _future(), "datasets": ["swebench", "gsm8k"]},
+            "rllm-env-b": {"backend": "modal", "ref": "im-2", "base_image": "img", "expires_at": _future(), "datasets": ["swebench"]},
+        },
+    }
+    path.write_text(json.dumps(v1))
+
+    reg = SnapshotRegistry.load()
+    on_disk = json.loads(path.read_text())
+    assert on_disk["version"] == 2  # migrated in place on load
+    # envs carry no datasets[] anymore; created_at backfilled.
+    assert "datasets" not in reg.env_entries()["rllm-env-a"]
+    assert reg.env_entries()["rllm-env-a"]["created_at"]
+
+    groups = reg.groups()
+    assert len(groups) == 2  # one per distinct dataset name
+    by_dataset = {g["dataset"]: g for g in groups.values()}
+    assert sorted(by_dataset) == ["gsm8k", "swebench"]
+    assert by_dataset["swebench"]["slice"]["kind"] == "all"
+    assert by_dataset["swebench"]["created_at"] == "(migrated)"  # honest: v1 had no real date
+    assert {t["env_key"] for t in by_dataset["swebench"]["tasks"]} == {"rllm-env-a", "rllm-env-b"}
+    assert all(t["id"] == "(migrated)" for g in groups.values() for t in g["tasks"])  # no real task ids in v1
+
+
+# --------------------------------------------------------------------------
+# Modal check-before-build — reuse when the (mocked) probe says alive, rebuild on NotFound
+# --------------------------------------------------------------------------
+
+
+def test_modal_build_reuses_when_prior_ref_alive(monkeypatch):
+    import rllm.sandbox.backends.modal_backend as mb
+
+    monkeypatch.setattr(mb, "_modal_ref_alive", lambda ref: True)
+    # a live prior ref must short-circuit before any sandbox build.
+    import rllm.eval._resolution as res
+
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda *a, **k: pytest.fail("rebuilt despite a live prior ref"))
+    assert mb.build_modal_snapshot(_task(), "rllm-env-a", prior_ref="im-old") == "im-old"
+
+
+def test_modal_build_rebuilds_when_prior_ref_gone(monkeypatch):
+    import rllm.eval._resolution as res
+    import rllm.sandbox.backends.modal_backend as mb
+
+    monkeypatch.setattr(mb, "_modal_ref_alive", lambda ref: False)  # NotFound → rebuild
+
+    class _Img:
+        object_id = "im-new"
+
+    class _SB:
+        _sandbox = type("S", (), {"snapshot_filesystem": staticmethod(lambda: _Img())})()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda *a, **k: _SB())
+    monkeypatch.setattr(res, "_replay_dockerfile", lambda *a, **k: None)
+    assert mb.build_modal_snapshot(_task(), "rllm-env-a", prior_ref="im-old") == "im-new"
+
+
+def test_modal_build_force_rebuilds_even_when_alive(monkeypatch):
+    import rllm.eval._resolution as res
+    import rllm.sandbox.backends.modal_backend as mb
+
+    monkeypatch.setattr(mb, "_modal_ref_alive", lambda ref: pytest.fail("probe should be skipped under force"))
+
+    class _Img:
+        object_id = "im-new"
+
+    class _SB:
+        _sandbox = type("S", (), {"snapshot_filesystem": staticmethod(lambda: _Img())})()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda *a, **k: _SB())
+    monkeypatch.setattr(res, "_replay_dockerfile", lambda *a, **k: None)
+    assert mb.build_modal_snapshot(_task(), "rllm-env-a", prior_ref="im-old", force=True) == "im-new"
+
+
+def test_snapshot_absent_modal_prunes_only_on_notfound(monkeypatch):
+    """Modal sync prunes ONLY on a confirmed NotFound — never on an auth/unknown error (the keep invariant)."""
+    import modal
+    from modal.exception import AuthError, NotFoundError
+
+    from rllm.sandbox.sandboxed_flow import snapshot_absent
+
+    class _Probe:
+        def __init__(self, exc):
+            self._exc = exc
+
+        def hydrate(self):
+            if self._exc:
+                raise self._exc
+
+    monkeypatch.setattr(modal.Image, "from_id", lambda ref: _Probe(NotFoundError("gone")))
+    assert snapshot_absent("modal", "im-x") is True  # confirmed gone → prune
+
+    monkeypatch.setattr(modal.Image, "from_id", lambda ref: _Probe(AuthError("nope")))
+    assert snapshot_absent("modal", "im-x") is False  # auth → cannot confirm → keep
+
+    monkeypatch.setattr(modal.Image, "from_id", lambda ref: _Probe(None))
+    assert snapshot_absent("modal", "im-x") is False  # present → not absent
+
+
+def test_daytona_ref_absent_reads_enum_or_string_state(monkeypatch):
+    """Daytona's snapshot.state is a SnapshotState enum; terminal states prune, others are kept."""
+    import daytona
+
+    from rllm.sandbox.backends.daytona import _daytona_ref_absent
+
+    class _Snap:
+        def __init__(self, state):
+            self.state = state
+
+    def fake_daytona(state):
+        svc = type("Svc", (), {"get": lambda self, ref: _Snap(state)})()
+        return type("FakeDaytona", (), {"snapshot": svc})()
+
+    enum_state = type("State", (), {"value": "removing"})()  # mimic SnapshotState.REMOVING
+    monkeypatch.setattr(daytona, "Daytona", lambda *a, **k: fake_daytona(enum_state))
+    assert _daytona_ref_absent("rllm-env-x") is True  # terminal enum → absent
+
+    active_state = type("State", (), {"value": "active"})()
+    monkeypatch.setattr(daytona, "Daytona", lambda *a, **k: fake_daytona(active_state))
+    assert _daytona_ref_absent("rllm-env-x") is False  # present → keep
+
+    monkeypatch.setattr(daytona, "Daytona", lambda *a, **k: fake_daytona("error"))  # plain string also works
+    assert _daytona_ref_absent("rllm-env-x") is True


### PR DESCRIPTION
## Summary

Sandboxed eval and training pay a **cold start** on every rollout — the backend pulls a (often multi-GB) image and replays the Dockerfile setup before any real work. This PR adds **environment snapshots**: a snapshot bakes a task's base image + `RUN` steps into a reusable backend artifact, so later rollouts boot from a warmed environment in ~a second.

Snapshots are **persistable, user-managed objects** (like datasets, but TTL-mortal), never owned by a run:

- **Eval/training are snapshot-agnostic** — one primitive, `get_sandbox(task, backend, registry)`, boots from a snapshot when one exists (fast) or creates a cold sandbox otherwise. The caller never knows which happened.
- **A run never builds or destroys snapshots** — that is always an explicit `rllm snapshot` action.

## How it works

**Identity.** A snapshot is keyed by an environment fingerprint, never a task instance:

```
env_key = "rllm-env-" + sha256(backend + base_image + RUN_block)[:12]
```

Task-`id`-independent, so GRPO group copies share one snapshot and eval + training reuse the same set; the agent harness is not part of the key (agent install stays on the hot path).

**Two tables, two lifetimes** (`~/.rllm/snapshots.json`, atomic write, migrated in place):

- **`envs`** — the content layer: one content-addressed, TTL-mortal artifact per `env_key` (`{backend, ref, base_image, created_at, expires_at}`).
- **`groups`** — a thin named **manifest** of one `create` invocation: the *exact tasks* it covered and the env_keys they resolved to. Groups are what a human names, lists, inspects, and destroys; two groups freely share an env_key (GRPO copies, overlapping slices). Liveness and refcounts are **derived** by scanning groups — never stored.

**`get_sandbox` — two cheap gates, no wasted round-trips:**

1. **Local lookup** — pure-local, O(1); an absent or expired entry goes straight to cold with **no network call**.
2. **Optimistic boot** from the stored ref; if it vanished backend-side the create raises a typed `SnapshotNotFound` and the run **self-heals to cold** (and persists the prune). A missing snapshot never fails a run.

**Backends own their mechanism** behind `build_snapshot` / `delete_snapshot`:

- **Modal** — live-filesystem capture; ref = image id. Builds are idempotent (check-before-build via a no-boot `from_id().hydrate()` probe), so re-creating an env no longer orphans the previous image.
- **Daytona** — declarative `Image.base(...).run_commands(...)` baked into a named snapshot; ref = the name.
- **docker / local** — no snapshot mechanism; always cold (their local image cache already amortizes setup).

**Correctness invariants.** A local record is dropped **only on verified backend absence** (typed `NotFound` / terminal state), never on auth / permission / rate-limit — so a scoped key can't silently erase a pointer while the remote leaks. A non-`--force` re-create **reuses** envs without renewing their TTL; only `--force` / `renew` move a horizon forward.

## CLI

```bash
# Build snapshots for a dataset slice → prints the group id
rllm snapshot create harbor:swebench-verified --sandbox-backend modal --max-examples 5
rllm snapshot create harbor:swebench-verified --sandbox-backend modal --task-indices 0,5,9 [--force]

rllm snapshot list                       # one row per group (--verbose for per-env rows)
rllm snapshot info    <group_id>         # metadata: dataset, slice, members, sharing
rllm snapshot inspect <group_id>         # the exact tasks in the group (or a bare env_key's groups)
rllm snapshot renew   <group_id> --ttl-hours 168
rllm snapshot destroy <group_id>         # refcounted: a shared env survives until its last group goes
rllm snapshot sync    --sandbox-backend modal   # reconcile local records against the backend

# eval uses snapshots transparently; a per-backend reconcile runs once at start; --no-snapshot forces cold
rllm eval harbor:swebench-verified --sandbox-backend modal
```

## Testing

**Offline** (`tests/sandbox/test_snapshot.py`, 26 tests): `env_key`/GRPO invariance, the two-gate `get_sandbox` (hit → boot, gone → self-heal + prune, miss → cold with no live call), v1→v2 migration, derived-refcount `destroy` (shared survives; kept on an unconfirmed delete), verified-absence `sync` (keeps all on auth failure), no-TTL-renew-on-reuse, and the Modal/Daytona absence probes.

**Live on Daytona** (1 small sandbox, account restored to baseline, 0 leaks): `create` → `list` / `info` / `inspect` (exact tasks) → `sync` → re-create (`reused`, idempotent) → `destroy` ×2 (the shared env survived the first group, deleted on the second).

## Notes

- Local TTL governs *trust* (when to stop using a local entry), not backend reclamation; snapshots persist until `rllm snapshot destroy`.
- The registry is per-machine; the backend account is shared. `sync` reconciles a stale local view against backend truth, scoped to the one backend in use.
