### PR TITLE
docs: add Blog tab to docs navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -186,16 +186,11 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Blog",
+        "href": "https://rllm-project.com/blog.html"
       }
-    ],
-    "global": {
-      "anchors": [
-        {
-          "anchor": "Blog",
-          "href": "https://rllm-project.com/blog.html",
-          "icon": "newspaper"
-        }
-      ]
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add a top-level **Blog** tab in `docs/docs.json` linking to https://rllm-project.com/blog.html
- Remove the redundant Blog entry from `global.anchors` since the new tab serves the same purpose more prominently

## Test plan
- [ ] Mintlify preview renders the Blog tab in the top nav alongside Documentation, Cookbooks, Projects, API Reference
- [ ] Clicking Blog navigates to https://rllm-project.com/blog.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)