### PR TITLE
fix(rollout,gateway): stamp weight_version at dispatch, not completion

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -134,6 +134,7 @@ class ReverseProxy:
 
     async def handle(self, request: Request) -> Response:
         """Proxy *request* to an inference worker, capture trace, return response."""
+        request.state.weight_version = self.weight_version
         await self._ensure_started()
         session_id: str | None = request.state.session_id
         originally_requested_logprobs: bool = getattr(request.state, "originally_requested_logprobs", False)
@@ -227,7 +228,7 @@ class ReverseProxy:
 
         # Persist trace
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=self.weight_version)
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version)
             await self._persist(trace)
 
             # Ingest first turn into accumulator for cumulative token mode
@@ -348,7 +349,7 @@ class ReverseProxy:
         response_body["object"] = "chat.completion"
 
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=self.weight_version)
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version)
             await self._persist(trace)
 
         sanitized = response_body
@@ -484,7 +485,7 @@ class ReverseProxy:
                 # Ingest accumulated token data
                 if chunks:
                     latency_ms = (time.perf_counter() - t0) * 1000
-                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=self.weight_version)
+                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version)
                     prompt_ids = trace.prompt_token_ids or token_ids
                     completion_ids = trace.completion_token_ids
 
@@ -514,7 +515,7 @@ class ReverseProxy:
         originally_requested_logprobs: bool = False,
     ) -> StreamingResponse:
         if self.local_handler is not None:
-            return await self._handle_streaming_local(request_body, session_id, originally_requested_logprobs)
+            return await self._handle_streaming_local(request_body, session_id, originally_requested_logprobs, request.state.weight_version)
 
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
@@ -610,7 +611,7 @@ class ReverseProxy:
                 # finally block may run during GeneratorExit, where await
                 # on real async I/O (e.g. aiosqlite) is not reliable.
                 if session_id and chunks:
-                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=self.weight_version)
+                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version)
                     task = asyncio.create_task(
                         self._safe_store(
                             trace.trace_id,
@@ -642,6 +643,7 @@ class ReverseProxy:
         request_body: dict[str, Any],
         session_id: str | None,
         originally_requested_logprobs: bool = False,
+        weight_version: int | None = None,
     ) -> StreamingResponse:
         """Handle streaming when using a local handler (fake-streaming)."""
         assert self.local_handler is not None
@@ -651,7 +653,7 @@ class ReverseProxy:
 
         # Persist trace from the full response
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=self.weight_version)
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=weight_version)
             await self._persist(trace)
 
         needs_strip_vllm = self.strip_vllm

--- a/rllm/engine/rollout/rollout_engine.py
+++ b/rllm/engine/rollout/rollout_engine.py
@@ -83,8 +83,9 @@ class RolloutEngine:
         raise NotImplementedError(f"_get_model_response is not implemented for {self.__class__.__name__}")
 
     async def get_model_response(self, messages: list[dict], **kwargs) -> ModelOutput:
+        weight_version = self.weight_version
         result = await self._get_model_response(messages, **kwargs)
-        result.weight_version = self.weight_version
+        result.weight_version = weight_version
         return result
 
     def assemble_model_output(self, token_input: TokenInput, token_output: TokenOutput) -> ModelOutput:


### PR DESCRIPTION
## Summary

The weight version recorded for a rollout was read *after* generation completed, on both the rollout-engine path and the gateway path. Under `partial_rollout`, a weight sync that lands mid-generation would then mislabel an old-weights rollout with the newer version, under-counting staleness. This captures the version at **dispatch / request entry** instead, so the stamp reflects the policy a rollout actually ran under, and makes the two paths consistent.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Rollout engine (`RolloutEngine.get_model_response`): read `self.weight_version` before the generation `await`, not after.
- Gateway (`proxy.py`): snapshot `self.weight_version` into `request.state` at request entry in `handle()`, and use that snapshot at every trace-build site instead of reading `self.weight_version` after the response/stream completes. The local-handler (Tinker fake-stream) method takes the snapshot as a parameter since it has no `request`.
- Net effect: both paths now stamp the version the rollout was dispatched under (pre-generation), consistently.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest rllm-model-gateway/tests/ tests/engine/test_tinker_engine.py`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Gateway suite: 211 passed, 16 skipped. `tests/engine/test_tinker_engine.py`: 12 passed.
- Commit-stage hooks (ruff, ruff-format) ran on the changed files and passed; `pre-commit run --all-files` not run.
- No end-to-end training run; `weight_version` is metrics-only (`async/staleness_*`) and never gates or drops a group.

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Related to #<fix/gateway-plumbing PR> — that PR adds the "prefer the response-embedded weight_version, else the gateway stamp" logic in `build_trace_record`. This PR supplies the correctly-timed gateway stamp. They're independent in code (no conflict) but compose on the gateway path: with both, non-streaming/Tinker prefers the dispatch-time engine stamp and falls back to the request-entry gateway snapshot; real SSE streaming (vLLM/verl) uses the request-entry gateway snapshot.
- Fixes #
- Stacked on / depends on #

## Screenshots / logs

- N/A
