### PR TITLE
feat(cli,trainer): train sandboxed agents on separate local train/val benchmarks

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -19,6 +19,7 @@ from rllm import paths
 from rllm.cli._pull import load_dataset_catalog, pull_dataset
 from rllm.cli._sampling import SAMPLING_PARAMS_HELP as _SAMPLING_PARAMS_HELP
 from rllm.cli._ui import console, fail, info_panel, not_found, parse_index_spec
+from rllm.types import Task
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ def _suggest_benchmarks(name: str, catalog_names: list[str], max_suggestions: in
     return get_close_matches(name, catalog_names, n=max_suggestions, cutoff=0.5)
 
 
-def _dict_rows_to_tasks(rows: list[dict]) -> list:
+def _dict_rows_to_tasks(rows: list[dict]) -> list[Task]:
     """Wrap dict-rows from a catalog dataset as Task objects.
 
     Harbor rows carry ``task_path``; we root the Task there and merge the task's
@@ -42,7 +43,6 @@ def _dict_rows_to_tasks(rows: list[dict]) -> list:
     from pathlib import Path
 
     from rllm.tasks.loader import _merge_task_toml_metadata
-    from rllm.types import Task
 
     tasks: list[Task] = []
     for idx, row in enumerate(rows):

--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -188,8 +188,18 @@ def _run_train(
     val_ds_name = val_dataset_name or benchmark
 
     if BenchmarkLoader.is_local_benchmark(benchmark):
+        from rllm.data.dataset import Dataset as _Dataset
+
+        # --train/--val-dataset may each point at a separate local benchmark dir;
+        # an unset (or non-local) --val-dataset falls back to reusing the train tasks.
+        train_dir = train_dataset_name if (train_dataset_name and BenchmarkLoader.is_local_benchmark(train_dataset_name)) else benchmark
+        val_dir = val_dataset_name if (val_dataset_name and BenchmarkLoader.is_local_benchmark(val_dataset_name)) else None
+        if val_dataset_name and val_dir is None:
+            console.print(f"  [key]--val-dataset '{val_dataset_name}' is not a local benchmark dir; reusing train tasks for validation.[/]")
+
         # For local sandbox tasks, --agent picks the AgentFlow.
-        bench_result = BenchmarkLoader.load(benchmark, harness_name=agent_name)
+        bench_result = BenchmarkLoader.load(train_dir, harness_name=agent_name)
+        train_ds_name = bench_result.name
         catalog_entry = {
             "description": bench_result.description,
             "category": bench_result.category,
@@ -203,10 +213,9 @@ def _run_train(
         except (KeyError, ImportError, AttributeError, TypeError) as e:
             fail(f"Cannot load agent '{agent_name}': {e}")
 
-        # Evaluator: --evaluator > dataset.toml [verifier].
-        # Sandbox-shell verifiers aren't supported here (per-task sandbox
-        # lifecycle lives inside Runner) — use --evaluator to override.
-        evaluator_display = "N/A"
+        # Evaluator: --evaluator > train dataset.toml [verifier]; one host-side
+        # evaluator scores both train and val. Sandbox-shell verifiers aren't
+        # supported here — use --evaluator to override.
         if evaluator_name is not None:
             evaluator = load_evaluator(evaluator_name)
             evaluator_display = evaluator_name
@@ -215,7 +224,7 @@ def _run_train(
 
             from rllm.eval._resolution import build_dataset_evaluator
 
-            evaluator = build_dataset_evaluator(_Path(benchmark).resolve())
+            evaluator = build_dataset_evaluator(_Path(train_dir).resolve())
             if evaluator is None:
                 fail(
                     "Could not resolve a verifier for this benchmark. "
@@ -225,25 +234,23 @@ def _run_train(
                 )
             evaluator_display = f"{type(evaluator).__name__} (from dataset.toml)"
 
-        # Datasets: pass the Task list as both train and val for now
-        from rllm.data.dataset import Dataset as _Dataset
-
         if train_split is None:
             train_split = bench_result.split or "train"
-        train_dataset = _Dataset(
-            data=list(bench_result.tasks),
-            name=bench_result.name,
-            split=train_split,
-        )
+        train_dataset = _Dataset(data=list(bench_result.tasks), name=bench_result.name, split=train_split)
         if max_examples is not None and max_examples < len(train_dataset):
             train_dataset = train_dataset.select(range(max_examples))
-        val_dataset = _Dataset(
-            data=list(bench_result.tasks),
-            name=bench_result.name,
-            split=bench_result.split or "test",
-        )
-        if val_split is None:
-            val_split = train_dataset.split or "test"
+
+        if val_dir is not None:
+            val_result = BenchmarkLoader.load(val_dir, harness_name=agent_name)
+            val_ds_name = val_result.name
+            if val_split is None:
+                val_split = val_result.split or "test"
+            val_dataset = _Dataset(data=list(val_result.tasks), name=val_result.name, split=val_split)
+        else:
+            val_ds_name = bench_result.name
+            if val_split is None:
+                val_split = bench_result.split or "test"
+            val_dataset = _Dataset(data=list(bench_result.tasks), name=bench_result.name, split=val_split)
 
     # ------------------------------------------------------------------
     # Catalog / Harbor path (existing behavior)

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -978,8 +978,13 @@ class AgentTrainer:
         store: Store | None = None,
         **kwargs,
     ):
-        # Auto-wire sandbox hooks + gateway loopback unless caller set hooks/evaluator.
-        if agent_flow is not None and hooks is None and evaluator is None:
+        # Auto-wire sandbox hooks + gateway loopback unless the caller set hooks.
+        # A SandboxedAgentFlow always needs the per-task sandbox even when the caller
+        # also passed a host-side evaluator, so fold that evaluator into the hooks as
+        # the override (mirrors how ``rllm eval`` wires evaluator_override). For the
+        # other isolation case (harbor task_path rows) keep the prior behavior of
+        # auto-wiring only when no evaluator was given.
+        if agent_flow is not None and hooks is None:
             from rllm.hooks import (
                 SandboxTaskHooks,
                 enable_tunnel_for_remote_sandbox,
@@ -987,8 +992,16 @@ class AgentTrainer:
                 pin_gateway_host_loopback,
             )
 
-            if needs_sandbox_isolation(agent_flow, train_dataset, val_dataset):
-                hooks = SandboxTaskHooks(sandbox_backend=sandbox_backend)
+            try:
+                from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+
+                is_sandboxed_flow = isinstance(agent_flow, SandboxedAgentFlow)
+            except ImportError:
+                is_sandboxed_flow = False
+
+            if needs_sandbox_isolation(agent_flow, train_dataset, val_dataset) and (evaluator is None or is_sandboxed_flow):
+                hooks = SandboxTaskHooks(evaluator_override=evaluator, sandbox_backend=sandbox_backend)
+                evaluator = None
                 config = pin_gateway_host_loopback(config)
                 config = enable_tunnel_for_remote_sandbox(config, sandbox_backend)
 

--- a/tests/cli/test_train_command.py
+++ b/tests/cli/test_train_command.py
@@ -483,6 +483,40 @@ class TestTrainCommand:
         assert "train_bench" in result.output
         assert "val_bench" in result.output
 
+    def test_train_local_separate_val_dataset(self, runner, tmp_rllm_home, tmp_path):
+        """Local benchmark dirs: --val-dataset pointing at a separate local dir yields a distinct val set."""
+
+        def _make_bench(root, name, n_tasks, split):
+            root.mkdir()
+            (root / "dataset.toml").write_text(f'[dataset]\nname = "{name}"\ntype = "sandbox"\nsplit = "{split}"\n')
+            for i in range(n_tasks):
+                td = root / f"task_{i}"
+                td.mkdir()
+                (td / "task.toml").write_text(f'[task]\nname = "{name}_{i}"\n')
+                (td / "instruction.md").write_text(f"do {i}")
+
+        train_dir = tmp_path / "train_bench"
+        val_dir = tmp_path / "val_bench"
+        _make_bench(train_dir, "train_bench", 2, "train")
+        _make_bench(val_dir, "val_bench", 1, "test")
+
+        mock_trainer = MagicMock()
+        with (
+            patch("rllm.eval.agent_loader.load_agent", return_value=_MockAgentFlow()),
+            patch("rllm.eval._resolution.build_dataset_evaluator", return_value=_MockEvaluator()),
+            patch("rllm.trainer.AgentTrainer", return_value=mock_trainer) as mock_at_cls,
+        ):
+            result = runner.invoke(
+                cli,
+                ["train", str(train_dir), "--val-dataset", str(val_dir), "--agent", "react", "--model", "test-model"],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_at_cls.call_args.kwargs
+        assert len(kwargs["train_dataset"]) == 2
+        assert len(kwargs["val_dataset"]) == 1
+        assert kwargs["train_dataset"] is not kwargs["val_dataset"]
+
     def test_train_no_evaluator_found(self, runner, tmp_rllm_home, mock_train_dataset):
         """Train should fail if no evaluator can be resolved."""
         catalog = {"datasets": {"test_math": {"default_agent": "math"}}}


### PR DESCRIPTION
## What

Unblocks `rllm train` (CLI) from training a rLLM-native `SandboxedAgentFlow` (e.g. `mini-swe-agent`) on a **local** train benchmark while validating on a **separate local** benchmark, with snapshot + warm-pool acceleration on Tinker + Daytona. Two gaps:

1. **`rllm/cli/train.py`** — the local-benchmark branch ignored `--train-dataset`/`--val-dataset` and reused the train tasks as validation. It now resolves each flag to its own local benchmark dir and loads a distinct val set (falls back to the prior "train doubles as val" when `--val-dataset` is unset or not a local dir).

2. **`rllm/trainer/unified_trainer.py`** — `AgentTrainer` only auto-wired `SandboxTaskHooks` when `evaluator is None`. A `SandboxedAgentFlow` *always* needs its per-task sandbox, but the local path *must* pass a host-side verifier — so passing it disabled the sandbox lifecycle and the harness crashed with `requires a sandbox`. The evaluator is now folded in as `SandboxTaskHooks(evaluator_override=...)` (the pattern `rllm eval` already uses), so the sandbox is created and the verifier still scores. Guarded by `evaluator is None or isinstance(agent_flow, SandboxedAgentFlow)`, so behavior is identical to before for every other path (plain AgentFlows, harbor/remote, verl).

## Verification

E2E on **Tinker + Daytona** with `mini-swe-agent` on mini local SWE-style benchmarks (snapshots pre-built for both train & val):

- ✅ **1 validation step + 5 training steps**, 18 rollouts, 0 errors (`termination_reason/error: 0.0`).
- ✅ Snapshot active — sandboxes boot `image: snapshot:rllm-env-…` → per-rollout `setup` 0–1s vs ~60s cold install.
- ✅ Warm pool active — `training warm queue started: 2 ahead over 2 scheduled tasks`.
- ✅ **0 leaked sandboxes** (checked via the Daytona SDK after each run).

Adds `tests/cli/test_train_command.py::test_train_local_separate_val_dataset`. Reviewed adversarially (APPROVE-WITH-NITS → nits addressed → confirmed via a guard truth-table check).

## Notes

- The pre-existing `test_train_sampling_params_reach_rollout_config` failure (a `max_tokens` 2048-vs-30720 base.yaml default mismatch) already fails on `terminal-rl` and is unrelated to this diff.
- Local-benchmark training still supports only host-side verifiers (`build_dataset_evaluator` returns `None` for `python-hybrid`); in-sandbox / SWE-bench verifiers are the next gap for real-dataset SWE training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
