### PR TITLE
refactor(hooks,engine): one env-requirement join + always-hooks engine (AgentFlow phases 0–1)

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -38,7 +38,7 @@ def _dict_rows_to_tasks(rows: list[dict]) -> list[Task]:
     ``task.toml`` + ``environment/Dockerfile`` metadata (workdir, verifier
     timeout, per-task image) so per-task verifier resolution and an rllm-native
     harness get the right sandbox. Other rows get ``dataset_dir=Path(".")`` and
-    rely on ``evaluator_override``.
+    rely on the fixed-evaluator policy.
     """
     from pathlib import Path
 
@@ -474,7 +474,7 @@ def _run_eval(
             agent_name=agent_name,
             dataset_name=getattr(dataset, "name", benchmark) or benchmark,
             on_episode_complete=on_episode_complete,
-            evaluator_override=evaluator,
+            evaluator=evaluator,
             sampling_params=(sampling_config.as_dict() if sampling_config is not None else None),
         )
     )

--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -213,26 +213,27 @@ def _run_train(
         except (KeyError, ImportError, AttributeError, TypeError) as e:
             fail(f"Cannot load agent '{agent_name}': {e}")
 
-        # Evaluator: --evaluator > train dataset.toml [verifier]; one host-side
-        # evaluator scores both train and val. Sandbox-shell verifiers aren't
-        # supported here — use --evaluator to override.
+        # Evaluator: --evaluator > train dataset.toml [verifier]; a host-side
+        # evaluator scores both train and val. Env-style verifiers
+        # (sandbox-shell / python-hybrid) resolve per task inside the sandbox
+        # via SandboxTaskHooks, so leave ``evaluator`` unset for those.
         if evaluator_name is not None:
             evaluator = load_evaluator(evaluator_name)
             evaluator_display = evaluator_name
         else:
             from pathlib import Path as _Path
 
-            from rllm.eval._resolution import build_dataset_evaluator
+            from rllm.eval._resolution import build_dataset_evaluator, dataset_verifier_kind
 
-            evaluator = build_dataset_evaluator(_Path(train_dir).resolve())
-            if evaluator is None:
-                fail(
-                    "Could not resolve a verifier for this benchmark. "
-                    "Declare a host-side verifier in dataset.toml ([verifier].name / "
-                    ".module / .import_path) or pass --evaluator explicitly. "
-                    "Sandbox-shell verifiers aren't supported in training yet."
-                )
-            evaluator_display = f"{type(evaluator).__name__} (from dataset.toml)"
+            train_dir_path = _Path(train_dir).resolve()
+            evaluator = build_dataset_evaluator(train_dir_path)
+            if evaluator is not None:
+                evaluator_display = f"{type(evaluator).__name__} (from dataset.toml)"
+            else:
+                kind = dataset_verifier_kind(train_dir_path)
+                if kind == "missing":
+                    fail("Could not resolve a verifier for this benchmark. Declare a verifier in dataset.toml ([verifier].name / .module / .import_path / .script) or pass --evaluator explicitly.")
+                evaluator_display = f"per-task ({kind}, in-sandbox)"
 
         if train_split is None:
             train_split = bench_result.split or "train"
@@ -476,9 +477,9 @@ def _describe_sandbox_routing(
 ) -> str | None:
     """One-line description of sandbox + gateway routing for the header. Returns ``None`` when no sandbox is needed."""
     from rllm.gateway.tunnel import is_local_sandbox_backend, parse_tunnel
-    from rllm.hooks import needs_sandbox_isolation
+    from rllm.hooks import scan_env_requirements
 
-    if not needs_sandbox_isolation(agent_flow, train_dataset, val_dataset):
+    if not scan_env_requirements(agent_flow, train_dataset, val_dataset, sandbox_backend=sandbox_backend).needs_env:
         return None
 
     backend = (sandbox_backend or "docker").lower()

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -2,13 +2,14 @@
 
 Single execution engine for both training and eval. Each rollout:
 
-1. ``hooks.setup(task, agent_flow, uid)`` runs (if hooks provided) — eval
-   uses this to create a per-task sandbox + resolve a per-task verifier;
-   training leaves hooks unset.
+1. ``hooks.setup(task, agent_flow, uid)`` runs — sandbox-style hooks create
+   a per-task sandbox + resolve a per-task verifier; a bare ``evaluator=``
+   is wrapped in :class:`rllm.hooks.FixedEvaluatorHooks` so the engine has
+   exactly one execution path.
 2. The agent flow runs against the gateway session URL.
-3. Traces are fetched and the Episode is enriched with token-level Steps.
-4. The evaluator scores the enriched Episode (per-task evaluator from the
-   hook context if hooks set; otherwise the engine-bound ``self.evaluator``).
+3. Traces are fetched and the Episode is enriched with token-level Steps
+   (strict for training, relaxed for validation).
+4. The hook-resolved evaluator scores the enriched Episode.
 5. Reward is written back; the hook context is torn down. Sessions are
    batch-deleted from the trace store at the end of the step.
 
@@ -88,9 +89,9 @@ class TaskHooks(Protocol):
 
     The engine calls :meth:`setup` before the agent flow runs and
     :meth:`TaskContext.run_teardown` after the evaluator runs (or on failure).
-    Eval installs hooks that create a sandbox and resolve a per-task verifier;
-    training leaves hooks unset and the engine uses ``self.evaluator``
-    directly.
+    Sandbox-style hooks create a sandbox and resolve a per-task verifier;
+    :class:`rllm.hooks.FixedEvaluatorHooks` binds one evaluator to every task
+    and provisions nothing.
     """
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext: ...
@@ -349,10 +350,13 @@ class AgentFlowEngine:
         val_sampling_params: dict | None = None,
     ) -> None:
         if evaluator is None and hooks is None:
-            raise ValueError("AgentFlowEngine requires either an `evaluator` (single evaluator, typical training) or `hooks` (per-task evaluator + setup/teardown, typical eval). Both cannot be None.")
+            raise ValueError("AgentFlowEngine requires either an `evaluator` (single evaluator for every task) or `hooks` (per-task evaluator + setup/teardown). Both cannot be None.")
+        if hooks is None:
+            from rllm.hooks import FixedEvaluatorHooks
+
+            hooks = FixedEvaluatorHooks(evaluator)
 
         self.agent_flow = agent_flow
-        self.evaluator = evaluator
         self.gateway = gateway
         self.model = model
         self.n_parallel_tasks = n_parallel_tasks
@@ -460,13 +464,7 @@ class AgentFlowEngine:
         the new attempt's enrich doesn't see a mix of trace records.
         """
         task_for_episode = task.metadata if isinstance(task, Task) else task
-
-        if isinstance(task, Task):
-            task_obj = task
-            task_dict = task.metadata
-        else:
-            task_dict = task
-            task_obj = task_from_row(task, task_id)
+        task_obj = task if isinstance(task, Task) else task_from_row(task, task_id)
 
         async with self._semaphore:
             for retry_attempt in range(1, self.retry_limit + 1):
@@ -477,7 +475,7 @@ class AgentFlowEngine:
                     except Exception as cleanup_err:
                         logger.warning("[%s] failed to clear prior traces before retry: %s", uid, cleanup_err)
                 try:
-                    episode = await self._run_single(task_obj, task_dict, uid, is_validation=is_validation)
+                    episode = await self._run_single(task_obj, uid, is_validation=is_validation)
                     episode.id = uid
                     episode.task = task_for_episode
 
@@ -519,7 +517,7 @@ class AgentFlowEngine:
 
             raise RuntimeError(f"[{task_id}:{rollout_idx}] Exhausted all retries")
 
-    async def _run_single(self, task_obj: Task, task_dict: dict, uid: str, is_validation: bool = False) -> Episode:
+    async def _run_single(self, task_obj: Task, uid: str, is_validation: bool = False) -> Episode:
         """Run one full per-task pipeline: flow → fetch traces → enrich → evaluate.
 
         Records ``time/<phase>_s`` for setup/agentflow/traces/evaluator/
@@ -534,7 +532,6 @@ class AgentFlowEngine:
 
         raw_episode, ctx = await self._run_flow_only(
             task_obj=task_obj,
-            task_dict=task_dict,
             uid=uid,
             is_validation=is_validation,
             _timings=timings,
@@ -549,8 +546,8 @@ class AgentFlowEngine:
                 traces=traces,
                 uid=uid,
                 task_obj=task_obj,
-                task_dict=task_dict,
                 ctx=ctx,
+                is_validation=is_validation,
                 _timings=timings,
             )
             enriched.metrics.update(timings)
@@ -558,13 +555,12 @@ class AgentFlowEngine:
             return enriched
         finally:
             # Offload Modal's blocking terminate()/detach() to the executor.
-            if ctx is not None:
-                t = time.perf_counter()
-                try:
-                    await loop.run_in_executor(self.executor, ctx.run_teardown)
-                except Exception:
-                    logger.exception("[%s] task teardown failed; continuing", uid)
-                timings["time/teardown_s"] = time.perf_counter() - t
+            t = time.perf_counter()
+            try:
+                await loop.run_in_executor(self.executor, ctx.run_teardown)
+            except Exception:
+                logger.exception("[%s] task teardown failed; continuing", uid)
+            timings["time/teardown_s"] = time.perf_counter() - t
             timings["time/rollout_s"] = time.perf_counter() - rollout_start
             ep = result_holder.get("episode")
             if ep is not None:
@@ -573,11 +569,10 @@ class AgentFlowEngine:
     async def _run_flow_only(
         self,
         task_obj: Task,
-        task_dict: dict,
         uid: str,
         is_validation: bool = False,
         _timings: dict[str, float] | None = None,
-    ) -> tuple[Episode, TaskContext | None]:
+    ) -> tuple[Episode, TaskContext]:
         """Run hook setup + the agent flow. Returns ``(raw_episode, ctx)``.
 
         On flow failure, tears down ``ctx`` and re-raises. On success, the
@@ -589,17 +584,15 @@ class AgentFlowEngine:
             _timings = {}
 
         # Offload hook setup (blocking Modal/docker I/O) to the executor.
-        ctx: TaskContext | None = None
-        if self.hooks is not None:
-            t = time.perf_counter()
-            ctx = await loop.run_in_executor(
-                self.executor,
-                self.hooks.setup,
-                task_obj,
-                self.agent_flow,
-                uid,
-            )
-            _timings["time/setup_s"] = time.perf_counter() - t
+        t = time.perf_counter()
+        ctx: TaskContext = await loop.run_in_executor(
+            self.executor,
+            self.hooks.setup,
+            task_obj,
+            self.agent_flow,
+            uid,
+        )
+        _timings["time/setup_s"] = time.perf_counter() - t
 
         try:
             # Attach resolved sampling params to the session so the gateway
@@ -608,7 +601,14 @@ class AgentFlowEngine:
             if session_sampling_params:
                 await self.gateway.acreate_session(uid, is_validation=is_validation, sampling_params=session_sampling_params)
 
-            session_url = self.gateway.get_session_url(uid)
+            # Prefer the per-task flow from the hook so parallel tasks don't
+            # share mutable sandbox state on the engine-bound flow.
+            flow_for_task = ctx.agent_flow if ctx.agent_flow is not None else self.agent_flow
+
+            # Flows whose LLM client runs *inside* the env (CLI harnesses)
+            # need the publicly-reachable URL; host-side flows keep the local
+            # gateway URL so they never depend on a tunnel hostname.
+            session_url = self.gateway.get_session_url(uid, public=getattr(flow_for_task, "llm_inside_env", False))
 
             config = AgentConfig(
                 base_url=session_url,
@@ -617,10 +617,6 @@ class AgentFlowEngine:
                 is_validation=is_validation,
                 sampling_params=session_sampling_params or {},
             )
-
-            # Prefer the per-task flow from the hook so parallel tasks don't
-            # share mutable sandbox state on the engine-bound flow.
-            flow_for_task = ctx.agent_flow if (ctx is not None and ctx.agent_flow is not None) else self.agent_flow
             logger.debug("[%s] Starting agent flow at %s", uid, session_url)
             t = time.perf_counter()
             episode = await run_agent_flow(flow_for_task, task_obj, config, executor=self.executor)
@@ -629,11 +625,10 @@ class AgentFlowEngine:
             return episode, ctx
         except BaseException:
             # Tear down on failure; success path defers teardown to the caller.
-            if ctx is not None:
-                try:
-                    await loop.run_in_executor(self.executor, ctx.run_teardown)
-                except Exception:
-                    logger.exception("[%s] hook teardown failed during error recovery", uid)
+            try:
+                await loop.run_in_executor(self.executor, ctx.run_teardown)
+            except Exception:
+                logger.exception("[%s] hook teardown failed during error recovery", uid)
             raise
 
     async def _finish_episode(
@@ -642,14 +637,18 @@ class AgentFlowEngine:
         traces: list[TraceRecord],
         uid: str,
         task_obj: Task,
-        task_dict: dict,
-        ctx: TaskContext | None,
+        ctx: TaskContext,
+        is_validation: bool = False,
         _timings: dict[str, float] | None = None,
     ) -> Episode:
         """Enrich the raw episode with traces, run the evaluator, apply rewards.
 
-        Records ``time/evaluator_s``, ``time/agentflow_llm_{sum,wall}_s``, and
-        ``n_turns`` when ``_timings`` is provided.
+        Training rollouts enrich strictly (empty token IDs raise so the retry
+        path reissues — they're required for loss math); validation relaxes
+        (non-vLLM upstreams legitimately return no token IDs and evaluators
+        read message text). Records ``time/evaluator_s``,
+        ``time/agentflow_llm_{sum,wall}_s``, and ``n_turns`` when ``_timings``
+        is provided.
         """
         loop = asyncio.get_event_loop()
 
@@ -657,27 +656,19 @@ class AgentFlowEngine:
             raw_episode,
             traces,
             uid,
-            task_dict,
-            strict=self.hooks is None,
+            task_obj.metadata,
+            strict=not is_validation,
         )
 
-        # Hook-resolved evaluator wins; receives Task. Engine-bound takes the dict.
+        # The hook-resolved evaluator always receives the Task (legacy
+        # dict-style evaluators are adapted at hook-construction time).
         t = time.perf_counter()
-        if ctx is not None:
-            eval_output: EvalOutput = await loop.run_in_executor(
-                self.executor,
-                ctx.evaluator.evaluate,
-                task_obj,
-                enriched,
-            )
-        else:
-            assert self.evaluator is not None  # __init__ guarantees one of evaluator/hooks
-            eval_output = await loop.run_in_executor(
-                self.executor,
-                self.evaluator.evaluate,
-                task_dict,
-                enriched,
-            )
+        eval_output: EvalOutput = await loop.run_in_executor(
+            self.executor,
+            ctx.evaluator.evaluate,
+            task_obj,
+            enriched,
+        )
         if _timings is not None:
             _timings["time/evaluator_s"] = time.perf_counter() - t
             _agentflow_s = _timings.get("time/agentflow_s", 0.0)

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -139,6 +139,18 @@ def _resolve_evaluator(
     raise RuntimeError(f"No verifier configured for task '{task.id}' (dataset_dir={task.dataset_dir})")
 
 
+def dataset_verifier_kind(dataset_dir: Path, sub_dir: Path | None = None) -> str:
+    """The dataset-level verifier kind (``"missing"`` when none is configured).
+
+    Used by the train CLI to distinguish env-style verifiers (resolved per
+    task inside the sandbox — leave the trainer's ``evaluator`` unset) from a
+    genuinely missing verifier (fail fast).
+    """
+    probe = Task(id="", instruction="", metadata={}, dataset_dir=dataset_dir, sub_dir=sub_dir)
+    kind, _ = _detect_verifier(probe)
+    return kind
+
+
 def build_dataset_evaluator(dataset_dir: Path, sub_dir: Path | None = None) -> Evaluator | None:
     """Build a single :class:`Evaluator` from a dataset's ``[verifier]`` config.
 
@@ -176,16 +188,6 @@ def _wrap_with_sandbox_if_needed(ev: PythonModuleEvaluator, sandbox: Sandbox | N
 # ---------------------------------------------------------------------------
 # Sandbox setup (extracted from rllm/tasks/runner.py)
 # ---------------------------------------------------------------------------
-
-
-def _needs_sandbox(task: Task, verifier_kind: str) -> bool:
-    """Decide whether the Runner should set up a sandbox."""
-    if verifier_kind in ("sandbox-shell", "python-hybrid"):
-        return True
-    # If the task ships an environment/, treat it as sandboxed
-    if (task.task_dir / "environment").is_dir() or (task.dataset_dir / "environment").is_dir():
-        return True
-    return False
 
 
 def _resolve_backend(task: Task, sandbox_backend: str | None) -> str:

--- a/rllm/eval/rollout_decorator.py
+++ b/rllm/eval/rollout_decorator.py
@@ -62,6 +62,10 @@ class AgentFlowFn:
     :func:`run_agent_flow` can await it directly.
     """
 
+    # Host-only by declaration: @rollout flows run on the host and never
+    # require a sandbox themselves (the task/verifier may still bring one).
+    needs_env: bool = False
+
     def __init__(self, fn: Callable, *, name: str = "solver") -> None:
         self._fn = fn
         self._name = name

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -16,7 +16,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from rllm.eval.results import EvalItem, EvalResult
-from rllm.hooks import SandboxTaskHooks
+from rllm.hooks import FixedEvaluation, SandboxTaskHooks
 from rllm.types import AgentFlow, Evaluator
 from rllm.workflows.workflow import TerminationReason
 
@@ -39,7 +39,7 @@ async def run_dataset(
     agent_name: str = "",
     dataset_name: str = "unknown",
     on_episode_complete=None,
-    evaluator_override: Evaluator | None = None,
+    evaluator: Evaluator | None = None,
     gateway: GatewayManager | None = None,
     sampling_params: dict | None = None,
 ) -> tuple[EvalResult, list]:
@@ -47,7 +47,7 @@ async def run_dataset(
 
     Per-task: the engine creates a gateway session, runs the agent flow
     against the session URL, fetches traces, enriches the Episode, then
-    runs the per-task evaluator (or ``evaluator_override`` if set).
+    runs the per-task evaluator (or the fixed ``evaluator`` if set).
 
     Args:
         gateway: Optional pre-started gateway. When ``None``, this function
@@ -55,10 +55,10 @@ async def run_dataset(
             ``base_url`` and tears it down on exit. When provided, the
             caller owns the lifecycle (used by ``rllm.cli.eval`` so the
             gateway can stay up across multiple runs).
-        evaluator_override: Bind a single evaluator to all tasks (CLI's
-            ``--evaluator`` flag). When ``None``, ``SandboxTaskHooks``
-            resolves a per-task verifier from the task's ``[verifier]``
-            config.
+        evaluator: Bind a single evaluator to all tasks (CLI's
+            ``--evaluator`` flag; the hooks' ``FixedEvaluation`` policy).
+            When ``None``, ``SandboxTaskHooks`` resolves a per-task verifier
+            from the task's ``[verifier]`` config.
         sampling_params: Resolved sampling params from the CLI, attached to each
             gateway session so the gateway enforces them on every LLM call. ``None``
             or empty → flows/harnesses keep their own params.
@@ -88,7 +88,7 @@ async def run_dataset(
         gateway = EvalGatewayManager(upstream_url=base_url, model=model, tunnel=gateway_tunnel)
         gateway.start()
 
-    hooks = SandboxTaskHooks(evaluator_override=evaluator_override, sandbox_backend=sandbox_backend, use_snapshot=use_snapshot)
+    hooks = SandboxTaskHooks(evaluation=FixedEvaluation(evaluator) if evaluator is not None else None, sandbox_backend=sandbox_backend, use_snapshot=use_snapshot)
 
     engine = AgentFlowEngine(
         agent_flow=agent_flow,

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -263,8 +263,16 @@ class GatewayManager:
         sp = sampling_params if sampling_params is not None else (self._val_sampling_params if is_validation else self._train_sampling_params)
         return self.client.create_session(session_id=session_id, sampling_params=sp or None)
 
-    def get_session_url(self, session_id: str) -> str:
-        if self.public_url:
+    def get_session_url(self, session_id: str, *, public: bool = True) -> str:
+        """Session-scoped base URL for the flow's LLM client.
+
+        ``public=False`` returns the host-local gateway URL even when a tunnel
+        is up — for flows whose LLM client runs on the host (e.g. a sandboxed
+        bash loop driving the sandbox via ``exec``). The tunnel hostname only
+        matters to clients *inside* the env, and free quick-tunnel hostnames
+        can die mid-run; host-side clients should never depend on them.
+        """
+        if public and self.public_url:
             base = self.public_url.rstrip("/")
             return f"{base}/sessions/{session_id}/v1"
         return self.client.get_session_url(session_id)

--- a/rllm/gateway/tunnel.py
+++ b/rllm/gateway/tunnel.py
@@ -50,6 +50,7 @@ def parse_tunnel(value: str | None) -> tuple[str | None, str | None]:
 
 _TRYCF_URL_RE = re.compile(r"https?://[a-zA-Z0-9.-]+\.trycloudflare\.com")
 _DEFAULT_READY_TIMEOUT = env_float("RLLM_TUNNEL_READY_TIMEOUT_S", 30.0)  # set env var: export RLLM_TUNNEL_READY_TIMEOUT_S=xxx
+_DEFAULT_REACHABLE_TIMEOUT = env_float("RLLM_TUNNEL_REACHABLE_TIMEOUT_S", 120.0)  # set env var: export RLLM_TUNNEL_REACHABLE_TIMEOUT_S=xxx
 # Retry transient Cloudflare QuickTunnel allocator 5xx blips.
 _DEFAULT_MAX_ATTEMPTS = 4
 
@@ -107,6 +108,7 @@ class CloudflaredTunnel:
         for attempt in range(1, self.max_attempts + 1):
             try:
                 url = self._start_once()
+                self._wait_reachable(url)
                 _status.print(f"  [bold green]✓[/] Tunnel ready: [bold]{url}[/]")
                 return url
             except TunnelStartError as e:
@@ -130,6 +132,35 @@ class CloudflaredTunnel:
                 raise
         assert last_error is not None
         raise last_error
+
+    def _wait_reachable(self, url: str, timeout: float = _DEFAULT_REACHABLE_TIMEOUT) -> None:
+        """Block until the public URL answers over HTTP, or warn and continue.
+
+        cloudflared printing the URL only means the hostname was *assigned* —
+        not that this host can resolve it or that the edge has connected to
+        the origin. Any response with status < 500 (404 included) proves
+        DNS + edge + origin are live. Timeout is warn-not-raise: an
+        in-sandbox consumer may still resolve the hostname through its own
+        (cloud) DNS even when this host's resolver lags.
+        """
+        import urllib.error
+        import urllib.request
+
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                with urllib.request.urlopen(urllib.request.Request(url, method="GET"), timeout=5) as resp:
+                    if resp.status < 500:
+                        return
+            except urllib.error.HTTPError as e:
+                if e.code < 500:  # 4xx: resolvable and the origin answered
+                    return
+            except Exception:  # noqa: S110 — DNS/connect failures: keep polling
+                pass
+            if time.monotonic() > deadline:
+                logger.warning("tunnel %s not reachable from this host after %.0fs — continuing (in-sandbox DNS may still resolve it)", url, timeout)
+                return
+            time.sleep(2)
 
     def _reset_state(self) -> None:
         """Clear per-attempt state before a retry."""

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -51,6 +51,9 @@ class BaseCliHarness(SandboxedAgentFlow):
 
     # Display name used by the agent registry.
     name: str = "cli"
+    # The CLI process makes its LLM calls from inside the sandbox, so it needs
+    # the publicly-reachable gateway URL (tunnel) on remote backends.
+    llm_inside_env: bool = True
     # Default sandbox backend — overridable via class attr or kwargs.
     sandbox_backend: str = "docker"
     # Default container image. Tasks usually override via per-task images.

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -2,34 +2,208 @@
 
 :class:`SandboxTaskHooks` is the canonical implementation, used by
 ``rllm eval`` and by :class:`rllm.trainer.unified_trainer.AgentTrainer`
-for sandbox-style harnesses on harbor task dirs.
+for sandbox-style flows and env-carrying datasets.
+
+The central question — *does this rollout need a sandbox?* — is answered in
+exactly one place, :func:`resolve_rollout_plan`, as the join of three
+declared needs:
+
+* the **flow** declares it (``needs_env`` attr — ``True`` on
+  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow`, ``False`` on
+  ``@rllm.rollout`` flows),
+* the **evaluation policy** needs it (:class:`FromTaskEvaluation` resolving a
+  ``sandbox-shell`` / ``python-hybrid`` verifier; :class:`FixedEvaluation` never does),
+* the **task** declares it (``environment/`` dir or ``task_path`` metadata).
+
+Wiring-time call sites (trainer/CLI) use :func:`scan_env_requirements` over
+the datasets to decide *whether to install these hooks at all* and whether
+the gateway needs a public tunnel — the same predicate, evaluated before
+any per-task bind.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from omegaconf import DictConfig, OmegaConf
 
 from rllm.gateway.tunnel import is_local_sandbox_backend
-from rllm.types import Evaluator
+from rllm.types import Evaluator, Task
 
 if TYPE_CHECKING:
     from rllm.engine.agentflow_engine import TaskContext
+    from rllm.sandbox.protocol import Sandbox
     from rllm.sandbox.snapshot import SnapshotRegistry
     from rllm.sandbox.warm_queue import WarmQueue
-    from rllm.types import AgentFlow, Task
+    from rllm.types import AgentFlow
 
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Evaluation policies
+# ---------------------------------------------------------------------------
+
+
+class FixedEvaluation:
+    """Evaluation policy: one host-side evaluator scores every task.
+
+    Host-side by definition — it never contributes an env requirement.
+    """
+
+    def __init__(self, evaluator: Evaluator):
+        from rllm.eval._resolution import _adapt_legacy_evaluator
+
+        self.evaluator = _adapt_legacy_evaluator(evaluator)
+
+    def detect(self, task: Task) -> tuple[str, dict]:  # noqa: ARG002
+        return "fixed", {}
+
+    def resolve(self, task: Task, sandbox: Sandbox | None, kind: str, config: dict) -> Evaluator:  # noqa: ARG002
+        return self.evaluator
+
+
+class FromTaskEvaluation:
+    """Evaluation policy: resolve a per-task verifier from the task's ``[verifier]`` config."""
+
+    def detect(self, task: Task) -> tuple[str, dict]:
+        from rllm.eval._resolution import _detect_verifier
+
+        return _detect_verifier(task)
+
+    def resolve(self, task: Task, sandbox: Sandbox | None, kind: str, config: dict) -> Evaluator:
+        from rllm.eval._resolution import _resolve_evaluator
+
+        return _resolve_evaluator(task, sandbox, kind, config)
+
+
+EvaluationPolicy = FixedEvaluation | FromTaskEvaluation
+
+# Verifier kinds that must run against a live sandbox.
+_ENV_VERIFIER_KINDS = frozenset({"sandbox-shell", "python-hybrid"})
+
+
+# ---------------------------------------------------------------------------
+# The env-requirement join (one place, pure, per task)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RolloutPlan:
+    """Pure bind-time resolution for one task: env requirement + verifier choice."""
+
+    needs_env: bool
+    verifier_kind: str
+    verifier_config: dict = field(default_factory=dict)
+
+
+def flow_needs_env(agent_flow: Any) -> bool:
+    """The flow's declared env requirement (``False`` when undeclared)."""
+    return bool(getattr(agent_flow, "needs_env", False))
+
+
+def task_declares_env(task_or_row: Any) -> bool:
+    """True when a task (or raw dataset row) declares a sandbox environment.
+
+    Carriers: ``task_path`` metadata (harbor-sourced rows) or an
+    ``environment/`` dir next to the task/dataset (local benchmarks).
+    """
+    meta = getattr(task_or_row, "metadata", None)
+    if meta is None and isinstance(task_or_row, dict):
+        meta = task_or_row
+    if isinstance(meta, dict) and meta.get("task_path"):
+        return True
+    if isinstance(task_or_row, Task):
+        return (task_or_row.task_dir / "environment").is_dir() or (task_or_row.dataset_dir / "environment").is_dir()
+    return False
+
+
+# Warn once per task id, not once per rollout (the same task repeats across
+# group rollouts and epochs).
+_warned_no_consumer: set[str] = set()
+
+
+def resolve_rollout_plan(task: Task, agent_flow: Any, evaluation: EvaluationPolicy) -> RolloutPlan:
+    """Decide once whether this rollout needs a sandbox, and which verifier scores it.
+
+    ``needs_env = flow ∨ evaluator ∨ task`` — with the no-consumer rule: a
+    task-declared env that neither the flow nor the evaluator can reach is
+    downgraded (with a warning) instead of provisioned for nobody.
+    """
+    kind, config = evaluation.detect(task)
+    flow_env = flow_needs_env(agent_flow)
+    eval_env = kind in _ENV_VERIFIER_KINDS
+    task_env = task_declares_env(task)
+
+    needs_env = flow_env or eval_env or task_env
+    if needs_env and not flow_env and not eval_env:
+        if task.id not in _warned_no_consumer:
+            _warned_no_consumer.add(task.id)
+            logger.warning(
+                "task '%s' declares a sandbox environment, but neither the agent flow (%s) nor the verifier (kind=%s) can use one — skipping sandbox provisioning",
+                task.id,
+                type(agent_flow).__name__,
+                kind,
+            )
+        needs_env = False
+
+    return RolloutPlan(needs_env=needs_env, verifier_kind=kind, verifier_config=config)
+
+
+# ---------------------------------------------------------------------------
+# Wiring-time scan (trainer/CLI: install hooks? tunnel?)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnvRequirements:
+    """Run-level env requirements: whether any rollout may need a sandbox, and remoteness."""
+
+    needs_env: bool
+    any_remote: bool
+
+
+def scan_env_requirements(agent_flow: Any, *datasets: Any, sandbox_backend: str | None = None) -> EnvRequirements:
+    """Scan flow + all dataset rows for env requirements before wiring.
+
+    ``any_remote`` drives the run-global gateway tunnel decision: when
+    ``sandbox_backend`` is explicitly set it wins (it overrides per-task
+    metadata at provision time); otherwise any row's ``sandbox_backend``
+    metadata counts.
+    """
+    needs_env = flow_needs_env(agent_flow)
+    any_remote = sandbox_backend is not None and not is_local_sandbox_backend(sandbox_backend)
+
+    for ds in datasets:
+        if ds is None:
+            continue
+        for row in ds:
+            if not needs_env and task_declares_env(row):
+                needs_env = True
+            if sandbox_backend is None and not any_remote:
+                meta = getattr(row, "metadata", None) or (row if isinstance(row, dict) else {})
+                row_backend = meta.get("sandbox_backend") if isinstance(meta, dict) else None
+                if row_backend and not is_local_sandbox_backend(row_backend):
+                    any_remote = True
+            if needs_env and (any_remote or sandbox_backend is not None):
+                return EnvRequirements(needs_env=needs_env, any_remote=any_remote)
+
+    return EnvRequirements(needs_env=needs_env, any_remote=any_remote)
+
+
+# ---------------------------------------------------------------------------
+# SandboxTaskHooks
+# ---------------------------------------------------------------------------
+
+
 class SandboxTaskHooks:
-    """Per-task setup/teardown hook with sandbox + per-task verifier resolution.
+    """Per-task setup/teardown hook with sandbox lifecycle + verifier resolution.
 
     Args:
-        evaluator_override: If set, used for every task and per-task
-            verifier detection is skipped.
+        evaluation: :class:`FixedEvaluation` (one host evaluator for every task) or
+            :class:`FromTaskEvaluation` (per-task ``[verifier]`` resolution, the default).
         sandbox_backend: Override for the sandbox backend
             (``"docker"``, ``"local"``, ``"modal"``, ...). Falls back to
             per-task ``metadata['sandbox_backend']`` then ``"docker"``.
@@ -40,16 +214,16 @@ class SandboxTaskHooks:
 
     def __init__(
         self,
-        evaluator_override: Evaluator | None = None,
+        evaluation: EvaluationPolicy | None = None,
         sandbox_backend: str | None = None,
         use_snapshot: bool = True,
     ) -> None:
         from rllm.sandbox.snapshot import SnapshotRegistry
 
-        self.evaluator_override = evaluator_override
+        self.evaluation: EvaluationPolicy = evaluation if evaluation is not None else FromTaskEvaluation()
         self.sandbox_backend = sandbox_backend
-        # Optional per-run warm queue (set by run_dataset); when present, setup
-        # pops a prefetched sandbox from it instead of creating one inline.
+        # Optional per-run warm queue (set by run_dataset / the trainer); when
+        # present, setup pops a prefetched sandbox instead of creating one inline.
         self.warm_queue: WarmQueue | None = None
         # Read-only registry, loaded once and shared across this run's tasks
         # (None disables snapshots, e.g. eval --no-snapshot).
@@ -70,21 +244,10 @@ class SandboxTaskHooks:
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:
         from rllm.engine.agentflow_engine import TaskContext
-        from rllm.eval._resolution import (
-            _adapt_legacy_evaluator,
-            _detect_verifier,
-            _needs_sandbox,
-            _resolve_evaluator,
-            _setup_task_environment,
-        )
+        from rllm.eval._resolution import _setup_task_environment
         from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
 
-        if self.evaluator_override is not None:
-            verifier_kind, verifier_config = "override", {}
-            needs_sandbox = isinstance(agent_flow, SandboxedAgentFlow)
-        else:
-            verifier_kind, verifier_config = _detect_verifier(task)
-            needs_sandbox = _needs_sandbox(task, verifier_kind) or isinstance(agent_flow, SandboxedAgentFlow)
+        plan = resolve_rollout_plan(task, agent_flow, self.evaluation)
 
         # Shallow-copy SandboxedAgentFlow so parallel rollouts get their own _sandbox.
         task_flow: AgentFlow = agent_flow
@@ -92,7 +255,7 @@ class SandboxTaskHooks:
             task_flow = agent_flow.create_instance()
 
         sandbox = None
-        if needs_sandbox:
+        if plan.needs_env:
             from rllm.sandbox.snapshot import get_sandbox
 
             sandbox = self.warm_queue.pop(task) if self.warm_queue is not None else get_sandbox(task, self.sandbox_backend, self._registry)
@@ -101,10 +264,7 @@ class SandboxTaskHooks:
                 task_flow.set_sandbox(sandbox)
                 task_flow.on_sandbox_ready({"task_path": str(task.task_dir)}, None)
 
-        if self.evaluator_override is not None:
-            evaluator = _adapt_legacy_evaluator(self.evaluator_override)
-        else:
-            evaluator = _resolve_evaluator(task, sandbox, verifier_kind, verifier_config)
+        evaluator = self.evaluation.resolve(task, sandbox, plan.verifier_kind, plan.verifier_config)
 
         def teardown() -> None:
             # Sandboxes are ephemeral — the hook owns this one's lifecycle and
@@ -125,24 +285,29 @@ class SandboxTaskHooks:
         return TaskContext(evaluator=evaluator, agent_flow=ctx_flow, teardown=teardown)
 
 
-def needs_sandbox_isolation(agent_flow: Any, train_dataset: Any, val_dataset: Any) -> bool:
-    """True when ``agent_flow`` is a :class:`SandboxedAgentFlow` or any task carries ``task_path`` metadata."""
-    try:
-        from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+class FixedEvaluatorHooks:
+    """Hooks that bind one evaluator to every task and provision nothing.
 
-        if isinstance(agent_flow, SandboxedAgentFlow):
-            return True
-    except ImportError:
-        pass
+    What :class:`~rllm.engine.agentflow_engine.AgentFlowEngine` wraps a bare
+    ``evaluator=`` in, so the engine has exactly one execution path
+    (always-hooks). Routes through ``_adapt_legacy_evaluator`` so dict-style
+    ``evaluate(task: dict, episode)`` evaluators keep working.
+    """
 
-    for ds in (train_dataset, val_dataset):
-        if ds is None or len(ds) == 0:
-            continue
-        first = ds[0]
-        meta = getattr(first, "metadata", None) or (first if isinstance(first, dict) else None)
-        if isinstance(meta, dict) and meta.get("task_path"):
-            return True
-    return False
+    def __init__(self, evaluator: Evaluator):
+        from rllm.eval._resolution import _adapt_legacy_evaluator
+
+        self.evaluator = _adapt_legacy_evaluator(evaluator)
+
+    def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:  # noqa: ARG002
+        from rllm.engine.agentflow_engine import TaskContext
+
+        return TaskContext(evaluator=self.evaluator)
+
+
+# ---------------------------------------------------------------------------
+# Gateway wiring helpers
+# ---------------------------------------------------------------------------
 
 
 def pin_gateway_host_loopback(config: DictConfig) -> DictConfig:
@@ -155,10 +320,12 @@ def pin_gateway_host_loopback(config: DictConfig) -> DictConfig:
     )
 
 
-def enable_tunnel_for_remote_sandbox(config: DictConfig, sandbox_backend: str | None) -> DictConfig:
-    """Auto-wire ``rllm.gateway.tunnel="cloudflared"`` when sandboxes run off-host and no tunnel is already set."""
-    if is_local_sandbox_backend(sandbox_backend):
-        return config
+def enable_gateway_tunnel(config: DictConfig) -> DictConfig:
+    """Auto-wire ``rllm.gateway.tunnel="cloudflared"`` when no tunnel is already set.
+
+    Callers decide *when* (sandboxes run off-host — see
+    :func:`scan_env_requirements`); this helper only applies the setting.
+    """
     gw = config.rllm.get("gateway", {}) or {}
     if gw.get("tunnel"):
         return config
@@ -169,8 +336,15 @@ def enable_tunnel_for_remote_sandbox(config: DictConfig, sandbox_backend: str | 
 
 
 __all__ = [
+    "EnvRequirements",
+    "EvaluationPolicy",
+    "FixedEvaluation",
+    "FixedEvaluatorHooks",
+    "FromTaskEvaluation",
+    "RolloutPlan",
     "SandboxTaskHooks",
-    "needs_sandbox_isolation",
+    "enable_gateway_tunnel",
     "pin_gateway_host_loopback",
-    "enable_tunnel_for_remote_sandbox",
+    "resolve_rollout_plan",
+    "scan_env_requirements",
 ]

--- a/rllm/sandbox/sandboxed_flow.py
+++ b/rllm/sandbox/sandboxed_flow.py
@@ -6,8 +6,8 @@ front of :class:`rllm.engine.agentflow_engine.AgentFlowEngine`):
 1. The hook creates a Sandbox via ``_create_sandbox_for_task`` and injects
    it with ``set_sandbox()``, then calls ``on_sandbox_ready(task, config)``.
 2. The engine calls ``run(task, config)`` — the agent uses ``self.sandbox``.
-3. The hook resolves an Evaluator from the Task's verifier config (or uses
-   ``evaluator_override``) and runs ``evaluator.evaluate(task, episode)``.
+3. The hook resolves an Evaluator from the Task's verifier config (or its
+   ``FixedEvaluation`` policy) and runs ``evaluator.evaluate(task, episode)``.
 4. The hook's teardown closure calls ``teardown_sandbox()`` — guaranteed
    cleanup, no-op when the sandbox was injected externally.
 """
@@ -34,6 +34,12 @@ class SandboxedAgentFlow(ABC):
     :meth:`get_image` or :meth:`on_sandbox_ready` for task-specific setup.
     """
 
+    # Declared env requirement — read by rllm.hooks.resolve_rollout_plan.
+    needs_env: bool = True
+    # Where the flow's LLM client runs. Host-side loops (bash/oracle) keep the
+    # local gateway URL; CLI harnesses (BaseCliHarness) override to True so
+    # the in-sandbox process gets the publicly-reachable (tunneled) URL.
+    llm_inside_env: bool = False
     sandbox_backend: str = "docker"
     image: str = "python:3.11-slim"
     max_concurrent: int = 4

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -948,11 +948,13 @@ class AgentTrainer:
 
     This trainer will simply delegate the task to the corresponding launcher class.
 
-    Provide exactly one of ``workflow_class`` or ``agent_flow``. For sandbox-style
-    flows (``SandboxedAgentFlow`` agent or tasks with ``task_path`` metadata),
-    ``hooks`` and gateway loopback are auto-wired via
-    :class:`rllm.hooks.SandboxTaskHooks`; pass ``hooks=`` or ``evaluator=``
-    explicitly to override.
+    Provide exactly one of ``workflow_class`` or ``agent_flow``. When the run
+    needs sandboxes (the flow declares ``needs_env``, or any dataset row
+    carries an environment — see :func:`rllm.hooks.scan_env_requirements`),
+    :class:`rllm.hooks.SandboxTaskHooks` and gateway loopback/tunnel are
+    auto-wired. A passed ``evaluator`` becomes the hooks' FixedEvaluation
+    policy (it does not disable the sandbox lifecycle); pass ``hooks=``
+    explicitly to take over per-task setup entirely.
 
     Args:
         sandbox_backend: Backend for the auto-wired sandbox hooks
@@ -978,32 +980,33 @@ class AgentTrainer:
         store: Store | None = None,
         **kwargs,
     ):
-        # Auto-wire sandbox hooks + gateway loopback unless the caller set hooks.
-        # A SandboxedAgentFlow always needs the per-task sandbox even when the caller
-        # also passed a host-side evaluator, so fold that evaluator into the hooks as
-        # the override (mirrors how ``rllm eval`` wires evaluator_override). For the
-        # other isolation case (harbor task_path rows) keep the prior behavior of
-        # auto-wiring only when no evaluator was given.
-        if agent_flow is not None and hooks is None:
+        # Loopback/tunnel pinning must happen here, before the launcher
+        # constructs GatewayManager, and applies to explicitly-passed hooks too.
+        if agent_flow is not None:
+            from rllm.gateway.tunnel import is_local_sandbox_backend
             from rllm.hooks import (
+                FixedEvaluation,
                 SandboxTaskHooks,
-                enable_tunnel_for_remote_sandbox,
-                needs_sandbox_isolation,
+                enable_gateway_tunnel,
                 pin_gateway_host_loopback,
+                scan_env_requirements,
             )
 
-            try:
-                from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
-
-                is_sandboxed_flow = isinstance(agent_flow, SandboxedAgentFlow)
-            except ImportError:
-                is_sandboxed_flow = False
-
-            if needs_sandbox_isolation(agent_flow, train_dataset, val_dataset) and (evaluator is None or is_sandboxed_flow):
-                hooks = SandboxTaskHooks(evaluator_override=evaluator, sandbox_backend=sandbox_backend)
+            scan = scan_env_requirements(agent_flow, train_dataset, val_dataset, sandbox_backend=sandbox_backend)
+            if hooks is None and scan.needs_env:
+                hooks = SandboxTaskHooks(
+                    evaluation=FixedEvaluation(evaluator) if evaluator is not None else None,
+                    sandbox_backend=sandbox_backend,
+                )
                 evaluator = None
+            if hooks is not None and scan.needs_env:
                 config = pin_gateway_host_loopback(config)
-                config = enable_tunnel_for_remote_sandbox(config, sandbox_backend)
+                # The hooks-backend clause matters only for explicitly-passed
+                # hooks; auto-wired hooks share `sandbox_backend`, already
+                # folded into `scan.any_remote`.
+                hooks_backend = getattr(hooks, "sandbox_backend", None)
+                if scan.any_remote or not is_local_sandbox_backend(hooks_backend):
+                    config = enable_gateway_tunnel(config)
 
         # Forward concurrency + backend overrides onto a SandboxedAgentFlow.
         if agent_flow is not None and (sandbox_concurrency is not None or sandbox_backend is not None):

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -1,6 +1,9 @@
 import asyncio
 
+import pytest
+
 from rllm.agents.agent import Episode, Trajectory
+from rllm.data.utils import task_from_row
 from rllm.engine.agentflow_engine import AgentFlowEngine
 from rllm.eval.types import EvalOutput
 from rllm.workflows.workflow import TerminationReason
@@ -25,21 +28,27 @@ class _Evaluator:
 
 
 class _Gateway:
-    def __init__(self):
+    """Minimal gateway double; stocked traces are returned for every session."""
+
+    def __init__(self, traces=None):
         self.created = None
         self.deleted = None
+        self._traces = traces or []
 
-    async def acreate_session(self, session_id, is_validation=False):
+    async def acreate_session(self, session_id, is_validation=False, sampling_params=None):
         self.created = (session_id, is_validation)
 
-    def get_session_url(self, session_id):
+    def get_session_url(self, session_id, public=True):
         return f"http://gateway/{session_id}"
 
     async def aget_traces(self, session_id):
-        return []
+        return self._traces
 
     async def adelete_session(self, session_id):
         self.deleted = session_id
+
+    async def adelete_sessions(self, session_ids):
+        self.deleted = session_ids[-1] if session_ids else None
 
 
 def test_run_single_passes_validation_flag_and_preserves_termination_reason():
@@ -51,15 +60,68 @@ def test_run_single_passes_validation_flag_and_preserves_termination_reason():
         gateway=gateway,
         model="test-model",
         n_parallel_tasks=1,
+        val_sampling_params={"temperature": 0.1},
     )
+    task = task_from_row({"question": "q"}, "task")
 
     try:
-        episode = asyncio.run(engine._run_single({"question": "q"}, "task:0", is_validation=True))
+        episode = asyncio.run(engine._run_single(task, "task:0", is_validation=True))
     finally:
         engine.shutdown()
 
     assert gateway.created == ("task:0", True)
-    assert gateway.deleted == "task:0"
     assert agent.config.is_validation is True
     assert agent.config.session_uid == "task:0"
     assert episode.termination_reason == TerminationReason.ERROR
+
+
+def _empty_token_trace(session_id: str):
+    from rllm_model_gateway.models import TraceRecord
+
+    return TraceRecord(
+        trace_id=f"t-{session_id}",
+        session_id=session_id,
+        model="m",
+        messages=[{"role": "user", "content": "Q"}],
+        response_message={"role": "assistant", "content": "A"},
+        prompt_token_ids=[],  # empty → corrupts loss math if it reaches training
+        completion_token_ids=[],
+        logprobs=[],
+        finish_reason="stop",
+        metadata={},
+    )
+
+
+@pytest.mark.parametrize("is_validation", [False, True])
+def test_strict_enrichment_follows_is_validation(is_validation):
+    """Training rollouts must reject empty token IDs (EnrichMismatchError →
+    retry); validation tolerates them (evaluators read message text). The old
+    ``strict = hooks is None`` proxy silently disabled this for sandboxed
+    training, which always has hooks."""
+
+    @__import__("rllm").rollout(name="noop")
+    def noop_flow(task, config):
+        return None
+
+    gateway = _Gateway(traces=[_empty_token_trace("task:0")])
+    engine = AgentFlowEngine(
+        agent_flow=noop_flow,
+        evaluator=_Evaluator(),
+        gateway=gateway,
+        model="test-model",
+        n_parallel_tasks=1,
+        retry_limit=1,
+    )
+    task = task_from_row({"question": "q"}, "task")
+
+    try:
+        if is_validation:
+            episode = asyncio.run(engine._run_single(task, "task:0", is_validation=True))
+            assert episode is not None
+        else:
+            from rllm.engine.agentflow_engine import EnrichMismatchError
+
+            with pytest.raises(EnrichMismatchError):
+                asyncio.run(engine._run_single(task, "task:0", is_validation=False))
+    finally:
+        engine.shutdown()

--- a/tests/eval/test_env_join.py
+++ b/tests/eval/test_env_join.py
@@ -1,0 +1,166 @@
+"""Tests for the env-requirement join (``resolve_rollout_plan``) and the
+wiring-time scan (``scan_env_requirements``) in :mod:`rllm.hooks`.
+
+The invariant under test:
+
+    needs_env = flow.needs_env ∨ evaluator-needs-env ∨ task-declares-env
+
+plus the no-consumer rule (a task-declared env nobody can reach is downgraded
+with a warning instead of provisioned for nobody).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import rllm
+from rllm.hooks import FixedEvaluation, FromTaskEvaluation, flow_needs_env, resolve_rollout_plan, scan_env_requirements, task_declares_env
+from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+from rllm.types import Task
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@rllm.rollout(name="host-flow")
+def _host_flow(task, config):
+    return None
+
+
+class _SandboxedStub(SandboxedAgentFlow):
+    def run(self, task, config):
+        return None
+
+
+class _HostEvaluator:
+    def evaluate(self, task, episode):
+        return None
+
+
+def _plain_task(tmp_path: Path, *, with_env_dir: bool = False, verifier_block: str = "") -> Task:
+    bench = tmp_path / ("bench-env" if with_env_dir else "bench")
+    bench.mkdir(exist_ok=True)
+    (bench / "dataset.toml").write_text('[dataset]\nname = "bench"\n\n' + verifier_block)
+    if with_env_dir:
+        (bench / "environment").mkdir(exist_ok=True)
+    return Task(id="t0", instruction="x?", metadata={}, dataset_dir=bench)
+
+
+# ---------------------------------------------------------------------------
+# Declared needs
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_flows_declare_host_only():
+    assert flow_needs_env(_host_flow) is False
+
+
+def test_sandboxed_flows_declare_env():
+    assert flow_needs_env(_SandboxedStub()) is True
+
+
+def test_task_declares_env_via_environment_dir(tmp_path):
+    assert task_declares_env(_plain_task(tmp_path, with_env_dir=True)) is True
+    assert task_declares_env(_plain_task(tmp_path)) is False
+
+
+def test_task_declares_env_via_task_path_metadata():
+    assert task_declares_env({"task_path": "/some/harbor/task"}) is True
+    assert task_declares_env({"question": "2+2?"}) is False
+
+
+# ---------------------------------------------------------------------------
+# The join
+# ---------------------------------------------------------------------------
+
+
+def test_host_flow_host_evaluator_no_env(tmp_path):
+    """Case 1 shape: classic math RL — nothing requires a sandbox."""
+    task = _plain_task(tmp_path)
+    plan = resolve_rollout_plan(task, _host_flow, FixedEvaluation(_HostEvaluator()))
+    assert plan.needs_env is False
+    assert plan.verifier_kind == "fixed"
+
+
+def test_sandboxed_flow_forces_env_even_with_fixed_evaluator(tmp_path):
+    """Case 2 shape: the flow's declared need wins — a host-side evaluator
+    must not disable the sandbox."""
+    task = _plain_task(tmp_path)
+    plan = resolve_rollout_plan(task, _SandboxedStub(), FixedEvaluation(_HostEvaluator()))
+    assert plan.needs_env is True
+
+
+def test_env_verifier_forces_env_for_host_flow(tmp_path):
+    """Case 3 shape: a sandbox-shell verifier needs the env even when the flow doesn't."""
+    bench = tmp_path / "bench"
+    bench.mkdir()
+    (bench / "tests").mkdir()
+    (bench / "tests" / "test.sh").write_text("#!/bin/sh\necho ok\n")
+    (bench / "dataset.toml").write_text('[dataset]\nname = "bench"\n')
+    task = Task(id="t0", instruction="x?", metadata={}, dataset_dir=bench)
+
+    plan = resolve_rollout_plan(task, _host_flow, FromTaskEvaluation())
+    assert plan.verifier_kind == "sandbox-shell"
+    assert plan.needs_env is True
+
+
+def test_no_consumer_rule_downgrades_task_env(tmp_path, caplog):
+    """A task-declared env with a host-only flow and host-only verifier is
+    downgraded (with a warning) instead of provisioned for nobody."""
+    task = _plain_task(tmp_path, with_env_dir=True, verifier_block='[verifier]\nname = "math_reward_fn"\n')
+
+    import rllm.hooks as hooks_mod
+
+    hooks_mod._warned_no_consumer.discard(task.id)  # the warning fires once per task id
+    with caplog.at_level("WARNING", logger="rllm.hooks"):
+        plan = resolve_rollout_plan(task, _host_flow, FromTaskEvaluation())
+
+    assert plan.verifier_kind == "registered"
+    assert plan.needs_env is False
+    assert any("skipping sandbox provisioning" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Wiring-time scan
+# ---------------------------------------------------------------------------
+
+
+def test_scan_flow_declaration_wins():
+    scan = scan_env_requirements(_SandboxedStub(), None, None)
+    assert scan.needs_env is True
+    assert scan.any_remote is False
+
+
+def test_scan_finds_env_row_beyond_the_first(tmp_path):
+    """An env requirement may appear on any row, not just the first."""
+    rows = [{"question": "2+2?"}, {"task_path": "/harbor/task-001"}]
+    scan = scan_env_requirements(_host_flow, rows)
+    assert scan.needs_env is True
+
+
+def test_scan_detects_remote_backend_from_rows():
+    rows = [{"task_path": "/t", "sandbox_backend": "daytona"}]
+    scan = scan_env_requirements(_host_flow, rows)
+    assert scan.any_remote is True
+
+
+def test_scan_explicit_backend_overrides_row_metadata():
+    """An explicit local backend wins over remote row metadata (same precedence
+    as _resolve_backend at provision time) — no tunnel."""
+    rows = [{"task_path": "/t", "sandbox_backend": "daytona"}]
+    scan = scan_env_requirements(_host_flow, rows, sandbox_backend="docker")
+    assert scan.needs_env is True
+    assert scan.any_remote is False
+
+
+def test_scan_explicit_remote_backend():
+    scan = scan_env_requirements(_SandboxedStub(), None, sandbox_backend="daytona")
+    assert scan.any_remote is True
+
+
+def test_scan_no_env_anywhere():
+    rows = [{"question": "2+2?", "ground_truth": "4"}]
+    scan = scan_env_requirements(_host_flow, rows)
+    assert scan.needs_env is False
+    assert scan.any_remote is False

--- a/tests/eval/test_eval_engine.py
+++ b/tests/eval/test_eval_engine.py
@@ -6,8 +6,8 @@ whether ``hooks`` are installed. This test verifies the eval path works:
 1. A flow that ``return None``s.
 2. A fake gateway that captures whatever URL the flow's HTTP call would
    hit and returns canned ``TraceRecord`` objects on ``aget_traces``.
-3. ``SandboxTaskHooks`` with an ``evaluator_override`` so we don't need a
-   real verifier on disk.
+3. ``SandboxTaskHooks`` with a ``FixedEvaluation`` policy so we don't
+   need a real verifier on disk.
 4. Assert: the evaluator received an Episode with populated Steps (from
    the gateway traces), the reward was written back to the trajectory,
    and ``is_correct`` reflects the evaluator's verdict.
@@ -25,7 +25,7 @@ from rllm_model_gateway.models import TraceRecord
 import rllm
 from rllm.engine.agentflow_engine import AgentFlowEngine
 from rllm.eval.types import EvalOutput
-from rllm.hooks import SandboxTaskHooks
+from rllm.hooks import FixedEvaluation, SandboxTaskHooks
 from rllm.types import AgentConfig, Episode, Task
 
 # ---------------------------------------------------------------------------
@@ -64,27 +64,28 @@ class _FakeGateway:
 
     def __init__(self, response_per_uid: dict[str, str]):
         self._responses = response_per_uid
-        self._sessions: set[str] = set()
         self.create_calls: list[str] = []
         self.delete_calls: list[str] = []
 
-    async def acreate_session(self, session_id: str, is_validation: bool = False) -> str:
-        self._sessions.add(session_id)
+    async def acreate_session(self, session_id: str, is_validation: bool = False, sampling_params: dict | None = None) -> str:
         self.create_calls.append(session_id)
         return session_id
 
-    def get_session_url(self, session_id: str) -> str:
+    def get_session_url(self, session_id: str, public: bool = True) -> str:
         return f"http://fake-gateway/sessions/{session_id}/v1"
 
     async def aget_traces(self, session_id: str) -> list[TraceRecord]:
-        if session_id not in self._sessions:
+        if session_id not in self._responses:
             return []
         return [_make_trace(self._responses[session_id], session_id=session_id)]
 
     async def adelete_session(self, session_id: str) -> int:
-        self._sessions.discard(session_id)
         self.delete_calls.append(session_id)
         return 1
+
+    async def adelete_sessions(self, session_ids: list[str]) -> int:
+        self.delete_calls.extend(session_ids)
+        return len(session_ids)
 
 
 class _StubEvaluator:
@@ -119,7 +120,7 @@ def test_eval_engine_populates_steps_from_gateway_traces():
 
     gateway = _FakeGateway(response_per_uid={"task-0:0": r"The answer is \boxed{42}"})
     evaluator = _StubEvaluator(ground_truth="42")
-    hooks = SandboxTaskHooks(evaluator_override=evaluator)
+    hooks = SandboxTaskHooks(evaluation=FixedEvaluation(evaluator))
 
     engine = AgentFlowEngine(
         agent_flow=fake_flow,
@@ -130,6 +131,7 @@ def test_eval_engine_populates_steps_from_gateway_traces():
         retry_limit=1,
         raise_on_error=True,
         hooks=hooks,
+        val_sampling_params={"temperature": 0.2},
     )
 
     task = Task(id="task-0", instruction="What is the answer?", metadata={"answer": "42"}, dataset_dir=Path("."))
@@ -162,7 +164,7 @@ def test_eval_engine_populates_steps_from_gateway_traces():
 def test_eval_engine_marks_wrong_answer_incorrect():
     gateway = _FakeGateway(response_per_uid={"task-0:0": r"\boxed{99}"})
     evaluator = _StubEvaluator(ground_truth="42")
-    hooks = SandboxTaskHooks(evaluator_override=evaluator)
+    hooks = SandboxTaskHooks(evaluation=FixedEvaluation(evaluator))
 
     engine = AgentFlowEngine(
         agent_flow=fake_flow,

--- a/tests/eval/test_unified_runner.py
+++ b/tests/eval/test_unified_runner.py
@@ -8,7 +8,7 @@ host-only verifier paths are now exercised through ``SandboxTaskHooks.setup``:
 - ``[verifier].module`` (Python module verifier)
 - ``[verifier].import_path`` (bare callable)
 - Auto-detect via ``tests/evaluate.py``
-- ``evaluator_override`` short-circuits per-task resolution
+- a ``FixedEvaluation`` policy short-circuits per-task resolution
 - ``"missing"`` verifier raises a clear error
 
 Sandbox-shell + python-hybrid paths need a real container and live in
@@ -24,7 +24,7 @@ import pytest
 
 from rllm.eval._resolution import build_dataset_evaluator
 from rllm.eval.types import EvalOutput
-from rllm.hooks import SandboxTaskHooks
+from rllm.hooks import FixedEvaluation, SandboxTaskHooks
 from rllm.types import AgentConfig, Episode, Step, Task, Trajectory, run_agent_flow
 
 # ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@ def _write_data_dataset(root: Path, *, verifier_block: str) -> Path:
     return bench
 
 
-def _run_through_hooks(agent_flow, task: Task, config: AgentConfig, evaluator_override=None) -> Episode:
+def _run_through_hooks(agent_flow, task: Task, config: AgentConfig, evaluator=None) -> Episode:
     """Replicate the Runner.run lifecycle through SandboxTaskHooks for unit tests.
 
     Real eval goes through ``AgentFlowEngine``, which inserts the gateway
@@ -75,7 +75,7 @@ def _run_through_hooks(agent_flow, task: Task, config: AgentConfig, evaluator_ov
     (the StubAgent doesn't make LLM calls) and just exercise the hook's
     verifier resolution + reward writeback paths.
     """
-    hooks = SandboxTaskHooks(evaluator_override=evaluator_override)
+    hooks = SandboxTaskHooks(evaluation=FixedEvaluation(evaluator) if evaluator is not None else None)
     ctx = hooks.setup(task, agent_flow, "test-uid")
     try:
         episode = asyncio.run(run_agent_flow(agent_flow, task, config))
@@ -168,7 +168,7 @@ def test_runner_auto_detects_tests_evaluate_py(tmp_path, cfg):
 
 
 # ---------------------------------------------------------------------------
-# evaluator_override short-circuits resolution
+# FixedEvaluation policy short-circuits resolution
 # ---------------------------------------------------------------------------
 
 
@@ -182,13 +182,13 @@ class _FixedEvaluator:
         return self._output
 
 
-def test_evaluator_override_bypasses_per_task_verifier(tmp_path, cfg):
+def test_fixed_evaluation_bypasses_per_task_verifier(tmp_path, cfg):
     bench = _write_data_dataset(tmp_path, verifier_block='[verifier]\nname = "math_reward_fn"\n')
     task = Task(id="0", instruction="x?", metadata={"ground_truth": "4"}, dataset_dir=bench)
 
-    # Per-task verifier would say wrong → 0; override says correct → 1
-    override = _FixedEvaluator(EvalOutput(reward=1.0, is_correct=True))
-    episode = _run_through_hooks(_StubAgent(answer="totally wrong"), task, cfg, evaluator_override=override)
+    # Per-task verifier would say wrong → 0; the fixed evaluator says correct → 1
+    evaluator = _FixedEvaluator(EvalOutput(reward=1.0, is_correct=True))
+    episode = _run_through_hooks(_StubAgent(answer="totally wrong"), task, cfg, evaluator=evaluator)
 
     assert episode.is_correct is True
     assert episode.trajectories[0].reward == 1.0
@@ -256,7 +256,7 @@ def test_hooks_close_sandbox_for_sandboxed_agent_flow(tmp_path, cfg, monkeypatch
     bench.mkdir()
     task = Task(id="0", instruction="x?", metadata={}, dataset_dir=bench)
 
-    hooks = SandboxTaskHooks(evaluator_override=_FixedEvaluator(EvalOutput(reward=1.0, is_correct=True)))
+    hooks = SandboxTaskHooks(evaluation=FixedEvaluation(_FixedEvaluator(EvalOutput(reward=1.0, is_correct=True))))
     ctx = hooks.setup(task, _SandboxedStub(), "test-uid")
     ctx.run_teardown()
 

--- a/tests/integration/test_sampling_e2e.py
+++ b/tests/integration/test_sampling_e2e.py
@@ -143,7 +143,7 @@ def test_eval_run_dataset_enforces_sampling(mock_upstream):
             base_url=mock_upstream.url,
             model="mock-model",
             concurrency=2,
-            evaluator_override=e2e_eval,
+            evaluator=e2e_eval,
             sampling_params=sampling,
         )
     )


### PR DESCRIPTION
## Intuition

> See https://github.com/rllm-org/rllm/discussions/639 for design doc.

Whether a rollout needs a sandbox used to be answered by **three different formulas in three places** (`needs_sandbox_isolation`, an `isinstance` check inside `SandboxTaskHooks.setup`, and `_needs_sandbox` in eval resolution) — and they disagreed. Each component now **declares** what it needs, and one pure function joins the declarations:

```
needs_env = flow.needs_env  ∨  env-style verifier (sandbox-shell / python-hybrid)  ∨  task declares an environment
```

- **Per task** (`resolve_rollout_plan`): decides sandbox + verifier at bind time. Includes the *no-consumer rule*: a task-declared env that neither the flow nor the verifier can reach is downgraded with a warning instead of provisioned for nobody.
- **Per run** (`scan_env_requirements`): the same predicate over **all** dataset rows (the old probe only looked at the first), deciding whether to install hooks and whether the gateway needs a public tunnel.
- **Declarations instead of isinstance**: `needs_env` (`SandboxedAgentFlow=True`, `@rllm.rollout=False`) and `llm_inside_env` (`BaseCliHarness=True` → in-sandbox process gets the public/tunnel URL; host-side loops keep the local URL so they never depend on a quick-tunnel hostname that can rotate mid-run).
- **Always-hooks engine**: evaluation policies `FixedEvaluation` / `FromTaskEvaluation` replace `evaluator_override` threading; a bare `evaluator=` wraps into `FixedEvaluatorHooks`, so `AgentFlowEngine` has exactly one execution path (the `ctx is None` forks and dict-vs-Task calling-convention split are deleted).

## Bug fixes shipped with the join

- **Training ran with strict trace enrichment silently off** for sandboxed flows (`strict = hooks is None`, but sandboxed training always has hooks) — empty token IDs could reach loss math. Now `strict = not is_validation`.
- Gateway loopback pin + tunnel decision now also apply when `hooks=` is passed explicitly (previously skipped entirely).
- `CloudflaredTunnel` blocks until the hostname actually answers over HTTP (`RLLM_TUNNEL_REACHABLE_TIMEOUT_S`, default 120 s) — cloudflared printing the URL only means it was *assigned*; rollouts burned all retries on the DNS race in ~4 s.
- `rllm train` no longer hard-fails on `sandbox-shell` / `python-hybrid` verifiers — the per-task policy resolves them in-sandbox, enabling **harbor-style graded training from the CLI for the first time**.

## Verification

- `tests/eval/test_env_join.py` (new): the join, the no-consumer rule, the all-rows scan, tunnel precedence.
- Full suite vs pristine HEAD: 0 regressions, 2 previously-broken test modules fixed (`test_eval_engine`, `test_agentflow_engine`), 14 shared pre-existing failures untouched (verl import drift etc.).
- **E2E on Tinker + Daytona** (snapshot + warm pool on; 1 val + 2 train steps each, rollouts/rewards inspected per episode):
  1. `@rllm.rollout` + NullEnv + host evaluator (math RL) — rewards 1.0, real token-level updates.
  2. BashHarness + Daytona + host evaluator — secrets baked via Dockerfile read back in observations (proves the snapshot env); one genuine agent hallucination correctly scored 0.0; warm-prefetched rollouts at `setup=0s`.
  3. mini-swe `BaseCliHarness` + Daytona + sandbox-shell verifier — content-addressed snapshot reuse across dataset dirs, warm queue active, in-sandbox `test.sh` grading at 1–2 s/rollout.

A reviewer pass tightened the public API before commit: `Fixed`/`FromTask` → `FixedEvaluation`/`FromTaskEvaluation`, `EnvScan` → `EnvRequirements`, `llm_from_env` → `llm_inside_env`, the no-consumer warning deduped per task id, and history-narrating comments removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)