### PR TITLE
fix(loader,eval,oracle): honor task/dataset declarations for harbor-style dirs (rllm-swesmith integration)

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -148,6 +148,13 @@ def _run_eval(
             "category": bench_result.category,
         }
 
+        # dataset.toml's default_sandbox applies when --sandbox-backend wasn't
+        # given; it reaches the agent and hooks through agent_metadata like the
+        # CLI flag would.
+        if not sandbox_backend and bench_result.sandbox_backend:
+            agent_metadata = dict(agent_metadata or {})
+            agent_metadata["sandbox_backend"] = bench_result.sandbox_backend
+
         if split is None:
             split = bench_result.split or "test"
 

--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -198,7 +198,11 @@ def _run_train(
             console.print(f"  [key]--val-dataset '{val_dataset_name}' is not a local benchmark dir; reusing train tasks for validation.[/]")
 
         # For local sandbox tasks, --agent picks the AgentFlow.
-        bench_result = BenchmarkLoader.load(train_dir, harness_name=agent_name)
+        bench_result = BenchmarkLoader.load(train_dir, sandbox_backend=sandbox_backend, harness_name=agent_name)
+        # dataset.toml's default_sandbox applies when --sandbox-backend wasn't
+        # given (same rule as the eval CLI).
+        if not sandbox_backend and bench_result.sandbox_backend:
+            sandbox_backend = bench_result.sandbox_backend
         train_ds_name = bench_result.name
         catalog_entry = {
             "description": bench_result.description,

--- a/rllm/data/swesmith_builder.py
+++ b/rllm/data/swesmith_builder.py
@@ -1,0 +1,191 @@
+"""Builder for the rllm-swesmith sandbox benchmark.
+
+``kylemontgomery/swesmith-filtered`` is a flat HF dataset repo of ~4.8K
+harbor-format task directories (105 Python repos), each shipping
+``task.toml``, ``instruction.md``, ``environment/Dockerfile``,
+``solution/solve.sh``, and ``tests/`` (an in-sandbox pytest verifier that
+writes ``/logs/verifier/reward.txt``). That layout is already rLLM's
+``type="sandbox"`` task-per-directory shape, so building the benchmark is:
+download, screen out unsolvable instances, patch resource limits, and write
+a ``dataset.toml``.
+
+Single source of truth for materializing the dataset, used by
+``rllm dataset pull rllm-swesmith`` (via the ``builder`` field in
+``rllm/registry/datasets.json`` → :func:`rllm.cli._pull.pull_dataset`).
+
+On-disk output (``<out_dir>/``):
+
+    rllm-swesmith/
+    ├── dataset.toml             # [dataset] type="sandbox", default_agent="mini-swe-agent"
+    ├── <instance_id>/           # the harbor task dir, verbatim + patched task.toml
+    └── ...
+
+Registered rows carry ``task_path`` pointing at each task dir, so the
+name-based flows (``rllm eval rllm-swesmith``, ``rllm train rllm-swesmith``)
+root every Task at the real on-disk directory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REPO_ID = "kylemontgomery/swesmith-filtered"
+
+# Upstream tasks declare no [environment] resources; remote backends then run
+# at their defaults (Daytona: 1 GiB), which OOMs the verifier's in-sandbox
+# ``uv add pytest swebench datasets swesmith`` resolution. Docker ignores these.
+_DEFAULT_RESOURCES = {"cpus": 2, "memory_mb": 4096, "storage_mb": 10240}
+
+
+def bug_in_test_file(task_dir: Path) -> bool:
+    """True when the injected bug lives in a FAIL_TO_PASS test file.
+
+    Each instance branch is ``[base] → Bug Patch → Remove F2P Tests``: the
+    agent works at the tip, where the F2P test files are deleted, and the
+    verifier's ``git checkout HEAD~1`` restores them around the agent's
+    uncommitted fix. When the bug patch itself targets a F2P test file
+    (e.g. gpxpy keeps its whole suite in root ``test.py``), the deleted file
+    *is* the one needing the fix — the task cannot be solved, and even the
+    oracle's ``git apply --reverse`` fails on it.
+    """
+    cfg = json.loads((task_dir / "tests" / "config.json").read_text())
+    targets = [line.split(" b/")[-1] for line in cfg["patch"].splitlines() if line.startswith("diff --git")]
+    f2p_files = {t.split("::")[0] for t in cfg["FAIL_TO_PASS"]}
+    return any(t in f2p_files for t in targets)
+
+
+def patch_task_toml(task_dir: Path, resources: dict | None = None) -> None:
+    """Append a default ``[environment]`` resource block when the task has none."""
+    toml_path = task_dir / "task.toml"
+    text = toml_path.read_text()
+    if "[environment]" in text:
+        return
+    res = resources or _DEFAULT_RESOURCES
+    block = "\n[environment]\n" + "".join(f"{k} = {v}\n" for k, v in res.items())
+    toml_path.write_text(text + block)
+
+
+def _write_dataset_toml(out: Path, *, name: str, split: str, description: str, default_agent: str) -> None:
+    content = "\n".join(
+        [
+            "[dataset]",
+            f'name = "{name}"',
+            'type = "sandbox"',
+            f'description = "{description}"',
+            'default_sandbox = "docker"',
+            f'default_agent = "{default_agent}"',
+            f'split = "{split}"',
+            "",
+            "[verifier]",
+            'script = "tests/test.sh"',
+            "",
+        ]
+    )
+    (out / "dataset.toml").write_text(content, encoding="utf-8")
+
+
+def build_benchmark(
+    *,
+    name: str = "rllm-swesmith",
+    split: str = "train",
+    out_dir: str | Path,
+    catalog_entry: dict | None = None,
+    task_ids: list[str] | None = None,
+    limit: int | None = None,
+    default_agent: str = "mini-swe-agent",
+    clean: bool = False,
+    register: bool = True,
+) -> Path:
+    """Materialize swesmith-filtered into a sandbox benchmark directory.
+
+    Args:
+        name: Dataset/registry name (also the dataset.toml ``name``).
+        split: Split label written into dataset.toml and the registry.
+        out_dir: Output benchmark directory.
+        catalog_entry: Optional catalog entry (datasets.json); ``description``/
+            ``default_agent``/``limit`` are read from it when present.
+        task_ids: Build only these instance ids (downloads just their files).
+            Default: the full repo.
+        limit: Keep only the first N solvable tasks (sorted by id).
+        default_agent: ``default_agent`` written into dataset.toml.
+        clean: Remove ``out_dir`` before building.
+        register: Also register ``task_path`` rows in ``DatasetRegistry`` so
+            the name-based eval/train flows and ``rllm dataset list`` work.
+
+    Returns:
+        Path to the built benchmark directory.
+    """
+    from huggingface_hub import snapshot_download
+
+    if catalog_entry:
+        default_agent = catalog_entry.get("default_agent") or default_agent
+        limit = limit if limit is not None else catalog_entry.get("limit")
+
+    out = Path(out_dir).expanduser()
+    if clean and out.exists():
+        logger.info("[swesmith] removing existing %s", out)
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    patterns = [f"{t}/*" for t in task_ids] if task_ids else None
+    logger.info("[swesmith] downloading %s (%s) ...", REPO_ID, f"{len(task_ids)} tasks" if task_ids else "full repo")
+    cache = Path(snapshot_download(REPO_ID, repo_type="dataset", allow_patterns=patterns))
+
+    candidates = sorted(d for d in cache.iterdir() if d.is_dir() and (d / "task.toml").exists())
+    if task_ids:
+        wanted = set(task_ids)
+        candidates = [d for d in candidates if d.name in wanted]
+
+    kept: list[Path] = []
+    skipped = 0
+    for d in candidates:
+        if bug_in_test_file(d):
+            skipped += 1
+            continue
+        kept.append(d)
+        if limit is not None and len(kept) >= limit:
+            break
+    logger.info("[swesmith] %d tasks kept, %d skipped (bug injected into a F2P test file — unsolvable)", len(kept), skipped)
+
+    for d in kept:
+        dst = out / d.name
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(d, dst)
+        patch_task_toml(dst)
+
+    description = (catalog_entry or {}).get("description") or "SWE-smith filtered: bug-fixing tasks across 105 Python repos (in-sandbox pytest grading)."
+    _write_dataset_toml(out, name=name, split=split, description=description, default_agent=default_agent)
+    logger.info("[swesmith] wrote %d task dirs to %s", len(kept), out)
+
+    # task_path rows root each Task at its real directory, so the bare-name
+    # eval/train flows pick up the per-task Dockerfile, verifier, and timeouts.
+    if register:
+        try:
+            from rllm.data import DatasetRegistry
+
+            reg_rows = [
+                {
+                    "id": d.name,
+                    "instruction": (out / d.name / "instruction.md").read_text(encoding="utf-8"),
+                    "task_path": str(out / d.name),
+                }
+                for d in kept
+            ]
+            DatasetRegistry.register_dataset(
+                name=name,
+                data=reg_rows,
+                split=split,
+                source=REPO_ID,
+                description=description,
+                category=(catalog_entry or {}).get("category", "agentic"),
+            )
+        except Exception:  # registry parity is best-effort; the benchmark dir is what eval uses
+            logger.warning("[swesmith] could not register rows in DatasetRegistry (non-fatal)", exc_info=True)
+
+    return out

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -66,6 +66,11 @@ class OracleHarness(SandboxedAgentFlow):
         solution_env = (task.metadata.get("solution", {}) or {}).get("env", {}) or {}
         env_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in solution_env.items())
         cmd = (env_prefix + " " if env_prefix else "") + container_solve
+        # solve.sh scripts assume they run in the task workdir (e.g. swesmith's
+        # ``git apply`` needs cwd inside /testbed); exec defaults elsewhere.
+        workdir = task.metadata.get("workdir")
+        if workdir:
+            cmd = f"cd {shlex.quote(workdir)} && {cmd}"
 
         try:
             output = sandbox.exec(cmd, timeout=timeout, user=agent_user)

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -13,6 +13,18 @@
       "default_agent": "zeroclaw",
       "reward_fn": "claw_eval_reward_fn"
     },
+    "rllm-swesmith": {
+      "description": "SWE-smith filtered: ~4.7K solvable bug-fixing tasks across 105 Python repos (sandbox; in-sandbox pytest grading)",
+      "source": "kylemontgomery/swesmith-filtered",
+      "builder": "rllm.data.swesmith_builder:build_benchmark",
+      "category": "agentic",
+      "splits": [
+        "train"
+      ],
+      "eval_split": "train",
+      "train_split": "train",
+      "default_agent": "mini-swe-agent"
+    },
     "gsm8k": {
       "description": "Grade school math word problems (8.5K train, 1.3K test)",
       "source": "openai/gsm8k",

--- a/rllm/tasks/dataset_config.py
+++ b/rllm/tasks/dataset_config.py
@@ -41,8 +41,10 @@ class DatasetConfig:
     data: str = ""  # path to data file relative to dataset dir
     evaluation: EvaluationConfig | None = None
 
-    # Sandbox datasets only
-    default_sandbox: str = "docker"
+    # Sandbox datasets only. None = not declared — callers fall back to their
+    # own default; an undeclared value must NOT override a task-level
+    # ``sandbox_backend`` (see rllm.eval._resolution._resolve_backend).
+    default_sandbox: str | None = None
 
     # Shared
     default_agent: str | None = None
@@ -88,7 +90,7 @@ def load_dataset_config(path: str | Path) -> DatasetConfig:
         description=ds.get("description", ""),
         data=ds.get("data", ""),
         evaluation=evaluation,
-        default_sandbox=ds.get("default_sandbox", "docker"),
+        default_sandbox=ds.get("default_sandbox"),
         default_agent=ds.get("default_agent"),
         split=ds.get("split", "test"),
         tasks=tasks,

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -474,10 +474,21 @@ def _load_task_from_dir(
 
     # Lift commonly-used config into top-level metadata for the Runner
     metadata: dict = dict(raw)
-    env_section = raw.get("environment", {}) or {}
-    # Only set workdir when explicitly declared — see _merge_task_toml_metadata
-    # for the same rationale (Dockerfile WORKDIR vs forced /workspace).
-    declared_workdir = env_section.get("workdir")
+    env_section = dict(raw.get("environment", {}) or {})
+    # Same Dockerfile lifting as _merge_task_toml_metadata (the row path):
+    # FROM fills a missing docker_image so non-docker backends pull the right
+    # image; WORKDIR fills a missing workdir. Explicit task.toml values win.
+    dockerfile = task_dir / "environment" / "Dockerfile"
+    if not dockerfile.exists():
+        dockerfile = dataset_dir / "environment" / "Dockerfile"
+    base_image, dockerfile_workdir = _parse_dockerfile_image_workdir(dockerfile)
+    if base_image and not env_section.get("docker_image"):
+        env_section["docker_image"] = base_image
+    if env_section:
+        metadata["environment"] = env_section
+    # Only set workdir when declared (task.toml or Dockerfile WORKDIR) — see
+    # _merge_task_toml_metadata for the rationale (never force /workspace).
+    declared_workdir = env_section.get("workdir") or dockerfile_workdir
     if declared_workdir is not None:
         metadata["workdir"] = declared_workdir
     metadata["env_vars"] = env_section.get("env", {}) or {}

--- a/tests/data/test_swesmith_builder.py
+++ b/tests/data/test_swesmith_builder.py
@@ -1,0 +1,75 @@
+"""Tests for the rllm-swesmith benchmark builder (no network)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import tomllib
+
+from rllm.data.swesmith_builder import _write_dataset_toml, bug_in_test_file, patch_task_toml
+
+_TASK_TOML = """\
+version = "1.0"
+
+[metadata]
+instance_id = "demo__repo.abc123.func_basic__x1"
+
+[verifier]
+timeout_sec = 3000.0
+
+[agent]
+timeout_sec = 3000.0
+"""
+
+
+def _make_task(tmp_path: Path, *, patch_target: str, f2p_file: str) -> Path:
+    task_dir = tmp_path / "demo__repo.abc123.func_basic__x1"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "task.toml").write_text(_TASK_TOML)
+    cfg = {
+        "patch": f"diff --git a/{patch_target} b/{patch_target}\n--- a/{patch_target}\n+++ b/{patch_target}\n",
+        "FAIL_TO_PASS": [f"{f2p_file}::TestX::test_y"],
+        "PASS_TO_PASS": [],
+    }
+    (task_dir / "tests" / "config.json").write_text(json.dumps(cfg))
+    return task_dir
+
+
+class TestBugInTestFile:
+    def test_source_bug_is_solvable(self, tmp_path):
+        task = _make_task(tmp_path, patch_target="src/repo/core.py", f2p_file="tests/test_core.py")
+        assert not bug_in_test_file(task)
+
+    def test_bug_in_f2p_test_file_is_unsolvable(self, tmp_path):
+        # gpxpy-style: the whole suite lives in root test.py and the bug was
+        # injected there — the F2P-removal commit deletes the file to fix.
+        task = _make_task(tmp_path, patch_target="test.py", f2p_file="test.py")
+        assert bug_in_test_file(task)
+
+
+class TestPatchTaskToml:
+    def test_adds_default_resources_when_absent(self, tmp_path):
+        task = _make_task(tmp_path, patch_target="src/a.py", f2p_file="tests/test_a.py")
+        patch_task_toml(task)
+        meta = tomllib.loads((task / "task.toml").read_text())
+        assert meta["environment"]["memory_mb"] == 4096
+        # untouched upstream sections survive
+        assert meta["verifier"]["timeout_sec"] == 3000.0
+
+    def test_existing_environment_wins(self, tmp_path):
+        task = _make_task(tmp_path, patch_target="src/a.py", f2p_file="tests/test_a.py")
+        toml_path = task / "task.toml"
+        toml_path.write_text(toml_path.read_text() + "\n[environment]\nmemory_mb = 8192\n")
+        patch_task_toml(task)
+        meta = tomllib.loads(toml_path.read_text())
+        assert meta["environment"]["memory_mb"] == 8192
+
+
+class TestDatasetToml:
+    def test_loader_recognizes_output(self, tmp_path):
+        _write_dataset_toml(tmp_path, name="rllm-swesmith", split="train", description="d", default_agent="mini-swe-agent")
+        meta = tomllib.loads((tmp_path / "dataset.toml").read_text())
+        assert meta["dataset"]["type"] == "sandbox"
+        assert meta["dataset"]["default_agent"] == "mini-swe-agent"
+        assert meta["verifier"]["script"] == "tests/test.sh"


### PR DESCRIPTION
Adds **`rllm-swesmith`** — the SWE-smith filtered benchmark ([`kylemontgomery/swesmith-filtered`](https://huggingface.co/datasets/kylemontgomery/swesmith-filtered), ~4.8K harbor-format bug-fixing tasks across 105 Python repos) — as a first-class rLLM dataset, and fixes the wiring gaps that integrating it surfaced.

## The dataset

```bash
rllm dataset pull rllm-swesmith                    # download, screen, register
rllm eval  rllm-swesmith --agent oracle            # smoke-test via reference solutions
rllm train rllm-swesmith --agent mini-swe-agent    # in-sandbox pytest grading
```

The HF repo is already rLLM's task-per-directory sandbox shape, so the builder (`rllm/data/swesmith_builder.py`, same pattern as `claw_eval`) just downloads it, patches missing `[environment]` resource limits (remote backends OOM the verifier's in-sandbox `uv add` at the 1 GiB default), writes `dataset.toml`, and registers `task_path` rows so both name-based eval and bare-name training root each Task at its real directory. Partial builds via `task_ids=`/`limit=` kwargs.

**Unsolvable-task screen.** swesmith instance branches are `[base] → Bug Patch → Remove F2P Tests`: the agent works at the tip where the failing-test files are deleted, and the verifier's `git checkout HEAD~1` restores them around the agent's uncommitted fix. When the bug patch itself targets one of those test files (e.g. every gpxpy instance whose suite lives in root `test.py`), the file the agent would need to fix doesn't exist in its tree — unsolvable by construction; even the oracle's reverse-apply fails. The builder drops these at build time (`bug_in_test_file`).

## Issues fixed along the way

All four are the same shape — *a declaration the task or dataset already makes was silently ignored on one path* — and none is swesmith-specific:

- **Loader parity for per-task Dockerfiles** (`rllm/tasks/loader.py`): directory-loaded tasks now lift the Dockerfile's `FROM`/`WORKDIR` into missing `docker_image`/`workdir` metadata, exactly like the harbor-row path already did. Previously the same task dir produced a *different sandbox image* depending on how it was loaded — on Daytona/Modal it silently booted `python:3.11-slim`. Explicit `task.toml` values still win; existing datasets keep byte-identical snapshot keys (case2/case4 verified).
- **`dataset.toml` `default_sandbox` is honored** by both `rllm eval` and `rllm train` when `--sandbox-backend` is absent (previously only the flag flowed; the agent's class default silently won). `DatasetConfig.default_sandbox` is now `None` when undeclared, so an implicit "docker" can never override a task-level `sandbox_backend`.
- **Oracle runs `solve.sh` from the task's workdir** (`rllm/harnesses/oracle.py`, same `cd` convention as `BaseCliHarness`). Solve scripts that use `git`/relative paths need it; Daytona's exec lands in the image WORKDIR by accident, Docker/Modal don't.

## Evidence

On a 5-train / 3-val subset (Tinker + Daytona, one snapshot per task):
- **Oracle eval 3/3 reward 1.0** (~20 s/task); a **do-nothing probe scores 0** — the reward signal is bracketed from both sides.
- **Training run** (Qwen3-8B LoRA, mini-swe-agent, 5 tasks × group 2, val-before-train + final val): exit 0, 22 genuine multi-turn rollouts (7–48 steps), `dropped_malformed_sequences: 0`, zero leaked sandboxes. (All rewards 0.0 — base 8B can't solve these yet; pipeline health was the goal.)
- Builder validated on an 8-id subset: 5 solvable materialized, 3 known-unsolvable screened; every task resolves the right `jyangballin/...` image + `/testbed` on both load paths.
- Unit suite: 899 passed (+5 new builder tests), same 14 pre-existing failures as the base branch.

Full integration write-up (verifier semantics, commands, run logs): `tmp/terminal_rl/swesmith/INTEGRATION.md` (untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
