### PR TITLE
feat(env): expose operational magic values as RLLM_* configurable env vars

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -91,7 +91,8 @@
             "pages": [
               "guides/customizing-training",
               "guides/distributed-training",
-              "guides/ray-runtime-env"
+              "guides/ray-runtime-env",
+              "guides/environment-variables"
             ]
           },
           {

--- a/docs/guides/environment-variables.mdx
+++ b/docs/guides/environment-variables.mdx
@@ -1,0 +1,99 @@
+---
+title: Environment variables
+description: The RLLM_* operational environment variables rLLM reads for timeouts, retries, and TTLs, and how they propagate to Ray training workers
+---
+
+rLLM exposes a small set of `RLLM_*` environment variables for *operational* knobs — timeouts, retries, TTLs — that you tune per environment (CI vs. cluster vs. laptop) without editing code or touching the experiment config. These are deliberately env vars rather than config fields: the config system is for experiment design, while env vars cover the operational surface.
+
+Every one of these parses through the typed readers in `rllm/env.py` (`env_int` / `env_float` / `env_str`), which read `os.environ` when called — usually once at module import to produce a module-level constant. This follows the existing `RLLM_HOME` / `RLLM_LOG_LEVEL` / `RLLM_SYMPY_TIMEOUT_S` precedent.
+
+<Note>
+  `env_int` and `env_float` raise `ValueError` on a malformed value — a typo in an ops knob fails loudly rather than silently falling back to the default.
+</Note>
+
+## Tier-1 operational knobs
+
+| Environment variable | Default | What it controls |
+| -------------------- | ------- | ---------------- |
+| `RLLM_SNAPSHOT_TTL_HOURS` | `168.0` | Snapshot-registry trust horizon (hours) before eviction |
+| `RLLM_OPENAI_REQUEST_TIMEOUT_S` | `3600` | Per-request HTTP timeout for OpenAI-compatible rollout calls |
+| `RLLM_GATEWAY_HEALTH_TIMEOUT_S` | `30.0` | Wait for the gateway subprocess to report healthy |
+| `RLLM_TUNNEL_READY_TIMEOUT_S` | `30.0` | Wait for cloudflared to publish a public URL |
+| `RLLM_HARNESS_RUN_TIMEOUT_S` | `1800` | Global per-task agent-CLI wall-clock ceiling (per-task metadata still overrides) |
+| `RLLM_HARNESS_INSTALL_TIMEOUT_S` | `600` | In-sandbox install-script timeout |
+| `RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S` | `30.0` | Deadline for the litellm proxy to accept connections |
+| `RLLM_EVAL_PROXY_NUM_RETRIES` | `3` | litellm `num_retries` baked into the proxy config |
+| `RLLM_FIREJAIL_EXEC_TIMEOUT_S` | `30` | firejail per-invocation code-exec timeout |
+| `RLLM_TACO_EXEC_TIMEOUT_S` | `90` | TACO / APPS / code-contests per-test exec timeout |
+| `RLLM_UI_HTTP_TIMEOUT_S` | `5.0` | httpx timeout for `UILogger` calls to the rLLM UI |
+| `RLLM_HARBOR_SESSION_TIMEOUT_S` | `900.0` | Per-task Harbor trial timeout (closes the gap where the eval path had no override) |
+
+### Usage
+
+Export the variable before running the command. Each knob falls back to its default when unset or empty.
+
+```bash
+# Give long-running harness tasks more headroom and loosen the firejail exec ceiling.
+export RLLM_HARNESS_RUN_TIMEOUT_S=3600
+export RLLM_FIREJAIL_EXEC_TIMEOUT_S=60
+
+python -m rllm.cli.train ...
+```
+
+<Tip>
+  An unset or empty value always resolves to the default shown above, so you only need to export the knobs you actually want to change.
+</Tip>
+
+## Use in distributed (Ray) training
+
+Because `"RLLM_"` is one of the `FORWARD_PREFIXES` in `rllm/trainer/verl/ray_runtime_env.py`, any `RLLM_*` variable exported on the launching node is **snapshotted into the Ray `runtime_env`** at `ray.init()` time and is therefore visible in `os.environ` on every Ray worker. So the knobs read inside workers — reward exec timeouts, harness timeouts, sandbox/snapshot TTLs — just work, without any per-worker plumbing.
+
+### How forwarding works
+
+`_get_forwarded_env_vars()` snapshots every `os.environ` key starting with a forwarded prefix into a dict; `get_ppo_ray_runtime_env()` does `env.update(_get_forwarded_env_vars())` and returns `{"env_vars": env, ...}`. That dict is passed straight to `ray.init(runtime_env=...)` (in `rllm/trainer/agent_trainer.py` and identically in `rllm/trainer/verl/train_agent_ppo.py`). Ray injects `runtime_env["env_vars"]` into every worker process's `os.environ`, so any `RLLM_*` re-read inside a worker sees the launcher-node value.
+
+<Note>
+  The snapshot is taken **once**, at `ray.init()` time, reading directly from the launching process's `os.environ`. Export your `RLLM_*` knobs *before* launching training — a value set after `ray.init()` will not reach the workers.
+</Note>
+
+### Why import-time reads still work
+
+Most of these vars are read at **module-import time** as module-level constants (firejail, TACO, harness, gateway, tunnel, snapshot, Harbor, UI-http). Ray imports those modules fresh inside the worker process, and the `runtime_env` has *already* populated `os.environ` before user modules import — so the constant captures the operator-set value. This ordering (env injected before modules import) is exactly the design the `rllm/env.py` docstring describes.
+
+### Architecture nuance: where the knobs actually run
+
+In rLLM training, the agent rollout loop, gateway/tunnel, harness execution, reward computation (firejail/TACO), and sandbox/snapshot all run inside the **`TaskRunner` Ray actor**, which hosts the workflow engine on a background asyncio loop. They do **not** run in the FSDP GPU workers (which only do `compute_log_prob` / `update_actor` / vLLM generation). The `TaskRunner` actor is a separate worker process from the launching driver, so forwarding still matters: `RLLM_*` must reach the actor, and it does via the `runtime_env` on `ray.init()`.
+
+The `RLLM_*` knobs that are read inside Ray workers (the `TaskRunner` actor) include:
+
+- `RLLM_HARNESS_INSTALL_TIMEOUT_S`, `RLLM_HARNESS_RUN_TIMEOUT_S`
+- `RLLM_FIREJAIL_EXEC_TIMEOUT_S`, `RLLM_TACO_EXEC_TIMEOUT_S`
+- `RLLM_GATEWAY_HEALTH_TIMEOUT_S`, `RLLM_TUNNEL_READY_TIMEOUT_S`
+- `RLLM_SNAPSHOT_TTL_HOURS`, `RLLM_UI_HTTP_TIMEOUT_S`
+- `RLLM_HARBOR_SESSION_TIMEOUT_S`
+
+<Note>
+  The primary verl rollout uses `VerlEngine` (talking to in-process vLLM servers via `AsyncLLMServerManager`), **not** `OpenAIEngine`, so `RLLM_OPENAI_REQUEST_TIMEOUT_S` does not affect it. That timeout applies only when `OpenAIEngine` is used — as the teacher engine for distillation, or in the eval-protocol / Fireworks engines — and even then it runs inside the `TaskRunner` actor.
+</Note>
+
+### Client-side knobs (not read in training workers)
+
+A few `RLLM_*` vars are read on the **driver / CLI side**, not inside Ray training workers:
+
+- `RLLM_EVAL_PROXY_NUM_RETRIES`, `RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S` (litellm proxy)
+- `RLLM_JUDGE_MODEL` / `RLLM_JUDGE_BASE_URL` (LLM-equality judge)
+- `RLLM_UI_URL` / `RLLM_API_KEY` (CLI login / tracking)
+
+The eval path does not go through `ray.init()`, so for evaluation these are simply read in the CLI process.
+
+### The Fireworks backend forwards `RLLM_*` too
+
+The Fireworks (pipeline) backend builds its `runtime_env` from the installed `verl.trainer.constants_ppo.get_ppo_ray_runtime_env`, which copies only a fixed PPO env dict and has no `RLLM_` forwarding of its own. To keep behaviour consistent with the default verl backend, `_train_fireworks` merges rLLM's `_get_forwarded_env_vars()` into that dict before `ray.init()`, so operator-set `RLLM_*` (and the other forwarded prefixes) reach the pipeline workers as well. The same `RLLM_EXCLUDE` opt-out applies.
+
+### Opting a variable out of forwarding
+
+Forwarding is governed by the same mechanism described in [Ray runtime environment](/guides/ray-runtime-env). `RLLM_EXCLUDE` opts variables out of the host-forwarding step: a specific name (`RLLM_EXCLUDE=RLLM_TACO_EXEC_TIMEOUT_S`) excludes that var, and `RLLM_EXCLUDE=RLLM*` strips **all** `RLLM_` forwarding by removing the prefix entirely.
+
+## See also
+
+All of these knobs parse through `rllm/env.py`. For parameters that shape the *experiment* rather than the operational surface, use the [config system](/training/configuration) — those are config fields, not environment variables.

--- a/docs/guides/environment-variables.mdx
+++ b/docs/guides/environment-variables.mdx
@@ -86,10 +86,6 @@ A few `RLLM_*` vars are read on the **driver / CLI side**, not inside Ray traini
 
 The eval path does not go through `ray.init()`, so for evaluation these are simply read in the CLI process.
 
-### The Fireworks backend forwards `RLLM_*` too
-
-The Fireworks (pipeline) backend builds its `runtime_env` from the installed `verl.trainer.constants_ppo.get_ppo_ray_runtime_env`, which copies only a fixed PPO env dict and has no `RLLM_` forwarding of its own. To keep behaviour consistent with the default verl backend, `_train_fireworks` merges rLLM's `_get_forwarded_env_vars()` into that dict before `ray.init()`, so operator-set `RLLM_*` (and the other forwarded prefixes) reach the pipeline workers as well. The same `RLLM_EXCLUDE` opt-out applies.
-
 ### Opting a variable out of forwarding
 
 Forwarding is governed by the same mechanism described in [Ray runtime environment](/guides/ray-runtime-env). `RLLM_EXCLUDE` opts variables out of the host-forwarding step: a specific name (`RLLM_EXCLUDE=RLLM_TACO_EXEC_TIMEOUT_S`) excludes that var, and `RLLM_EXCLUDE=RLLM*` strips **all** `RLLM_` forwarding by removing the prefix entirely.

--- a/rllm/engine/rollout/openai_engine.py
+++ b/rllm/engine/rollout/openai_engine.py
@@ -8,10 +8,13 @@ import openai
 from PIL import Image
 
 from rllm.engine.rollout.rollout_engine import ModelOutput, RolloutEngine
+from rllm.env import env_int
 from rllm.globals import THOUGHT_DELIMITER_END, THOUGHT_DELIMITER_START
 from rllm.parser import ChatTemplateParser
 from rllm.tools.tool_base import Tool
 from rllm.workflows import TerminationEvent, TerminationReason
+
+_REQUEST_TIMEOUT_S = env_int("RLLM_OPENAI_REQUEST_TIMEOUT_S", 3600)  # set env var: export RLLM_OPENAI_REQUEST_TIMEOUT_S=xxx
 
 
 class OpenAIEngine(RolloutEngine):
@@ -110,7 +113,7 @@ class OpenAIEngine(RolloutEngine):
         retries = self.api_retries
         while retries > 0:
             try:
-                response = await self.client.chat.completions.create(model=self.model, messages=converted_messages, timeout=3600, **create_params, **sampling_params)
+                response = await self.client.chat.completions.create(model=self.model, messages=converted_messages, timeout=_REQUEST_TIMEOUT_S, **create_params, **sampling_params)
 
                 content = response.choices[0].message.content
                 reasoning = response.choices[0].message.reasoning if hasattr(response.choices[0].message, "reasoning") and isinstance(response.choices[0].message.reasoning, str) else ""

--- a/rllm/env.py
+++ b/rllm/env.py
@@ -1,0 +1,46 @@
+"""Typed readers for ``RLLM_*`` operational environment variables.
+
+These knobs tune *infrastructure* behaviour — timeouts, retries, TTLs — that an
+operator may need to change per environment (CI vs. cluster vs. laptop) without
+editing code or touching the experiment config. They are deliberately env vars
+rather than config fields: config is for experiment design, env vars are for the
+operational surface. See ``docs/guides/environment-variables.mdx`` for the catalogue.
+
+The environment is read when the helper is called. Call it at module import to
+get a constant (the common case), or per-use if you need a live value. Every
+``RLLM_*`` name is forwarded to verl training workers automatically via
+``FORWARD_PREFIXES`` in ``rllm/trainer/verl/ray_runtime_env.py``, so a worker that
+re-imports the module sees the value the operator set on the launching node.
+
+Prefer these helpers over re-deriving ``os.getenv("RLLM_X", ...)`` inline so the
+parsing (and the ``RLLM_`` naming convention) lives in one place.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def env_str(name: str, default: str) -> str:
+    """Return ``$name`` if set and non-empty, else ``default``."""
+    value = os.environ.get(name)
+    return value if value else default
+
+
+def env_int(name: str, default: int) -> int:
+    """Return ``$name`` parsed as ``int`` if set and non-empty, else ``default``.
+
+    Raises ``ValueError`` on a malformed value — a typo in an ops knob should fail
+    loudly rather than silently fall back to the default.
+    """
+    value = os.environ.get(name)
+    return int(value) if value else default
+
+
+def env_float(name: str, default: float) -> float:
+    """Return ``$name`` parsed as ``float`` if set and non-empty, else ``default``.
+
+    Raises ``ValueError`` on a malformed value (see :func:`env_int`).
+    """
+    value = os.environ.get(name)
+    return float(value) if value else default

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -28,7 +28,12 @@ from typing import Any
 import requests
 import yaml
 
+from rllm.env import env_float, env_int
+
 logger = logging.getLogger(__name__)
+
+_NUM_RETRIES = env_int("RLLM_EVAL_PROXY_NUM_RETRIES", 3)  # set env var: export RLLM_EVAL_PROXY_NUM_RETRIES=xxx
+_STARTUP_TIMEOUT_S = env_float("RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S", 30.0)  # set env var: export RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S=xxx
 
 
 class _ProxyManagerBase:
@@ -146,7 +151,7 @@ class EvalProxyManager(_ProxyManagerBase):
             ],
             "litellm_settings": {
                 "drop_params": True,
-                "num_retries": 3,
+                "num_retries": _NUM_RETRIES,
             },
         }
 
@@ -204,7 +209,7 @@ class EvalProxyManager(_ProxyManagerBase):
         )
 
         try:
-            self._wait_for_proxy(timeout=30.0)
+            self._wait_for_proxy(timeout=_STARTUP_TIMEOUT_S)
             logger.info("Proxy server started, sending configuration...")
             self.reload_proxy_config(config=config)
             logger.info("Proxy configuration loaded successfully")

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -39,6 +39,8 @@ from typing import TYPE_CHECKING, Any
 from rllm_model_gateway.client import AsyncGatewayClient, GatewayClient
 from rllm_model_gateway.models import TraceRecord
 
+from rllm.env import env_float
+
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
@@ -47,7 +49,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _HEALTH_POLL_INTERVAL = 0.5
-_HEALTH_POLL_TIMEOUT = 30.0
+_HEALTH_POLL_TIMEOUT = env_float("RLLM_GATEWAY_HEALTH_TIMEOUT_S", 30.0)  # set env var: export RLLM_GATEWAY_HEALTH_TIMEOUT_S=xxx
 _TRACE_API_TIMEOUT = 600.0
 
 

--- a/rllm/gateway/tunnel.py
+++ b/rllm/gateway/tunnel.py
@@ -18,6 +18,8 @@ import time
 
 from rich.console import Console
 
+from rllm.env import env_float
+
 logger = logging.getLogger(__name__)
 
 _status = Console()
@@ -47,7 +49,7 @@ def parse_tunnel(value: str | None) -> tuple[str | None, str | None]:
 
 
 _TRYCF_URL_RE = re.compile(r"https?://[a-zA-Z0-9.-]+\.trycloudflare\.com")
-_DEFAULT_READY_TIMEOUT = 30.0
+_DEFAULT_READY_TIMEOUT = env_float("RLLM_TUNNEL_READY_TIMEOUT_S", 30.0)  # set env var: export RLLM_TUNNEL_READY_TIMEOUT_S=xxx
 # Retry transient Cloudflare QuickTunnel allocator 5xx blips.
 _DEFAULT_MAX_ATTEMPTS = 4
 

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -34,6 +34,7 @@ import shlex
 import uuid
 from abc import abstractmethod
 
+from rllm.env import env_int
 from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
 from rllm.types import AgentConfig, Task
 
@@ -61,8 +62,8 @@ class BaseCliHarness(SandboxedAgentFlow):
     # Path inside the sandbox where the CLI's stdout is teed.
     stdout_log_path: str = "/tmp/agent-stdout.log"
     # Per-call timeouts (seconds). Tasks may override via metadata.
-    install_timeout: int = 600
-    run_timeout: int = 1800
+    install_timeout: int = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)  # set env var: export RLLM_HARNESS_INSTALL_TIMEOUT_S=xxx
+    run_timeout: int = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 1800)  # set env var: export RLLM_HARNESS_RUN_TIMEOUT_S=xxx
 
     # ---------------------------------------------------------------------
     # Sandbox helpers

--- a/rllm/integrations/harbor/runtime.py
+++ b/rllm/integrations/harbor/runtime.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 from typing import Any
 
+from rllm.env import env_float
 from rllm.integrations.harbor.trial_helper import (
     MODEL_PLACEHOLDER,
     HarborTaskOutcome,
@@ -21,6 +22,8 @@ from rllm.integrations.harbor.trial_helper import (
 )
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_SESSION_TIMEOUT_S = env_float("RLLM_HARBOR_SESSION_TIMEOUT_S", 900.0)  # set env var: export RLLM_HARBOR_SESSION_TIMEOUT_S=xxx
 
 
 class HarborRuntime:
@@ -48,7 +51,7 @@ class HarborRuntime:
         verifier_timeout_multiplier: float | None = None,
         agent_setup_timeout_multiplier: float | None = None,
         environment_build_timeout_multiplier: float | None = None,
-        session_timeout: float = 900.0,
+        session_timeout: float = _DEFAULT_SESSION_TIMEOUT_S,
     ):
         self.agent_name = agent_name
         self.environment_type = environment_type

--- a/rllm/rewards/code_utils/firejail_exec.py
+++ b/rllm/rewards/code_utils/firejail_exec.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
+from rllm.env import env_int
+
 from .utils import BASE_IMPORTS, BASE_LEETCODE_IMPORTS
 
 # sudo add-apt-repository ppa:deki/firejail
@@ -12,7 +14,7 @@ from .utils import BASE_IMPORTS, BASE_LEETCODE_IMPORTS
 CLI_ARG_SIZE_LIMIT = 1024 * 3
 
 _ERROR_MSG_PREFIX = "Failed to execute program: "
-_DEFAULT_TIMEOUT_SECONDS = 30
+_DEFAULT_TIMEOUT_SECONDS = env_int("RLLM_FIREJAIL_EXEC_TIMEOUT_S", 30)  # set env var: export RLLM_FIREJAIL_EXEC_TIMEOUT_S=xxx
 
 
 def code_exec_firejail(code, stdin: str = None, timeout=_DEFAULT_TIMEOUT_SECONDS, pytest: str = None):

--- a/rllm/rewards/code_utils/taco.py
+++ b/rllm/rewards/code_utils/taco.py
@@ -18,6 +18,7 @@ from unittest.mock import mock_open, patch
 
 import numpy as np
 
+from rllm.env import env_int
 from rllm.rewards.code_utils.pyext2 import RuntimeModule
 
 from .utils import BASE_IMPORTS
@@ -70,7 +71,7 @@ try:
     signal.signal(signal.SIGALRM, timeout_handler)
 except ValueError:
     pass  # signal only works in main thread; skip in Ray workers
-TIMEOUT = 90  # seconds
+TIMEOUT = env_int("RLLM_TACO_EXEC_TIMEOUT_S", 90)  # set env var: export RLLM_TACO_EXEC_TIMEOUT_S=xxx
 
 EXECUTION_RESULTS = {1: "passed", 0: "false", -1: "timeout", -2: "runtime_error", -3: "returncode:{code}", -4: "compile_error"}
 

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -17,6 +17,8 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
+from rllm.env import env_float
+
 if TYPE_CHECKING:
     from rllm.sandbox.protocol import Sandbox
     from rllm.types import Task
@@ -27,7 +29,7 @@ logger = logging.getLogger(__name__)
 _NO_SNAPSHOT_BACKENDS = {"docker", "local"}
 
 # Default local trust horizon for a snapshot entry (7 days).
-_DEFAULT_TTL_HOURS = 168.0
+_DEFAULT_TTL_HOURS = env_float("RLLM_SNAPSHOT_TTL_HOURS", 168.0)  # set env var: export RLLM_SNAPSHOT_TTL_HOURS=xxx
 
 
 def _registry_path() -> str:

--- a/rllm/trainer/agent_trainer.py
+++ b/rllm/trainer/agent_trainer.py
@@ -101,10 +101,16 @@ class AgentTrainer:
         import ray
 
         if not ray.is_initialized():
-            # TODO: check whether we need a separate function to retrieve the runtime environment (for fireworks)
             from verl.trainer.constants_ppo import get_ppo_ray_runtime_env as get_fireworks_ray_runtime_env
 
-            ray.init(runtime_env=get_fireworks_ray_runtime_env(), num_cpus=self.config.ray_init.num_cpus)
+            from rllm.trainer.verl.ray_runtime_env import _get_forwarded_env_vars
+
+            # verl's builder doesn't forward operator env vars; merge in the same
+            # RLLM_*/inference/CUDA prefixes the verl backend forwards so RLLM_*
+            # knobs reach the pipeline workers (see guides/environment-variables).
+            runtime_env = get_fireworks_ray_runtime_env()
+            runtime_env.setdefault("env_vars", {}).update(_get_forwarded_env_vars())
+            ray.init(runtime_env=runtime_env, num_cpus=self.config.ray_init.num_cpus)
 
         # Lazy import to avoid requiring fireworks package for users who don't use it
         from rllm.trainer.verl.train_workflow_pipeline import PipelineTaskRunner

--- a/rllm/trainer/verl/ray_runtime_env.py
+++ b/rllm/trainer/verl/ray_runtime_env.py
@@ -62,7 +62,9 @@ def _get_forwarded_env_vars():
 
     forward_prefix = FORWARD_PREFIXES.copy()
 
-    exclude_vars = set()
+    # RLLM_EXCLUDE is a control var read on the launching node; it matches the
+    # RLLM_ prefix but must never be forwarded into workers.
+    exclude_vars = {"RLLM_EXCLUDE"}
     for name in rllm_exclude:
         if "*" in name:  # denote a prefix match, e.g. "VLLM*"
             prefix = name.replace("*", "_")

--- a/rllm/utils/tracking.py
+++ b/rllm/utils/tracking.py
@@ -29,6 +29,10 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
+from rllm.env import env_float
+
+_UI_HTTP_TIMEOUT_S = env_float("RLLM_UI_HTTP_TIMEOUT_S", 5.0)  # set env var: export RLLM_UI_HTTP_TIMEOUT_S=xxx
+
 
 def concat_dict_to_str(dict: dict, step):
     output = [f"step:{step}"]
@@ -345,7 +349,7 @@ class UILogger:
         headers = {}
         if api_key:
             headers["X-API-Key"] = api_key
-        self.client = httpx.Client(base_url=self.ui_url, timeout=5.0, headers=headers)
+        self.client = httpx.Client(base_url=self.ui_url, timeout=_UI_HTTP_TIMEOUT_S, headers=headers)
         self._heartbeat_stop = threading.Event()
 
         try:


### PR DESCRIPTION
## What

Exposes a tight set of **operational** magic values as `RLLM_*` environment
variables so they can be tuned per environment (CI vs. cluster vs. laptop)
without editing code or touching the experiment config. Config is for experiment
design; env vars are for the ops surface. Follows the existing
`RLLM_HOME` / `RLLM_SYMPY_TIMEOUT_S` precedent.

A small typed reader — **`rllm/env.py`** (`env_int` / `env_float` / `env_str`) —
centralizes parsing (empty/unset → default, malformed → loud `ValueError`).
**Behaviour is unchanged when a var is unset** (same default and type as before).

### Knobs (12)

| Env var | Default | Controls |
| --- | --- | --- |
| `RLLM_SNAPSHOT_TTL_HOURS` | `168.0` | Snapshot-registry trust horizon (hours) |
| `RLLM_OPENAI_REQUEST_TIMEOUT_S` | `3600` | OpenAI-compatible rollout request timeout |
| `RLLM_GATEWAY_HEALTH_TIMEOUT_S` | `30.0` | Gateway health-poll timeout |
| `RLLM_TUNNEL_READY_TIMEOUT_S` | `30.0` | cloudflared public-URL wait |
| `RLLM_HARNESS_RUN_TIMEOUT_S` | `1800` | Per-task agent-CLI ceiling (task metadata still overrides) |
| `RLLM_HARNESS_INSTALL_TIMEOUT_S` | `600` | In-sandbox install-script timeout |
| `RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S` | `30.0` | litellm proxy startup deadline |
| `RLLM_EVAL_PROXY_NUM_RETRIES` | `3` | litellm `num_retries` |
| `RLLM_FIREJAIL_EXEC_TIMEOUT_S` | `30` | firejail code-exec timeout |
| `RLLM_TACO_EXEC_TIMEOUT_S` | `90` | TACO/APPS per-test exec timeout |
| `RLLM_UI_HTTP_TIMEOUT_S` | `5.0` | UILogger httpx timeout |
| `RLLM_HARBOR_SESSION_TIMEOUT_S` | `900.0` | Harbor trial timeout (closes the eval-path gap) |

Selected from a broader audit; per-dataset / already-configurable / core
hyperparameter values were intentionally **not** exposed to avoid env-var sprawl.
The example tool integrations (`e2b` / `gsearch` / `firecrawl`) are likewise left
hardcoded — they're demo tools and don't belong in the `RLLM_*` namespace.

## Ray propagation

The default verl backend already forwards `RLLM_*` to workers (`RLLM_` is in
`FORWARD_PREFIXES`), so knobs read inside the `TaskRunner` actor work. Two fixes:

- **Fireworks backend**: `_train_fireworks` built its `runtime_env` from verl's own
  `constants_ppo` (no `RLLM_` forwarding). Merge in `_get_forwarded_env_vars()` so
  the fireworks path forwards `RLLM_*` too — resolves the standing `TODO`.
- **`RLLM_EXCLUDE`** is no longer forwarded to workers (it's a launching-node
  control var that happened to match the `RLLM_` prefix). Fixes the pre-existing
  `test_exclude_specific_var_names` failure.

## Docs

New `guides/environment-variables.mdx` (catalogue + Ray-propagation notes,
mirroring `ray-runtime-env`), added to the Guides nav.

## Verification

- ruff clean; all 12 vars verified default-when-unset / override-when-set; all
  edited modules import clean.
- `tests/trainer/verl/test_ray_runtime_env.py` 15/15 (was 14/1), plus
  `tests/cli` + harness tests green (no regressions).
- Fireworks forwarding asserted directly (RLLM_* merged into verl's runtime_env,
  verl defaults preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
