### PR TITLE
refactor(flows,hooks): engine owns the sandbox; flows become plain programs (AgentFlow phase 3)

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -31,6 +31,18 @@ def _suggest_benchmarks(name: str, catalog_names: list[str], max_suggestions: in
     return get_close_matches(name, catalog_names, n=max_suggestions, cutoff=0.5)
 
 
+def _apply_sandbox_overrides(agent, agent_metadata: dict | None) -> None:
+    """Route CLI sandbox flags through the flow's ``configure()`` and warn about leftovers."""
+    if not agent_metadata:
+        return
+    configure = getattr(agent, "configure", None)
+    leftovers = dict(configure(dict(agent_metadata)) if callable(configure) else agent_metadata)
+    # run_dataset / the sandbox hooks consume the backend regardless of the flow.
+    leftovers.pop("sandbox_backend", None)
+    for flag in leftovers:
+        logger.warning("--%s has no effect for agent %s", flag.replace("_", "-"), type(agent).__name__)
+
+
 def _dict_rows_to_tasks(rows: list[dict]) -> list[Task]:
     """Wrap dict-rows from a catalog dataset as Task objects.
 
@@ -150,15 +162,7 @@ def _run_eval(
         except (KeyError, ImportError, AttributeError, TypeError) as e:
             fail(f"Cannot load agent '{agent_name}': {e}")
 
-        # Apply CLI sandbox overrides
-        if agent_metadata:
-            from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
-
-            if isinstance(agent, SandboxedAgentFlow):
-                if "sandbox_backend" in agent_metadata:
-                    agent.sandbox_backend = agent_metadata["sandbox_backend"]
-                if "sandbox_concurrency" in agent_metadata:
-                    agent.max_concurrent = agent_metadata["sandbox_concurrency"]
+        _apply_sandbox_overrides(agent, agent_metadata)
 
         # Evaluator: comes from each Task's [verifier] config by default.
         # CLI --evaluator (when provided) overrides for every task.
@@ -243,19 +247,7 @@ def _run_eval(
         except (KeyError, ImportError, AttributeError, TypeError) as e:
             fail(f"Error loading agent '{agent_name}': {e}")
 
-        # Apply sandbox CLI overrides
-        if agent_metadata:
-            from rllm.integrations.harbor.runtime import HarborRuntime
-            from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
-
-            if isinstance(agent, HarborRuntime):
-                if "sandbox_backend" in agent_metadata:
-                    agent.environment_type = agent_metadata["sandbox_backend"]
-            elif isinstance(agent, SandboxedAgentFlow):
-                if "sandbox_backend" in agent_metadata:
-                    agent.sandbox_backend = agent_metadata["sandbox_backend"]
-                if "sandbox_concurrency" in agent_metadata:
-                    agent.max_concurrent = agent_metadata["sandbox_concurrency"]
+        _apply_sandbox_overrides(agent, agent_metadata)
 
         # Resolve evaluator: explicit --evaluator > catalog auto-resolve >
         # catalog reward_fn > None. When ``evaluator`` is None ``SandboxTaskHooks``

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -34,7 +34,8 @@ from tqdm import tqdm
 from rllm.data.utils import task_from_row
 from rllm.engine.trace_converter import compute_step_metrics, trace_record_to_step
 from rllm.eval.types import EvalOutput
-from rllm.types import AgentConfig, Episode, Step, Task, Trajectory, run_agent_flow
+from rllm.gateway.manager import container_reachable_url
+from rllm.types import AgentConfig, Episode, Step, Task, Trajectory, flow_accepts_env, run_agent_flow
 from rllm.utils import colorful_print
 from rllm.workflows.workflow import TerminationReason
 
@@ -64,14 +65,15 @@ class TaskContext:
     """Per-task state returned by :meth:`TaskHooks.setup`.
 
     Encapsulates the per-task evaluator (resolved by the hook from a task's
-    [verifier] config, or pre-bound by the caller), an optional per-task
-    agent flow (so SandboxedAgentFlow's per-task sandbox can't leak across
-    parallel rollouts), and a teardown callback that releases any per-task
+    [verifier] config, or pre-bound by the caller), the task's live sandbox
+    (``env``, ``None`` for host-only rollouts) with the backend that
+    provisioned it, and a teardown callback that releases any per-task
     resources (sandboxes, temp dirs, ...).
     """
 
     evaluator: Evaluator
-    agent_flow: Any = None  # AgentFlow | None — kept loose for the import-cycle reason below
+    env: Any = None  # Sandbox | None — kept loose for the import-cycle reason below
+    env_backend: str | None = None  # backend that actually provisioned env
     teardown: Any = None  # Callable[[], None] | None — kept loose to avoid Callable import loop
 
     def run_teardown(self) -> None:
@@ -356,6 +358,10 @@ class AgentFlowEngine:
 
             hooks = FixedEvaluatorHooks(evaluator)
 
+        self._flow_accepts_env = flow_accepts_env(agent_flow)
+        if getattr(agent_flow, "needs_env", False) and not self._flow_accepts_env:
+            raise TypeError(f"{type(agent_flow).__name__} declares needs_env but its run/arun has no keyword-only 'env' parameter; declare run(self, task, config, *, env).")
+
         self.agent_flow = agent_flow
         self.gateway = gateway
         self.model = model
@@ -595,20 +601,26 @@ class AgentFlowEngine:
         _timings["time/setup_s"] = time.perf_counter() - t
 
         try:
+            if getattr(self.agent_flow, "needs_env", False) and ctx.env is None:
+                raise RuntimeError(
+                    f"{type(self.agent_flow).__name__} needs a sandbox but hooks {type(self.hooks).__name__} provisioned none — pass hooks=SandboxTaskHooks(...) or run via AgentTrainer / run_dataset."
+                )
+
             # Attach resolved sampling params to the session so the gateway
             # enforces them on every LLM call; skip when there are none.
             session_sampling_params = (self.val_sampling_params if is_validation else self.train_sampling_params) or None
             if session_sampling_params:
                 await self.gateway.acreate_session(uid, is_validation=is_validation, sampling_params=session_sampling_params)
 
-            # Prefer the per-task flow from the hook so parallel tasks don't
-            # share mutable sandbox state on the engine-bound flow.
-            flow_for_task = ctx.agent_flow if ctx.agent_flow is not None else self.agent_flow
-
             # Flows whose LLM client runs *inside* the env (CLI harnesses)
-            # need the publicly-reachable URL; host-side flows keep the local
-            # gateway URL so they never depend on a tunnel hostname.
-            session_url = self.gateway.get_session_url(uid, public=getattr(flow_for_task, "llm_inside_env", False))
+            # need the publicly-reachable URL — rewritten for in-container
+            # networking on the backend that actually provisioned this task's
+            # sandbox. Host-side flows keep the local gateway URL so they
+            # never depend on a tunnel hostname.
+            llm_inside_env = getattr(self.agent_flow, "llm_inside_env", False)
+            session_url = self.gateway.get_session_url(uid, public=llm_inside_env)
+            if llm_inside_env and ctx.env is not None:
+                session_url = container_reachable_url(session_url, ctx.env_backend)
 
             config = AgentConfig(
                 base_url=session_url,
@@ -619,7 +631,7 @@ class AgentFlowEngine:
             )
             logger.debug("[%s] Starting agent flow at %s", uid, session_url)
             t = time.perf_counter()
-            episode = await run_agent_flow(flow_for_task, task_obj, config, executor=self.executor)
+            episode = await run_agent_flow(self.agent_flow, task_obj, config, executor=self.executor, env=ctx.env if self._flow_accepts_env else None)
             _timings["time/agentflow_s"] = time.perf_counter() - t
             logger.debug("[%s] Agent flow completed, %d trajectories", uid, len(episode.trajectories))
             return episode, ctx

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -118,7 +118,8 @@ def _resolve_evaluator(
         for base in (task.task_dir, task.dataset_dir):
             try:
                 ev = PythonModuleEvaluator.from_module(base, module, function)
-                return _wrap_with_sandbox_if_needed(ev, sandbox)
+                ev.sandbox = sandbox
+                return ev
             except FileNotFoundError:
                 continue
         raise FileNotFoundError(f"Verifier module '{module}' not found in {task.task_dir} or {task.dataset_dir}")
@@ -167,23 +168,6 @@ def build_dataset_evaluator(dataset_dir: Path, sub_dir: Path | None = None) -> E
     if kind in ("sandbox-shell", "python-hybrid", "missing"):
         return None
     return _resolve_evaluator(probe, sandbox=None, kind=kind, verifier_config=config)
-
-
-def _wrap_with_sandbox_if_needed(ev: PythonModuleEvaluator, sandbox: Sandbox | None) -> Evaluator:
-    """If the user's evaluate() signature includes ``sandbox``, inject it."""
-    if sandbox is None:
-        return ev
-    if any(p.name == "sandbox" for p in ev._params):  # noqa: SLF001
-        # Bind the sandbox into kwargs at call time
-        original_build = ev._build_kwargs  # noqa: SLF001
-
-        def build_with_sandbox(task: Task, episode: Episode) -> dict:
-            kwargs = original_build(task, episode)
-            kwargs["sandbox"] = sandbox
-            return kwargs
-
-        ev._build_kwargs = build_with_sandbox  # type: ignore[method-assign]
-    return ev
 
 
 # ---------------------------------------------------------------------------
@@ -412,8 +396,10 @@ class _FunctionEvaluator:
 def _adapt_legacy_evaluator(ev: Any) -> Evaluator:
     """Adapt evaluators with ``evaluate(task: dict, episode)`` to ``evaluate(task: Task, episode)``.
 
-    With ``from __future__ import annotations`` annotations are strings,
-    so we compare both ``is dict`` and string forms.
+    Only an explicit ``dict`` annotation (string form included — with
+    ``from __future__ import annotations`` annotations are strings) or a
+    legacy parameter name opts into the dict calling convention; an
+    unannotated evaluator gets the ``Task``.
     """
     sig = inspect.signature(ev.evaluate)
     params = list(sig.parameters.values())
@@ -423,7 +409,7 @@ def _adapt_legacy_evaluator(ev: Any) -> Evaluator:
     annotation = first.annotation if first.annotation is not inspect.Parameter.empty else None
 
     is_dict_annotation = annotation is dict or annotation == "dict" or (isinstance(annotation, str) and annotation.startswith("dict"))
-    if is_dict_annotation or first.name in ("task_data", "task_info") or annotation is None:
+    if is_dict_annotation or first.name in ("task_data", "task_info"):
         return _LegacyDictAdapter(ev)
     return ev
 

--- a/rllm/eval/module_evaluator.py
+++ b/rllm/eval/module_evaluator.py
@@ -34,6 +34,9 @@ class PythonModuleEvaluator:
     def __init__(self, fn: Callable, module_name: str = "<unknown>"):
         self.fn = fn
         self.module_name = module_name
+        # Live sandbox handle for hybrid verifiers whose evaluate() declares
+        # a ``sandbox`` parameter; set by the resolution layer per task.
+        self.sandbox = None
         # Inspect signature once
         sig = inspect.signature(fn)
         self._params = list(sig.parameters.values())
@@ -90,6 +93,7 @@ class PythonModuleEvaluator:
           - ``metadata`` → ``task.metadata`` dict
           - ``episode`` → the Episode object
           - ``trajectory`` → ``episode.trajectories[-1]`` as a plain dict
+          - ``sandbox`` → the live sandbox handle (hybrid verifiers)
         Any remaining positional params get filled in the natural order.
         """
         out: dict = {}
@@ -103,6 +107,8 @@ class PythonModuleEvaluator:
                 out[name] = episode
             elif name == "trajectory":
                 out[name] = _trajectory_as_dict(episode)
+            elif name == "sandbox" and self.sandbox is not None:
+                out[name] = self.sandbox
         # If nothing matched, fall back to (task, episode) positionally
         if not out:
             return {"task": task, "episode": episode}

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -29,6 +29,7 @@ For Tinker backends, an in-process handler is injected into the gateway
 from __future__ import annotations
 
 import logging
+import re
 import socket
 import subprocess
 import sys
@@ -58,6 +59,26 @@ def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
+
+
+def container_reachable_url(url: str, backend: str | None) -> str:
+    """Rewrite host loopback addresses so a process inside a container can reach the gateway.
+
+    The gateway binds to 127.0.0.1 on the host; inside a Docker container
+    that loopback addresses the container itself. Docker Desktop resolves
+    ``host.docker.internal`` to the host, and on Linux Docker 20.10+ the
+    same hostname works when the container is started with
+    ``--add-host=host.docker.internal:host-gateway``. Keyed on the backend
+    that actually provisioned the task's sandbox; a no-op for everything
+    but ``docker`` (remote backends get a public tunnel URL instead).
+    """
+    if backend != "docker":
+        return url
+    return re.sub(
+        r"(https?://)(?:127\.0\.0\.1|localhost)(:\d+|/|$)",
+        r"\1host.docker.internal\2",
+        url,
+    )
 
 
 def _normalize_worker_url(raw_url: str) -> str:

--- a/rllm/harnesses/aider.py
+++ b/rllm/harnesses/aider.py
@@ -72,7 +72,7 @@ class AiderHarness(BaseCliHarness):
         return _INSTALL_SCRIPT
 
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         provider, _, _ = self.ensure_provider_prefix(config.model)
         api_key = self.gateway_api_key(config, _PROVIDER_KEY_VAR.get(provider, "OPENAI_API_KEY"))
 

--- a/rllm/harnesses/bash.py
+++ b/rllm/harnesses/bash.py
@@ -42,19 +42,18 @@ _DONE_MARKERS = ("task completed", "task is complete", "done", "finished", "i ha
 class BashHarness(SandboxedAgentFlow):
     """Sandbox bash-loop harness.
 
-    The Runner sets the sandbox via ``set_sandbox()`` before ``run()`` is called.
+    The engine passes the per-task sandbox in as ``env``; the LLM client
+    loop runs on the host and only command execution happens in-sandbox.
     """
 
     name = "bash"
     sandbox_backend = "docker"
     max_concurrent = 4
 
-    def run(self, task: Task, config) -> Episode:
+    def run(self, task: Task, config, *, env) -> Episode:
         from openai import OpenAI
 
-        sandbox = self.sandbox
-        if sandbox is None:
-            raise RuntimeError("BashHarness requires a sandbox. The Runner should set one before calling run().")
+        sandbox = env
 
         client = OpenAI(base_url=config.base_url, api_key="EMPTY")
         max_turns = int(task.metadata.get("rllm", {}).get("max_turns") or 50)

--- a/rllm/harnesses/claude_code.py
+++ b/rllm/harnesses/claude_code.py
@@ -111,7 +111,7 @@ class ClaudeCodeHarness(BaseCliHarness):
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
         # Anthropic's SDK appends ``/v1/messages`` itself, so strip a
         # trailing ``/v1`` from the gateway URL or it doubles up.
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         anthropic_url = gateway_url.rstrip("/").removesuffix("/v1") or gateway_url
         api_key = self.gateway_api_key(config, "ANTHROPIC_API_KEY")
         model = config.model

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -29,12 +29,12 @@ propagates ``config.base_url`` through the appropriate env var
 from __future__ import annotations
 
 import logging
-import re
 import shlex
 import uuid
 from abc import abstractmethod
 
 from rllm.env import env_int
+from rllm.sandbox.protocol import Sandbox
 from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
 from rllm.types import AgentConfig, Task
 
@@ -72,19 +72,14 @@ class BaseCliHarness(SandboxedAgentFlow):
     # Sandbox helpers
     # ---------------------------------------------------------------------
 
-    def _exec_root(self, command: str, timeout: float | None = None) -> str:
-        """Run *command* as root inside the sandbox."""
-        if self.sandbox is None:
-            raise RuntimeError(f"{type(self).__name__} requires a sandbox.")
-        return self.sandbox.exec(command, timeout=timeout, user="root")
-
     def _exec_agent(
         self,
+        sandbox: Sandbox,
         command: str,
         timeout: float | None = None,
         env: dict[str, str] | None = None,
     ) -> str:
-        """Run *command* as the agent user, with *env* exported.
+        """Run *command* in *sandbox* as the agent user, with *env* exported.
 
         Uses ``export`` (not the inline ``K=V cmd`` prefix), because
         invocations like ``cd /workspace && claude ...`` are compound
@@ -93,12 +88,10 @@ class BaseCliHarness(SandboxedAgentFlow):
         ``cd`` and gone by the time the CLI runs, leaving the agent
         looking like it had no auth even though we passed it.
         """
-        if self.sandbox is None:
-            raise RuntimeError(f"{type(self).__name__} requires a sandbox.")
         if env:
             exports = "; ".join(f"export {k}={shlex.quote(v)}" for k, v in env.items() if v is not None)
             command = f"{exports}; {command}"
-        return self.sandbox.exec(command, timeout=timeout, user=self.agent_user)
+        return sandbox.exec(command, timeout=timeout, user=self.agent_user)
 
     @staticmethod
     def infer_provider(model_name: str) -> str:
@@ -199,26 +192,6 @@ class BaseCliHarness(SandboxedAgentFlow):
         provider = cls.infer_provider(model_name)
         return provider, model_name, f"{provider}/{model_name}"
 
-    def _container_url(self, url: str) -> str:
-        """Rewrite host loopback addresses for in-container reachability.
-
-        The gateway binds to 127.0.0.1 on the host. From inside a Docker
-        container, that loopback addresses the container itself, not the
-        host. Docker Desktop (macOS/Windows) resolves the magic hostname
-        ``host.docker.internal`` to the host; on Linux Docker 20.10+ the
-        same hostname works when the container is started with
-        ``--add-host=host.docker.internal:host-gateway``.
-
-        For the ``local`` and ``modal`` backends this is a no-op.
-        """
-        if self.sandbox_backend != "docker":
-            return url
-        return re.sub(
-            r"(https?://)(?:127\.0\.0\.1|localhost)(:\d+|/|$)",
-            r"\1host.docker.internal\2",
-            url,
-        )
-
     @staticmethod
     def _cd_prefix(task: Task) -> str:
         """Return ``cd <workdir> && `` only when the task explicitly sets ``workdir``.
@@ -261,8 +234,10 @@ class BaseCliHarness(SandboxedAgentFlow):
     def install_script(self) -> str:
         """Return a shell script that installs the CLI in the sandbox.
 
-        Runs as root via ``on_sandbox_ready``. Must be idempotent — the
-        hook may fire on a container where the CLI is already present.
+        Baked into snapshot images by ``rllm snapshot create --agent``;
+        otherwise run as root by ``SandboxTaskHooks`` on cold sandboxes.
+        Must be idempotent — it may run on a container where the CLI is
+        already present.
         """
 
     @abstractmethod
@@ -271,6 +246,7 @@ class BaseCliHarness(SandboxedAgentFlow):
 
     def write_configs(
         self,
+        sandbox: Sandbox,
         task: Task,
         config: AgentConfig,
         env: dict[str, str],
@@ -299,42 +275,25 @@ class BaseCliHarness(SandboxedAgentFlow):
     # Lifecycle
     # ---------------------------------------------------------------------
 
-    def on_sandbox_ready(self, task: dict, config: AgentConfig) -> None:  # noqa: ARG002
-        """Install the CLI inside the sandbox before the first run.
+    def run(self, task: Task, config: AgentConfig, *, env: Sandbox) -> None:
+        """Exec the CLI in the sandbox; let the gateway build the trajectory.
 
-        Skipped when the sandbox's image already contains exactly this
-        harness's install (``baked_install``, recorded at snapshot boot by
-        :func:`rllm.sandbox.snapshot.get_sandbox`). Cold boots and task-only
-        snapshot boots install as usual.
+        The install has already happened by the time this runs — either
+        baked into the snapshot image or executed by the hook on a cold
+        sandbox. Returns ``None`` so :func:`rllm.types._coerce_to_episode`
+        builds an empty single-trajectory Episode whose Steps the engine
+        enriches from gateway-captured traces.
         """
-        if self.sandbox is None:
-            return
-        if getattr(self.sandbox, "baked_install", "") == self.install_script():
-            return
-        try:
-            self._exec_root(self.install_script(), timeout=self.install_timeout)
-        except Exception as e:
-            raise RuntimeError(f"Failed to install {self.name} in sandbox: {e}") from e
-
-    def run(self, task: Task, config: AgentConfig) -> None:
-        """Exec the CLI; let the gateway build the trajectory.
-
-        Returns ``None`` so :func:`rllm.types._coerce_to_episode` builds
-        an empty single-trajectory Episode. The engine then enriches its
-        Steps from the gateway-captured traces during ``execute_tasks``.
-        """
-        if self.sandbox is None:
-            raise RuntimeError(f"{type(self).__name__} requires a sandbox.")
-
-        env = self.build_env(task, config)
-        self.write_configs(task, config, env)
+        sandbox = env
+        env_vars = self.build_env(task, config)
+        self.write_configs(sandbox, task, config, env_vars)
 
         instruction = str(task.instruction).strip()
         timeout = float(task.metadata.get("agent_timeout", self.run_timeout))
         cmd = self.build_invocation(instruction, task, config)
 
         try:
-            self._exec_agent(cmd, timeout=timeout, env=env)
+            self._exec_agent(sandbox, cmd, timeout=timeout, env=env_vars)
         except Exception as e:
             # Surface as a warning for operator visibility; the engine
             # still gets None and the gateway traces (if any LLM calls

--- a/rllm/harnesses/codex.py
+++ b/rllm/harnesses/codex.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
 from rllm.types import AgentConfig, Task
 
 # apt branch hardened against arm64 ubuntu-ports GPG flakes — same
@@ -77,7 +78,7 @@ class CodexHarness(BaseCliHarness):
         return _INSTALL_SCRIPT
 
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         return {
             # Custom CODEX_HOME so auth/config files don't touch $HOME/.codex.
             "CODEX_HOME": _CODEX_HOME,
@@ -92,6 +93,7 @@ class CodexHarness(BaseCliHarness):
 
     def write_configs(
         self,
+        sandbox: Sandbox,
         task: Task,
         config: AgentConfig,
         env: dict[str, str],
@@ -107,7 +109,7 @@ class CodexHarness(BaseCliHarness):
           required (and was the source of the silent no-op in earlier
           versions of this harness).
         """
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         api_key = env.get("OPENAI_API_KEY", self.gateway_api_key(config, "OPENAI_API_KEY"))
 
         # JSON has to be escaped enough to survive a single-quoted heredoc
@@ -131,7 +133,7 @@ class CodexHarness(BaseCliHarness):
             f"{config_toml}"
             "_RLLM_CODEX_CFG_EOF"
         )
-        self._exec_agent(cmd, env=env)
+        self._exec_agent(sandbox, cmd, env=env)
 
     def build_invocation(
         self,

--- a/rllm/harnesses/kimi_cli.py
+++ b/rllm/harnesses/kimi_cli.py
@@ -27,6 +27,7 @@ import json
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
 from rllm.types import AgentConfig, Task
 
 _INSTALL_SCRIPT = r"""
@@ -85,12 +86,13 @@ class KimiCliHarness(BaseCliHarness):
 
     def write_configs(
         self,
+        sandbox: Sandbox,
         task: Task,
         config: AgentConfig,
         env: dict[str, str],
     ) -> None:
         """Write kimi-cli's config JSON pointing at the gateway as a custom provider."""
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         _, model_id, _ = self.ensure_provider_prefix(config.model)
         api_key = env.get("OPENAI_API_KEY", self.gateway_api_key(config, "OPENAI_API_KEY"))
 
@@ -117,7 +119,7 @@ class KimiCliHarness(BaseCliHarness):
             },
         }
         content = json.dumps(kimi_config, indent=2)
-        self._exec_agent(self._heredoc_write(_KIMI_CONFIG_PATH, content), env=env)
+        self._exec_agent(sandbox, self._heredoc_write(_KIMI_CONFIG_PATH, content), env=env)
 
     def build_invocation(
         self,

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
 from rllm.types import AgentConfig, Task
 
 # Model-name prefix → provider env-var mapping. Mirrors litellm's logic
@@ -77,7 +78,7 @@ class MiniSweAgentHarness(BaseCliHarness):
         return _INSTALL_SCRIPT
 
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         env: dict[str, str] = {
             # Legacy v1 wizard-skip (still honoured by some forks); v2
             # ignores it and instead checks for ~/.config/mini-swe-agent/.env
@@ -99,6 +100,7 @@ class MiniSweAgentHarness(BaseCliHarness):
 
     def write_configs(
         self,
+        sandbox: Sandbox,
         task: Task,
         config: AgentConfig,
         env: dict[str, str],
@@ -119,7 +121,7 @@ class MiniSweAgentHarness(BaseCliHarness):
         # the dotenv with ``override=True`` — it would otherwise unset
         # ``OPENAI_API_BASE`` we exported in :meth:`build_env`, sending
         # every call to api.openai.com and bypassing the gateway.
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         dotenv_lines = [
             f"MSWEA_GLOBAL_MODEL={qualified}",
             f"{api_var}={api_key}",
@@ -134,6 +136,7 @@ class MiniSweAgentHarness(BaseCliHarness):
         # ``_heredoc_write`` quotes the target path, which kills
         # ``$HOME`` expansion — write the heredoc inline instead.
         self._exec_agent(
+            sandbox,
             f"mkdir -p $HOME/.config/mini-swe-agent && cat > {path} << 'MSWEA_DOTENV_EOF'\n{content}\nMSWEA_DOTENV_EOF",
             env=env,
         )

--- a/rllm/harnesses/opencode.py
+++ b/rllm/harnesses/opencode.py
@@ -16,6 +16,7 @@ import os
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
 from rllm.types import AgentConfig, Task
 
 # Map ``provider`` (left side of provider/model) to the env var holding
@@ -88,7 +89,7 @@ class OpenCodeHarness(BaseCliHarness):
 
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
         provider, _, _ = self._split_provider(config.model)
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
 
         env: dict[str, str] = {
             # opencode uses an OpenAI-shaped client for openai/anthropic
@@ -108,12 +109,13 @@ class OpenCodeHarness(BaseCliHarness):
 
     def write_configs(
         self,
+        sandbox: Sandbox,
         task: Task,
         config: AgentConfig,
         env: dict[str, str],
     ) -> None:
         _, model_id, _ = self._split_provider(config.model)
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         api_key_var = _PROVIDER_AUTH.get(self._split_provider(config.model)[0], "OPENAI_API_KEY")
         # Same key build_env injected — bearer token when gateway is
         # exposed, else the user's real provider key.
@@ -145,7 +147,7 @@ class OpenCodeHarness(BaseCliHarness):
         # giving the misleading ``ProviderModelNotFoundError``.
         marker = f"_RLLM_OPENCODE_EOF_{os.urandom(4).hex()}"
         cmd = f"mkdir -p $HOME/.config/opencode && cat > $HOME/.config/opencode/opencode.json << '{marker}'\n{content}\n{marker}"
-        self._exec_agent(cmd, env=env)
+        self._exec_agent(sandbox, cmd, env=env)
 
     def build_invocation(
         self,

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -45,10 +45,8 @@ class OracleHarness(SandboxedAgentFlow):
     # comparing the two implementations doesn't trip on path drift.
     _SOLUTION_DIR = "/solution"
 
-    def run(self, task: Task, config: AgentConfig) -> Episode:
-        sandbox = self.sandbox
-        if sandbox is None:
-            raise RuntimeError("OracleHarness requires a sandbox; the eval hooks should set one before run().")
+    def run(self, task: Task, config: AgentConfig, *, env) -> Episode:
+        sandbox = env
 
         solution_dir = task.task_dir / "solution"
         solve_path = solution_dir / "solve.sh"

--- a/rllm/harnesses/qwen_code.py
+++ b/rllm/harnesses/qwen_code.py
@@ -63,7 +63,7 @@ class QwenCodeHarness(BaseCliHarness):
         return _INSTALL_SCRIPT
 
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         # Qwen Code uses the OpenAI-compatible client, so a bare model
         # id (the part after ``provider/``) is what the wire expects;
         # the gateway routes by model name, not by env var.

--- a/rllm/harnesses/tool_calling.py
+++ b/rllm/harnesses/tool_calling.py
@@ -23,10 +23,10 @@ class ToolCallingMixin:
     Usage::
 
         class MyAgent(SandboxedAgentFlow, ToolCallingMixin):
-            def run(self, task, config):
+            def run(self, task, config, *, env):
                 steps, messages, final = self.run_tool_loop(
                     client, config.model, messages,
-                    tools=[BashTool()], sandbox=self.sandbox,
+                    tools=[BashTool()], sandbox=env,
                 )
     """
 

--- a/rllm/harnesses/zeroclaw.py
+++ b/rllm/harnesses/zeroclaw.py
@@ -12,7 +12,7 @@ Three facts established from the ZeroClaw docs/installer:
 1. **Install** via the official installer with ``--prebuilt --skip-onboard``
    (downloads a checksum-verified release binary; no Rust toolchain needed).
    The binary lands in ``$CARGO_HOME/bin/zeroclaw`` (``/root/.cargo/bin`` when
-   installed as root, which ``on_sandbox_ready`` does).
+   installed as root, which the install hook does).
 2. **One-shot, non-interactive** execution is ``zeroclaw agent -m "<prompt>"``
    ("if -m is provided, runs a single turn and exits").
 3. **Autonomy** must be ``level = "full"`` for the agent to run shell/filesystem
@@ -29,6 +29,7 @@ from __future__ import annotations
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
 from rllm.types import AgentConfig, Task
 
 # Idempotent install. Bootstraps curl/ca-certs/tar/coreutils (the installer
@@ -84,7 +85,7 @@ class ZeroClawHarness(BaseCliHarness):
         # ZeroClaw resolves credentials in the order: explicit config.toml →
         # env vars (OPENAI_API_KEY/OPENAI_BASE_URL) → fallbacks. We set both:
         # config.toml is authoritative, these env vars are belt-and-suspenders.
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         api_key = self.gateway_api_key(config, "OPENAI_API_KEY")
         return {
             "OPENAI_API_KEY": api_key,
@@ -102,7 +103,7 @@ class ZeroClawHarness(BaseCliHarness):
         ``ModelProviderConfig`` struct. If a ZeroClaw version rejects it,
         switch to ``uri`` (older docs used that name).
         """
-        gateway_url = self._container_url(config.base_url)
+        gateway_url = config.base_url
         api_key = self.gateway_api_key(config, "OPENAI_API_KEY")
         model = config.model
         return "\n".join(
@@ -137,11 +138,12 @@ class ZeroClawHarness(BaseCliHarness):
             ]
         )
 
-    def write_configs(self, task: Task, config: AgentConfig, env: dict[str, str]) -> None:
+    def write_configs(self, sandbox: Sandbox, task: Task, config: AgentConfig, env: dict[str, str]) -> None:
         content = self._config_toml(config)
         # Write inline (not via _heredoc_write) so $HOME expands — the helper
         # single-quotes the path which would kill the expansion.
         self._exec_agent(
+            sandbox,
             f"mkdir -p $HOME/.zeroclaw && cat > {_CONFIG_PATH} << 'ZC_CONFIG_EOF'\n{content}\nZC_CONFIG_EOF",
             env=env,
         )
@@ -158,6 +160,7 @@ class ZeroClawHarness(BaseCliHarness):
         workdir = task.metadata.get("workdir")
         if workdir:
             self._exec_agent(
+                sandbox,
                 f'rm -rf "$HOME/.zeroclaw/workspace" && ln -sfn {shlex.quote(workdir)} "$HOME/.zeroclaw/workspace"',
                 env=env,
             )

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -244,45 +244,51 @@ class SandboxTaskHooks:
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:
         from rllm.engine.agentflow_engine import TaskContext
-        from rllm.eval._resolution import _setup_task_environment
-        from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+        from rllm.eval._resolution import _resolve_backend, _setup_task_environment
 
         plan = resolve_rollout_plan(task, agent_flow, self.evaluation)
 
-        # Shallow-copy SandboxedAgentFlow so parallel rollouts get their own _sandbox.
-        task_flow: AgentFlow = agent_flow
-        if isinstance(agent_flow, SandboxedAgentFlow):
-            task_flow = agent_flow.create_instance()
-
         sandbox = None
-        if plan.needs_env:
-            from rllm.sandbox.snapshot import get_sandbox, install_script_for
+        env_backend = None
+        try:
+            if plan.needs_env:
+                from rllm.env import env_int
+                from rllm.sandbox.snapshot import get_sandbox, install_script_for
 
-            sandbox = self.warm_queue.pop(task) if self.warm_queue is not None else get_sandbox(task, self.sandbox_backend, self._registry, install_script_for(task_flow))
-            _setup_task_environment(task, sandbox)
-            if isinstance(task_flow, SandboxedAgentFlow):
-                task_flow.set_sandbox(sandbox)
-                task_flow.on_sandbox_ready({"task_path": str(task.task_dir)}, None)
+                install = install_script_for(agent_flow)
+                sandbox = self.warm_queue.pop(task) if self.warm_queue is not None else get_sandbox(task, self.sandbox_backend, self._registry, install)
+                env_backend = _resolve_backend(task, self.sandbox_backend)
+                _setup_task_environment(task, sandbox)
+                # CLI install, unless the image already contains exactly this
+                # script (baked_install, recorded at snapshot boot).
+                if install and getattr(sandbox, "baked_install", "") != install:
+                    try:
+                        sandbox.exec(install, timeout=getattr(agent_flow, "install_timeout", env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)), user="root")
+                    except Exception as e:
+                        raise RuntimeError(f"Failed to install {getattr(agent_flow, 'name', type(agent_flow).__name__)} in sandbox: {e}") from e
 
-        evaluator = self.evaluation.resolve(task, sandbox, plan.verifier_kind, plan.verifier_config)
+            evaluator = self.evaluation.resolve(task, sandbox, plan.verifier_kind, plan.verifier_config)
+        except BaseException:
+            # Nothing has registered a teardown yet — close the sandbox here
+            # or it leaks (and the retry path provisions another).
+            if sandbox is not None:
+                try:
+                    sandbox.close()
+                except Exception:
+                    logger.exception("sandbox.close failed after setup error")
+            raise
 
         def teardown() -> None:
             # Sandboxes are ephemeral — the hook owns this one's lifecycle and
-            # closes it directly (the #616 fix). Going through
-            # ``task_flow.teardown_sandbox()`` would no-op because
-            # ``set_sandbox()`` marks it externally-managed, leaking cloud
-            # sandboxes (Daytona/Modal/e2b) that bill by duration.
+            # closes it directly (the #616 fix); flows never hold one.
             if sandbox is None:
                 return
             try:
                 sandbox.close()
             except Exception:
                 logger.exception("sandbox.close failed")
-            if isinstance(task_flow, SandboxedAgentFlow):
-                task_flow._sandbox = None  # noqa: SLF001
 
-        ctx_flow = task_flow if task_flow is not agent_flow else None
-        return TaskContext(evaluator=evaluator, agent_flow=ctx_flow, teardown=teardown)
+        return TaskContext(evaluator=evaluator, env=sandbox, env_backend=env_backend, teardown=teardown)
 
 
 class FixedEvaluatorHooks:

--- a/rllm/integrations/harbor/runtime.py
+++ b/rllm/integrations/harbor/runtime.py
@@ -63,6 +63,21 @@ class HarborRuntime:
         self.session_timeout = session_timeout
         self._initialized = False
 
+    def configure(self, overrides: dict) -> dict:
+        """Apply caller/CLI overrides this runtime understands; return the rest.
+
+        Harbor provisions its own environments, so ``sandbox_backend`` maps
+        to harbor's ``environment_type``.
+        """
+        leftovers = dict(overrides)
+        backend = leftovers.pop("sandbox_backend", None)
+        if backend is not None:
+            self.environment_type = backend
+        concurrency = leftovers.pop("sandbox_concurrency", None)
+        if concurrency is not None:
+            self.max_concurrent = concurrency
+        return leftovers
+
     # ------------------------------------------------------------------
     # Shared initialization
     # ------------------------------------------------------------------

--- a/rllm/sandbox/sandboxed_flow.py
+++ b/rllm/sandbox/sandboxed_flow.py
@@ -1,20 +1,14 @@
-"""SandboxedAgentFlow: base class for agents that need sandboxed execution environments.
+"""SandboxedAgentFlow: base class for agents that run against a sandbox.
 
-Lifecycle managed by :class:`rllm.hooks.SandboxTaskHooks` (which sits in
-front of :class:`rllm.engine.agentflow_engine.AgentFlowEngine`):
-
-1. The hook creates a Sandbox via ``_create_sandbox_for_task`` and injects
-   it with ``set_sandbox()``, then calls ``on_sandbox_ready(task, config)``.
-2. The engine calls ``run(task, config)`` — the agent uses ``self.sandbox``.
-3. The hook resolves an Evaluator from the Task's verifier config (or its
-   ``FixedEvaluation`` policy) and runs ``evaluator.evaluate(task, episode)``.
-4. The hook's teardown closure calls ``teardown_sandbox()`` — guaranteed
-   cleanup, no-op when the sandbox was injected externally.
+The flow holds no sandbox state. :class:`rllm.hooks.SandboxTaskHooks` owns
+the lifecycle: it creates the sandbox, runs the harness install (when not
+already baked into the image), and closes it after evaluation. The engine
+passes the live sandbox into ``run(task, config, *, env)`` as a call
+argument, so parallel rollouts can share one flow instance safely.
 """
 
 from __future__ import annotations
 
-import copy
 import logging
 from abc import ABC, abstractmethod
 
@@ -25,13 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 class SandboxedAgentFlow(ABC):
-    """Base class for agents that need sandboxed execution environments.
+    """Base class for agents that run against a sandboxed execution environment.
 
     The sandbox backend is pluggable via ``sandbox_backend``:
     ``"docker"`` | ``"local"`` | ``"modal"`` | ``"daytona"``.
 
-    Subclasses must implement :meth:`run` and may override
-    :meth:`get_image` or :meth:`on_sandbox_ready` for task-specific setup.
+    Subclasses implement :meth:`run` and may override :meth:`get_image`
+    for per-task images.
     """
 
     # Declared env requirement — read by rllm.hooks.resolve_rollout_plan.
@@ -45,60 +39,30 @@ class SandboxedAgentFlow(ABC):
     max_concurrent: int = 4
 
     def __init__(self, **kwargs):
-        self._sandbox: Sandbox | None = None
-        self._sandbox_externally_managed: bool = False
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    @property
-    def sandbox(self) -> Sandbox | None:
-        return self._sandbox
+    def configure(self, overrides: dict) -> dict:
+        """Apply caller/CLI overrides this flow understands; return the rest.
 
-    def set_sandbox(self, sandbox: Sandbox) -> None:
-        """Inject a sandbox managed by an external orchestrator (e.g. ``Runner``).
-
-        The agent flow will use this sandbox but will not close it; the
-        orchestrator owns the lifecycle. ``teardown_sandbox`` becomes a no-op.
+        The wiring layer warns about anything returned, so a flag that a
+        given agent can't honor is visible instead of a silent no-op.
         """
-        self._sandbox = sandbox
-        self._sandbox_externally_managed = True
-
-    def create_instance(self) -> SandboxedAgentFlow:
-        """Create a per-task copy with fresh sandbox state.
-
-        Called by :func:`rllm.eval.runner.run_dataset` so each parallel
-        task gets its own sandbox.
-        """
-        instance = copy.copy(self)
-        instance._sandbox = None
-        instance._sandbox_externally_managed = False
-        return instance
-
-    def on_sandbox_ready(self, task: dict, config: AgentConfig) -> None:  # noqa: B027
-        """Hook for subclasses to run additional setup after sandbox creation."""
-
-    def teardown_sandbox(self) -> None:
-        """Destroy sandbox. Called by the Runner after evaluate(), even on failure.
-
-        No-op when the sandbox was injected externally (the orchestrator owns it).
-        """
-        if self._sandbox is None:
-            return
-        if self._sandbox_externally_managed:
-            self._sandbox = None
-            return
-        try:
-            self._sandbox.close()
-        except Exception:
-            logger.exception("Sandbox teardown error")
-        self._sandbox = None
+        leftovers = dict(overrides)
+        backend = leftovers.pop("sandbox_backend", None)
+        if backend is not None:
+            self.sandbox_backend = backend
+        concurrency = leftovers.pop("sandbox_concurrency", None)
+        if concurrency is not None:
+            self.max_concurrent = concurrency
+        return leftovers
 
     def get_image(self, task: dict) -> str:
         """Return container image for this task. Override for per-task images."""
         return self.image
 
     @abstractmethod
-    def run(self, task: Task, config: AgentConfig) -> Episode: ...
+    def run(self, task: Task, config: AgentConfig, *, env: Sandbox) -> Episode: ...
 
 
 def create_sandbox(backend: str, name: str, image: str, **kwargs) -> Sandbox:

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -1010,18 +1010,17 @@ class AgentTrainer:
                 if scan.any_remote or not is_local_sandbox_backend(hooks_backend):
                     config = enable_gateway_tunnel(config)
 
-        # Forward concurrency + backend overrides onto a SandboxedAgentFlow.
-        if agent_flow is not None and (sandbox_concurrency is not None or sandbox_backend is not None):
-            try:
-                from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
-
-                if isinstance(agent_flow, SandboxedAgentFlow):
-                    if sandbox_concurrency is not None:
-                        agent_flow.max_concurrent = sandbox_concurrency
-                    if sandbox_backend is not None:
-                        agent_flow.sandbox_backend = sandbox_backend
-            except ImportError:
-                pass
+        # Forward CLI overrides through the flow's configure(); the wiring
+        # warns about anything it returns unconsumed.
+        overrides = {k: v for k, v in {"sandbox_backend": sandbox_backend, "sandbox_concurrency": sandbox_concurrency}.items() if v is not None}
+        if agent_flow is not None and overrides:
+            configure = getattr(agent_flow, "configure", None)
+            leftovers = dict(configure(overrides) if callable(configure) else overrides)
+            if hooks is not None:
+                # The sandbox hooks consume the backend regardless of the flow.
+                leftovers.pop("sandbox_backend", None)
+            for flag in leftovers:
+                logger.warning("--%s has no effect for agent %s", flag.replace("_", "-"), type(agent_flow).__name__)
 
         has_agent_flow = agent_flow is not None and (evaluator is not None or hooks is not None)
         remote_runtime_enabled = config.rllm.get("remote_runtime", {}).get("enabled", False)

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -18,6 +18,7 @@ as a backward-compat re-export shim.
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import uuid
 from copy import deepcopy
@@ -438,6 +439,11 @@ class AgentFlow(Protocol):
     (async). If both are present, callers should prefer ``arun`` when
     running inside an event loop — see :func:`run_agent_flow`.
 
+    Flows that work against a sandbox declare ``needs_env = True`` and
+    accept it as a keyword-only argument: ``run(self, task, config, *,
+    env)`` — see :func:`flow_accepts_env`. The engine provisions the
+    sandbox and passes it in; flows hold no sandbox state.
+
     Return value: ``Episode`` for full control (multi-trajectory flows
     must use this), a ``Trajectory`` (auto-wrapped in an Episode), or
     ``None`` (framework builds an Episode with one empty Trajectory;
@@ -495,26 +501,53 @@ class Evaluator(Protocol):
     def evaluate(self, task: Any, episode: Episode) -> EvalOutput: ...
 
 
+def flow_accepts_env(agent: AgentFlow) -> bool:
+    """True when the flow's entry point declares a keyword-only ``env`` parameter.
+
+    Flows that work inside a sandbox receive it as a call argument
+    (``run(self, task, config, *, env)``) instead of holding it as state.
+    Checked once at engine bind time, not per rollout.
+    """
+    fn = agent.arun if hasattr(agent, "arun") and inspect.iscoroutinefunction(getattr(agent, "arun", None)) else getattr(agent, "run", None)
+    if fn is None:
+        return False
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+    env_param = params.get("env")
+    if env_param is not None and env_param.kind is inspect.Parameter.KEYWORD_ONLY:
+        return True
+    # A **kwargs entry point (proxy/decorator wrappers) forwards env fine.
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
 async def run_agent_flow(
     agent: AgentFlow,
     task: Any,
     config: AgentConfig,
     executor=None,
+    env: Any = None,
 ) -> Episode:
     """Run an :class:`AgentFlow`, preferring its async ``arun`` when present.
 
     Falls back to running ``run`` in *executor* (a ``ThreadPoolExecutor``)
     so that sync agent flows don't block the event loop.
 
+    ``env`` (a live :class:`~rllm.sandbox.protocol.Sandbox`, when the rollout
+    has one) is forwarded keyword-only to flows that declare it — see
+    :func:`flow_accepts_env`; pass ``None`` for flows that don't.
+
     The return value is coerced into an :class:`Episode` via
     :func:`_coerce_to_episode`, so flows may return ``Episode``,
     ``Trajectory``, or ``None``.
     """
+    kwargs = {"env": env} if env is not None else {}
     if hasattr(agent, "arun") and inspect.iscoroutinefunction(agent.arun):
-        result = await agent.arun(task, config)
+        result = await agent.arun(task, config, **kwargs)
     else:
         loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(executor, agent.run, task, config)
+        result = await loop.run_in_executor(executor, functools.partial(agent.run, task, config, **kwargs))
 
     traj_name = getattr(agent, "name", None) or _DEFAULT_TRAJ_NAME
     return _coerce_to_episode(result, task, traj_name)

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -125,3 +125,67 @@ def test_strict_enrichment_follows_is_validation(is_validation):
                 asyncio.run(engine._run_single(task, "task:0", is_validation=False))
     finally:
         engine.shutdown()
+
+
+def test_needs_env_flow_must_declare_env_param():
+    """Binding a needs_env flow whose run() lacks the keyword-only ``env``
+    parameter fails at construction, not mid-rollout."""
+    from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+
+    class _LegacyFlow(SandboxedAgentFlow):
+        def run(self, task, config):  # no env param
+            return None
+
+    with pytest.raises(TypeError, match="keyword-only 'env'"):
+        AgentFlowEngine(
+            agent_flow=_LegacyFlow(),
+            evaluator=_Evaluator(),
+            gateway=_Gateway(),
+            model="test-model",
+            n_parallel_tasks=1,
+        )
+
+
+def test_env_flow_receives_sandbox_and_container_url():
+    """A needs_env flow gets the hook-provisioned sandbox as ``env`` and, when
+    its LLM client runs in-sandbox on docker, a container-reachable URL."""
+    from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+
+    seen = {}
+
+    class _EnvFlow(SandboxedAgentFlow):
+        llm_inside_env = True
+
+        def run(self, task, config, *, env):
+            seen["env"] = env
+            seen["base_url"] = config.base_url
+            return None
+
+    sandbox = object()
+
+    class _Hooks:
+        def setup(self, task, agent_flow, uid):
+            from rllm.engine.agentflow_engine import TaskContext
+
+            return TaskContext(evaluator=_Evaluator(), env=sandbox, env_backend="docker")
+
+    class _LoopbackGateway(_Gateway):
+        def get_session_url(self, session_id, public=True):
+            return f"http://127.0.0.1:9131/sessions/{session_id}/v1"
+
+    engine = AgentFlowEngine(
+        agent_flow=_EnvFlow(),
+        evaluator=None,
+        gateway=_LoopbackGateway(),
+        model="test-model",
+        n_parallel_tasks=1,
+        hooks=_Hooks(),
+    )
+    task = task_from_row({"question": "q"}, "task")
+    try:
+        asyncio.run(engine._run_single(task, "task:0", is_validation=True))
+    finally:
+        engine.shutdown()
+
+    assert seen["env"] is sandbox
+    assert seen["base_url"].startswith("http://host.docker.internal:9131/")

--- a/tests/eval/test_unified_runner.py
+++ b/tests/eval/test_unified_runner.py
@@ -228,17 +228,15 @@ class _FakeSandbox:
 
 
 def test_hooks_close_sandbox_for_sandboxed_agent_flow(tmp_path, cfg, monkeypatch):
-    """Regression: SandboxedAgentFlow sandboxes were leaked because the hook
-    teardown went through ``task_flow.teardown_sandbox()``, which is a no-op
-    when ``set_sandbox()`` marked the sandbox externally-managed. The hook
-    creates the sandbox, so it must close it.
+    """The hook creates the sandbox, so its teardown must close it (#616) —
+    flows never own sandbox lifecycle.
     """
     from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
 
     fake_sandbox = _FakeSandbox()
 
     class _SandboxedStub(SandboxedAgentFlow):
-        def run(self, task: Task, config: AgentConfig) -> Episode:
+        def run(self, task: Task, config: AgentConfig, *, env) -> Episode:
             traj = Trajectory(uid="t", name="stub", task=task.id, steps=[], output="")
             return Episode(id=task.id, task=task.id, trajectories=[traj])
 

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -71,26 +71,13 @@ def _make_config(base_url: str = "http://gw:8000/sessions/eval-0/v1", model: str
 # ---------------------------------------------------------------------------
 
 
-def test_on_sandbox_ready_runs_install_script_as_root():
-    h = OpenCodeHarness()
-    sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
-    h.on_sandbox_ready({}, _make_config())
-
-    assert len(sandbox.calls) == 1
-    call = sandbox.calls[0]
-    assert call.user == "root"
-    assert "opencode-ai" in call.command
-
-
 def test_run_returns_none_so_gateway_drives_trajectory():
     """Harnesses don't build Episodes — the gateway captures LLM calls and
     the engine's enrichment pass populates Steps from those traces."""
     h = OpenCodeHarness()
     sandbox = FakeSandbox(stdout="opencode said hi")
-    h.set_sandbox(sandbox)
 
-    result = h.run(_make_task(), _make_config())
+    result = h.run(_make_task(), _make_config(), env=sandbox)
 
     assert result is None
 
@@ -102,9 +89,8 @@ def test_run_execs_cli_against_agent_user_with_env_exported():
     be set for ``cd`` and lost before the CLI runs."""
     h = OpenCodeHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
 
-    h.run(_make_task(), _make_config())
+    h.run(_make_task(), _make_config(), env=sandbox)
 
     # Last call is the CLI invocation; preceding calls are write_configs.
     invocation = sandbox.calls[-1]
@@ -119,9 +105,8 @@ def test_run_swallows_cli_failure_and_returns_none():
     the point of failure) plus the verifier still drive the reward."""
     h = OpenCodeHarness()
     sandbox = FakeSandbox(fail_on_substring="opencode --model")
-    h.set_sandbox(sandbox)
 
-    result = h.run(_make_task(), _make_config())
+    result = h.run(_make_task(), _make_config(), env=sandbox)
 
     assert result is None
 
@@ -171,11 +156,10 @@ def test_opencode_writes_config_via_unquoted_path_so_home_expands():
     finds it."""
     h = OpenCodeHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
     config = _make_config(model="gpt-5.4-mini")
     env = h.build_env(_make_task(), config)
 
-    h.write_configs(_make_task(), config, env)
+    h.write_configs(sandbox, _make_task(), config, env)
 
     write_cmd = sandbox.calls[-1].command
     # $HOME left unquoted so the shell expands it at exec time.
@@ -193,11 +177,10 @@ def test_opencode_writes_config_with_custom_provider_to_bypass_models_dev():
     so arbitrary model ids work."""
     h = OpenCodeHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
     config = _make_config(base_url="http://gw:8000/sessions/eval-0/v1", model="openai/gpt-4o")
     env = h.build_env(_make_task(), config)
 
-    h.write_configs(_make_task(), config, env)
+    h.write_configs(sandbox, _make_task(), config, env)
 
     written = sandbox.calls[-1].command
     assert sandbox.calls[-1].user is None  # written as agent user
@@ -260,10 +243,9 @@ def test_opencode_writes_provider_config_with_model_id_only():
     used for env-var key selection, not for opencode routing."""
     h = OpenCodeHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
     config = _make_config(model="claude-opus-4-1")  # bare anthropic name
     env = h.build_env(_make_task(), config)
-    h.write_configs(_make_task(), config, env)
+    h.write_configs(sandbox, _make_task(), config, env)
 
     written = sandbox.calls[-1].command
     assert '"rllm-gateway"' in written
@@ -310,11 +292,10 @@ def test_mini_swe_agent_writes_dotenv_at_home_path():
     (not just env) because v2 loads dotenv with override=True."""
     h = MiniSweAgentHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
     config = _make_config(base_url="http://gw:8000/sessions/eval-0/v1", model="claude-opus-4-1")
     env = h.build_env(_make_task(), config)
 
-    h.write_configs(_make_task(), config, env)
+    h.write_configs(sandbox, _make_task(), config, env)
 
     written = sandbox.calls[-1].command
     assert "$HOME/.config/mini-swe-agent/.env" in written
@@ -426,8 +407,7 @@ def test_claude_code_invocation_extends_path_for_local_bin():
 def test_claude_code_run_returns_none():
     h = ClaudeCodeHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
-    assert h.run(_make_task(), _make_config(model="claude-opus-4-1")) is None
+    assert h.run(_make_task(), _make_config(model="claude-opus-4-1"), env=sandbox) is None
 
 
 # ---------------------------------------------------------------------------
@@ -462,11 +442,10 @@ def test_codex_writes_auth_json_and_config_toml():
     The earlier custom ``model_provider`` block was a silent no-op."""
     h = CodexHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
     config = _make_config(base_url="http://gw:8000/sessions/eval-0/v1", model="gpt-5")
     env = h.build_env(_make_task(), config)
 
-    h.write_configs(_make_task(), config, env)
+    h.write_configs(sandbox, _make_task(), config, env)
 
     written = sandbox.calls[-1].command
     assert sandbox.calls[-1].user is None  # written as agent user
@@ -515,8 +494,7 @@ def test_codex_invocation_strips_provider_prefix_from_model():
 def test_codex_run_swallows_failure_and_returns_none():
     h = CodexHarness()
     sandbox = FakeSandbox(fail_on_substring="codex exec")
-    h.set_sandbox(sandbox)
-    assert h.run(_make_task(), _make_config(model="gpt-5")) is None
+    assert h.run(_make_task(), _make_config(model="gpt-5"), env=sandbox) is None
 
 
 # ---------------------------------------------------------------------------
@@ -557,8 +535,7 @@ def test_qwen_code_run_returns_none():
     gateway-captured traces drive trajectory enrichment."""
     h = QwenCodeHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
-    assert h.run(_make_task(), _make_config(model="qwen3-coder-plus")) is None
+    assert h.run(_make_task(), _make_config(model="qwen3-coder-plus"), env=sandbox) is None
 
 
 # ---------------------------------------------------------------------------
@@ -615,10 +592,9 @@ def test_kimi_cli_writes_config_with_custom_provider_block():
     the chosen model at it."""
     h = KimiCliHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
     config = _make_config(base_url="http://gw:8000/sessions/eval-0/v1", model="gpt-4o")
     env = h.build_env(_make_task(), config)
-    h.write_configs(_make_task(), config, env)
+    h.write_configs(sandbox, _make_task(), config, env)
     written = sandbox.calls[-1].command
     assert "/tmp/kimi-config.json" in written
     assert '"rllm-gateway"' in written
@@ -667,18 +643,18 @@ def test_kimi_cli_invocation_breaks_loop_on_matching_response_id():
 
 
 def test_container_url_rewrites_loopback_for_docker_backend():
-    h = OpenCodeHarness()
-    h.sandbox_backend = "docker"
-    assert h._container_url("http://127.0.0.1:8000/v1") == "http://host.docker.internal:8000/v1"
-    assert h._container_url("http://localhost:9001/sessions/x/v1") == "http://host.docker.internal:9001/sessions/x/v1"
+    from rllm.gateway.manager import container_reachable_url
+
+    assert container_reachable_url("http://127.0.0.1:8000/v1", "docker") == "http://host.docker.internal:8000/v1"
+    assert container_reachable_url("http://localhost:9001/sessions/x/v1", "docker") == "http://host.docker.internal:9001/sessions/x/v1"
 
 
 def test_container_url_passthrough_for_non_docker_backends():
-    h = OpenCodeHarness()
-    h.sandbox_backend = "modal"
-    assert h._container_url("http://127.0.0.1:8000/v1") == "http://127.0.0.1:8000/v1"
-    h.sandbox_backend = "local"
-    assert h._container_url("http://localhost:9000/v1") == "http://localhost:9000/v1"
+    from rllm.gateway.manager import container_reachable_url
+
+    assert container_reachable_url("http://127.0.0.1:8000/v1", "modal") == "http://127.0.0.1:8000/v1"
+    assert container_reachable_url("http://localhost:9000/v1", "local") == "http://localhost:9000/v1"
+    assert container_reachable_url("http://127.0.0.1:8000/v1", None) == "http://127.0.0.1:8000/v1"
 
 
 # ---------------------------------------------------------------------------
@@ -719,7 +695,6 @@ def test_gateway_api_key_returns_placeholder_when_env_unset(monkeypatch):
 def test_opencode_uses_gateway_token_in_config_when_metadata_set():
     h = OpenCodeHarness()
     sandbox = FakeSandbox()
-    h.set_sandbox(sandbox)
     config = AgentConfig(
         base_url="http://gw/sessions/eval-0/v1",
         model="gpt-4o",
@@ -727,7 +702,7 @@ def test_opencode_uses_gateway_token_in_config_when_metadata_set():
         metadata={"gateway_auth_token": "tok-xyz"},
     )
     env = h.build_env(_make_task(), config)
-    h.write_configs(_make_task(), config, env)
+    h.write_configs(sandbox, _make_task(), config, env)
 
     written = sandbox.calls[-1].command
     assert '"apiKey": "tok-xyz"' in written

--- a/tests/sandbox/test_sandboxed_flow.py
+++ b/tests/sandbox/test_sandboxed_flow.py
@@ -1,0 +1,31 @@
+"""SandboxedAgentFlow contract: stateless flows, configure() override routing."""
+
+from __future__ import annotations
+
+from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+
+
+class _Flow(SandboxedAgentFlow):
+    def run(self, task, config, *, env):
+        return None
+
+
+def test_configure_applies_known_overrides_and_returns_leftovers():
+    flow = _Flow()
+    leftovers = flow.configure({"sandbox_backend": "daytona", "sandbox_concurrency": 2, "made_up_flag": 1})
+    assert flow.sandbox_backend == "daytona"
+    assert flow.max_concurrent == 2
+    assert leftovers == {"made_up_flag": 1}
+
+
+def test_configure_leaves_defaults_when_not_overridden():
+    flow = _Flow()
+    assert flow.configure({}) == {}
+    assert flow.sandbox_backend == "docker"
+    assert flow.max_concurrent == 4
+
+
+def test_flow_holds_no_sandbox_state():
+    flow = _Flow()
+    for attr in ("_sandbox", "sandbox", "set_sandbox", "create_instance", "teardown_sandbox"):
+        assert not hasattr(flow, attr), f"stateless flows must not have {attr}"

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -547,48 +547,64 @@ def test_get_sandbox_cold_leaves_baked_install_unset(monkeypatch, tmp_path):
     assert getattr(sb, "baked_install", None) is None
 
 
-def test_cli_harness_skips_install_iff_exact_baked_install():
-    from rllm.harnesses.cli_harness import BaseCliHarness
+def _hook_setup(monkeypatch, sandbox, flow):
+    """Run the real SandboxTaskHooks.setup with provisioning stubbed out."""
+    import rllm.eval._resolution as res
+    import rllm.sandbox.snapshot as snap
+    from rllm.hooks import FixedEvaluation, SandboxTaskHooks
 
-    class _Stub(BaseCliHarness):
+    class _Evaluator:
+        def evaluate(self, task, episode):
+            return None
+
+    monkeypatch.setattr(snap, "get_sandbox", lambda task, backend, registry=None, install_script="": sandbox)
+    monkeypatch.setattr(res, "_setup_task_environment", lambda task, sb: None)
+    hooks = SandboxTaskHooks(evaluation=FixedEvaluation(_Evaluator()), sandbox_backend="docker", use_snapshot=False)
+    return hooks.setup(_task(backend="docker"), flow, "uid")
+
+
+def _install_flow():
+    from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+
+    class _InstallFlow(SandboxedAgentFlow):
         name = "stub"
 
         def install_script(self):
             return "echo installing"
 
-        def build_env(self, task, config):
-            return {}
+        def run(self, task, config, *, env):
+            return None
 
-        def build_invocation(self, instruction, task, config):
-            return "true"
+    return _InstallFlow()
 
-    class _Sandbox:
-        def __init__(self):
-            self.calls = []
 
-        def exec(self, command, timeout=None, user=None):
-            self.calls.append(command)
-            return ""
+class _ExecRecordingSandbox(_FakeSandbox):
+    def __init__(self):
+        self.calls = []
 
-        def close(self):
-            pass
+    def exec(self, command, timeout=None, user=None):
+        self.calls.append((command, user))
+        return ""
 
-    cold = _Stub()
-    cold_box = _Sandbox()
-    cold.set_sandbox(cold_box)
-    cold.on_sandbox_ready({}, None)
-    assert cold_box.calls == ["echo installing"]  # cold boot → install runs
 
-    warm = _Stub()
-    warm_box = _Sandbox()
-    warm_box.baked_install = "echo installing"
-    warm.set_sandbox(warm_box)
-    warm.on_sandbox_ready({}, None)
-    assert warm_box.calls == []  # image contains exactly this install → skip
+def test_hook_installs_on_cold_sandbox(monkeypatch):
+    sandbox = _ExecRecordingSandbox()  # no baked_install attr → cold
+    ctx = _hook_setup(monkeypatch, sandbox, _install_flow())
+    assert sandbox.calls == [("echo installing", "root")]
+    assert ctx.env is sandbox
 
-    stale = _Stub()
-    stale_box = _Sandbox()
-    stale_box.baked_install = "echo OLD install"  # baked for a different harness/version
-    stale.set_sandbox(stale_box)
-    stale.on_sandbox_ready({}, None)
-    assert stale_box.calls == ["echo installing"]  # mismatch → install runs
+
+def test_hook_skips_install_when_exactly_baked(monkeypatch):
+    sandbox = _ExecRecordingSandbox()
+    sandbox.baked_install = "echo installing"
+    ctx = _hook_setup(monkeypatch, sandbox, _install_flow())
+    assert sandbox.calls == []
+    assert ctx.env is sandbox
+
+
+def test_hook_installs_when_baked_script_differs(monkeypatch):
+    sandbox = _ExecRecordingSandbox()
+    sandbox.baked_install = "echo OLD install"  # baked for a different harness/version
+    ctx = _hook_setup(monkeypatch, sandbox, _install_flow())
+    assert sandbox.calls == [("echo installing", "root")]
+    assert ctx.env is sandbox


### PR DESCRIPTION
Stacked on #637 (phase 2), which stacks on #636 (phases 0–1) — merge in order; this PR's own diff is the single commit `2b0269ae`.

## Intuition

A flow should describe **what to run**; the engine should own **where it runs**. Until now, `SandboxedAgentFlow` stashed a live sandbox in a mutable field (`self._sandbox`), which forced per-task shallow copies, an "externally managed" flag, and teardown guards — machinery that existed only to protect the stash, and the root of the #616 leak class. This PR removes the stash: the hook provisions the sandbox, the engine passes it into the flow as a keyword-only call argument, and the hook closes it.

```python
def run(self, task, config, *, env): ...   # flows that need a sandbox declare it
```

- **Detected once, fails early.** `flow_accepts_env` checks the parameter at engine bind time; a `needs_env` flow without it gets a clear `TypeError` at construction (with the exact signature to add), and a `needs_env` flow paired with hooks that provision nothing gets a clear `RuntimeError` naming both — not a confusing mid-rollout crash. `**kwargs` entry points (wrappers/proxies) count as accepting.
- **One shared instance, no copies.** With no per-rollout state on flows, `SandboxTaskHooks.setup` stops shallow-copying; every harness was audited for `self`-mutation during `run` (none mutate).
- **The install belongs to the lifecycle owner.** The CLI install moved from `on_sandbox_ready` into the hook — same skip-when-baked logic from #637, plus a fix the review caught: a setup failure *after* provisioning (env upload, install, or verifier resolution) now closes the sandbox instead of leaking it once per retry on billed-by-duration backends.
- **URL rewriting keys on reality.** `host.docker.internal` rewriting used to read a harness *class attribute* that could drift from the backend that actually provisioned this task's sandbox. It's now `container_reachable_url(url, ctx.env_backend)` in the engine, applied only to flows whose LLM client runs in-sandbox; host-side loops (bash/oracle) keep the plain host URL as before.
- **CLI flags land in one place.** `configure(overrides) → leftovers` replaces post-hoc attribute mutation in the trainer and two isinstance blocks in `rllm eval`; anything a flow can't honor produces a warning instead of a silent no-op. `HarborRuntime` maps `sandbox_backend` → its `environment_type`.
- **Riders:** unannotated evaluators now receive the real `Task` (the dict path needs an explicit `dict` annotation or legacy parameter name); python-hybrid sandbox injection became a plain `PythonModuleEvaluator` attribute instead of a per-resolution `_build_kwargs` monkeypatch.

## Verification

- Unit: new `tests/sandbox/test_sandboxed_flow.py` (configure routing, statelessness), engine bind-failure + env-forwarding/URL-rewrite tests, hook-level install tests (cold / baked-exact / baked-stale); `tests/harnesses/test_cli_harness.py` migrated to the call-argument convention (63 pass). Full suite: 894 passed, same 14 pre-existing failures as base.
- E2E on Tinker + Daytona, re-run on the final post-review code: `@rollout` math (no sandbox), BashHarness host loop, and mini-swe from a phase-2-baked snapshot — all 1 val + 2 train + 1 val with rewards 1.0, 12/12 snapshot boots per sandbox case, healthy token-level training (`dropped_malformed_sequences: 0`), 0 leaked sandboxes.
- Adversarial review applied: the provision-then-fail sandbox leak, the opaque needs-env-no-hooks error, a false "--sandbox-backend has no effect" warning (the hooks consume it independently of the flow), and the eval-CLI half of the configure migration were all found by the reviewer and fixed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)