### PR TITLE
feat(trainer): deterministic optimizer steps with decoupled batch sizes to deal with variable seqs

### DIFF
--- a/rllm/trainer/verl/verl_backend.py
+++ b/rllm/trainer/verl/verl_backend.py
@@ -497,24 +497,69 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         if dp_size is None:
             return batch
 
-        # From verl RayPPOTrainer._update_actor: ppo_mini_batch_size is multiplied
-        # by rollout.n before being passed as mini_batch_size to update_actor and
-        # make_iterator enforces batch_per_gpu % mini_batch_size == 0. Globally this
-        # requires batch_size % (ppo_mini_batch_size * rollout.n) == 0.
+        # Multi-turn rollouts are prefix-merged into training rows on a best-effort
+        # basis; the merge frequently breaks (chat-template re-render, context
+        # management), so the real row count N is much larger than the rollout
+        # count and varies step-to-step. We make the number of optimizer steps a
+        # deterministic quantity r derived from config, and decouple the two batch
+        # sizes the verl worker consumes (which it treats independently):
+        #   - mini_batch_size = m  (ROWS per optimizer step) controls how
+        #     train_mini_batch chunks the batch, hence the update count. Verl
+        #     requires m % dp_size == 0 and total_rows % m == 0.
+        #   - global_batch_size = gbs (ROLLOUTS per update) is the seq-mean loss
+        #     denominator. Keeping it at the constant rollout count R_total // r
+        #     (not the drifting row count) gives the conventional per-example loss
+        #     scale and keeps it stable across steps regardless of merge ratio.
         rollout_n = self.config.actor_rollout_ref.rollout.n
         ppo_mbs = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
-        mini_batch_global = ppo_mbs * rollout_n
-        divisor = math.lcm(dp_size, mini_batch_global)
+        train_batch_size = self.config.data.train_batch_size
+        r = max(1, train_batch_size // ppo_mbs)  # desired optimizer steps per generation batch
+        r_total = train_batch_size * rollout_n  # total rollouts in this generation batch
 
         batch = self._remove_padding(batch)  # Remove any padded steps from the batch (just in case)
         original_batch_size = batch.batch["prompts"].shape[0]
+        n_rows = original_batch_size
+
+        # m = smallest multiple of dp_size that is >= ceil(N / r). Padding N up to
+        # the next multiple of m then yields exactly r chunks (one optimizer step
+        # each). Rounding m up to dp_size can rarely overshoot so that N spans only
+        # r-1 multiples; in that case accept the smaller achievable count.
+        #
+        # Infeasibility (actual_r < r): each mini-batch must split across the
+        # dp_size ranks, so m >= dp_size always. The most chunks N can be cut into
+        # is therefore ceil(N / dp_size); requesting r > ceil(N / dp_size) is
+        # physically impossible (e.g. N=10, dp_size=8, r=4 -> m=8 -> only 2 chunks).
+        # This requires a tiny (heavily filtered) batch or an extreme
+        # train_batch_size // ppo_mini_batch_size ratio; it does not occur for
+        # normal configs where N (hundreds-thousands) >> dp_size * r. actual_r
+        # is always <= r, so this only ever lowers the update count, never raises it.
+        per_update = math.ceil(n_rows / r)
+        m = math.ceil(per_update / dp_size) * dp_size
+        actual_r = math.ceil(n_rows / m)
+        if actual_r != r:
+            logger.warning(f"[update-count] requested r={r} infeasible after dp_size rounding (N={n_rows}, m={m}); using r={actual_r}")
+            r = actual_r
+        gbs = max(1, r_total // r)
+        divisor = m
+
         batch, pad_size = pad_dataproto_to_divisor(batch, divisor)
+
+        # Stash the decoupled sizes; read back in _update_actor_with_loss_routing.
+        # They are computed here (pad time) because the pad divisor and the
+        # update-time sizes must agree, and these run in different trainer phases.
+        batch.meta_info["rllm_actor_mini_batch_size"] = m
+        batch.meta_info["rllm_actor_global_batch_size"] = gbs
+        batch.meta_info["rllm_actor_num_updates"] = r
+        batch.meta_info["rllm_actor_rows_pre_pad"] = n_rows
 
         # Neutralise the padded rows. `advantages=0` (set by
         # update_dataproto_with_advantages via is_pad_step) zeros the loss
-        # numerator; zeroing `response_mask` keeps pad tokens out of
-        # `batch_num_tokens` so the loss denominator equals the real-token
-        # count and loss magnitude is invariant to pad_size.
+        # numerator; zeroing `response_mask` keeps pad tokens out of the loss.
+        # The seq-mean denominator (global_batch_size = gbs) is a fixed rollout
+        # count, not a live row/token count, so pad rows do not dilute it at r=1.
+        # At r>1 the single chunk holding the pad rows is under-scaled by ~pad/m
+        # (bounded by r*dp_size rows total), but the aggregate over all r updates
+        # is exact — an accepted trade-off vs. a variable per-step denominator.
         pad_start, pad_end = original_batch_size, original_batch_size + pad_size
         batch.batch["response_mask"][pad_start:pad_end] = 0
         batch.non_tensor_batch["is_last_step"][pad_start:pad_end] = False
@@ -542,6 +587,14 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             # pad batch size to world size for batch balancing
             batch = self._pad_dataproto_to_world_size(batch=batch)
             balance_batch(batch, self.actor_rollout_wg, metrics=metrics, use_prefix_grouper=self.use_prefix_grouper)
+            # Surface the now-deterministic update count and the decoupled batch
+            # sizes computed in _pad_dataproto_to_world_size.
+            if "rllm_actor_num_updates" in batch.meta_info:
+                metrics["actor/num_updates"] = batch.meta_info["rllm_actor_num_updates"]
+                metrics["actor/mini_batch_rows"] = batch.meta_info["rllm_actor_mini_batch_size"]
+                metrics["actor/global_batch_rollouts"] = batch.meta_info["rllm_actor_global_batch_size"]
+                metrics["batch/rows_pre_pad"] = batch.meta_info["rllm_actor_rows_pre_pad"]
+                metrics["batch/rows_post_pad"] = batch.batch["prompts"].shape[0]
 
         # Set meta_info needed by workers
         batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
@@ -690,19 +743,30 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         loss_fn_map = self.algorithm_config.loss_fn_map if self.algorithm_config is not None else {}
         group_roles = batch.non_tensor_batch.get("group_roles") if hasattr(batch, "non_tensor_batch") and batch.non_tensor_batch is not None else None
 
-        # Common training metadata
+        # Common training metadata. mini_batch_size (ROWS per optimizer step) and
+        # global_batch_size (ROLLOUTS, the seq-mean loss denominator) are decoupled
+        # and computed in _pad_dataproto_to_world_size; read them back here. The
+        # fallback (both = ppo_mini_batch_size * rollout.n) preserves the legacy
+        # behavior when balance_batch is off and no meta was stashed.
         rollout_n = self.config.actor_rollout_ref.rollout.n
         actor_cfg = self.config.actor_rollout_ref.actor
-        ppo_mbs = actor_cfg.ppo_mini_batch_size * rollout_n
+        default_mbs = actor_cfg.ppo_mini_batch_size * rollout_n
+        full_mini_batch_size = batch.meta_info.get("rllm_actor_mini_batch_size", default_mbs)
+        full_global_batch_size = batch.meta_info.get("rllm_actor_global_batch_size", default_mbs)
 
-        def _send_actor_update(sub_batch: DataProto, loss_override: str | None = None) -> None:
+        def _send_actor_update(
+            sub_batch: DataProto,
+            loss_override: str | None = None,
+            mini_batch_size: int | None = None,
+            global_batch_size: int | None = None,
+        ) -> None:
             """Convert DataProto to TensorDict, inject metadata, send to worker."""
             batch_td = sub_batch.to_tensordict()
             batch_td = left_right_2_no_padding(batch_td)
             metadata: dict[str, Any] = dict(
                 calculate_entropy=(actor_cfg.entropy_coeff != 0.0),
-                global_batch_size=ppo_mbs,
-                mini_batch_size=ppo_mbs,
+                global_batch_size=global_batch_size if global_batch_size is not None else full_global_batch_size,
+                mini_batch_size=mini_batch_size if mini_batch_size is not None else full_mini_batch_size,
                 epochs=actor_cfg.ppo_epochs,
                 seed=actor_cfg.data_loader_seed,
                 dataloader_kwargs={"shuffle": actor_cfg.shuffle},
@@ -740,12 +804,14 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             return
 
         # Multiple distinct losses: split batch by loss group, update each.
+        # TODO: multi-loss path still uses flat ppo_mbs*rollout_n semantics;
+        # needs per-group padding when exercised with the new const-steps logic.
         for loss_name, roles in loss_to_roles.items():
             role_set = set(roles)
-            mask = np.array([r in role_set for r in group_roles])
+            mask = np.array([role in role_set for role in group_roles])
             indices = np.where(mask)[0]
             sub_batch = batch[indices]
-            _send_actor_update(sub_batch, loss_name)
+            _send_actor_update(sub_batch, loss_name, mini_batch_size=default_mbs, global_batch_size=default_mbs)
 
     def shutdown(self) -> None:
         """Free GPU memory held by the rollout replicas.

--- a/rllm/trainer/verl/verl_backend.py
+++ b/rllm/trainer/verl/verl_backend.py
@@ -590,7 +590,7 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             # Surface the now-deterministic update count and the decoupled batch
             # sizes computed in _pad_dataproto_to_world_size.
             if "rllm_actor_num_updates" in batch.meta_info:
-                metrics["actor/num_updates"] = batch.meta_info["rllm_actor_num_updates"]
+                metrics["actor/num_updates_per_epoch"] = batch.meta_info["rllm_actor_num_updates"]
                 metrics["actor/mini_batch_rows"] = batch.meta_info["rllm_actor_mini_batch_size"]
                 metrics["actor/global_batch_rollouts"] = batch.meta_info["rllm_actor_global_batch_size"]
                 metrics["batch/rows_pre_pad"] = batch.meta_info["rllm_actor_rows_pre_pad"]


### PR DESCRIPTION
### Summary

- Decouple `mini_batch_size` (rows per optimizer step) from `global_batch_size` (seq-mean loss denominator) in the verl actor update path. Multi-turn rollouts produce a variable row count N that drifts across steps; the old code tied both sizes to `ppo_mini_batch_size * rollout_n`, which could cause excessive padding or variable number of optimizer updates, which makes it challenging to control the optimization process. 
- The number of optimizer steps per generation batch is now a deterministic `r = train_batch_size // ppo_mini_batch_size`, with padding minimized to the smallest multiple of `dp_size` that yields exactly `r` chunks.
- The loss denominator (`global_batch_size`) is fixed at `total_rollouts // r`, preserving conventional per-example loss scale regardless of row count drift.
- Padding is reduced from `lcm(dp_size, ppo_mbs * rollout_n)` to `ceil(N/r)` rounded to `dp_size`. For example, with `dp_size=2, ppo_mbs=32, rollout_n=4, N=298`: old divisor = `lcm(2, 128) = 128`, padding 298 to 384 (86 wasted rows); new divisor = 150, padding 298 to 300 (2 wasted rows).

### Test plan

Tested on agentcore-math (Qwen3-4B, GRPO, megatron, LoRA) with two configurations:

- **TP=8, dp=1, r=1** (`ppo_mini_batch_size=64`): almost full training, stable reward curve, `num_updates=1` and `global_batch_rollouts=256` every step.
- **TP=4, dp=2, r=2** (`ppo_mini_batch_size=32`): 22 steps (early terminated), `num_updates=2` and `global_batch_rollouts=128` every step, padding correctly rounds to multiples of 2 (e.g. 298->300, 289->292).

We can see that with this PR, the training performance still closely tracks the previous run (grey curve). But this should give a more consistent behavior that makes tuning easier to reason. The padding waste is also greatly reduced as mentioned in the example above.

### Limitation
- Multi-agent training use case was NOT covered. 

<img width="1149" height="876" alt="Screenshot 2026-06-08 at 12 32 53 PM" src="https://github.com/user-attachments/assets/d5895aa6-38f8-4e27-8819-e09e755700a2" />