### PR TITLE
feat(sandbox): bake CLI installs into snapshots (AgentFlow phase 2)

### DIFF
--- a/rllm/cli/snapshot_cmd.py
+++ b/rllm/cli/snapshot_cmd.py
@@ -145,7 +145,7 @@ def snapshot():
     type=click.Choice(["modal", "daytona"], case_sensitive=False),
     help="Backend to build snapshots on (only modal/daytona have snapshots).",
 )
-@click.option("--agent", "agent_name", default=None, help="Agent scaffold (only affects local-benchmark resolution).")
+@click.option("--agent", "agent_name", default=None, help="Agent scaffold; its CLI install (if any) is baked into the snapshots.")
 @click.option("--split", default=None, help="Dataset split (default: from catalog eval_split).")
 @click.option("--max-examples", default=None, type=int, help="Snapshot only the first N tasks (e.g. the slice you'll eval).")
 @click.option("--task-indices", default=None, type=str, help="Snapshot only these task indices (e.g. '0', '3,7,12', '0-9').")
@@ -155,15 +155,22 @@ def create_snapshots(benchmark: str, sandbox_backend: str, agent_name: str | Non
     """Build environment snapshots for a benchmark (or a slice of it) and record a group."""
     from rllm.eval._resolution import _resolve_image
     from rllm.sandbox.sandboxed_flow import build_snapshot
-    from rllm.sandbox.snapshot import SnapshotRegistry, env_key_for, keys_for_tasks
+    from rllm.sandbox.snapshot import SnapshotRegistry, env_key_for, install_script_for, keys_for_tasks
+
+    install = ""
+    if agent_name is not None:
+        from rllm.eval.agent_loader import load_agent
+
+        install = install_script_for(load_agent(agent_name))
 
     tasks = _slice_tasks(_resolve_dataset_tasks(benchmark, agent_name, sandbox_backend, split), max_examples, task_indices)
-    by_key = keys_for_tasks(tasks, sandbox_backend)
+    by_key = keys_for_tasks(tasks, sandbox_backend, install)
     if not by_key:
         console.print(f"  [dim]No snapshottable environments for '{benchmark}' on {sandbox_backend}.[/]")
         return
 
-    console.print(f"\n  Building [val]{len(by_key)}[/] snapshot(s) from [val]{len(tasks)}[/] task(s) on [val]{sandbox_backend}[/]\n")
+    baked = f" (baking [val]{agent_name}[/] install)" if install else ""
+    console.print(f"\n  Building [val]{len(by_key)}[/] snapshot(s) from [val]{len(tasks)}[/] task(s) on [val]{sandbox_backend}[/]{baked}\n")
     registry = SnapshotRegistry.load()
 
     def _build(item: tuple[str, object]) -> tuple[str, str | None, str, str | None, float]:
@@ -172,7 +179,7 @@ def create_snapshots(benchmark: str, sandbox_backend: str, agent_name: str | Non
         err = None
         try:
             prior_ref = registry.lookup_env(key, sandbox_backend)  # a live local ref to reuse when not forced
-            ref = build_snapshot(sandbox_backend, task, key, prior_ref, force=force)
+            ref = build_snapshot(sandbox_backend, task, key, prior_ref, force=force, install_script=install)
             reused = ref is not None and not force and prior_ref == ref
             status = "reused" if reused else "ok" if ref is not None else "no-snapshot"
         except Exception as e:  # noqa: BLE001
@@ -185,7 +192,7 @@ def create_snapshots(benchmark: str, sandbox_backend: str, agent_name: str | Non
     # the group's tasks: the exact sliced tasks whose env actually built
     built_tasks = []
     for task in tasks:
-        key = env_key_for(task, sandbox_backend)
+        key = env_key_for(task, sandbox_backend, install)
         ref = results.get(key, (None,))[0]
         if ref is not None:
             built_tasks.append({"id": task.id, "env_key": key, "ref": ref, "base_image": _resolve_image(task, sandbox_backend)})

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -16,6 +16,7 @@ Module is private (``_resolution``) — external callers should go through
 
 from __future__ import annotations
 
+import base64
 import importlib
 import inspect
 import logging
@@ -290,6 +291,19 @@ def _dockerfile_run_commands(task: Task) -> list[str]:
                 commands.append(cmd)
         i += 1
     return commands
+
+
+def _as_single_run_line(cmd: str) -> str:
+    """Collapse a multi-line shell command into one line for a Dockerfile ``RUN``.
+
+    Daytona builds snapshots declaratively: each command becomes a raw
+    ``RUN <command>`` line, which a multi-line script breaks. ``bash`` (not
+    ``sh``) matches how :meth:`Sandbox.exec` runs the same scripts live.
+    """
+    if "\n" not in cmd:
+        return cmd
+    encoded = base64.b64encode(cmd.encode("utf-8")).decode("ascii")
+    return f"echo {encoded} | base64 -d | bash"
 
 
 def _resolve_image(task: Task, backend: str) -> str:

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -108,10 +108,11 @@ async def run_dataset(
         # Negative size means "match concurrency"; it only helps when sandboxes
         # are actually created, so gate on a chosen sandbox backend.
         if warm_queue_size != 0 and sandbox_backend:
+            from rllm.sandbox.snapshot import install_script_for
             from rllm.sandbox.warm_queue import WarmQueue
 
             size = effective_concurrency if warm_queue_size < 0 else warm_queue_size
-            warm_queue = WarmQueue(list(tasks), sandbox_backend, hooks.registry, size)
+            warm_queue = WarmQueue(list(tasks), sandbox_backend, hooks.registry, size, install_script=install_script_for(agent_flow))
             hooks.warm_queue = warm_queue
             warm_queue.start()
 

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -300,8 +300,16 @@ class BaseCliHarness(SandboxedAgentFlow):
     # ---------------------------------------------------------------------
 
     def on_sandbox_ready(self, task: dict, config: AgentConfig) -> None:  # noqa: ARG002
-        """Install the CLI inside the sandbox before the first run."""
+        """Install the CLI inside the sandbox before the first run.
+
+        Skipped when the sandbox's image already contains exactly this
+        harness's install (``baked_install``, recorded at snapshot boot by
+        :func:`rllm.sandbox.snapshot.get_sandbox`). Cold boots and task-only
+        snapshot boots install as usual.
+        """
         if self.sandbox is None:
+            return
+        if getattr(self.sandbox, "baked_install", "") == self.install_script():
             return
         try:
             self._exec_root(self.install_script(), timeout=self.install_timeout)

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -256,9 +256,9 @@ class SandboxTaskHooks:
 
         sandbox = None
         if plan.needs_env:
-            from rllm.sandbox.snapshot import get_sandbox
+            from rllm.sandbox.snapshot import get_sandbox, install_script_for
 
-            sandbox = self.warm_queue.pop(task) if self.warm_queue is not None else get_sandbox(task, self.sandbox_backend, self._registry)
+            sandbox = self.warm_queue.pop(task) if self.warm_queue is not None else get_sandbox(task, self.sandbox_backend, self._registry, install_script_for(task_flow))
             _setup_task_environment(task, sandbox)
             if isinstance(task_flow, SandboxedAgentFlow):
                 task_flow.set_sandbox(sandbox)

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -301,7 +301,7 @@ def create_daytona_sandbox(name: str, image: str = "python:3.11-slim", **kwargs)
     return DaytonaSandbox(name=name, image=image, **kwargs)
 
 
-def build_daytona_snapshot(task, key: str, *, force: bool = False) -> str | None:
+def build_daytona_snapshot(task, key: str, *, force: bool = False, install_script: str = "") -> str | None:
     """Declaratively bake ``task``'s base image + RUN steps into a named snapshot; return the name.
 
     Idempotent: an already-registered snapshot is reused unless ``force``, which
@@ -309,7 +309,7 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False) -> str | None
     """
     from daytona import CreateSnapshotParams, Daytona, DaytonaNotFoundError, Image, Resources
 
-    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
+    from rllm.eval._resolution import _as_single_run_line, _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
 
     client = Daytona()
     try:
@@ -323,7 +323,9 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False) -> str | None
         pass
 
     img = Image.base(_resolve_image(task, "daytona"))
-    run_commands = _dockerfile_run_commands(task)
+    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)]
+    if install_script:
+        run_commands.append(_as_single_run_line(install_script))
     if run_commands:
         img = img.run_commands(*run_commands)
 

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -266,7 +266,7 @@ def _modal_ref_absent(ref: str) -> bool:
         return False
 
 
-def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force: bool = False) -> str | None:
+def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force: bool = False, install_script: str = "") -> str | None:
     """Build a Modal filesystem snapshot of ``task``'s environment; return its image id.
 
     Mirrors Daytona's idempotency: when a ``prior_ref`` is known and still live
@@ -274,8 +274,10 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     filesystem — every fresh capture orphans the old image forever. ``force``
     bypasses reuse and always rebuilds.
 
-    Create a base sandbox, replay the Dockerfile RUN steps, then capture the
-    live filesystem as a ``modal.Image`` (stored as a diff from the base).
+    Create a base sandbox, replay the Dockerfile RUN steps, run the install
+    script (if any), then capture the live filesystem as a ``modal.Image``
+    (stored as a diff from the base). A failed install fails the build — a
+    snapshot keyed on the install must actually contain it.
     """
     from rllm.eval._resolution import _create_base_sandbox, _replay_dockerfile
 
@@ -286,6 +288,10 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build")
     try:
         _replay_dockerfile(task, sb, "modal")
+        if install_script:
+            from rllm.env import env_int
+
+            sb.exec(install_script, timeout=env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900), user="root")
         image = sb._sandbox.snapshot_filesystem()  # noqa: SLF001 — modal.Image
         logger.info("modal snapshot built: %s -> %s", key, image.object_id)
         return image.object_id

--- a/rllm/sandbox/sandboxed_flow.py
+++ b/rllm/sandbox/sandboxed_flow.py
@@ -123,21 +123,23 @@ def create_sandbox(backend: str, name: str, image: str, **kwargs) -> Sandbox:
         raise ValueError(f"Unknown sandbox backend: {backend}. Available: docker, local, modal, daytona")
 
 
-def build_snapshot(backend: str, task: Task, key: str, prior_ref: str | None = None, *, force: bool = False) -> str | None:
+def build_snapshot(backend: str, task: Task, key: str, prior_ref: str | None = None, *, force: bool = False, install_script: str = "") -> str | None:
     """Build a snapshot of ``task``'s environment; return a backend ref, or ``None``.
 
     Each backend owns its mechanism (Modal: live-FS capture; Daytona:
     declarative bake). Backends without snapshots (docker/local) return ``None``.
     A known-live ``prior_ref`` is reused unless ``force``, which always rebuilds.
+    ``install_script`` is baked on top of the task's RUN steps — ``key`` must
+    have been computed with the same script.
     """
     if backend == "modal":
         from rllm.sandbox.backends.modal_backend import build_modal_snapshot
 
-        return build_modal_snapshot(task, key, prior_ref, force=force)
+        return build_modal_snapshot(task, key, prior_ref, force=force, install_script=install_script)
     elif backend == "daytona":
         from rllm.sandbox.backends.daytona import build_daytona_snapshot
 
-        return build_daytona_snapshot(task, key, force=force)
+        return build_daytona_snapshot(task, key, force=force, install_script=install_script)
     return None
 
 

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -51,27 +51,37 @@ def _expired(iso: str | None) -> bool:
     return _now() >= dt
 
 
-def env_key(backend: str, base_image: str, run_commands: list[str]) -> str:
+def env_key(backend: str, base_image: str, run_commands: list[str], install_script: str = "") -> str:
     """Content-hash fingerprint of an environment: ``rllm-env-<hash12>``.
 
-    Hashes only ``(backend, base_image, RUN block)`` — never ``task.id`` — so
-    GRPO group copies share one key and any image/RUN change yields a new key
-    (a clean miss, never a stale hit). Lowercase + dashes: a legal Daytona
-    snapshot name, Modal/Docker-safe.
+    Hashes ``(backend, base_image, RUN block, install script)`` — never
+    ``task.id`` — so GRPO group copies share one key and any image/RUN/install
+    change yields a new key (a clean miss, never a stale hit). An empty
+    ``install_script`` contributes nothing, keeping task-only keys stable.
+    Lowercase + dashes: a legal Daytona snapshot name, Modal/Docker-safe.
     """
-    payload = "\n".join([backend, base_image, *run_commands])
+    parts = [backend, base_image, *run_commands]
+    if install_script:
+        parts += ["install:", install_script]
+    payload = "\n".join(parts)
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
     return f"rllm-env-{digest}"
 
 
-def env_key_for(task: Task, backend: str) -> str:
+def env_key_for(task: Task, backend: str, install_script: str = "") -> str:
     """Fingerprint a task's environment via the shared image/RUN resolution."""
     from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image
 
-    return env_key(backend, _resolve_image(task, backend), _dockerfile_run_commands(task))
+    return env_key(backend, _resolve_image(task, backend), _dockerfile_run_commands(task), install_script)
 
 
-def keys_for_tasks(tasks: list[Task], backend: str | None) -> dict[str, Task]:
+def install_script_for(agent_flow: object) -> str:
+    """The flow's CLI install script, ``""`` when it has none (host flows, bash loops)."""
+    fn = getattr(agent_flow, "install_script", None)
+    return fn() if callable(fn) else ""
+
+
+def keys_for_tasks(tasks: list[Task], backend: str | None, install_script: str = "") -> dict[str, Task]:
     """Map distinct env_keys to a representative task (used by ``rllm snapshot create``)."""
     from rllm.eval._resolution import _resolve_backend
 
@@ -80,7 +90,7 @@ def keys_for_tasks(tasks: list[Task], backend: str | None) -> dict[str, Task]:
         eff = _resolve_backend(task, backend)
         if eff in _NO_SNAPSHOT_BACKENDS:
             continue
-        out.setdefault(env_key_for(task, eff), task)
+        out.setdefault(env_key_for(task, eff, install_script), task)
     return out
 
 
@@ -104,7 +114,7 @@ def _make_group_id(dataset: str, slice_spec: dict, task_count: int) -> str:
     return f"{_slug(dataset)}-{_slice_id_token(slice_spec, task_count)}-{os.urandom(4).hex()}"
 
 
-def get_sandbox(task: Task, backend: str | None, registry: SnapshotRegistry | None = None) -> Sandbox:
+def get_sandbox(task: Task, backend: str | None, registry: SnapshotRegistry | None = None, install_script: str = "") -> Sandbox:
     """Return a ready sandbox for ``task`` — from a snapshot when available, else cold.
 
     Snapshots are used iff ``registry`` is given. Two cheap gates before the cold
@@ -112,20 +122,34 @@ def get_sandbox(task: Task, backend: str | None, registry: SnapshotRegistry | No
     straight to cold), then an optimistic boot from the stored ref. If that ref
     vanished backend-side the boot raises :class:`SnapshotNotFound` and we fall back
     to cold. Read-only w.r.t. snapshots — building is ``rllm snapshot``'s job.
+
+    ``sandbox.baked_install`` records the install script the booted image
+    actually contains: the requested script on an exact-fingerprint hit, ``""``
+    when the boot came from the task-only fallback snapshot (better than cold,
+    but the caller must still install at runtime). Cold sandboxes leave the
+    attribute unset.
     """
     from rllm.eval._resolution import _create_base_sandbox, _create_sandbox_for_task, _resolve_backend
     from rllm.sandbox.protocol import SnapshotNotFound
 
     backend = _resolve_backend(task, backend)
     if registry is not None and backend not in _NO_SNAPSHOT_BACKENDS:
-        key = env_key_for(task, backend)
-        ref = registry.lookup_env(key, backend)
-        if ref is not None:
+        key = env_key_for(task, backend, install_script)
+        candidates = [key]
+        if install_script:
+            candidates.append(env_key_for(task, backend))
+        for candidate in candidates:
+            ref = registry.lookup_env(candidate, backend)
+            if ref is None:
+                continue
             try:
-                return _create_base_sandbox(task, backend, image=ref)  # snapshot has RUN baked — no replay
+                sandbox = _create_base_sandbox(task, backend, image=ref)  # snapshot has RUN baked — no replay
             except SnapshotNotFound:
                 logger.info("snapshot %s gone on %s — cold fallback", ref, backend)
-                registry.discard(key)  # so sibling tasks this run skip the doomed boot
+                registry.discard(candidate)  # so sibling tasks this run skip the doomed boot
+                continue
+            sandbox.baked_install = install_script if candidate == key else ""
+            return sandbox
     return _create_sandbox_for_task(task, backend)
 
 
@@ -385,4 +409,4 @@ class SnapshotRegistry:
         self._write(self.path, {"version": 2, "envs": self._envs, "groups": self._groups})
 
 
-__all__ = ["env_key", "env_key_for", "keys_for_tasks", "get_sandbox", "SnapshotRegistry"]
+__all__ = ["env_key", "env_key_for", "install_script_for", "keys_for_tasks", "get_sandbox", "SnapshotRegistry"]

--- a/rllm/sandbox/warm_queue.py
+++ b/rllm/sandbox/warm_queue.py
@@ -48,11 +48,12 @@ class WarmQueue:
     stays within ``size`` of how many pops have happened.
     """
 
-    def __init__(self, schedule: list[Task], backend: str | None, registry: SnapshotRegistry | None, size: int) -> None:
+    def __init__(self, schedule: list[Task], backend: str | None, registry: SnapshotRegistry | None, size: int, install_script: str = "") -> None:
         self._schedule = schedule
         self._backend = backend
         self._registry = registry
         self._size = size
+        self._install_script = install_script
 
         self._cond = threading.Condition()
         self._ready: dict[str, list[Sandbox]] = {}
@@ -75,7 +76,7 @@ class WarmQueue:
         for an almost-ready sandbox rather than spawning a duplicate); if none
         is ready or pending, it falls back to a direct ``get_sandbox`` at once.
         """
-        key = env_key_for(task, self._backend)
+        key = env_key_for(task, self._backend, self._install_script)
         with self._cond:
             while not self._ready.get(key) and self._pending.get(key, 0) > 0 and not self._stop:
                 self._cond.wait()
@@ -85,7 +86,7 @@ class WarmQueue:
                 self._free_slots += 1
                 self._cond.notify_all()
                 return sandbox
-        return get_sandbox(task, self._backend, self._registry)
+        return get_sandbox(task, self._backend, self._registry, self._install_script)
 
     def shutdown(self) -> None:
         """Stop the fillers and close the prefetched-but-unconsumed tail.
@@ -117,7 +118,7 @@ class WarmQueue:
                     task = self._schedule[self._cursor]
                     self._cursor += 1
                     self._free_slots -= 1
-                    key = env_key_for(task, self._backend)
+                    key = env_key_for(task, self._backend, self._install_script)
                     self._pending[key] = self._pending.get(key, 0) + 1
                     return task, key
                 self._cond.wait()
@@ -131,7 +132,7 @@ class WarmQueue:
             task, key = claim
             sandbox = None
             try:
-                sandbox = get_sandbox(task, self._backend, self._registry)
+                sandbox = get_sandbox(task, self._backend, self._registry, self._install_script)
             except Exception:
                 logger.exception("warm queue: prefetch failed for task %s", getattr(task, "id", "?"))
             with self._cond:

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -467,17 +467,19 @@ class UnifiedTrainer:
         if hooks is None or not getattr(hooks, "sandbox_backend", None) or warm_queue_size == 0:
             return None
 
+        from rllm.sandbox.snapshot import install_script_for
         from rllm.sandbox.train_schedule import build_train_schedule
         from rllm.sandbox.warm_queue import WarmQueue
 
-        frontier = getattr(getattr(self.agent_workflow_engine, "agent_flow", None), "max_concurrent", 8)
+        flow = getattr(self.agent_workflow_engine, "agent_flow", None)
+        frontier = getattr(flow, "max_concurrent", 8)
         size = frontier if warm_queue_size < 0 else warm_queue_size
         consumed = trainer_state.global_step - 1  # global_step is 1-based once fit_async starts
         remaining = self._total_training_steps - consumed
         if use_total_batches:
             remaining = min(remaining, self.rllm_config.trainer.total_batches - consumed)
         schedule = build_train_schedule(train_dataloader, group_size=self.rllm_config.rollout.n, total_epochs=total_epochs, remaining_batches=remaining)
-        warm_queue = WarmQueue(schedule, hooks.sandbox_backend, hooks.registry, size)
+        warm_queue = WarmQueue(schedule, hooks.sandbox_backend, hooks.registry, size, install_script=install_script_for(flow))
         hooks.warm_queue = warm_queue
         warm_queue.start()
         logger.info("training warm queue started: %d ahead over %d scheduled tasks", size, len(schedule))

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -462,3 +462,133 @@ def test_daytona_ref_absent_reads_enum_or_string_state(monkeypatch):
 
     monkeypatch.setattr(daytona, "Daytona", lambda *a, **k: fake_daytona("error"))  # plain string also works
     assert _daytona_ref_absent("rllm-env-x") is True
+
+
+# --------------------------------------------------------------------------
+# Install baking — fingerprint, single-line wrapper, baked_install, install skip
+# --------------------------------------------------------------------------
+
+
+def test_env_key_install_script_changes_key_and_empty_matches_old():
+    base = env_key("daytona", "img:tag", ["run a"])
+    assert env_key("daytona", "img:tag", ["run a"], "") == base  # no install → key unchanged
+    assert env_key("daytona", "img:tag", ["run a"], "curl install.sh | bash") != base
+    assert env_key_for(_task(), "modal", "curl install.sh | bash") != env_key_for(_task(), "modal")
+
+
+def test_install_script_for_reads_flow_or_empty():
+    from rllm.sandbox.snapshot import install_script_for
+
+    class _Harness:
+        def install_script(self):
+            return "apt-get install -y thing"
+
+    assert install_script_for(_Harness()) == "apt-get install -y thing"
+    assert install_script_for(object()) == ""
+    assert install_script_for(None) == ""
+
+
+def test_as_single_run_line_round_trips_and_executes():
+    import base64
+    import subprocess
+
+    from rllm.eval._resolution import _as_single_run_line
+
+    assert _as_single_run_line("apt-get update") == "apt-get update"  # one line passes through
+
+    script = "set -e\nFOO=bar\necho path-guard $FOO"
+    wrapped = _as_single_run_line(script)
+    assert "\n" not in wrapped
+    encoded = wrapped.removeprefix("echo ").split(" | ")[0]
+    assert base64.b64decode(encoded).decode() == script  # round-trips byte-exact
+    out = subprocess.run(["bash", "-c", wrapped], capture_output=True, text=True, check=True)
+    assert out.stdout.strip() == "path-guard bar"  # and actually runs through bash
+
+
+def test_get_sandbox_install_hit_records_baked_install(monkeypatch, tmp_path):
+    import rllm.eval._resolution as res
+
+    install = "curl install.sh | bash"
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))
+    key = env_key_for(_task(), "modal", install)
+    reg._envs[key] = {"backend": "modal", "ref": "im-baked", "expires_at": _future()}
+
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda task, backend, *, image=None, name=None: _FakeSandbox())
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: pytest.fail("cold path taken on a baked hit"))
+
+    sb = get_sandbox(_task(), "modal", reg, install)
+    assert sb.baked_install == install
+
+
+def test_get_sandbox_task_only_fallback_boots_but_does_not_claim_install(monkeypatch, tmp_path):
+    """Only a task-only snapshot exists: boot from it (better than cold) but
+    record an empty ``baked_install`` so the harness still installs at runtime."""
+    import rllm.eval._resolution as res
+
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))
+    task_only_key = env_key_for(_task(), "modal")
+    reg._envs[task_only_key] = {"backend": "modal", "ref": "im-task-only", "expires_at": _future()}
+
+    booted = {}
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda task, backend, *, image=None, name=None: booted.update(image=image) or _FakeSandbox())
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: pytest.fail("cold path taken despite a usable task-only snapshot"))
+
+    sb = get_sandbox(_task(), "modal", reg, "curl install.sh | bash")
+    assert booted["image"] == "im-task-only"
+    assert sb.baked_install == ""
+
+
+def test_get_sandbox_cold_leaves_baked_install_unset(monkeypatch, tmp_path):
+    import rllm.eval._resolution as res
+
+    reg = SnapshotRegistry(str(tmp_path / "s.json"))  # empty → miss
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: _FakeSandbox())
+    sb = get_sandbox(_task(), "modal", reg, "curl install.sh | bash")
+    assert getattr(sb, "baked_install", None) is None
+
+
+def test_cli_harness_skips_install_iff_exact_baked_install():
+    from rllm.harnesses.cli_harness import BaseCliHarness
+
+    class _Stub(BaseCliHarness):
+        name = "stub"
+
+        def install_script(self):
+            return "echo installing"
+
+        def build_env(self, task, config):
+            return {}
+
+        def build_invocation(self, instruction, task, config):
+            return "true"
+
+    class _Sandbox:
+        def __init__(self):
+            self.calls = []
+
+        def exec(self, command, timeout=None, user=None):
+            self.calls.append(command)
+            return ""
+
+        def close(self):
+            pass
+
+    cold = _Stub()
+    cold_box = _Sandbox()
+    cold.set_sandbox(cold_box)
+    cold.on_sandbox_ready({}, None)
+    assert cold_box.calls == ["echo installing"]  # cold boot → install runs
+
+    warm = _Stub()
+    warm_box = _Sandbox()
+    warm_box.baked_install = "echo installing"
+    warm.set_sandbox(warm_box)
+    warm.on_sandbox_ready({}, None)
+    assert warm_box.calls == []  # image contains exactly this install → skip
+
+    stale = _Stub()
+    stale_box = _Sandbox()
+    stale_box.baked_install = "echo OLD install"  # baked for a different harness/version
+    stale.set_sandbox(stale_box)
+    stale.on_sandbox_ready({}, None)
+    assert stale_box.calls == ["echo installing"]  # mismatch → install runs

--- a/tests/sandbox/test_warm_queue.py
+++ b/tests/sandbox/test_warm_queue.py
@@ -51,7 +51,7 @@ class _FakeGetSandbox:
         self.gate = gate
         self.made: list[_CountingSandbox] = []
 
-    def __call__(self, task: Task, backend: str | None, registry) -> _CountingSandbox:
+    def __call__(self, task: Task, backend: str | None, registry, install_script: str = "") -> _CountingSandbox:
         sandbox = _CountingSandbox(task)
         self.made.append(sandbox)
         if self.gate is not None:


### PR DESCRIPTION
Stacked on #636 (phases 0–1) — merge that first; this PR's own diff is the single commit `b664dfd2`.

## Intuition

A `BaseCliHarness` rollout used to install its CLI inside the sandbox **every time** (`uv tool install mini-swe-agent`, npm installs, …— up to ~600 s), and snapshots couldn't help because the snapshot fingerprint only covered the task's Dockerfile. Now the fingerprint optionally covers the harness's install script too: `rllm snapshot create <dataset> --agent mini-swe-agent` builds images with the CLI already inside, the warm queue prefetches them, and the runtime install is skipped.

The skip is safe by construction, twice over:
1. **Content addressing** — a with-install key only ever matches a snapshot built from exactly that install script; any change to the script (or Dockerfile, or base image) is a clean miss, never a stale hit.
2. **A local check** — `get_sandbox` records `sandbox.baked_install` = the install script the booted image actually contains; `on_sandbox_ready` skips only when that equals *this harness's* script. A mismatched provisioning call can't fool it (reviewer-hardened from an earlier truthiness check).

Nothing gets slower: empty install scripts contribute nothing to the hash, so **every existing task-only key is byte-identical** (no migration), and when only a task-only snapshot exists it still serves as a fallback boot with the install running at runtime, exactly as before.

Why not just rerun the install ("it's idempotent")? The scripts' already-installed guards (`command -v`) depend on PATH entries the installer itself creates, which aren't on a fresh shell's PATH — a rerun still curls installers and re-resolves `@latest` packages.

## Also fixed in passing

Daytona's declarative builds emit each command as a raw Dockerfile `RUN` line; multi-line scripts broke that — including **pre-existing** task Dockerfiles with `\`-continuations. Both now collapse to one line via `echo <base64> | base64 -d | bash` (bash to match how `Sandbox.exec` runs the same scripts live). The hash uses the raw commands, so wrapping never perturbs fingerprints.

## Verification

- Unit (`tests/sandbox/test_snapshot.py`, +8): key sensitivity / empty-install byte-equality, wrapper round-trip **and actual bash execution**, all three boot paths (exact hit / task-only fallback / cold), skip-iff-exact-match including a stale-install mismatch.
- E2E (Tinker + Daytona, 1 val + 2 train + 1 val, snapshot + warm pool on): a mini-swe dataset whose Dockerfile contains **no CLI** — `snapshot create --agent` built `rllm-env-b34b2ce88f1e` in 59 s (the multi-line install went through the base64 wrapper in a real declarative build), training booted 12/12 rollouts from it, rewards 1.0 throughout, setup 0–9 s with zero install activity. The agent could only have run because the baked install was present and the skip was correct. A BashHarness run then reused its **pre-phase-2** snapshot under an unchanged key (rewards 1.0, 0 leaked sandboxes in both runs).
- Full suite: 888 passed, same 14 pre-existing failures as the base branch.
- Adversarial review pass applied: exact-match `baked_install` skip (was truthiness), Modal bake honors `RLLM_HARNESS_INSTALL_TIMEOUT_S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)