### PR TITLE
feat(sampling): gateway-enforced sampling-parameters config for AgentFlow

### DIFF
--- a/cookbooks/agent_frameworks/agentflow/langgraph.py
+++ b/cookbooks/agent_frameworks/agentflow/langgraph.py
@@ -28,13 +28,11 @@ async def langgraph_math(task: Task, config: AgentConfig) -> None:
     auto-builds the Episode from those traces; the evaluator pulls the
     answer from the trajectory's last assistant message.
     """
-    # top_k isn't a ChatOpenAI constructor arg; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
+    # Sampling params are injected by the gateway; no need to pass them to ChatOpenAI.
     llm = ChatOpenAI(
         model=config.model,
         base_url=config.base_url,
         api_key="EMPTY",
-        **sampling,
     )
     agent = create_react_agent(llm, tools=[calculate], prompt=SYSTEM_PROMPT)
     await agent.ainvoke({"messages": [("user", task.instruction)]})

--- a/cookbooks/deepcoder/deepcoder_flow.py
+++ b/cookbooks/deepcoder/deepcoder_flow.py
@@ -62,14 +62,10 @@ async def deepcoder_flow(task: Task, config: AgentConfig) -> Episode:
         {"role": "user", "content": question},
     ]
 
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
-
     try:
         resp = await client.chat.completions.create(
             model=config.model,
             messages=messages,
-            **sampling,
             timeout=600,
         )
         content = resp.choices[0].message.content or ""

--- a/cookbooks/finqa/finqa_flow.py
+++ b/cookbooks/finqa/finqa_flow.py
@@ -108,16 +108,12 @@ async def finqa_flow(task: Task, config: AgentConfig) -> Episode:
     steps: list[Step] = []
     final_response = ""
 
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
-
     for turn in range(MAX_TURNS):
         try:
             resp = await client.chat.completions.create(
                 model=config.model,
                 messages=messages,
                 tools=TOOL_SPECS,
-                **sampling,
                 timeout=300,
             )
         except Exception as e:

--- a/cookbooks/frozenlake/frozenlake_flow.py
+++ b/cookbooks/frozenlake/frozenlake_flow.py
@@ -177,15 +177,11 @@ async def frozenlake_flow(task: Task, config: AgentConfig) -> Episode:
     won = False
     last_action_label: str | None = None
 
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
-
     for turn in range(max_turns):
         try:
             resp = await client.chat.completions.create(
                 model=config.model,
                 messages=messages,
-                **sampling,
                 timeout=120,
             )
         except Exception as e:

--- a/cookbooks/geo3k/geo3k_flow.py
+++ b/cookbooks/geo3k/geo3k_flow.py
@@ -41,15 +41,11 @@ async def geo3k_flow(task: Task, config: AgentConfig) -> Episode:
         {"role": "user", "content": user_content},
     ]
 
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
-
     response_text = ""
     try:
         response = await client.chat.completions.create(
             model=config.model,
             messages=messages,
-            **sampling,
         )
         response_text = response.choices[0].message.content or ""
     except Exception as e:

--- a/cookbooks/math/math_flow.py
+++ b/cookbooks/math/math_flow.py
@@ -54,14 +54,11 @@ async def math_flow(task: Task, config: AgentConfig) -> Episode:
         {"role": "user", "content": question},
     ]
 
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
-
+    # Sampling params are injected by the gateway; the flow just makes a plain call.
     try:
         resp = await client.chat.completions.create(
             model=config.model,
             messages=messages,
-            **sampling,
             timeout=300,
         )
         content = resp.choices[0].message.content or ""

--- a/cookbooks/math_tool_agent/math_tool_agent.py
+++ b/cookbooks/math_tool_agent/math_tool_agent.py
@@ -252,16 +252,12 @@ async def math_tool_agent(task: Task, config: AgentConfig) -> Episode:
     steps = []
     final_answer = ""
 
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
-
     for turn in range(MAX_TURNS):
         try:
             response = await client.chat.completions.create(
                 model=config.model,
                 messages=messages,
                 tools=TOOLS,
-                **sampling,
                 timeout=120,
             )
         except Exception as e:

--- a/cookbooks/solver_judge_flow/solver_judge_flow.py
+++ b/cookbooks/solver_judge_flow/solver_judge_flow.py
@@ -39,15 +39,11 @@ async def solver_judge_flow(task: Task, config: AgentConfig) -> Episode:
 
 
 async def _generate_solutions(client: AsyncOpenAI, config: AgentConfig, problem: str) -> list[Trajectory]:
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
-
     async def _solve() -> Trajectory:
         messages = [{"role": "user", "content": f"{problem}. Output the final answer within <answer>...</answer>"}]
         response = await client.chat.completions.create(
             model=config.model,
             messages=messages,
-            **sampling,
         )
         content = response.choices[0].message.content or ""
         parsed = _parse_answer(content)
@@ -68,12 +64,9 @@ async def _generate_solutions(client: AsyncOpenAI, config: AgentConfig, problem:
 async def _judge_solutions(client: AsyncOpenAI, config: AgentConfig, problem: str, solutions: list[str]) -> Trajectory:
     prompt = _create_judge_prompt(problem, solutions)
     messages = [{"role": "user", "content": prompt}]
-    # top_k is not a chat.completions parameter; drop it from the rollout sampling params.
-    sampling = {k: v for k, v in config.sampling_params.items() if k != "top_k"}
     response = await client.chat.completions.create(
         model=config.model,
         messages=messages,
-        **sampling,
     )
     content = response.choices[0].message.content or ""
     selected = _parse_judge_response(content, solutions)

--- a/rllm-model-gateway/src/rllm_model_gateway/middleware.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/middleware.py
@@ -40,16 +40,12 @@ class SessionRoutingMiddleware:
         add_logprobs: bool = True,
         add_return_token_ids: bool = True,
         sessions: Any | None = None,
-        sampling_params_priority: str = "client",
         model: str | None = None,
     ) -> None:
-        if sampling_params_priority not in ("client", "session"):
-            raise ValueError(f"sampling_params_priority must be 'client' or 'session', got {sampling_params_priority!r}")
         self.app = app
         self.add_logprobs = add_logprobs
         self.add_return_token_ids = add_return_token_ids
         self.sessions = sessions  # SessionManager — for per-session sampling params
-        self.sampling_params_priority = sampling_params_priority
         self.model = model
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -126,7 +122,11 @@ class SessionRoutingMiddleware:
         await self.app(scope, patched_receive, send)
 
     def _mutate(self, payload: dict[str, Any], session_id: str | None = None) -> None:
-        """Inject ``logprobs``, ``return_token_ids``, and session sampling params."""
+        """Inject logprobs / return_token_ids / model pin, then overwrite the session's sampling params.
+
+        Keys in the session config overwrite whatever the client sent; keys absent
+        from it pass through untouched.
+        """
         if self.add_logprobs and "logprobs" not in payload:
             payload["logprobs"] = True
         if self.add_return_token_ids and "return_token_ids" not in payload:
@@ -134,13 +134,7 @@ class SessionRoutingMiddleware:
         # Pin the model the gateway forwards to (overrides whatever the client sets)
         if self.model:
             payload["model"] = self.model
-        # Inject per-session sampling params using the configured priority.
         if session_id and self.sessions is not None:
             sp = self.sessions.get_sampling_params(session_id)
             if sp:
-                if self.sampling_params_priority == "session":
-                    payload.update(sp)  # session wins on conflict
-                else:  # "client"
-                    for key, value in sp.items():
-                        if key not in payload:
-                            payload[key] = value
+                payload.update(sp)

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -121,7 +121,6 @@ class GatewayConfig(BaseModel):
     health_check_interval: float = 10.0
     log_level: str = "INFO"
     sync_traces: bool = False
-    sampling_params_priority: str = "client"
     model: str | None = None  # When set, overrides ``body.model``
     cumulative_token_mode: bool = False
     # renderers family for the cumulative-mode bridge. Check supported model families

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -229,7 +229,6 @@ def create_app(
         add_logprobs=config.add_logprobs,
         add_return_token_ids=config.add_return_token_ids,
         sessions=sessions,
-        sampling_params_priority=config.sampling_params_priority,
         model=config.model,
     )
 
@@ -498,8 +497,6 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["log_level"] = args.log_level
     if getattr(args, "store", None) is not None:
         data["store_worker"] = args.store
-    if getattr(args, "sampling_params_priority", None) is not None:
-        data["sampling_params_priority"] = args.sampling_params_priority
     if getattr(args, "model", None) is not None:
         data["model"] = args.model
     if getattr(args, "cumulative_token_mode", False):
@@ -534,13 +531,6 @@ def main() -> None:
     parser.add_argument("--db-path", type=str, default=None)
     parser.add_argument("--store", type=str, default=None, choices=["sqlite", "memory"])
     parser.add_argument("--log-level", type=str, default=None)
-    parser.add_argument(
-        "--sampling-params-priority",
-        type=str,
-        default=None,
-        choices=["client", "session"],
-        help="Conflict resolution for sampling params: 'client' (default) or 'session'.",
-    )
     parser.add_argument(
         "--model",
         type=str,

--- a/rllm-model-gateway/tests/integration/test_sampling_enforcement_e2e.py
+++ b/rllm-model-gateway/tests/integration/test_sampling_enforcement_e2e.py
@@ -1,0 +1,84 @@
+"""E2E proof of the gateway "one rule": session sampling params always win.
+
+Runs a real gateway (thread) in front of a mock vLLM that records every
+forwarded request body. No GPU, no pytest_asyncio — uses the sync OpenAI client.
+Asserts that, for a session created with sampling params:
+  * a configured key overrides the client's conflicting value (gateway wins);
+  * a configured extra key (presence_penalty) is injected;
+  * an unconfigured key the client sent passes through untouched.
+And that with no session params, client values pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import openai
+import pytest
+from rllm_model_gateway import GatewayClient, GatewayConfig, create_app
+
+from tests.helpers.gateway_server import GatewayServer
+from tests.helpers.mock_vllm import MockVLLMServer
+
+
+@pytest.fixture
+def mock_upstream():
+    server = MockVLLMServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture
+def gateway(mock_upstream):
+    # External-provider-style gateway: no vLLM-only field injection.
+    cfg = GatewayConfig(
+        workers=[{"url": mock_upstream.url}],
+        add_logprobs=False,
+        add_return_token_ids=False,
+    )
+    server = GatewayServer(create_app(cfg))
+    server.start()
+    yield server, mock_upstream
+    server.stop()
+
+
+def test_session_params_override_client_and_inject_extra(gateway):
+    server, mock_upstream = gateway
+    client = GatewayClient(server.url)
+    sid = client.create_session(
+        session_id="enforce",
+        sampling_params={"temperature": 0.123, "presence_penalty": 0.7},
+    )
+    oai = openai.OpenAI(base_url=client.get_session_url(sid), api_key="dummy")
+
+    oai.chat.completions.create(
+        model="mock-model",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.9,  # conflicts with session config → gateway must win
+        top_p=0.5,  # not configured → must pass through
+    )
+
+    fwd = mock_upstream.request_log[-1]
+    assert fwd["temperature"] == 0.123, "gateway session config must override client temperature"
+    assert fwd["presence_penalty"] == 0.7, "configured extra key must be injected"
+    assert fwd["top_p"] == 0.5, "unconfigured key must pass through untouched"
+    client.close()
+
+
+def test_no_session_params_passes_client_values_through(gateway):
+    server, mock_upstream = gateway
+    client = GatewayClient(server.url)
+    sid = client.create_session(session_id="passthrough")  # no sampling params
+    oai = openai.OpenAI(base_url=client.get_session_url(sid), api_key="dummy")
+
+    oai.chat.completions.create(
+        model="mock-model",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.9,
+        top_p=0.5,
+    )
+
+    fwd = mock_upstream.request_log[-1]
+    assert fwd["temperature"] == 0.9
+    assert fwd["top_p"] == 0.5
+    assert "presence_penalty" not in fwd
+    client.close()

--- a/rllm-model-gateway/tests/unit/test_middleware.py
+++ b/rllm-model-gateway/tests/unit/test_middleware.py
@@ -1,0 +1,74 @@
+"""Unit tests for SessionRoutingMiddleware._mutate.
+
+Configured session keys overwrite whatever the client sent; unconfigured keys
+pass through untouched.
+"""
+
+from __future__ import annotations
+
+from rllm_model_gateway.middleware import SessionRoutingMiddleware
+
+
+class _FakeSessions:
+    def __init__(self, sampling_params: dict | None) -> None:
+        self._sp = sampling_params
+
+    def get_sampling_params(self, session_id: str):  # noqa: ARG002
+        return self._sp
+
+
+def _mw(sampling_params=None, *, add_logprobs=False, add_return_token_ids=False, model=None):
+    return SessionRoutingMiddleware(
+        app=lambda *a, **k: None,
+        add_logprobs=add_logprobs,
+        add_return_token_ids=add_return_token_ids,
+        sessions=_FakeSessions(sampling_params),
+        model=model,
+    )
+
+
+def test_configured_key_overwrites_client_value():
+    mw = _mw({"temperature": 0.2})
+    payload = {"temperature": 0.9, "messages": []}
+    mw._mutate(payload, session_id="s1")
+    assert payload["temperature"] == 0.2  # gateway wins
+
+
+def test_unconfigured_key_passes_through():
+    mw = _mw({"temperature": 0.2})
+    payload = {"temperature": 0.9, "top_p": 0.5}
+    mw._mutate(payload, session_id="s1")
+    assert payload["temperature"] == 0.2  # owned by config
+    assert payload["top_p"] == 0.5  # not in config → flow keeps it
+
+
+def test_extra_keys_injected():
+    mw = _mw({"presence_penalty": 0.1, "min_p": 0.05})
+    payload = {"messages": []}
+    mw._mutate(payload, session_id="s1")
+    assert payload["presence_penalty"] == 0.1
+    assert payload["min_p"] == 0.05
+
+
+def test_no_session_params_leaves_payload_untouched():
+    mw = _mw(None)
+    payload = {"temperature": 0.9}
+    mw._mutate(payload, session_id="s1")
+    assert payload == {"temperature": 0.9}
+
+
+def test_no_session_id_skips_injection():
+    mw = _mw({"temperature": 0.2})
+    payload = {"temperature": 0.9}
+    mw._mutate(payload, session_id=None)
+    assert payload["temperature"] == 0.9
+
+
+def test_model_pin_and_logprobs_still_applied():
+    mw = _mw({"temperature": 0.2}, add_logprobs=True, add_return_token_ids=True, model="served-model")
+    payload = {"model": "whatever", "messages": []}
+    mw._mutate(payload, session_id="s1")
+    assert payload["model"] == "served-model"
+    assert payload["logprobs"] is True
+    assert payload["return_token_ids"] is True
+    assert payload["temperature"] == 0.2

--- a/rllm/cli/_sampling.py
+++ b/rllm/cli/_sampling.py
@@ -1,0 +1,174 @@
+"""Sampling-params resolution for the ``rllm eval`` / ``rllm train`` CLIs.
+
+A small :class:`SamplingConfig` (typed core + open ``extra`` passthrough) plus
+the resolvers that turn ``--sampling-params`` (a ``"key=value,..."`` string or
+``@file.yaml`` / ``@file.json``) and the ``--temperature`` / ``--top-p`` /
+``--max-tokens`` shortcuts into the dict the gateway enforces on every LLM call.
+
+Precedence (low to high): ``base.yaml rollout.{train,val}`` < ``@file`` /
+string < standalone flags.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+_CORE_KEYS = ("temperature", "top_p", "top_k", "max_tokens")
+
+SAMPLING_PARAMS_HELP = (
+    "Sampling params as 'key=value,...' (e.g. \"temperature=0.6,top_p=0.95,presence_penalty=0.1\") or @file.yaml / @file.json. Unknown keys (presence_penalty, min_p, ...) pass through to the backend."
+)
+
+
+@dataclass
+class SamplingConfig:
+    """Typed core sampling params plus an open ``extra`` passthrough.
+
+    A field left ``None`` is omitted from :meth:`as_dict` and is not enforced.
+    """
+
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    max_tokens: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_obj(cls, obj: Mapping | None) -> SamplingConfig:
+        """Build from a mapping: core keys → fields, unknown keys → ``extra`` (``None`` values dropped)."""
+        if obj is None:
+            return cls()
+        core: dict[str, Any] = {}
+        extra: dict[str, Any] = {}
+        for raw_key, value in obj.items():
+            key = str(raw_key)
+            if value is None:
+                continue
+            if key == "extra" and isinstance(value, Mapping):
+                extra.update(value)
+            elif key in _CORE_KEYS:
+                core[key] = value
+            else:
+                extra[key] = value
+        return cls(**core, extra=extra)
+
+    @classmethod
+    def from_string(cls, spec: str) -> SamplingConfig:
+        """Parse ``"key=value,key=value"`` into a config; unknown keys go to ``extra``."""
+        raw: dict[str, Any] = {}
+        for token in (spec or "").split(","):
+            token = token.strip()
+            if not token:
+                continue
+            if "=" not in token:
+                raise ValueError(f"Invalid --sampling-params token {token!r}; expected key=value")
+            key, _, value = token.partition("=")
+            raw[key.strip()] = _coerce(value.strip())
+        return cls.from_obj(raw)
+
+    def merged(self, other: SamplingConfig | None) -> SamplingConfig:
+        """Layer ``other`` on top of ``self`` per key (``other`` wins; its ``None`` core fields don't override)."""
+        other = other or SamplingConfig()
+        return SamplingConfig(
+            temperature=other.temperature if other.temperature is not None else self.temperature,
+            top_p=other.top_p if other.top_p is not None else self.top_p,
+            top_k=other.top_k if other.top_k is not None else self.top_k,
+            max_tokens=other.max_tokens if other.max_tokens is not None else self.max_tokens,
+            extra={**self.extra, **other.extra},
+        )
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.as_dict()
+
+    def as_dict(self) -> dict[str, Any]:
+        """Flatten set keys (core non-None + extra) to a plain dict."""
+        out: dict[str, Any] = {key: getattr(self, key) for key in _CORE_KEYS if getattr(self, key) is not None}
+        for key, value in self.extra.items():
+            out.setdefault(key, value)
+        return out
+
+
+def _coerce(value: str) -> Any:
+    """Coerce a CLI value to int, then float, else leave as a string."""
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _load_file(path: str) -> dict[str, Any]:
+    """Load a flat YAML/JSON mapping of sampling params."""
+    expanded = os.path.expanduser(path)
+    if not os.path.isfile(expanded):
+        raise FileNotFoundError(f"sampling-params file not found: {path}")
+    with open(expanded) as f:
+        text = f.read()
+    try:
+        import yaml
+
+        data = yaml.safe_load(text)
+    except ImportError:
+        data = json.loads(text)
+    if data is None:
+        return {}
+    if not isinstance(data, Mapping):
+        raise ValueError(f"sampling-params file {path} must contain a mapping at the top level")
+    return dict(data)
+
+
+def _parse(source: str | None) -> SamplingConfig:
+    """Parse a ``--sampling-params`` argument (``"k=v,..."`` string or ``@file``)."""
+    source = (source or "").strip()
+    if not source:
+        return SamplingConfig()
+    if source.startswith("@"):
+        return SamplingConfig.from_obj(_load_file(source[1:]))
+    return SamplingConfig.from_string(source)
+
+
+def _flags(temperature: float | None, top_p: float | None, max_tokens: int | None) -> SamplingConfig:
+    """The standalone ``--temperature`` / ``--top-p`` / ``--max-tokens`` shortcuts (top precedence)."""
+    d: dict[str, Any] = {}
+    if temperature is not None:
+        d["temperature"] = temperature
+    if top_p is not None:
+        d["top_p"] = top_p
+    if max_tokens is not None:
+        d["max_tokens"] = max_tokens
+    return SamplingConfig.from_obj(d)
+
+
+def resolve_eval_sampling(
+    sampling_params: str | None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+) -> SamplingConfig:
+    """Resolve the SamplingConfig for ``rllm eval`` (string/@file, overridden by flags)."""
+    return _parse(sampling_params).merged(_flags(temperature, top_p, max_tokens))
+
+
+def resolve_train_sampling(
+    sampling_params: str | None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    *,
+    base_train: Mapping | None = None,
+    base_val: Mapping | None = None,
+) -> tuple[SamplingConfig, SamplingConfig]:
+    """Resolve ``(train, val)`` configs: base.yaml rollout.{train,val} < --sampling-params < flags."""
+    source = _parse(sampling_params)
+    flags = _flags(temperature, top_p, max_tokens)
+    train_cfg = SamplingConfig.from_obj(base_train).merged(source).merged(flags)
+    val_cfg = SamplingConfig.from_obj(base_val).merged(source).merged(flags)
+    return train_cfg, val_cfg

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -21,6 +21,7 @@ from rich.theme import Theme
 
 from rllm import paths
 from rllm.cli._pull import load_dataset_catalog, pull_dataset
+from rllm.cli._sampling import SAMPLING_PARAMS_HELP as _SAMPLING_PARAMS_HELP
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ def _run_eval(
     save_episodes: bool = True,
     episodes_dir: str | None = None,
     use_snapshot: bool = True,
+    sampling_config=None,
 ):
     """Core eval logic, extracted for clean proxy lifecycle management."""
     from rllm.data import DatasetRegistry
@@ -382,6 +384,8 @@ def _run_eval(
     table.add_row("Evaluator", f"[dim]{evaluator_display}[/]")
     if not use_snapshot:
         table.add_row("Snapshots", "[dim]disabled (--no-snapshot, cold start)[/]")
+    if sampling_config is not None and not sampling_config.is_empty:
+        table.add_row("Sampling", f"[dim]{sampling_config.as_dict()} (gateway-enforced)[/]")
     console.print()
     console.print(Panel(table, border_style="cyan", expand=False))
     console.print()
@@ -487,6 +491,7 @@ def _run_eval(
             dataset_name=getattr(dataset, "name", benchmark) or benchmark,
             on_episode_complete=on_episode_complete,
             evaluator_override=evaluator,
+            sampling_params=(sampling_config.as_dict() if sampling_config is not None else None),
         )
     )
 
@@ -578,6 +583,10 @@ def _run_eval(
 @click.option("--ui/--no-ui", "enable_ui", default=None, help="Enable/disable live UI logging. Default: auto-enabled when logged in (see 'rllm login').")
 @click.option("--save-episodes/--no-save-episodes", "save_episodes", default=True, help="Save each Episode as its own JSON file for later visualization (default: enabled).")
 @click.option("--episodes-dir", "episodes_dir", default=None, help="Directory to write the episode JSONs into. Default: ~/.rllm/eval_results/<bench>_<model>_<timestamp>/.")
+@click.option("--sampling-params", "sampling_params", default=None, help=_SAMPLING_PARAMS_HELP)
+@click.option("--temperature", default=None, type=float, help="Sampling temperature (shortcut for --sampling-params temperature=...).")
+@click.option("--top-p", "top_p", default=None, type=float, help="Nucleus sampling top_p (shortcut for --sampling-params top_p=...).")
+@click.option("--max-tokens", "max_tokens", default=None, type=int, help="Max generated tokens per call (shortcut for --sampling-params max_tokens=...).")
 def eval_cmd(
     benchmark: str,
     agent_name: str | None,
@@ -596,8 +605,19 @@ def eval_cmd(
     enable_ui: bool | None,
     save_episodes: bool,
     episodes_dir: str | None,
+    sampling_params: str | None,
+    temperature: float | None,
+    top_p: float | None,
+    max_tokens: int | None,
 ):
     """Evaluate a model on a benchmark dataset."""
+    from rllm.cli._sampling import resolve_eval_sampling
+
+    try:
+        sampling_config = resolve_eval_sampling(sampling_params, temperature, top_p, max_tokens)
+    except (ValueError, FileNotFoundError, TypeError) as e:
+        console.print(f"  [error]Invalid --sampling-params: {e}[/]")
+        raise SystemExit(1) from None
     # Auto-detect UI logging: enable if user is logged in (has ui_api_key or RLLM_API_KEY)
     _ui_explicit = enable_ui is not None
     if enable_ui is None:
@@ -698,6 +718,7 @@ def eval_cmd(
             save_episodes=save_episodes,
             episodes_dir=episodes_dir,
             use_snapshot=use_snapshot,
+            sampling_config=sampling_config,
         )
     finally:
         if proxy_manager is not None:

--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -21,6 +21,7 @@ from rich.table import Table
 from rich.theme import Theme
 
 from rllm.cli._pull import load_dataset_catalog, pull_dataset
+from rllm.cli._sampling import SAMPLING_PARAMS_HELP as _SAMPLING_PARAMS_HELP
 
 theme = Theme({"label": "dim", "success": "bold green", "error": "bold red", "val": "bold", "key": "yellow"})
 console = Console(theme=theme)
@@ -164,6 +165,10 @@ def _run_train(
     enable_ui: bool = False,
     sandbox_backend: str | None = None,
     sandbox_concurrency: int | None = None,
+    sampling_params: str | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
 ):
     """Core training logic: resolve catalog, load data, build config, launch trainer."""
 
@@ -384,6 +389,21 @@ def _run_train(
         config_file=config_file,
     )
 
+    # Layer --sampling-params over base.yaml rollout.{train,val}; gateway-enforced.
+    from omegaconf import OmegaConf
+
+    from rllm.cli._sampling import resolve_train_sampling
+
+    base_train = OmegaConf.to_container(config.rllm.rollout.train, resolve=True)
+    base_val = OmegaConf.to_container(config.rllm.rollout.val, resolve=True)
+    try:
+        train_sc, val_sc = resolve_train_sampling(sampling_params, temperature, top_p, max_tokens, base_train=base_train, base_val=base_val)
+    except (ValueError, FileNotFoundError, TypeError) as e:
+        console.print(f"  [error]Invalid --sampling-params: {e}[/]")
+        raise SystemExit(1) from None
+    config.rllm.rollout.train = train_sc.as_dict()
+    config.rllm.rollout.val = val_sc.as_dict()
+
     # ---- Wire UI logging ----
     if enable_ui:
         if not os.environ.get("RLLM_UI_URL"):
@@ -417,6 +437,11 @@ def _run_train(
     sandbox_row = _describe_sandbox_routing(agent_flow, train_dataset, val_dataset, sandbox_backend, sandbox_concurrency, tunnel_cfg)
     if sandbox_row is not None:
         table.add_row("Sandbox", sandbox_row)
+    train_sp = train_sc.as_dict()
+    val_sp = val_sc.as_dict()
+    if train_sp or val_sp:
+        sp_text = f"train={train_sp}" + (f"  val={val_sp}" if val_sp != train_sp else "")
+        table.add_row("Sampling", f"[dim]{sp_text} (gateway-enforced)[/]")
     table.add_row("Group size", f"[dim]{group_size}[/]")
     table.add_row("Batch size", f"[dim]{batch_size}[/]")
     table.add_row("Learning rate", f"[dim]{lr}[/]")
@@ -554,6 +579,11 @@ def _load_or_pull_dataset(name: str, split: str, catalog: dict, catalog_entry_ov
     help="Sandbox backend for SandboxedAgentFlow harnesses (default: per-task or docker). Remote backends auto-spawn a cloudflared tunnel for the gateway.",
 )
 @click.option("--sandbox-concurrency", "sandbox_concurrency", default=None, type=int, help="Override max concurrent sandboxes (default: agent's max_concurrent — usually 4).")
+# Sampling options (resolved into rollout.{train,val}; gateway-enforced)
+@click.option("--sampling-params", "sampling_params", default=None, help=_SAMPLING_PARAMS_HELP)
+@click.option("--temperature", default=None, type=float, help="Sampling temperature for train+val (shortcut for --sampling-params temperature=...).")
+@click.option("--top-p", "top_p", default=None, type=float, help="Nucleus sampling top_p for train+val (shortcut).")
+@click.option("--max-tokens", "max_tokens", default=None, type=int, help="Max generated tokens per call for train+val (shortcut).")
 def train_cmd(
     benchmark: str,
     train_dataset: str | None,
@@ -579,6 +609,10 @@ def train_cmd(
     enable_ui: bool | None,
     sandbox_backend: str | None,
     sandbox_concurrency: int | None,
+    sampling_params: str | None,
+    temperature: float | None,
+    top_p: float | None,
+    max_tokens: int | None,
 ):
     """Train a model on a benchmark dataset using RL."""
     # Auto-detect UI logging: enable if user is logged in (has ui_api_key or RLLM_API_KEY)
@@ -620,4 +654,8 @@ def train_cmd(
         enable_ui=enable_ui,
         sandbox_backend=sandbox_backend,
         sandbox_concurrency=sandbox_concurrency,
+        sampling_params=sampling_params,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
     )

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -607,6 +607,12 @@ class AgentFlowEngine:
             _timings["time/setup_s"] = time.perf_counter() - t
 
         try:
+            # Attach resolved sampling params to the session so the gateway
+            # enforces them on every LLM call; skip when there are none.
+            session_sampling_params = (self.val_sampling_params if is_validation else self.train_sampling_params) or None
+            if session_sampling_params:
+                await self.gateway.acreate_session(uid, is_validation=is_validation, sampling_params=session_sampling_params)
+
             session_url = self.gateway.get_session_url(uid)
 
             config = AgentConfig(
@@ -614,7 +620,7 @@ class AgentFlowEngine:
                 model=self.model,
                 session_uid=uid,
                 is_validation=is_validation,
-                sampling_params=(self.train_sampling_params if not is_validation else self.val_sampling_params) or {},
+                sampling_params=session_sampling_params or {},
             )
 
             # Prefer the per-task flow from the hook so parallel tasks don't

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -40,6 +40,7 @@ async def run_dataset(
     on_episode_complete=None,
     evaluator_override: Evaluator | None = None,
     gateway: GatewayManager | None = None,
+    sampling_params: dict | None = None,
 ) -> tuple[EvalResult, list]:
     """Run a list of :class:`rllm.types.Task` objects through :class:`AgentFlowEngine`.
 
@@ -57,6 +58,9 @@ async def run_dataset(
             ``--evaluator`` flag). When ``None``, ``SandboxTaskHooks``
             resolves a per-task verifier from the task's ``[verifier]``
             config.
+        sampling_params: Resolved sampling params from the CLI, attached to each
+            gateway session so the gateway enforces them on every LLM call. ``None``
+            or empty → flows/harnesses keep their own params.
 
     Returns ``(EvalResult, list[Episode])``.
     """
@@ -94,6 +98,7 @@ async def run_dataset(
         retry_limit=1,  # eval doesn't retry on flow errors
         raise_on_error=False,  # capture per-task errors as error Episodes
         hooks=hooks,
+        val_sampling_params=sampling_params or None,  # eval is always validation
     )
 
     try:

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -136,7 +136,6 @@ class GatewayManager:
         from rllm.gateway.tunnel import parse_tunnel
 
         self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
-        self.sampling_params_priority: str = gw_cfg.get("sampling_params_priority", "client")
         # The gateway always pins ``body.model`` to whatever the trainer is serving
         self.model: str | None = config.get("model", {}).get("name", None)
 
@@ -258,8 +257,8 @@ class GatewayManager:
 
     # -- Session / trace API -------------------------------------------------
 
-    def create_session(self, session_id: str, is_validation: bool = False) -> str:
-        sp = self._val_sampling_params if is_validation else self._train_sampling_params
+    def create_session(self, session_id: str, is_validation: bool = False, sampling_params: dict[str, Any] | None = None) -> str:
+        sp = sampling_params if sampling_params is not None else (self._val_sampling_params if is_validation else self._train_sampling_params)
         return self.client.create_session(session_id=session_id, sampling_params=sp or None)
 
     def get_session_url(self, session_id: str) -> str:
@@ -274,8 +273,8 @@ class GatewayManager:
 
     # -- Async session / trace API -------------------------------------------
 
-    async def acreate_session(self, session_id: str, is_validation: bool = False) -> str:
-        sp = self._val_sampling_params if is_validation else self._train_sampling_params
+    async def acreate_session(self, session_id: str, is_validation: bool = False, sampling_params: dict[str, Any] | None = None) -> str:
+        sp = sampling_params if sampling_params is not None else (self._val_sampling_params if is_validation else self._train_sampling_params)
         return await self.async_client.create_session(session_id=session_id, sampling_params=sp or None)
 
     async def aget_traces(self, session_id: str) -> list[TraceRecord]:
@@ -325,8 +324,6 @@ class GatewayManager:
         cmd.extend(["--store", self.store])
         if self.db_path:
             cmd.extend(["--db-path", self.db_path])
-        if self.sampling_params_priority != "client":
-            cmd.extend(["--sampling-params-priority", self.sampling_params_priority])
         if self.model:
             cmd.extend(["--model", self.model])
         if self.cumulative_token_mode:
@@ -367,7 +364,6 @@ class GatewayManager:
             port=self.port,
             db_path=self.db_path,
             store_worker=self.store,
-            sampling_params_priority=self.sampling_params_priority,
             model=self.model,
             add_logprobs=self.add_logprobs,
             add_return_token_ids=self.add_return_token_ids,

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -29,26 +29,23 @@ workflow:
   retry_limit: 3
   raise_on_error: true
 
-# Rollout Configuration. Backend-agnostic source of truth for sampling
-# parameters; ``rllm/trainer/verl/utils.py:sync_config`` mirrors
-# ``rollout.{train,val}.*`` into ``actor_rollout_ref.rollout`` and
-# ``actor_rollout_ref.rollout.val_kwargs`` respectively.
-# The AgentFlowEngine forwards ``rollout.train`` / ``rollout.val`` into
-# ``AgentConfig.sampling_params``, so AgentFlows spread them straight into
-# their LLM calls (``**config.sampling_params``; ``top_k`` dropped for
-# OpenAI-compatible chat-completions clients that don't accept it).
+# Rollout configuration: backend-agnostic source of truth for sampling params.
+# For AgentFlow, rollout.{train,val} are attached to the gateway session and
+# enforced on every LLM call; extra keys (e.g. presence_penalty) pass through.
+# sync_config mirrors the core keys into actor_rollout_ref.rollout for verl's
+# native rollout.
 rollout:
   n: 8
   n_val: 1  # number of validation samples per prompt
+  # Only defaults the params every backend accepts. Set top_k / penalties / etc.
+  # explicitly (CLI or here) when your served backend supports them.
   train:
     temperature: 1.0
     top_p: 1.0
-    top_k: -1
     max_tokens: 2048
   val:
     temperature: 1.0
     top_p: 1.0
-    top_k: -1
     max_tokens: 2048
 
 # Trainer Configuration
@@ -147,7 +144,8 @@ gateway:
                       # (your own tailscale IP, bore/ngrok/frp URL, internal DNS, etc.).
   store: memory       # "memory" (non-persistent) | "sqlite" (writes traces to disk)
   db_path: null       # Only used when store=sqlite; null → auto-resolved path (logged at startup)
-  sampling_params_priority: session   # "session" | "client" — who wins when both set the same key
+  # Sampling params attached to a session overwrite those keys on every LLM call;
+  # keys not set pass through untouched.
   cumulative_token_mode: false   # Drift-free multi-turn token forwarding: rewrites turn 2+ to
                                  # /v1/completions with cumulative raw token IDs built by the renderer.
                                  # The tokenizer is loaded from the served model path (model.name).

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -422,6 +422,8 @@ class AgentConfig:
     session_uid: str
     metadata: dict = field(default_factory=dict)
     is_validation: bool = False
+    # Informational copy of the gateway-enforced sampling config; not authoritative
+    # (the gateway applies it server-side regardless of what the flow passes).
     sampling_params: dict = field(default_factory=dict)
 
 

--- a/tests/cli/test_sampling_config.py
+++ b/tests/cli/test_sampling_config.py
@@ -1,0 +1,73 @@
+"""Unit tests for rllm.cli._sampling.SamplingConfig."""
+
+from __future__ import annotations
+
+import pytest
+
+from rllm.cli._sampling import SamplingConfig
+
+
+def test_from_obj_splits_core_and_extra():
+    cfg = SamplingConfig.from_obj({"temperature": 0.6, "top_p": 0.95, "presence_penalty": 0.1, "min_p": 0.05})
+    assert cfg.temperature == 0.6
+    assert cfg.top_p == 0.95
+    assert cfg.extra == {"presence_penalty": 0.1, "min_p": 0.05}
+
+
+def test_from_obj_drops_none_values():
+    cfg = SamplingConfig.from_obj({"temperature": 0.7, "top_p": None})
+    assert cfg.as_dict() == {"temperature": 0.7}
+
+
+def test_from_string_coerces_int_and_float():
+    cfg = SamplingConfig.from_string("temperature=0.6,max_tokens=2048")
+    assert cfg.temperature == 0.6 and isinstance(cfg.temperature, float)
+    assert cfg.max_tokens == 2048 and isinstance(cfg.max_tokens, int)
+
+
+def test_from_string_unknown_keys_go_to_extra():
+    cfg = SamplingConfig.from_string("temperature=0.6,presence_penalty=0.1")
+    assert cfg.temperature == 0.6
+    assert cfg.extra == {"presence_penalty": 0.1}
+
+
+def test_from_string_rejects_token_without_equals():
+    with pytest.raises(ValueError, match="key=value"):
+        SamplingConfig.from_string("temperature")
+
+
+def test_merged_other_wins_and_keeps_untouched_keys():
+    out = SamplingConfig.from_obj({"temperature": 1.0, "top_p": 1.0}).merged(SamplingConfig.from_obj({"temperature": 0.6}))
+    assert out.temperature == 0.6  # override wins
+    assert out.top_p == 1.0  # untouched kept
+
+
+def test_merged_none_field_does_not_override():
+    out = SamplingConfig.from_obj({"temperature": 1.0}).merged(SamplingConfig.from_obj({"top_p": 0.8}))
+    assert out.temperature == 1.0 and out.top_p == 0.8
+
+
+def test_merged_extra_shallow_merge():
+    base = SamplingConfig.from_obj({"presence_penalty": 0.1, "min_p": 0.0})
+    out = base.merged(SamplingConfig.from_obj({"min_p": 0.2, "frequency_penalty": 0.5}))
+    assert out.extra == {"presence_penalty": 0.1, "min_p": 0.2, "frequency_penalty": 0.5}
+
+
+def test_merged_precedence_chain():
+    # base < file < string < flags
+    out = (
+        SamplingConfig.from_obj({"temperature": 1.0, "top_p": 1.0, "top_k": -1})
+        .merged(SamplingConfig.from_obj({"temperature": 0.9}))
+        .merged(SamplingConfig.from_string("temperature=0.7,presence_penalty=0.1"))
+        .merged(SamplingConfig.from_obj({"temperature": 0.5}))
+    )
+    assert out.temperature == 0.5
+    assert out.top_p == 1.0 and out.top_k == -1
+    assert out.extra == {"presence_penalty": 0.1}
+
+
+def test_as_dict_flattens_core_and_extra_unfiltered():
+    # Every set key reaches the dict verbatim — no provider-specific filtering.
+    cfg = SamplingConfig.from_obj({"temperature": 0.6, "top_k": 20, "presence_penalty": 0.1})
+    assert cfg.as_dict() == {"temperature": 0.6, "top_k": 20, "presence_penalty": 0.1}
+    assert SamplingConfig().is_empty

--- a/tests/cli/test_sampling_resolution.py
+++ b/tests/cli/test_sampling_resolution.py
@@ -1,0 +1,61 @@
+"""Unit tests for the rllm eval / rllm train sampling-params resolution precedence."""
+
+from __future__ import annotations
+
+import pytest
+
+from rllm.cli._sampling import resolve_eval_sampling, resolve_train_sampling
+
+BASE = {"temperature": 1.0, "top_p": 1.0, "top_k": -1, "max_tokens": 2048}
+
+
+# -- eval: single config, empty base, always validation ---------------------
+
+
+def test_eval_empty_by_default():
+    assert resolve_eval_sampling(None).is_empty
+
+
+def test_eval_string_only():
+    assert resolve_eval_sampling("temperature=0.3,top_k=20").as_dict() == {"temperature": 0.3, "top_k": 20}
+
+
+def test_eval_flags_beat_string():
+    assert resolve_eval_sampling("temperature=0.3", temperature=0.9).temperature == 0.9
+
+
+def test_eval_standalone_flags_only():
+    assert resolve_eval_sampling(None, 0.5, 0.8, 256).as_dict() == {"temperature": 0.5, "top_p": 0.8, "max_tokens": 256}
+
+
+def test_eval_flat_file(tmp_path):
+    p = tmp_path / "sp.yaml"
+    p.write_text("temperature: 0.42\npresence_penalty: 0.3\n")
+    assert resolve_eval_sampling(f"@{p}").as_dict() == {"temperature": 0.42, "presence_penalty": 0.3}
+
+
+def test_eval_nonmapping_file_raises(tmp_path):
+    p = tmp_path / "bad.yaml"
+    p.write_text("- 1\n- 2\n")  # top-level list, not a mapping
+    with pytest.raises(ValueError):
+        resolve_eval_sampling(f"@{p}")
+
+
+# -- train: (train, val) pair layered over base.yaml rollout.{train,val} -----
+
+
+def test_train_base_only_passthrough():
+    t, v = resolve_train_sampling(None, base_train=BASE, base_val=BASE)
+    assert t.as_dict() == BASE and v.as_dict() == BASE
+
+
+def test_train_string_overrides_base_for_both_incl_extra():
+    t, v = resolve_train_sampling("temperature=0.6,presence_penalty=0.1", base_train=BASE, base_val=BASE)
+    assert t.temperature == 0.6 and v.temperature == 0.6
+    assert t.as_dict()["presence_penalty"] == 0.1 and v.as_dict()["presence_penalty"] == 0.1
+    assert t.top_k == -1  # untouched base key kept
+
+
+def test_train_flags_beat_string():
+    t, v = resolve_train_sampling("temperature=0.6", temperature=0.2, base_train=BASE, base_val=BASE)
+    assert t.temperature == 0.2 and v.temperature == 0.2

--- a/tests/cli/test_train_command.py
+++ b/tests/cli/test_train_command.py
@@ -300,6 +300,48 @@ class TestTrainCommand:
         mock_load_agent.assert_called_once_with("custom_agent")
         mock_load_eval.assert_called_once_with("custom_evaluator")
 
+    def test_train_sampling_params_reach_rollout_config(self, runner, tmp_rllm_home, mock_train_dataset):
+        """--sampling-params (+ standalone flags) must land in rllm.rollout.{train,val},
+        including extra keys, before the trainer is constructed."""
+        catalog = {"datasets": {"test_math": {"eval_split": "test"}}}
+        mock_trainer = MagicMock()
+
+        with (
+            patch("rllm.cli.train.load_dataset_catalog", return_value=catalog),
+            patch("rllm.eval.agent_loader.load_agent", return_value=_MockAgentFlow()),
+            patch("rllm.eval.evaluator_loader.load_evaluator", return_value=_MockEvaluator()),
+            patch("rllm.trainer.AgentTrainer", return_value=mock_trainer) as mock_cls,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "train",
+                    "test_math",
+                    "--agent",
+                    "a",
+                    "--evaluator",
+                    "e",
+                    "--model",
+                    "m",
+                    "--sampling-params",
+                    "temperature=0.3,presence_penalty=0.5",
+                    "--top-p",
+                    "0.9",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        cfg = mock_cls.call_args.kwargs["config"]
+        # Standalone flag, string param, and extra key all reach train + val.
+        assert cfg.rllm.rollout.train.temperature == 0.3
+        assert cfg.rllm.rollout.train.top_p == 0.9
+        assert cfg.rllm.rollout.train.presence_penalty == 0.5
+        assert cfg.rllm.rollout.val.temperature == 0.3
+        assert cfg.rllm.rollout.val.presence_penalty == 0.5
+        # Untouched base key preserved; top_k is no longer defaulted (opt-in).
+        assert cfg.rllm.rollout.train.max_tokens == 2048
+        assert "top_k" not in cfg.rllm.rollout.train
+
     def test_train_header_display(self, runner, tmp_rllm_home, mock_train_dataset):
         """Train should display a header panel with configuration info."""
         catalog = {"datasets": {"test_math": {"default_agent": "math", "reward_fn": "math_reward_fn", "eval_split": "test"}}}

--- a/tests/integration/test_sampling_e2e.py
+++ b/tests/integration/test_sampling_e2e.py
@@ -1,0 +1,189 @@
+"""Gateway enforcement through ``run_dataset`` and ``AgentFlowEngine.execute_tasks``.
+
+A real gateway in front of an in-process FastAPI mock upstream, driven by an
+inline flow (not the CLI or a cookbook). Confirms the gateway overwrites a
+configured key (overriding the flow's own temperature) and injects extra keys
+(presence_penalty / min_p / top_k) the OpenAI SDK never sent — on both the eval
+and the training-rollout paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+
+import pytest
+import uvicorn
+from fastapi import FastAPI, Request
+
+import rllm
+from rllm.types import Episode, Step, Task, Trajectory
+
+# ---------------------------------------------------------------------------
+# Tiny in-process OpenAI-compatible mock upstream that records request bodies
+# ---------------------------------------------------------------------------
+
+_MOCK_RESPONSE = {
+    "id": "chatcmpl-e2e",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "mock-model",
+    # Root-level prompt_token_ids + choices[].token_ids mimic a vLLM response with
+    # return_token_ids=True, so training-mode (strict) trace enrichment succeeds.
+    "prompt_token_ids": [1, 2, 3],
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": r"The answer is \boxed{4}"},
+            "token_ids": [4, 5, 6],
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 3, "completion_tokens": 3, "total_tokens": 6},
+}
+
+
+class MockUpstream:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        self.host = "127.0.0.1"
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((self.host, 0))
+            self.port = s.getsockname()[1]
+        app = FastAPI()
+
+        @app.get("/health")
+        async def health():
+            return {"status": "ok"}
+
+        @app.get("/v1/models")
+        async def models():
+            return {"data": [{"id": "mock-model", "object": "model"}]}
+
+        @app.post("/v1/chat/completions")
+        async def chat(request: Request):
+            self.requests.append(await request.json())
+            return _MOCK_RESPONSE
+
+        self._server = uvicorn.Server(uvicorn.Config(app, host=self.host, port=self.port, log_level="warning"))
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def start(self) -> None:
+        self._thread.start()
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not self._server.started:
+            time.sleep(0.05)
+        if not self._server.started:
+            raise TimeoutError("mock upstream did not start")
+
+    def stop(self) -> None:
+        self._server.should_exit = True
+        self._thread.join(timeout=5)
+
+
+@pytest.fixture
+def mock_upstream():
+    server = MockUpstream()
+    server.start()
+    yield server
+    server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Minimal flow + evaluator. The flow sends temperature=0.9 to prove the gateway
+# overrides a flow-set value.
+# ---------------------------------------------------------------------------
+
+
+@rllm.rollout(name="e2e")
+async def e2e_flow(task: Task, config) -> Episode:
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(base_url=config.base_url, api_key="EMPTY")
+    resp = await client.chat.completions.create(
+        model=config.model,
+        messages=[{"role": "user", "content": str(task.instruction)}],
+        temperature=0.9,  # flow's own value — gateway must override when configured
+    )
+    content = resp.choices[0].message.content or ""
+    return Episode(
+        trajectories=[Trajectory(name="e2e", steps=[Step(chat_completions=[], model_response=content, action=content)])],
+        artifacts={"answer": content},
+    )
+
+
+@rllm.evaluator
+def e2e_eval(task, episode):  # noqa: ARG001
+    return 1.0
+
+
+def _tasks(n: int) -> list[Task]:
+    return [Task(id=str(i), instruction="2+2?", metadata={"question": "2+2?", "ground_truth": "4"}) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# eval path: run_dataset
+# ---------------------------------------------------------------------------
+
+
+def test_eval_run_dataset_enforces_sampling(mock_upstream):
+    from rllm.eval.runner import run_dataset
+
+    sampling = {"temperature": 0.0, "presence_penalty": 0.7, "top_k": 20}
+    result, episodes = asyncio.run(
+        run_dataset(
+            tasks=_tasks(2),
+            agent_flow=e2e_flow,
+            base_url=mock_upstream.url,
+            model="mock-model",
+            concurrency=2,
+            evaluator_override=e2e_eval,
+            sampling_params=sampling,
+        )
+    )
+
+    assert len(mock_upstream.requests) >= 2
+    for req in mock_upstream.requests:
+        assert req["temperature"] == 0.0, "gateway must override the flow's temperature=0.9"
+        assert req["presence_penalty"] == 0.7, "extra key must be injected at the gateway"
+        assert req["top_k"] == 20, "top_k must reach upstream even though the OpenAI SDK never sent it"
+
+
+# ---------------------------------------------------------------------------
+# training rollout path: AgentFlowEngine.execute_tasks(is_validation=False)
+# ---------------------------------------------------------------------------
+
+
+def test_train_rollout_enforces_train_sampling(mock_upstream):
+    from rllm.engine.agentflow_engine import AgentFlowEngine
+    from rllm.gateway.manager import EvalGatewayManager
+
+    gw = EvalGatewayManager(upstream_url=mock_upstream.url, model="mock-model")
+    gw.start()
+    try:
+        engine = AgentFlowEngine(
+            agent_flow=e2e_flow,
+            evaluator=e2e_eval,
+            gateway=gw,
+            model="mock-model",
+            n_parallel_tasks=2,
+            raise_on_error=True,
+            train_sampling_params={"temperature": 0.5, "min_p": 0.1},
+            val_sampling_params={"temperature": 0.0},
+        )
+        tasks = _tasks(2)
+        asyncio.run(engine.execute_tasks(tasks, task_ids=[t.id for t in tasks], is_validation=False))
+        engine.shutdown()
+    finally:
+        gw.stop()
+
+    assert mock_upstream.requests
+    # Every forwarded request carries the train-mode params (temperature overridden, extra injected).
+    assert all(req["temperature"] == 0.5 for req in mock_upstream.requests)
+    assert all(req.get("min_p") == 0.1 for req in mock_upstream.requests)


### PR DESCRIPTION
## Summary

Wires sampling parameters into AgentFlow with **one rule**: sampling config is resolved at the launcher (CLI flags / script overrides) into a single `SamplingConfig`, attached to the gateway session, and the **gateway overwrites those keys on every outgoing LLM request** — whatever the agent program or harness put there. A key is owned by exactly one place: if it's in the resolved launcher config the gateway owns it and always wins; if it's absent, the flow/harness keeps it. Same behavior for whitebox (`@rllm.rollout`) and blackbox (Claude Code, mini-swe-agent) programs, because enforcement happens at the proxy every call already routes through.

Supersedes #578 (its three `rllm eval` flags become a subset of `--sampling-params`, now routed through the gateway session so they also bind blackbox harnesses).

## What changed

- **Schema + resolver** — `rllm/cli/_sampling.py`: a small `SamplingConfig` (typed core `temperature`/`top_p`/`top_k`/`max_tokens` + an open `extra` passthrough for `presence_penalty`, `min_p`, …) plus the CLI resolvers. `--sampling-params` accepts a `"k=v,…"` string or `@file.yaml`/`@file.json`; precedence is `base.yaml rollout.{train,val}` < `@file`/string < `--temperature`/`--top-p`/`--max-tokens` flags. Resolved params are forwarded to the backend as-is — no provider-specific filtering; an unsupported key fails at the backend (the user's responsibility).
- **Defaults** — `base.yaml rollout.{train,val}` defaults only the universally accepted params (`temperature`/`top_p`/`max_tokens`); `top_k` (and penalties, etc.) are opt-in, so nothing non-portable is auto-injected. Native verl keeps its own `top_k` default via `actor_rollout_ref.rollout.*`.
- **Gateway enforcement** — `_mutate` simplifies to `payload.update(sp)` (configured keys win). Removes the `sampling_params_priority` knob entirely (middleware, `GatewayConfig`, server CLI, `base.yaml`, `GatewayManager`).
- **CLI** — `--sampling-params` + `--temperature`/`--top-p`/`--max-tokens` on both `rllm eval` and `rllm train`. The local `AgentFlowEngine` attaches the resolved config to the gateway session, so **whitebox flows are gateway-enforced too** (previously only blackbox harnesses were).
- **Flow demotion** — `AgentConfig.sampling_params` is now an informational mirror; the 8 cookbook flows drop the `**config.sampling_params` spread + manual `top_k` strip and just make plain LLM calls (the gateway injects server-side).

## CLI examples

```bash
# eval — gateway pins temperature + presence_penalty for every call the agent makes
rllm eval math --agent math --temperature 0.6 --sampling-params "presence_penalty=0.1"

# eval of a blackbox harness that hard-wires temperature — gateway overrides it
rllm eval swe-bench --agent harbor:mini-swe-agent --sampling-params "temperature=0.2,top_p=0.9"

# AgentFlow training (Hydra) — extra keys via the rllm.rollout namespace
python train.py rllm/backend=tinker \
  rllm.rollout.train.temperature=0.6 +rllm.rollout.train.presence_penalty=0.1
```

## Breaking changes

- Conflict resolution is **gateway-always-wins** for configured keys (the old middleware default let per-call client values win). Intended; release-note it.
- `gateway.sampling_params_priority` removed from `base.yaml` and the middleware.
- `AgentConfig.sampling_params` demoted to an informational mirror (cookbooks no longer spread it).
- `base.yaml` no longer ships `top_k: -1` under `rollout.{train,val}` — it's opt-in now. Native verl is unaffected (keeps its own default); AgentFlow won't inject `top_k` unless you set it.

## Scope

Scoped to the AgentFlow + gateway path. Native (non-AgentFlow) verl rollout is untouched — it already reads `temperature`/`top_p`/`top_k` from `actor_rollout_ref.rollout.*`, mirrored from `rllm.rollout.*` by `sync_config`.

## Testing

- **Unit**: `SamplingConfig` schema + CLI resolver precedence; gateway middleware always-wins.
- **Integration / E2E**: real gateway + mock upstream enforcement (override / passthrough / extra-key injection); eval `run_dataset` and the training-rollout path through a real gateway.
- **Real Tinker run**: 2-step LoRA training; forwarded requests carried injected `temperature=0.123` + `presence_penalty=0.5` on every rollout call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
