### PR TITLE
refactor: single source of truth for RLLM_HOME paths

### DIFF
--- a/rllm/cli/_pull.py
+++ b/rllm/cli/_pull.py
@@ -7,10 +7,12 @@ import json
 import logging
 import os
 
+from rllm import paths
+
 logger = logging.getLogger(__name__)
 
-# Default root for rllm datasets (overridden by RLLM_HOME env var)
-_DATASETS_ROOT = os.path.join(os.environ.get("RLLM_HOME", os.path.expanduser("~/.rllm")), "datasets")
+# Default root for rllm datasets (under $RLLM_HOME, defaulting to ~/.rllm).
+_DATASETS_ROOT = paths.datasets_dir()
 
 
 def load_dataset_catalog() -> dict:

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -19,6 +19,7 @@ from rich.status import Status
 from rich.table import Table
 from rich.theme import Theme
 
+from rllm import paths
 from rllm.cli._pull import load_dataset_catalog, pull_dataset
 
 logger = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ def _run_eval(
     # so they go through the catalog branch's row-wrapping path instead).
     _materialised_path_override = None
     if not _is_local and not benchmark.startswith(("./", "../", "/", "~", "harbor:")):
-        _materialised = os.path.expanduser(os.path.join(os.environ.get("RLLM_HOME", "~/.rllm"), "datasets", benchmark))
+        _materialised = paths.rllm_path("datasets", benchmark)
         if os.path.isfile(os.path.join(_materialised, "dataset.toml")):
             _can_redirect = bool(agent_name) and not agent_name.startswith("harbor:")
             if _can_redirect and BenchmarkLoader.is_local_benchmark(_materialised):
@@ -319,7 +320,7 @@ def _run_eval(
         # environment/, so wrap their rows directly instead.
         bench_result = None
         if not _is_harbor_agent and not _is_harbor_source:
-            _materialised = os.path.expanduser(os.path.join(os.environ.get("RLLM_HOME", "~/.rllm"), "datasets", benchmark))
+            _materialised = paths.rllm_path("datasets", benchmark)
             if not os.path.isfile(os.path.join(_materialised, "dataset.toml")):
                 try:
                     from rllm.eval.materialize import materialize_benchmark as _materialize_benchmark
@@ -397,10 +398,9 @@ def _run_eval(
     if episodes_dir is not None:
         run_dir = os.path.expanduser(episodes_dir)
     else:
-        rllm_home = os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))
         model_safe = model.replace("/", "_").replace("\\", "_")
         bench_safe = benchmark.replace("/", "_").replace("\\", "_")
-        run_dir = os.path.join(rllm_home, "eval_results", f"{bench_safe}_{model_safe}_{timestamp}")
+        run_dir = paths.rllm_path("eval_results", f"{bench_safe}_{model_safe}_{timestamp}")
     run_store = EvalEpisodeStore(run_dir)
     run_store.write_meta(
         {

--- a/rllm/cli/view.py
+++ b/rllm/cli/view.py
@@ -12,18 +12,18 @@ The dashboard is served by the Python standard library
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import click
 from rich.console import Console
 
+from rllm import paths
+
 console = Console()
 
 
 def _eval_results_root() -> Path:
-    rllm_home = os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))
-    return Path(rllm_home) / "eval_results"
+    return Path(paths.eval_results_dir())
 
 
 def _resolve_target(arg: str | None) -> Path | None:

--- a/rllm/data/dataset.py
+++ b/rllm/data/dataset.py
@@ -4,6 +4,8 @@ import os
 import shutil
 from typing import Any
 
+from rllm import paths
+
 logger = logging.getLogger(__name__)
 
 
@@ -213,9 +215,9 @@ class DatasetRegistry:
     that includes metadata alongside file paths.
     """
 
-    _RLLM_HOME = os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))
-    _REGISTRY_FILE = os.path.join(_RLLM_HOME, "datasets", "registry.json")
-    _DATASET_DIR = os.path.join(_RLLM_HOME, "datasets")
+    _RLLM_HOME = paths.rllm_home()
+    _REGISTRY_FILE = paths.rllm_path("datasets", "registry.json")
+    _DATASET_DIR = paths.datasets_dir()
 
     # Legacy paths for v1 migration
     _LEGACY_REGISTRY_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "registry")

--- a/rllm/eval/agent_loader.py
+++ b/rllm/eval/agent_loader.py
@@ -7,10 +7,10 @@ import json
 import os
 from importlib.metadata import entry_points
 
+from rllm import paths
 from rllm.types import AgentFlow
 
-_RLLM_HOME = os.environ.get("RLLM_HOME", os.path.expanduser("~/.rllm"))
-_USER_AGENTS_FILE = os.path.join(_RLLM_HOME, "agents.json")
+_USER_AGENTS_FILE = paths.rllm_path("agents.json")
 
 
 def _load_user_agents() -> dict[str, dict]:

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -9,6 +9,8 @@ import json
 import os
 from dataclasses import dataclass, field
 
+from rllm import paths
+
 # Tinker's (beta) OpenAI-compatible inference endpoint. Used as a fixed
 # ``api_base`` so the Tinker provider routes through LiteLLM's OpenAI adapter
 # exactly like any other provider. See
@@ -320,12 +322,8 @@ def fetch_tinker_models(api_key: str | None = None) -> list[str]:
             os.environ["TINKER_API_KEY"] = prev
 
 
-def _rllm_home() -> str:
-    return os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))
-
-
 def _config_path() -> str:
-    return os.path.join(_rllm_home(), "config.json")
+    return paths.config_path()
 
 
 @dataclass

--- a/rllm/eval/evaluator_loader.py
+++ b/rllm/eval/evaluator_loader.py
@@ -15,11 +15,11 @@ import os
 from importlib.metadata import entry_points
 from typing import Any
 
+from rllm import paths
 from rllm.eval.types import EvalOutput, Signal
 from rllm.types import Evaluator
 
-_RLLM_HOME = os.environ.get("RLLM_HOME", os.path.expanduser("~/.rllm"))
-_USER_EVALUATORS_FILE = os.path.join(_RLLM_HOME, "evaluators.json")
+_USER_EVALUATORS_FILE = paths.rllm_path("evaluators.json")
 
 
 def _load_user_evaluators() -> dict[str, dict]:

--- a/rllm/eval/materialize.py
+++ b/rllm/eval/materialize.py
@@ -31,9 +31,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any
+
+from rllm import paths
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +62,7 @@ def materialize_benchmark(
         Path to the benchmark directory.
     """
     if benchmark_root is None:
-        benchmark_root = os.path.join(
-            os.environ.get("RLLM_HOME", os.path.expanduser("~/.rllm")),
-            "datasets",
-        )
+        benchmark_root = paths.datasets_dir()
     bench_dir = Path(benchmark_root) / name
     bench_dir.mkdir(parents=True, exist_ok=True)
 

--- a/rllm/eval/results.py
+++ b/rllm/eval/results.py
@@ -7,6 +7,8 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
+from rllm import paths
+
 
 @dataclass
 class EvalItem:
@@ -75,8 +77,7 @@ class EvalResult:
             The path the results were saved to.
         """
         if path is None:
-            rllm_home = os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))
-            results_dir = os.path.join(rllm_home, "eval_results")
+            results_dir = paths.eval_results_dir()
             os.makedirs(results_dir, exist_ok=True)
             # Sanitize names for filename
             model_safe = self.model.replace("/", "_").replace("\\", "_")

--- a/rllm/eval/visualizer.py
+++ b/rllm/eval/visualizer.py
@@ -954,10 +954,9 @@ def _make_handler(root_path: Path, html_factory):
 
 
 def _eval_results_root() -> Path:
-    import os
+    from rllm import paths
 
-    rllm_home = os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))
-    return Path(rllm_home) / "eval_results"
+    return Path(paths.eval_results_dir())
 
 
 def launch(

--- a/rllm/eval/vlm_utils.py
+++ b/rllm/eval/vlm_utils.py
@@ -10,10 +10,12 @@ import base64
 import logging
 import os
 
+from rllm import paths
+
 logger = logging.getLogger(__name__)
 
-# Default root for rllm datasets (overridden by RLLM_HOME env var)
-_DATASETS_ROOT = os.path.join(os.environ.get("RLLM_HOME", os.path.expanduser("~/.rllm")), "datasets")
+# Default root for rllm datasets (under $RLLM_HOME, defaulting to ~/.rllm).
+_DATASETS_ROOT = paths.datasets_dir()
 
 
 def _detect_mime_type(data: bytes) -> str:

--- a/rllm/paths.py
+++ b/rllm/paths.py
@@ -1,0 +1,55 @@
+"""Single source of truth for rLLM's on-disk home directory and the paths under it.
+
+rLLM stores user-level state (config, registered agents/evaluators, materialised
+datasets, eval results, sandbox traces) under a single home directory. That
+directory is ``$RLLM_HOME`` when set, otherwise ``~/.rllm``.
+
+Every helper resolves the environment at call time, so:
+
+* there is exactly one place that knows the default location and how ``~`` /
+  ``$RLLM_HOME`` are expanded, and
+* tests can redirect all storage with a single
+  ``monkeypatch.setenv("RLLM_HOME", tmp_path)`` instead of patching scattered
+  module constants.
+
+Prefer these helpers over re-deriving ``os.environ.get("RLLM_HOME", ...)`` inline.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Location used when ``$RLLM_HOME`` is not set. ``~`` is expanded by rllm_home().
+DEFAULT_RLLM_HOME = "~/.rllm"
+
+
+def rllm_home() -> str:
+    """Return the rLLM home directory: ``$RLLM_HOME`` if set, else ``~/.rllm``.
+
+    The result is always expanded (any leading ``~`` is resolved), so callers
+    can pass it straight to ``open``/``os.makedirs`` without further handling.
+    """
+    return os.path.expanduser(os.environ.get("RLLM_HOME", DEFAULT_RLLM_HOME))
+
+
+def rllm_path(*parts: str) -> str:
+    """Return an absolute path under the rLLM home directory.
+
+    ``rllm_path("datasets", "registry.json")`` -> ``<rllm_home>/datasets/registry.json``.
+    """
+    return os.path.join(rllm_home(), *parts)
+
+
+def datasets_dir() -> str:
+    """Return the datasets root (``<rllm_home>/datasets``)."""
+    return rllm_path("datasets")
+
+
+def eval_results_dir() -> str:
+    """Return the eval-results root (``<rllm_home>/eval_results``)."""
+    return rllm_path("eval_results")
+
+
+def config_path() -> str:
+    """Return the user-level config file path (``<rllm_home>/config.json``)."""
+    return rllm_path("config.json")

--- a/rllm/sandbox/result_store.py
+++ b/rllm/sandbox/result_store.py
@@ -15,6 +15,7 @@ import sqlite3
 import threading
 import time
 
+from rllm import paths
 from rllm.sandbox.protocol import ExecutionResult
 from rllm.sandbox.serialization import deserialize_execution_result
 
@@ -48,7 +49,7 @@ class ExecutionResultStore:
 
     def __init__(self, db_path: str | None = None, pool_size: int = 2):
         if db_path is None:
-            db_dir = os.path.expanduser("~/.rllm")
+            db_dir = paths.rllm_home()
             os.makedirs(db_dir, exist_ok=True)
             db_path = os.path.join(db_dir, "traces.db")
         else:

--- a/tests/eval/test_agent_loader.py
+++ b/tests/eval/test_agent_loader.py
@@ -122,7 +122,6 @@ class TestRegisterAgent:
         """Point the agent registry at a temp directory."""
         agents_file = str(tmp_path / "agents.json")
         monkeypatch.setattr("rllm.eval.agent_loader._USER_AGENTS_FILE", agents_file)
-        monkeypatch.setattr("rllm.eval.agent_loader._RLLM_HOME", str(tmp_path))
 
     def test_register_string_path_and_load(self):
         register_agent("test_agent", "rllm.harnesses.react:ReActHarness")

--- a/tests/eval/test_evaluator_loader.py
+++ b/tests/eval/test_evaluator_loader.py
@@ -191,7 +191,6 @@ class TestRegisterEvaluator:
     def _isolate_registry(self, tmp_path, monkeypatch):
         evals_file = str(tmp_path / "evaluators.json")
         monkeypatch.setattr("rllm.eval.evaluator_loader._USER_EVALUATORS_FILE", evals_file)
-        monkeypatch.setattr("rllm.eval.evaluator_loader._RLLM_HOME", str(tmp_path))
 
     def test_register_string_path_and_load(self):
         register_evaluator("test_eval", "rllm.eval.reward_fns.math:evaluate")


### PR DESCRIPTION
## What

The `$RLLM_HOME` / `~/.rllm` path resolution was copy-pasted across ~10 modules in two subtly different idioms:

```python
os.path.expanduser(os.environ.get("RLLM_HOME", "~/.rllm"))   # expands the result
os.environ.get("RLLM_HOME", os.path.expanduser("~/.rllm"))   # expands only the default
```

This PR centralizes it into one lightweight module, **`rllm/paths.py`** (imports only `os`, no cycles):

| helper | returns |
| --- | --- |
| `rllm_home()` | `$RLLM_HOME` or `~/.rllm`, always expanded |
| `rllm_path(*parts)` | join under the home dir |
| `datasets_dir()` | `<home>/datasets` |
| `eval_results_dir()` | `<home>/eval_results` |
| `config_path()` | `<home>/config.json` |

Every call site now uses these helpers, so there's exactly one place that knows the default location and how the env var is expanded — and no more `import os` purely to compute a home path.

## Why

Pure maintainability: the duplicated snippets were drift-prone (the two idioms differ when `RLLM_HOME` itself contains a `~`), and redirecting storage in tests required patching scattered module constants.

## Touched call sites

`rllm/data/dataset.py`, `rllm/eval/{config,results,materialize,agent_loader,evaluator_loader,vlm_utils,visualizer}.py`, `rllm/cli/{_pull,eval,view}.py`, `rllm/sandbox/result_store.py`.

## Behavior notes

- **No behavior change** for the common paths. Module/class-level constants that tests monkeypatch (`DatasetRegistry._DATASET_DIR`, `vlm_utils._DATASETS_ROOT`, the loader `*_FILE` attrs) are preserved — just derived from the new helpers.
- **Small consistency fix:** `rllm/sandbox/result_store.py` previously hardcoded `~/.rllm` and ignored `$RLLM_HOME`; it now honors it like everything else.
- Drops two redundant `_RLLM_HOME` monkeypatches in the loader tests (they already patch the `*_FILE` attribute the code actually reads).

## Testing

- `ruff check` clean on all touched files; pre-commit hooks pass.
- RLLM_HOME-relevant suites green: `tests/data/test_registry_migration.py`, `tests/data/test_arrow_ipc.py`, `tests/eval/test_eval_config.py`, `tests/eval/test_agent_loader.py`, `tests/eval/test_evaluator_loader.py`, `tests/eval/test_vlm_agents.py` — **124 passed**.
- The 13 unrelated `tests/cli/` failures (stale model-catalog defaults, `--ui-url` drift, dataset-list formatting) fail **identically on `main`** without this change — confirmed by stashing and re-running.
- End-to-end smoke test with `RLLM_HOME` pointed at a temp dir: `rllm dataset register` → writes under the custom home → `rllm dataset list` reads it back, with no leak into the real `~/.rllm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)