### PR TITLE
feat(eval,sandbox): pass@k via --attempts; fix Modal ARG_MAX uploads & sandbox lifetimes

### DIFF
--- a/docs/cookbooks/overview.mdx
+++ b/docs/cookbooks/overview.mdx
@@ -24,6 +24,7 @@ Each cookbook is a plain async function that calls an OpenAI-compatible endpoint
 | [`finqa`](/cookbooks/finqa) | Multi-turn + 4 tools | Financial QA over SEC 10-K tables: `get_table_names` / `get_table_info` / `sql_query` / `calculator`, judge-LLM grading. |
 | [`geo3k`](/cookbooks/geo3k) | VLM single-turn | Multimodal geometry on the Geometry3K dataset. |
 | [`solver_judge_flow`](/cookbooks/solver_judge_flow) | Multi-agent | Solver–judge pattern on the countdown task. |
+| [`terminal_bench`](/cookbooks/terminal_bench) | CLI-only, sandboxed harness | Evaluates Harbor's Terminus-2 terminal agent on all 89 Terminal-Bench 2.0 tasks via Modal sandboxes, snapshots, and pass@k. No plugin to install — the whole run is `rllm` CLI commands. |
 
 Click into any row for the deep-dive page — install flow, dataset, eval and train commands, and key code snippets. The full source, including the launch scripts, lives at [`cookbooks/`](https://github.com/rllm-org/rllm/tree/main/cookbooks) on GitHub.
 

--- a/docs/cookbooks/terminal_bench.mdx
+++ b/docs/cookbooks/terminal_bench.mdx
@@ -58,11 +58,11 @@ No local Docker is needed: images are pulled and run on Modal.
     A cold run pulls each task's Docker image and installs the agent at rollout time. Snapshots pay that cost once: each of the 89 environments is built, the Terminus-2 install (an isolated Python 3.12 venv with `harbor`, plus tmux) is baked in, and the live filesystem is captured as a Modal image.
 
     ```bash
-    rllm snapshot create harbor:terminal-bench@2.0 \
+    RLLM_SNAPSHOT_BUILD_WORKERS=10 rllm snapshot create harbor:terminal-bench@2.0 \
       --sandbox-backend modal --agent terminus2 --ttl-hours 168
     ```
 
-    Builds run 4-way parallel and take roughly an hour for all 89 (most images build in 30–60 s; a few multi-gigabyte ones take 15 minutes). Verify and inspect:
+    `RLLM_SNAPSHOT_BUILD_WORKERS` lifts build parallelism from its default of 4 — Modal absorbs 10 concurrent builds comfortably, finishing all 89 environments in roughly 20–30 minutes (most images build in 30–60 s; the few multi-gigabyte ones dominate the tail). Verify and inspect:
 
     ```bash
     rllm snapshot list

--- a/docs/cookbooks/terminal_bench.mdx
+++ b/docs/cookbooks/terminal_bench.mdx
@@ -1,0 +1,173 @@
+---
+title: Terminal-Bench 2.0
+description: Evaluate Harbor's Terminus-2 terminal agent on all 89 Terminal-Bench 2.0 tasks with Modal sandboxes, snapshots, and pass@k — entirely from the CLI
+---
+
+This cookbook runs Harbor's [Terminus-2](https://www.harborframework.com/docs/agents/terminus-2) agent against the full [Terminal-Bench 2.0](https://www.tbench.ai) benchmark. Unlike the other cookbooks, there is no plugin to install: the `terminus2` harness ships with rLLM, the dataset comes from the Harbor registry, and the whole run is driven by `rllm` CLI commands.
+
+Harbor is used only as a dataset registry and for the agent code itself. Execution stays on rLLM's own stack: each task boots a Modal sandbox from its prebuilt Docker image, the agent runs *inside* the sandbox (LLM calls route back through the rLLM gateway over a tunnel), and the task's own `tests/test.sh` produces the reward.
+
+## Pattern
+
+| Aspect | Value |
+|---|---|
+| Loop shape | Multi-turn terminal agent (tmux-driven), running inside the sandbox |
+| Dataset | `harbor:terminal-bench@2.0` — 89 tasks, each with a prebuilt Docker image |
+| Sandbox | Modal, booted from prebuilt environment snapshots |
+| Termination | Agent declares the task complete, or hits its turn limit (50) |
+| Reward shape | Per-task verifier: `tests/test.sh` writes `1.0` / `0.0` to `/logs/verifier/reward.txt` |
+| Metrics | Per-rollout accuracy, plus unbiased pass@k when `--attempts N` is set |
+
+## Prerequisites
+
+- **Python ≥ 3.12** — the `harbor` package requires it.
+- **A Modal account** — authenticate with `modal setup`, or export `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`.
+- **A configured model provider** — `rllm model setup` (any provider works; the gateway enforces sampling parameters either way).
+
+No local Docker is needed: images are pulled and run on Modal.
+
+<Steps>
+  <Step title="Install rLLM with the harbor extra">
+    The harness itself ships with rLLM; the `harbor` extra is what lets the CLI resolve `harbor:` dataset names from the Harbor registry.
+
+    ```bash
+    uv pip install -e ".[harbor]"
+    rllm agent list        # should include "terminus2"
+    ```
+
+    <Warning>
+    If `rllm eval harbor:terminal-bench@2.0` later reports *"Benchmark 'terminal-bench@2.0' not found in catalog"*, the harbor import is failing silently — usually because the extra isn't installed in the active environment. A leftover empty `site-packages/harbor/` directory from an old uninstall produces the same symptom (Python treats the bare directory as a namespace package); delete it and reinstall.
+    </Warning>
+  </Step>
+
+  <Step title="Pull the dataset">
+    Nothing to do explicitly — the first command that references `harbor:terminal-bench@2.0` downloads all 89 task directories into `~/.cache/harbor/tasks/` and registers the dataset locally. After that it shows up like any other dataset:
+
+    ```bash
+    rllm dataset list      # includes terminal-bench@2.0 after first use
+    ```
+
+    Each task directory carries its own `task.toml` (with the prebuilt `docker_image`), `instruction.md`, and `tests/test.sh`. rLLM lifts the image and workdir into task metadata and auto-detects the verifier — no evaluator flag is needed.
+
+    <Note>
+    The registered dataset's rows point into `~/.cache/harbor/`. If you clear that cache, re-pull before the next run — stale rows fall back to a default image and snapshots stop matching.
+    </Note>
+  </Step>
+
+  <Step title="Build environment snapshots">
+    A cold run pulls each task's Docker image and installs the agent at rollout time. Snapshots pay that cost once: each of the 89 environments is built, the Terminus-2 install (an isolated Python 3.12 venv with `harbor`, plus tmux) is baked in, and the live filesystem is captured as a Modal image.
+
+    ```bash
+    rllm snapshot create harbor:terminal-bench@2.0 \
+      --sandbox-backend modal --agent terminus2 --ttl-hours 168
+    ```
+
+    Builds run 4-way parallel and take roughly an hour for all 89 (most images build in 30–60 s; a few multi-gigabyte ones take 15 minutes). Verify and inspect:
+
+    ```bash
+    rllm snapshot list
+    rllm snapshot inspect <group-id>   # per-task env keys and live status
+    ```
+
+    With snapshots in place, eval-time sandbox setup drops to 2–3 seconds per rollout. Snapshots are keyed on content (image + Dockerfile steps + agent install), so rebuilding after a TTL expiry reuses nothing stale, and switching to a different agent simply misses to the cold path.
+  </Step>
+
+  <Step title="Set the sandbox lifetime">
+    Modal sandboxes live 30 minutes by default, and several Terminal-Bench tasks (`compile-compcert`, `sam-cell-seg`, `train-fasttext`) legitimately need rollouts longer than that — the sandbox would die mid-run. Raise the lifetime for the eval process:
+
+    ```bash
+    export RLLM_MODAL_SANDBOX_TIMEOUT_S=5400   # 90 minutes
+    ```
+
+    This is the one environment variable the full run requires. The default is left at 30 minutes on purpose, so unrelated Modal workloads don't hold stuck sandboxes longer than necessary.
+  </Step>
+
+  <Step title="Smoke-test two tasks">
+    Before spending hours, run two known-fast tasks with two attempts each. This exercises every moving part — snapshot boot, gateway tunnel, in-sandbox agent, verifier, pass@k aggregation — in a few minutes:
+
+    ```bash
+    rllm eval harbor:terminal-bench@2.0 \
+      --agent terminus2 --sandbox-backend modal \
+      --task-indices 84,64 --attempts 2 \
+      --max-tokens 4096 --temperature 0.7
+    ```
+
+    Indices 84 and 64 are `openssl-selfsigned-cert` and `regex-log`. A healthy smoke run finishes with `Errors: 0` and a pass@1 / pass@2 block in the results panel.
+
+    <Note>
+    `--sandbox-backend modal` is required even though the harness defaults to Modal — without it the CLI's Docker preflight check rejects harbor datasets on machines without a local Docker daemon.
+    </Note>
+  </Step>
+
+  <Step title="Run the full benchmark">
+    89 tasks × 2 attempts = 178 rollouts:
+
+    ```bash
+    RLLM_MODAL_SANDBOX_TIMEOUT_S=5400 rllm eval harbor:terminal-bench@2.0 \
+      --agent terminus2 --sandbox-backend modal \
+      --attempts 2 --concurrency 12 --sandbox-concurrency 12 \
+      --max-tokens 4096 --temperature 0.7 \
+      --output results/tb2_full.json
+    ```
+
+    Expect 3–4 hours at this concurrency, dominated by LLM latency. Rollout completions stream to the console as they finish (`[task:attempt] Rollout completed. Rewards: [terminus2: 1.0] in 67s …`), so you can watch reward signal arrive long before the run ends.
+
+    When it completes, the results panel reports per-rollout accuracy, the error count, and pass@k:
+
+    ```text
+    Accuracy   33.1%  (59/178)
+    Errors     0
+    pass@1     33.1%
+    pass@2     43.8%
+    ```
+
+    Those numbers are from `Qwen/Qwen3.6-35B-A3B`; treat them as a reference point, not a target — sampling at temperature 0.7 moves individual runs by a few points.
+  </Step>
+
+  <Step title="Inspect the rollouts">
+    Every rollout is saved as its own episode JSON (attempt-suffixed, e.g. `episode_000004_regex-log_1.json`) under the run directory, alongside `results.json` whose `items` carry per-attempt rewards and `pass_at` the aggregate. Browse trajectories interactively:
+
+    ```bash
+    rllm view <run-id>
+    ```
+  </Step>
+</Steps>
+
+## Flags that matter for this run
+
+Every flag below is documented in full in [Running evaluations](/core-concepts/running-evaluations); this table covers why each one is set the way it is *for this benchmark*.
+
+| Flag | Why |
+|---|---|
+| `--attempts 2` | Two independent rollouts per task; the report gains unbiased pass@1 and pass@2. Needs `--temperature > 0` or the attempts are identical. |
+| `--sandbox-concurrency 12` | The terminus2 harness caps itself at 4 concurrent sandboxes by default; this lifts the cap. 12 is a comfortable level for Modal and most providers. |
+| `--max-tokens 4096` | Terminus-2 rejects any response over 16384 tokens outright ("NONE of the actions were performed"), and weaker models ramble past it. Capping generation keeps every turn usable. |
+| `--temperature 0.7` | Sampling diversity for pass@k. Drop to 0.2 for a more deterministic single-attempt run. |
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title='"Harbor tasks require Docker — Docker CLI not found"'>
+    The preflight check ran against a local-Docker assumption. Add `--sandbox-backend modal` to the command — it must be explicit on machines without Docker.
+  </Accordion>
+  <Accordion title='"Sandbox has already shut down" mid-rollout'>
+    The rollout outlived the sandbox. Raise `RLLM_MODAL_SANDBOX_TIMEOUT_S` (the full-run command above uses 5400 s) and re-run the affected tasks with `--task-indices`.
+  </Accordion>
+  <Accordion title="Snapshot builds report a failed env">
+    Re-run the same `rllm snapshot create` command with `--task-indices <idx>` for just the failed task — already-built environments are recorded and shared between groups, so nothing is rebuilt. Transient image-pull slowness is the usual cause.
+  </Accordion>
+  <Accordion title="Rewards are all 0.0 but rollouts look busy">
+    Open an episode JSON and check the model outputs. Empty `content` on every step means the provider/API key is broken (the agent sees blank replies); valid-looking commands with 0.0 rewards usually just mean the model isn't strong enough for the task — Terminal-Bench 2.0 is hard.
+  </Accordion>
+</AccordionGroup>
+
+## Cleanup
+
+Snapshots expire after their TTL (168 hours above) but the backend images linger until destroyed:
+
+```bash
+rllm snapshot destroy <group-id>     # delete the group + unreferenced images
+rllm snapshot renew <group-id>       # or extend the TTL instead
+```
+
+Eval sandboxes are terminated as each rollout finishes; a crashed run's leftovers are cleaned up by Modal when their lifetime lapses.

--- a/docs/core-concepts/running-evaluations.mdx
+++ b/docs/core-concepts/running-evaluations.mdx
@@ -151,6 +151,10 @@ These flags shape how the evaluation executes and what it leaves behind.
   How many tasks run in parallel. Lower it if you hit provider rate limits; raise it for throughput.
 </ParamField>
 
+<ParamField path="--attempts" type="int" default="1">
+  Independent rollouts per task. With `--attempts N` the results report unbiased pass@k for every k from 1 to N alongside per-rollout accuracy. Use a temperature above 0 so attempts actually differ.
+</ParamField>
+
 <ParamField path="--evaluator" type="string">
   Override the scorer for every task (a registry name or `module:class`). By default each benchmark brings its own.
 </ParamField>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -127,7 +127,8 @@
               "cookbooks/deepcoder",
               "cookbooks/finqa",
               "cookbooks/geo3k",
-              "cookbooks/solver_judge_flow"
+              "cookbooks/solver_judge_flow",
+              "cookbooks/terminal_bench"
             ]
           }
         ]

--- a/docs/guides/environment-variables.mdx
+++ b/docs/guides/environment-variables.mdx
@@ -16,6 +16,8 @@ Every one of these parses through the typed readers in `rllm/env.py` (`env_int` 
 | Environment variable | Default | What it controls |
 | -------------------- | ------- | ---------------- |
 | `RLLM_SNAPSHOT_TTL_HOURS` | `168.0` | Snapshot-registry trust horizon (hours) before eviction |
+| `RLLM_SNAPSHOT_BUILD_WORKERS` | `4` | Parallel environment builds in `rllm snapshot create` |
+| `RLLM_MODAL_SANDBOX_TIMEOUT_S` | `1800` | Modal sandbox lifetime; raise when a single rollout can outlive 30 minutes |
 | `RLLM_OPENAI_REQUEST_TIMEOUT_S` | `3600` | Per-request HTTP timeout for OpenAI-compatible rollout calls |
 | `RLLM_GATEWAY_HEALTH_TIMEOUT_S` | `30.0` | Wait for the gateway subprocess to report healthy |
 | `RLLM_TUNNEL_READY_TIMEOUT_S` | `30.0` | Wait for cloudflared to publish a public URL |

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -95,6 +95,7 @@ def _run_eval(
     use_snapshot: bool = True,
     warm_queue_size: int = 0,
     sampling_config=None,
+    attempts: int = 1,
 ):
     """Core eval logic, extracted for clean proxy lifecycle management."""
     from rllm.data import DatasetRegistry
@@ -398,6 +399,7 @@ def _run_eval(
             "agent": agent_name,
             "split": split,
             "timestamp": timestamp,
+            "attempts": attempts,
         }
     )
     episode_store = run_store if save_episodes else None
@@ -475,6 +477,7 @@ def _run_eval(
             on_episode_complete=on_episode_complete,
             evaluator=evaluator,
             sampling_params=(sampling_config.as_dict() if sampling_config is not None else None),
+            attempts=attempts,
         )
     )
 
@@ -493,6 +496,8 @@ def _run_eval(
         ("Accuracy", f"[{score_style}]{pct}[/]  [dim]({result.correct}/{result.total})[/]"),
         ("Errors", f"[{error_style}]{result.errors}[/]"),
     ]
+    for k, v in sorted(result.pass_at.items()):
+        res_rows.append((f"pass@{k}", f"[bold]{v * 100:.1f}%[/]"))
 
     # Display signal breakdown if any
     if result.signal_averages:
@@ -538,6 +543,7 @@ def _run_eval(
 @click.option("--model", default=None, help="Model name to evaluate. Defaults to configured model from 'rllm setup'.")
 @click.option("--split", default=None, help="Dataset split (default: from catalog eval_split).")
 @click.option("--concurrency", default=64, type=int, help="Number of parallel requests.")
+@click.option("--attempts", default=1, type=int, help="Independent rollouts per task; reports pass@k for k=1..N (default: 1).")
 @click.option("--max-examples", default=None, type=int, help="Limit number of examples (for dev/testing).")
 @click.option("--task-indices", default=None, type=str, help="Comma-separated task indices to evaluate (e.g., '0', '3,7,12', '0-9').")
 @click.option("--output", "output_path", default=None, help="Output file path for results JSON.")
@@ -577,6 +583,7 @@ def eval_cmd(
     model: str | None,
     split: str | None,
     concurrency: int,
+    attempts: int,
     max_examples: int | None,
     task_indices: str | None,
     output_path: str | None,
@@ -599,6 +606,8 @@ def eval_cmd(
         sampling_config = resolve_eval_sampling(sampling_params, temperature, top_p, max_tokens)
     except (ValueError, FileNotFoundError, TypeError) as e:
         fail(f"Invalid --sampling-params: {e}")
+    if attempts < 1:
+        fail("--attempts must be >= 1.")
     # Auto-detect UI logging: enable if user is logged in (has ui_api_key or RLLM_API_KEY)
     _ui_explicit = enable_ui is not None
     if enable_ui is None:
@@ -684,6 +693,7 @@ def eval_cmd(
             use_snapshot=use_snapshot,
             warm_queue_size=warm_queue_size,
             sampling_config=sampling_config,
+            attempts=attempts,
         )
     finally:
         if proxy_manager is not None:

--- a/rllm/cli/snapshot_cmd.py
+++ b/rllm/cli/snapshot_cmd.py
@@ -24,8 +24,11 @@ import click
 from rich.table import Table
 
 from rllm.cli._ui import console, fail, info_panel, not_found, parse_index_spec
+from rllm.env import env_int
 
-_MAX_BUILD_WORKERS = 4  # snapshot builds are network/IO-bound; a few in parallel is a real win
+# Snapshot builds are network/IO-bound; a few in parallel is a real win. Raise
+# the env var for large benchmarks (cloud builders absorb 10+ comfortably).
+_MAX_BUILD_WORKERS = env_int("RLLM_SNAPSHOT_BUILD_WORKERS", 4)
 
 # Build outcome → cell markup (status is carried as a plain code, styled only at render).
 _STATUS_MARKUP = {

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -180,11 +180,12 @@ def _resolve_backend(task: Task, sandbox_backend: str | None) -> str:
     return sandbox_backend or task.metadata.get("sandbox_backend") or "docker"
 
 
-def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, name: str | None = None) -> Sandbox:
+def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, name: str | None = None, **backend_kwargs) -> Sandbox:
     """Create a sandbox from a base ``image`` — no Dockerfile RUN replay.
 
     ``image`` defaults to the task's resolved base image; pass a snapshot
-    ref to boot from a pre-warmed environment instead.
+    ref to boot from a pre-warmed environment instead. ``backend_kwargs``
+    pass through to the backend constructor (e.g. Modal's ``timeout``).
     """
     from rllm.sandbox.sandboxed_flow import create_sandbox
 
@@ -192,7 +193,7 @@ def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, 
     if name is None:
         safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
         name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
-    return create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend))
+    return create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend), **backend_kwargs)
 
 
 def _replay_dockerfile(task: Task, sandbox: Sandbox, backend: str) -> None:

--- a/rllm/eval/results.py
+++ b/rllm/eval/results.py
@@ -12,13 +12,36 @@ from rllm import paths
 
 @dataclass
 class EvalItem:
-    """Result for a single evaluation example."""
+    """Result for a single rollout. ``idx`` is the task index; with multiple
+    attempts per task (pass@k) sibling rollouts share an ``idx`` and are told
+    apart by ``attempt``."""
 
     idx: int
     reward: float
     is_correct: bool
     error: str | None = None
     signals: dict[str, float] = field(default_factory=dict)
+    attempt: int = 0
+
+
+def _pass_at_k(per_task_counts: list[tuple[int, int]], k: int) -> float:
+    """Unbiased pass@k (Chen et al. 2021) over ``(n_attempts, n_correct)`` pairs.
+
+    Per task: ``1 - C(n-c, k)/C(n, k)``, the probability that a random size-k
+    subset of the n attempts contains at least one success. Tasks with fewer
+    than ``k`` attempts fall back to their empirical any-pass rate.
+    """
+    from math import comb
+
+    scores = []
+    for n, c in per_task_counts:
+        if n < k:
+            scores.append(1.0 if c > 0 else 0.0)
+        elif n - c < k:
+            scores.append(1.0)
+        else:
+            scores.append(1.0 - comb(n - c, k) / comb(n, k))
+    return sum(scores) / len(scores) if scores else 0.0
 
 
 @dataclass
@@ -35,15 +58,31 @@ class EvalResult:
     items: list[EvalItem] = field(default_factory=list)
     signal_averages: dict[str, float] = field(default_factory=dict)
     timestamp: str = ""
+    attempts: int = 1
+    pass_at: dict[int, float] = field(default_factory=dict)
 
     @classmethod
-    def from_items(cls, dataset_name: str, model: str, agent: str, items: list[EvalItem]) -> EvalResult:
-        """Create an EvalResult from a list of EvalItems."""
+    def from_items(cls, dataset_name: str, model: str, agent: str, items: list[EvalItem], attempts: int = 1) -> EvalResult:
+        """Create an EvalResult from a list of EvalItems.
+
+        ``score``/``correct``/``total`` are always per-rollout (with equal
+        attempts everywhere, ``score`` equals unbiased pass@1). When
+        ``attempts > 1``, ``pass_at[k]`` is additionally computed for
+        ``k = 1..attempts`` by grouping items on their task ``idx``.
+        """
         total = len(items)
         correct = sum(1 for item in items if item.is_correct)
         errors = sum(1 for item in items if item.error is not None)
         score = correct / total if total > 0 else 0.0
         timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+        pass_at: dict[int, float] = {}
+        if attempts > 1 and items:
+            by_task: dict[int, list[EvalItem]] = {}
+            for item in items:
+                by_task.setdefault(item.idx, []).append(item)
+            counts = [(len(group), sum(1 for i in group if i.is_correct)) for group in by_task.values()]
+            pass_at = {k: _pass_at_k(counts, k) for k in range(1, attempts + 1)}
 
         # Compute signal averages
         signal_sums: dict[str, float] = {}
@@ -54,7 +93,20 @@ class EvalResult:
                 signal_counts[name] = signal_counts.get(name, 0) + 1
         signal_averages = {name: signal_sums[name] / signal_counts[name] for name in signal_sums}
 
-        return cls(dataset_name=dataset_name, model=model, agent=agent, score=score, total=total, correct=correct, errors=errors, items=items, signal_averages=signal_averages, timestamp=timestamp)
+        return cls(
+            dataset_name=dataset_name,
+            model=model,
+            agent=agent,
+            score=score,
+            total=total,
+            correct=correct,
+            errors=errors,
+            items=items,
+            signal_averages=signal_averages,
+            timestamp=timestamp,
+            attempts=attempts,
+            pass_at=pass_at,
+        )
 
     def summary_table(self) -> str:
         """Format a human-readable summary table."""
@@ -65,6 +117,8 @@ class EvalResult:
             f"  Accuracy:  {pct} ({self.correct}/{self.total})",
             f"  Errors:    {self.errors}",
         ]
+        for k, v in sorted(self.pass_at.items()):
+            lines.append(f"  pass@{k}:    {v * 100:.1f}%")
         return "\n".join(lines)
 
     def save(self, path: str | None = None) -> str:
@@ -94,7 +148,9 @@ class EvalResult:
             "errors": self.errors,
             "timestamp": self.timestamp,
             "signal_averages": self.signal_averages,
-            "items": [{"idx": item.idx, "reward": item.reward, "is_correct": item.is_correct, "error": item.error, "signals": item.signals} for item in self.items],
+            "attempts": self.attempts,
+            "pass_at": {str(k): v for k, v in self.pass_at.items()},
+            "items": [{"idx": item.idx, "attempt": item.attempt, "reward": item.reward, "is_correct": item.is_correct, "error": item.error, "signals": item.signals} for item in self.items],
         }
 
         with open(path, "w", encoding="utf-8") as f:
@@ -108,7 +164,10 @@ class EvalResult:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
 
-        items = [EvalItem(idx=item["idx"], reward=item["reward"], is_correct=item["is_correct"], error=item.get("error"), signals=item.get("signals", {})) for item in data["items"]]
+        items = [
+            EvalItem(idx=item["idx"], reward=item["reward"], is_correct=item["is_correct"], error=item.get("error"), signals=item.get("signals", {}), attempt=item.get("attempt", 0))
+            for item in data["items"]
+        ]
 
         return cls(
             dataset_name=data["dataset_name"],
@@ -121,4 +180,6 @@ class EvalResult:
             items=items,
             signal_averages=data.get("signal_averages", {}),
             timestamp=data.get("timestamp", ""),
+            attempts=data.get("attempts", 1),
+            pass_at={int(k): v for k, v in data.get("pass_at", {}).items()},
         )

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -42,6 +42,7 @@ async def run_dataset(
     evaluator: Evaluator | None = None,
     gateway: GatewayManager | None = None,
     sampling_params: dict | None = None,
+    attempts: int = 1,
 ) -> tuple[EvalResult, list]:
     """Run a list of :class:`rllm.types.Task` objects through :class:`AgentFlowEngine`.
 
@@ -62,6 +63,10 @@ async def run_dataset(
         sampling_params: Resolved sampling params from the CLI, attached to each
             gateway session so the gateway enforces them on every LLM call. ``None``
             or empty → flows/harnesses keep their own params.
+        attempts: Independent rollouts per task (pass@k). Each task is expanded
+            into ``attempts`` adjacent copies; the engine numbers sibling rollouts
+            ``task_id:0..n-1`` (training's GRPO convention) and the EvalResult
+            groups them back by task to compute ``pass_at``.
 
     Returns ``(EvalResult, list[Episode])``.
     """
@@ -72,6 +77,13 @@ async def run_dataset(
     from rllm.engine.agentflow_engine import AgentFlowEngine
     from rllm.gateway.manager import EvalGatewayManager
     from rllm.gateway.tunnel import is_local_sandbox_backend
+
+    # pass@k: expand each task into `attempts` adjacent copies. Everything
+    # downstream (warm queue, engine, episode callbacks) sees one entry per
+    # rollout; only the EvalItem aggregation below folds attempts back onto
+    # their task index.
+    if attempts > 1:
+        tasks = [task for task in tasks for _ in range(attempts)]
 
     # Cap concurrency by the agent flow's hint, if any. The engine's
     # internal semaphore enforces this on the rollout side.
@@ -131,12 +143,14 @@ async def run_dataset(
             except Exception:
                 logger.exception("gateway.stop() raised; suppressing")
 
-    # Aggregate per-task EvalItems for the report.
+    # Aggregate per-rollout EvalItems for the report; with attempts > 1 the
+    # expanded index folds back to (task index, attempt).
     items: list[EvalItem] = []
     surviving_episodes: list = []
     for idx, episode in enumerate(episodes):
+        task_idx, attempt = divmod(idx, attempts) if attempts > 1 else (idx, 0)
         if episode is None:
-            items.append(EvalItem(idx=idx, reward=0.0, is_correct=False, error="missing episode"))
+            items.append(EvalItem(idx=task_idx, attempt=attempt, reward=0.0, is_correct=False, error="missing episode"))
             continue
 
         error_msg = None
@@ -160,7 +174,8 @@ async def run_dataset(
 
         items.append(
             EvalItem(
-                idx=idx,
+                idx=task_idx,
+                attempt=attempt,
                 reward=reward,
                 is_correct=bool(episode.is_correct),
                 signals=signals,
@@ -170,4 +185,4 @@ async def run_dataset(
         if error_msg is None:
             surviving_episodes.append(episode)
 
-    return (EvalResult.from_items(dataset_name, model, agent_name, items), surviving_episodes)
+    return (EvalResult.from_items(dataset_name, model, agent_name, items, attempts=attempts), surviving_episodes)

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -21,12 +21,18 @@ import tarfile
 import threading
 import weakref
 
+from rllm.env import env_int
 from rllm.sandbox.protocol import SnapshotNotFound
 
 logger = logging.getLogger(__name__)
 
-# Default sandbox timeout: 30 minutes (Modal default is 5 min).
-_DEFAULT_TIMEOUT = 30 * 60
+# Default sandbox lifetime: 30 minutes (Modal default is 5 min). Raise via the
+# env var for workloads whose single rollout can exceed it (e.g. long builds).
+_DEFAULT_TIMEOUT = env_int("RLLM_MODAL_SANDBOX_TIMEOUT_S", 30 * 60)
+
+# Modal caps an exec's total argv at 64 KiB (ARG_MAX); payloads above this go
+# through a chunked temp-file path instead of being inlined in the command.
+_B64_ARGV_LIMIT = 50_000
 
 # atexit-tracked sandboxes; terminated on process exit to avoid leaks.
 _LIVE_SANDBOXES: weakref.WeakSet = weakref.WeakSet()
@@ -152,11 +158,30 @@ class ModalSandbox:
             raise RuntimeError(f"Command failed (exit {exit_code}) in sandbox {self.name}: {command}\n{stderr[:500]}")
         return stdout
 
+    def _push_b64(self, b64: str, consume: str) -> None:
+        """Feed a base64 payload to ``consume`` (a shell command reading stdin).
+
+        Modal rejects execs whose argv exceeds 64 KiB, so a small payload is
+        inlined while a large one is appended to a sandbox temp file in
+        argv-sized chunks and streamed from there.
+        """
+        if len(b64) <= _B64_ARGV_LIMIT:
+            self._exec_unchecked(f"echo '{b64}' | {consume}")
+            return
+        import uuid as _uuid
+
+        tmp = f"/tmp/.rllm-b64-{_uuid.uuid4().hex[:8]}"
+        self._exec_unchecked(f": > {tmp}")
+        for i in range(0, len(b64), _B64_ARGV_LIMIT):
+            self._exec_unchecked(f"printf %s '{b64[i : i + _B64_ARGV_LIMIT]}' >> {tmp}")
+        # Brace group so the stdin redirect feeds the FIRST pipeline member
+        # (`cmd1 | cmd2 < f` would bind f to cmd2 and leave cmd1 blocked).
+        self._exec_unchecked(f"{{ {consume}; }} < {tmp}; rc=$?; rm -f {tmp}; exit $rc")
+
     def upload_file(self, local_path: str, remote_path: str) -> None:
         """Upload a single file into the Modal sandbox.
 
-        Uses ``cat`` via exec to write file contents since Modal's file
-        API is in alpha.
+        Uses exec to write file contents since Modal's file API is in alpha.
         """
         remote_dir = os.path.dirname(remote_path)
         if remote_dir:
@@ -169,7 +194,7 @@ class ModalSandbox:
         import base64
 
         b64 = base64.b64encode(content).decode("ascii")
-        self._exec_unchecked(f"echo '{b64}' | base64 -d > {remote_path}")
+        self._push_b64(b64, f"base64 -d > {remote_path}")
         logger.debug("Uploaded %s -> %s in sandbox %s", local_path, remote_path, self.name)
 
     def upload_dir(self, local_path: str, remote_path: str) -> None:
@@ -197,7 +222,7 @@ class ModalSandbox:
         # Write tar to sandbox and extract. --no-same-owner: don't restore the
         # host's uid/gid (root extraction would otherwise chown to nonexistent
         # ids and error); permissions are kept so executables stay +x.
-        self._exec_unchecked(f"echo '{b64}' | base64 -d | tar xzf - --no-same-owner -C {remote_parent}")
+        self._push_b64(b64, f"base64 -d | tar xzf - --no-same-owner -C {remote_parent}")
         logger.debug("Uploaded dir %s -> %s in sandbox %s", local_path, remote_path, self.name)
 
     def is_alive(self) -> bool:
@@ -297,18 +322,22 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     (stored as a diff from the base). A failed install fails the build — a
     snapshot keyed on the install must actually contain it.
     """
-    from rllm.eval._resolution import _create_base_sandbox, _replay_dockerfile
+    from rllm.eval._resolution import _create_base_sandbox, _dockerfile_run_commands, _replay_dockerfile
 
     if prior_ref and not force and _modal_ref_alive(prior_ref):
         logger.info("modal snapshot %s already live (%s) — reusing", key, prior_ref)
         return prior_ref
 
-    sb = _create_base_sandbox(task, "modal", name=f"{key}-build")
+    # Size the build sandbox's lifetime to the worst-case replay: each RUN is
+    # bounded at 900s (a step that hangs against a prebuilt image burns its
+    # full bound), plus the install bound and pull/capture slack. With the
+    # 30-min default, two hung steps killed the sandbox mid-build.
+    install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
+    build_timeout = max(_DEFAULT_TIMEOUT, 900 * len(_dockerfile_run_commands(task)) + install_budget + 600)
+    sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
     try:
         _replay_dockerfile(task, sb, "modal")
         if install_script:
-            from rllm.env import env_int
-
             sb.exec(install_script, timeout=env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900), user="root")
         image = sb._sandbox.snapshot_filesystem()  # noqa: SLF001 — modal.Image
         logger.info("modal snapshot built: %s -> %s", key, image.object_id)

--- a/tests/eval/test_results.py
+++ b/tests/eval/test_results.py
@@ -1,0 +1,37 @@
+"""pass@k aggregation in EvalResult (--attempts N)."""
+
+import math
+
+from rllm.eval.results import EvalItem, EvalResult, _pass_at_k
+
+
+def _items_for(per_task: list[list[bool]]) -> list[EvalItem]:
+    """One EvalItem per attempt; per_task[i][j] = attempt j of task i passed."""
+    return [EvalItem(idx=i, attempt=j, reward=float(ok), is_correct=ok) for i, attempts in enumerate(per_task) for j, ok in enumerate(attempts)]
+
+
+def test_pass_at_k_unbiased_estimator():
+    assert _pass_at_k([(2, 0)], 2) == 0.0
+    assert _pass_at_k([(2, 2)], 1) == 1.0
+    assert _pass_at_k([(2, 1)], 1) == 0.5  # 1 - C(1,1)/C(2,1)
+    assert _pass_at_k([(2, 1)], 2) == 1.0  # any size-2 subset contains the success
+    assert math.isclose(_pass_at_k([(4, 1)], 2), 0.5)  # 1 - C(3,2)/C(4,2)
+
+
+def test_from_items_groups_attempts_by_task_idx():
+    result = EvalResult.from_items("d", "m", "a", _items_for([[True, False], [False, False], [True, True]]), attempts=2)
+    assert math.isclose(result.pass_at[1], 0.5)  # (0.5 + 0 + 1) / 3
+    assert math.isclose(result.pass_at[2], 2 / 3)  # (1 + 0 + 1) / 3
+    assert math.isclose(result.score, 0.5)  # 3/6 rollouts; equals unbiased pass@1 at equal n
+
+
+def test_single_attempt_keeps_legacy_shape():
+    result = EvalResult.from_items("d", "m", "a", _items_for([[True], [False]]))
+    assert result.attempts == 1 and result.pass_at == {}
+
+
+def test_save_load_round_trips_pass_at(tmp_path):
+    result = EvalResult.from_items("d", "m", "a", _items_for([[True, False]]), attempts=2)
+    loaded = EvalResult.load(result.save(str(tmp_path / "r.json")))
+    assert loaded.attempts == 2 and loaded.pass_at == result.pass_at
+    assert [(i.idx, i.attempt) for i in loaded.items] == [(0, 0), (0, 1)]


### PR DESCRIPTION
## What

Two things, both shaken out by running a full Terminal-Bench-2.0 eval (89 tasks × 2 attempts, Terminus-2 harness on Modal snapshots, Qwen3.6-35B-A3B via tinker):

### 1. `rllm eval --attempts N` → pass@k

- Each task expands into N adjacent rollouts inside `run_dataset`; the engine already numbers duplicate task_ids `task_id:0..N-1` (training's GRPO convention), so no engine changes.
- Results gain `attempts` + `pass_at` (unbiased estimator, Chen et al. 2021) for k=1..N, in the CLI panel, `results.json`, and `summary_table`. `EvalItem` gains `attempt`; episode files auto-suffix `_0/_1`.
- `score` stays per-rollout accuracy (≡ unbiased pass@1 at equal n); `--attempts 1` is byte-identical to today's behavior.

### 2. Three Modal backend fixes

| Bug | Symptom | Fix |
|---|---|---|
| `upload_file`/`upload_dir` inline the whole base64 payload in exec argv | `ARG_MAX (65536 bytes)` failures **at the evaluator stage** for tasks with large `tests/` fixtures (8 TB2 tasks ship 0.3–11.5 MB), wasting the entire rollout | `_push_b64`: chunk-append to a sandbox temp file, then consume. Redirect is brace-grouped — `cmd1 \| cmd2 < f` binds `f` to `cmd2`, leaving `cmd1` blocked on stdin forever |
| Hardcoded 30-min sandbox lifetime | Long rollouts (e.g. `compile-compcert`) die mid-run with "Sandbox has already shut down" | `RLLM_MODAL_SANDBOX_TIMEOUT_S` env override; default unchanged |
| Snapshot build sandbox uses the same 30-min lifetime | A Dockerfile RUN step that hangs when replayed against a prebuilt image (bounded at 900s each) kills the build before the steps can time out | `build_modal_snapshot` sizes the build sandbox lifetime to the worst-case replay budget |

## Validation

- New `tests/eval/test_results.py` (estimator math, grouping, save/load round-trip, attempts=1 back-compat); `tests/eval` + `tests/cli` + `tests/sandbox` suites green (67 tests).
- E2E: full TB2.0 89×2 = 178 rollouts on Modal snapshots → **0 infra errors, pass@1 33.1%, pass@2 43.8%**. Chunked upload live-verified (11.5 MB fixture in-eval); `compile-compcert` solved in a 2319s rollout that the old lifetime made impossible.

## Repro note

`RLLM_MODAL_SANDBOX_TIMEOUT_S=5400 rllm eval harbor:terminal-bench@2.0 --agent terminus2 --sandbox-backend modal --attempts 2 --concurrency 12 --sandbox-concurrency 12 --max-tokens 4096 --temperature 0.7` (snapshots via `rllm snapshot create harbor:terminal-bench@2.0 --sandbox-backend modal --agent terminus2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)