### PR TITLE
feat(cookbooks): add swe-rl recipe (R2E-Gym → SWE-bench Verified)

### DIFF
--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -1,0 +1,122 @@
+# SWE-RL
+
+End-to-end agentic-RL recipe for software engineering: train on [rllm-swesmith](https://huggingface.co/datasets/kylemontgomery/swesmith-filtered) (filtered SWE-smith, ~4.7K bug-fix tasks across 105 Python repos), validate on [SWE-bench Verified](https://www.swebench.com/) (500 real GitHub issues). The agent harness is [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent); the base model is `Qwen/Qwen3.5-9B`.
+
+This cookbook deliberately ships **no custom AgentFlow and no custom evaluator** — it's a thin wrapper around primitives that already live in `rllm/`. The flow is `mini-swe-agent` running as a CLI inside per-task sandboxes, and the evaluator is each task's own `tests/test.sh`. Both `rllm-swesmith` and `harbor:swebench-verified` ship that verifier with the dataset.
+
+## Architecture
+
+```
+AgentTrainer.train()
+  │
+  ├── for each task: launch a sandbox (Docker / Daytona)
+  │       │
+  │       └── mini-swe-agent --yolo --task=<problem_statement>
+  │             │   (multi-turn shell loop; each LLM call → gateway)
+  │             │
+  │             └── rLLM gateway routes to the trainer-hosted policy,
+  │                  capturing the full trajectory (prompt + response
+  │                  tokens + sampling params per turn).
+  │
+  └── verifier: tests/test.sh inside the sandbox
+        │   pytest for rllm-swesmith;  SWE-bench harness for verified.
+        │
+        └── writes /logs/verifier/reward.txt  →  RL reward signal
+```
+
+The trainer never parses tool calls or model outputs directly. The agent harness owns the action loop; the gateway owns the trajectory; the in-sandbox verifier owns the reward. This is the same setup as `examples/harbor_swe/` — the cookbook packages it as a versioned, installable recipe.
+
+## Installation
+
+```bash
+uv pip install -e ".[tinker]"                       # rllm + tinker backend
+uv pip install --no-deps -e cookbooks/swe-rl        # this cookbook (registers prepare_data)
+```
+
+`mini-swe-agent` is installed automatically into each task sandbox on first run — no host-side install required.
+
+## Datasets
+
+```bash
+python cookbooks/swe-rl/prepare_data.py
+# or, faster smoke run:
+python cookbooks/swe-rl/prepare_data.py --train-limit 50 --val-limit 20
+```
+
+This pulls:
+
+| Dataset | Role | Source | Verifier |
+|---|---|---|---|
+| `rllm-swesmith` | train (~4.7K) | `kylemontgomery/swesmith-filtered` | in-sandbox pytest (`tests/test.sh`) |
+| `harbor:swebench-verified` | eval (500) | `princeton-nlp/SWE-bench_Verified` | official SWE-bench harness (F2P / P2P) |
+
+Both materialize as Harbor-format task directories (`task.toml`, `instruction.md`, `environment/Dockerfile`, `tests/test.sh`).
+
+## Training
+
+### Tinker (single-machine, LoRA)
+
+```bash
+bash cookbooks/swe-rl/train_tinker.sh
+```
+
+Defaults: Qwen/Qwen3.5-9B + LoRA rank 32, GRPO with compact filtering, 64 parallel Daytona sandboxes, async rollout/training. Override anything via Hydra:
+
+```bash
+bash cookbooks/swe-rl/train_tinker.sh \
+    model.name=Qwen/Qwen3-8B \
+    rllm.workflow.n_parallel_tasks=32 \
+    rllm.remote_runtime.harbor.environment_type=docker
+```
+
+### Verl (distributed GPU)
+
+```bash
+uv pip install -e ".[verl]"
+bash scripts/install_megatron.sh <cu128|cu129|...>
+bash cookbooks/swe-rl/train_verl.sh
+```
+
+vLLM rollouts + FSDP/Megatron training. Sandboxes still run mini-swe-agent — only the trainer hosting changes.
+
+## Evaluation (no training)
+
+```bash
+rllm eval harbor:swebench-verified \
+    --agent mini-swe-agent \
+    --model Qwen/Qwen3.5-9B \
+    --base-url http://localhost:8000/v1 \
+    --max-examples 20
+```
+
+Per-task results land in `~/.rllm/eval_results/`; aggregated resolve rate is printed at the end. `rllm view` opens the per-task trajectory UI.
+
+## Sandbox backend
+
+The harness runs inside one sandbox per task. Pick a backend via `rllm.remote_runtime.harbor.environment_type`:
+
+| Backend | Setup | Notes |
+|---|---|---|
+| `docker` | local | Fastest iteration; needs the Docker daemon and ~20 GB free disk. |
+| `daytona` | `DAYTONA_API_KEY` | Default for training — scales to thousands of parallel sandboxes. |
+| `modal` | `modal token new` | Per-task billing; good for one-shot eval. |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `prepare_data.py` | Pulls `rllm-swesmith` (train) and `harbor:swebench-verified` (eval) |
+| `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
+| `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Daytona sandboxes |
+| `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
+| `test.py` | Catalog wiring + harness import smoke tests |
+| `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |
+
+## Why no custom flow or evaluator?
+
+Other cookbooks in this repo (`finqa`, `math`, `deepcoder`, …) ship a custom AgentFlow because their workloads either fit in a single LLM turn or need bespoke tool wiring. SWE doesn't — the existing in-tree primitives already cover it:
+
+- **`rllm.harnesses.mini_swe_agent`** is the agent. It exposes the `mini-swe-agent` CLI as an rLLM harness (installs in-sandbox on first run; reads the gateway URL from the env; logs to `/tmp/mini-swe-agent.log`).
+- **Per-task `tests/test.sh`** is the evaluator. The sandbox-shell verifier kind (`rllm.eval.script_evaluator`) reads `/logs/verifier/reward.txt` and returns it as the RL reward. For `harbor:swebench-verified`, that script invokes the official SWE-bench harness; for `rllm-swesmith`, it runs pytest against the FAIL_TO_PASS suite.
+
+The only thing this cookbook adds on top is the recipe: dataset pairing, sampling/optimizer hyperparams, and the `mini-swe-agent` harness selection. Forking `train_tinker.sh` is the place to start customizing.

--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -1,15 +1,15 @@
 # SWE-RL
 
-End-to-end agentic-RL recipe for software engineering: train on [rllm-swesmith](https://huggingface.co/datasets/kylemontgomery/swesmith-filtered) (filtered SWE-smith, ~4.7K bug-fix tasks across 105 Python repos), validate on [SWE-bench Verified](https://www.swebench.com/) (500 real GitHub issues). The agent harness is [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent); the base model is `Qwen/Qwen3.5-9B`.
+End-to-end agentic-RL recipe for software engineering: train on [R2E-Gym](https://huggingface.co/datasets/R2E-Gym/R2E-Gym-Subset) (R2E-Gym Subset, 4,578 bug-fix tasks across 12 Python repos), validate on [SWE-bench Verified](https://www.swebench.com/) (500 real GitHub issues). The agent harness is [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent); the base model is `Qwen/Qwen3.5-9B`.
 
-This cookbook deliberately ships **no custom AgentFlow and no custom evaluator** — it's a thin wrapper around primitives that already live in `rllm/`. The flow is `mini-swe-agent` running as a CLI inside per-task sandboxes, and the evaluator is each task's own `tests/test.sh`. Both `rllm-swesmith` and `harbor:swebench-verified` ship that verifier with the dataset.
+This cookbook deliberately ships **no custom AgentFlow and no custom evaluator** — it's a thin wrapper around primitives that already live in `rllm/`. The flow is `mini-swe-agent` running as a CLI inside per-task sandboxes, and the evaluator is each task's own `tests/test.sh`. Both `r2egym` and `harbor:swebench-verified` ship that verifier with the dataset.
 
 ## Architecture
 
 ```
 AgentTrainer.train()
   │
-  ├── for each task: launch a sandbox (Docker / Daytona)
+  ├── for each task: launch a sandbox (Modal / Daytona / Docker)
   │       │
   │       └── mini-swe-agent --yolo --task=<problem_statement>
   │             │   (multi-turn shell loop; each LLM call → gateway)
@@ -19,7 +19,7 @@ AgentTrainer.train()
   │                  tokens + sampling params per turn).
   │
   └── verifier: tests/test.sh inside the sandbox
-        │   pytest for rllm-swesmith;  SWE-bench harness for verified.
+        │   run_tests.sh for r2egym;  SWE-bench harness for verified.
         │
         └── writes /logs/verifier/reward.txt  →  RL reward signal
 ```
@@ -47,7 +47,7 @@ This pulls:
 
 | Dataset | Role | Source | Verifier |
 |---|---|---|---|
-| `rllm-swesmith` | train (~4.7K) | `kylemontgomery/swesmith-filtered` | in-sandbox pytest (`tests/test.sh`) |
+| `r2egym` | train (4,578) | `R2E-Gym/R2E-Gym-Subset` | in-sandbox `run_tests.sh`, pytest-output equality (`tests/test.sh`) |
 | `harbor:swebench-verified` | eval (500) | `princeton-nlp/SWE-bench_Verified` | official SWE-bench harness (F2P / P2P) |
 
 Both materialize as Harbor-format task directories (`task.toml`, `instruction.md`, `environment/Dockerfile`, `tests/test.sh`).
@@ -60,13 +60,12 @@ Both materialize as Harbor-format task directories (`task.toml`, `instruction.md
 bash cookbooks/swe-rl/train_tinker.sh
 ```
 
-Defaults: Qwen/Qwen3.5-9B + LoRA rank 32, GRPO with compact filtering, 64 parallel Daytona sandboxes, async rollout/training. Override anything via Hydra:
+Defaults: Qwen/Qwen3.5-9B + LoRA rank 32, GRPO with compact filtering, 64 parallel Modal sandboxes, async rollout/training. Override anything via Hydra:
 
 ```bash
-bash cookbooks/swe-rl/train_tinker.sh \
+SWE_SANDBOX_BACKEND=docker bash cookbooks/swe-rl/train_tinker.sh \
     model.name=Qwen/Qwen3-8B \
-    rllm.workflow.n_parallel_tasks=32 \
-    rllm.remote_runtime.harbor.environment_type=docker
+    rllm.workflow.n_parallel_tasks=32
 ```
 
 ### Verl (distributed GPU)
@@ -93,21 +92,23 @@ Per-task results land in `~/.rllm/eval_results/`; aggregated resolve rate is pri
 
 ## Sandbox backend
 
-The harness runs inside one sandbox per task. Pick a backend via `rllm.remote_runtime.harbor.environment_type`:
+Training uses rLLM's own `SandboxedAgentFlow` path (`AgentFlowEngine`) — not the
+remote Harbor runtime. `mini-swe-agent` runs inside one sandbox per task, created
+by `SandboxTaskHooks`. Pick a backend via the `SWE_SANDBOX_BACKEND` env var:
 
 | Backend | Setup | Notes |
 |---|---|---|
+| `modal` | `pip install modal` + `modal token new` | Default for training — per-task billing, scales to many parallel sandboxes. |
+| `daytona` | `pip install daytona` + `DAYTONA_API_KEY` | Cloud sandboxes; scales to thousands in parallel. |
 | `docker` | local | Fastest iteration; needs the Docker daemon and ~20 GB free disk. |
-| `daytona` | `DAYTONA_API_KEY` | Default for training — scales to thousands of parallel sandboxes. |
-| `modal` | `modal token new` | Per-task billing; good for one-shot eval. |
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `prepare_data.py` | Pulls `rllm-swesmith` (train) and `harbor:swebench-verified` (eval) |
+| `prepare_data.py` | Pulls `r2egym` (train) and `harbor:swebench-verified` (eval) |
 | `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
-| `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Daytona sandboxes |
+| `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Modal sandboxes |
 | `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
 | `test.py` | Catalog wiring + harness import smoke tests |
 | `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |
@@ -117,6 +118,6 @@ The harness runs inside one sandbox per task. Pick a backend via `rllm.remote_ru
 Other cookbooks in this repo (`finqa`, `math`, `deepcoder`, …) ship a custom AgentFlow because their workloads either fit in a single LLM turn or need bespoke tool wiring. SWE doesn't — the existing in-tree primitives already cover it:
 
 - **`rllm.harnesses.mini_swe_agent`** is the agent. It exposes the `mini-swe-agent` CLI as an rLLM harness (installs in-sandbox on first run; reads the gateway URL from the env; logs to `/tmp/mini-swe-agent.log`).
-- **Per-task `tests/test.sh`** is the evaluator. The sandbox-shell verifier kind (`rllm.eval.script_evaluator`) reads `/logs/verifier/reward.txt` and returns it as the RL reward. For `harbor:swebench-verified`, that script invokes the official SWE-bench harness; for `rllm-swesmith`, it runs pytest against the FAIL_TO_PASS suite.
+- **Per-task `tests/test.sh`** is the evaluator. The sandbox-shell verifier kind (`rllm.eval.script_evaluator`) reads `/logs/verifier/reward.txt` and returns it as the RL reward. For `harbor:swebench-verified`, that script invokes the official SWE-bench harness; for `r2egym`, it runs the image's own `/testbed/run_tests.sh` and scores 1.0 iff the pytest output matches the row's expected output.
 
 The only thing this cookbook adds on top is the recipe: dataset pairing, sampling/optimizer hyperparams, and the `mini-swe-agent` harness selection. Forking `train_tinker.sh` is the place to start customizing.

--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -68,6 +68,14 @@ SWE_SANDBOX_BACKEND=docker bash cookbooks/swe-rl/train_tinker.sh \
     rllm.workflow.n_parallel_tasks=32
 ```
 
+For a simpler on-policy loop (generate a full batch, then one optimizer step — easier to debug), use the synchronous variant:
+
+```bash
+bash cookbooks/swe-rl/train_tinker_sync.sh
+```
+
+It drops `async_training` and uses a real `data.train_batch_size` (default 4; effective batch = `train_batch_size × group_size`).
+
 ### Verl (distributed GPU)
 
 ```bash
@@ -109,6 +117,7 @@ by `SandboxTaskHooks`. Pick a backend via the `SWE_SANDBOX_BACKEND` env var:
 | `prepare_data.py` | Pulls `r2egym` (train) and `harbor:swebench-verified` (eval) |
 | `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
 | `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Modal sandboxes |
+| `train_tinker_sync.sh` | Tinker backend — synchronous (on-policy) variant, simpler for testing |
 | `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
 | `test.py` | Catalog wiring + harness import smoke tests |
 | `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |

--- a/cookbooks/swe-rl/prepare_data.py
+++ b/cookbooks/swe-rl/prepare_data.py
@@ -2,9 +2,10 @@
 
 Both are sandbox-format benchmarks (per-task ``environment/Dockerfile`` +
 ``tests/test.sh`` verifier). The training set is rLLM's native
-``rllm-swesmith`` (filtered SWE-smith, ~4.7K bug-fix tasks across 105
-Python repos). The eval set is ``harbor:swebench-verified`` (500
-real-world GitHub issues, evaluated against the official SWE-bench
+``r2egym`` (R2E-Gym Subset, 4,578 bug-fix tasks across 12 Python repos,
+each shipped as a per-instance Docker image graded by the image's own
+``/testbed/run_tests.sh``). The eval set is ``harbor:swebench-verified``
+(500 real-world GitHub issues, evaluated against the official SWE-bench
 harness inside the sandbox).
 
 This script is a thin wrapper around ``rllm dataset pull`` so the
@@ -24,7 +25,7 @@ import argparse
 import subprocess
 import sys
 
-TRAIN_DATASET = "rllm-swesmith"
+TRAIN_DATASET = "r2egym"
 VAL_DATASET = "harbor:swebench-verified"
 
 
@@ -42,7 +43,7 @@ def main() -> None:
         "--train-limit",
         type=int,
         default=None,
-        help="Cap training tasks (default: full ~4.7K). Useful for smoke runs.",
+        help="Cap training tasks (default: full ~4.6K). Useful for smoke runs.",
     )
     ap.add_argument(
         "--val-limit",

--- a/cookbooks/swe-rl/prepare_data.py
+++ b/cookbooks/swe-rl/prepare_data.py
@@ -1,0 +1,65 @@
+"""Pull the train + eval datasets for the swe-rl cookbook.
+
+Both are sandbox-format benchmarks (per-task ``environment/Dockerfile`` +
+``tests/test.sh`` verifier). The training set is rLLM's native
+``rllm-swesmith`` (filtered SWE-smith, ~4.7K bug-fix tasks across 105
+Python repos). The eval set is ``harbor:swebench-verified`` (500
+real-world GitHub issues, evaluated against the official SWE-bench
+harness inside the sandbox).
+
+This script is a thin wrapper around ``rllm dataset pull`` so the
+cookbook can be used end-to-end with a single command. Re-runs are
+no-ops once the on-disk benchmark directory exists.
+
+Usage::
+
+    python cookbooks/swe-rl/prepare_data.py
+    # or, smoke run with a small training cap (rebuilds the benchmark dir):
+    python cookbooks/swe-rl/prepare_data.py --train-limit 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+TRAIN_DATASET = "rllm-swesmith"
+VAL_DATASET = "harbor:swebench-verified"
+
+
+def _pull(name: str, limit: int | None = None) -> None:
+    cmd = [sys.executable, "-m", "rllm.cli.main", "dataset", "pull", name]
+    if limit is not None:
+        cmd += ["--limit", str(limit)]
+    print(f"[swe-rl] $ {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--train-limit",
+        type=int,
+        default=None,
+        help="Cap training tasks (default: full ~4.7K). Useful for smoke runs.",
+    )
+    ap.add_argument(
+        "--val-limit",
+        type=int,
+        default=None,
+        help="Cap eval tasks (default: full 500).",
+    )
+    args = ap.parse_args()
+
+    _pull(TRAIN_DATASET, limit=args.train_limit)
+    _pull(VAL_DATASET, limit=args.val_limit)
+
+    print(
+        f"\n[swe-rl] Done. Train: {TRAIN_DATASET}   Eval: {VAL_DATASET}\n        Run `bash cookbooks/swe-rl/train_tinker.sh` to train.",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/swe-rl/pyproject.toml
+++ b/cookbooks/swe-rl/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "swe-rl"
+version = "0.1.0"
+description = "End-to-end SWE-RL recipe: train on rllm-swesmith, eval on SWE-bench Verified"
+requires-python = ">=3.10"
+dependencies = ["rllm"]
+
+[tool.setuptools]
+py-modules = ["prepare_data"]

--- a/cookbooks/swe-rl/pyproject.toml
+++ b/cookbooks/swe-rl/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "swe-rl"
 version = "0.1.0"
-description = "End-to-end SWE-RL recipe: train on rllm-swesmith, eval on SWE-bench Verified"
+description = "End-to-end SWE-RL recipe: train on R2E-Gym, eval on SWE-bench Verified"
 requires-python = ">=3.10"
 dependencies = ["rllm"]
 

--- a/cookbooks/swe-rl/test.py
+++ b/cookbooks/swe-rl/test.py
@@ -1,0 +1,67 @@
+"""Smoke tests for the swe-rl cookbook.
+
+These tests don't boot sandboxes, run agents, or train. They only
+verify the wiring: the dataset names resolve in the catalog, the
+``mini-swe-agent`` harness is importable, and ``train.py`` can be
+imported without side effects.
+
+Run::
+
+    pytest cookbooks/swe-rl/test.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+# -- Dataset catalog entries --------------------------------------------------
+
+
+def _load_catalog() -> dict:
+    registry_path = Path(__file__).resolve().parents[2] / "rllm" / "registry" / "datasets.json"
+    return json.loads(registry_path.read_text())
+
+
+def test_train_dataset_in_catalog():
+    """rllm-swesmith must be registered as a sandbox dataset using mini-swe-agent."""
+    catalog = _load_catalog()
+    entry = catalog["datasets"]["rllm-swesmith"]
+    assert entry["category"] == "agentic"
+    assert entry["default_agent"] == "mini-swe-agent"
+    assert "train" in entry["splits"]
+
+
+def test_val_dataset_resolvable():
+    """SWE-bench Verified must be reachable either as the native row dataset
+    (``swebench_verified``) or as the Harbor sandbox dataset
+    (``harbor:swebench-verified``)."""
+    catalog = _load_catalog()
+    assert "swebench_verified" in catalog["datasets"], "native swebench_verified entry missing from registry"
+
+
+# -- Harness wiring -----------------------------------------------------------
+
+
+def test_mini_swe_agent_harness_importable():
+    """``mini-swe-agent`` is the harness this cookbook drives; it must import."""
+    mod = importlib.import_module("rllm.harnesses.mini_swe_agent")
+    assert hasattr(mod, "MiniSweAgentHarness")
+    assert mod.MiniSweAgentHarness.name == "mini-swe-agent"
+
+
+# -- Train script -------------------------------------------------------------
+
+
+def test_train_module_imports():
+    """``train.py`` must be importable without triggering Hydra or starting training."""
+    import sys
+
+    script_dir = Path(__file__).resolve().parent
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))
+    mod = importlib.import_module("train")
+    assert mod.TRAIN_DATASET == "rllm-swesmith"
+    assert mod.VAL_DATASET == "swebench-verified"
+    assert callable(mod.main)

--- a/cookbooks/swe-rl/test.py
+++ b/cookbooks/swe-rl/test.py
@@ -25,10 +25,10 @@ def _load_catalog() -> dict:
 
 
 def test_train_dataset_in_catalog():
-    """rllm-swesmith must be registered as a sandbox dataset using mini-swe-agent."""
+    """r2egym must be registered as a sandbox dataset using mini-swe-agent."""
     catalog = _load_catalog()
-    entry = catalog["datasets"]["rllm-swesmith"]
-    assert entry["category"] == "agentic"
+    entry = catalog["datasets"]["r2egym"]
+    assert entry["category"] == "code"
     assert entry["default_agent"] == "mini-swe-agent"
     assert "train" in entry["splits"]
 
@@ -62,6 +62,6 @@ def test_train_module_imports():
     if str(script_dir) not in sys.path:
         sys.path.insert(0, str(script_dir))
     mod = importlib.import_module("train")
-    assert mod.TRAIN_DATASET == "rllm-swesmith"
+    assert mod.TRAIN_DATASET == "r2egym"
     assert mod.VAL_DATASET == "swebench-verified"
     assert callable(mod.main)

--- a/cookbooks/swe-rl/train.py
+++ b/cookbooks/swe-rl/train.py
@@ -1,52 +1,86 @@
-"""Train an SWE agent on rllm-swesmith, validate on SWE-bench Verified.
+"""Train an SWE agent on R2E-Gym, validate on SWE-bench Verified.
 
 This cookbook deliberately ships no custom AgentFlow or evaluator:
 
-* The **agent** is the in-tree ``mini-swe-agent`` harness — a CLI scaffold
-  installed inside each task's sandbox. The rLLM gateway intercepts every
-  LLM call, so the trainer sees full trajectories without the harness
-  knowing it's being trained.
-* The **evaluator** is each task's own ``tests/test.sh`` (sandbox-shell
-  verifier) — pytest for rllm-swesmith, the SWE-bench harness for the
-  Verified split. The verifier writes a reward to
-  ``/logs/verifier/reward.txt`` and rLLM reads it back.
+* The **agent** is the in-tree ``mini-swe-agent`` harness
+  (:class:`rllm.harnesses.mini_swe_agent.MiniSweAgentHarness`) — a
+  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow` that installs the
+  ``mini-swe-agent`` CLI inside each task's sandbox. The rLLM gateway
+  intercepts every LLM call, so the trainer sees full trajectories without
+  the harness knowing it's being trained.
+* The **evaluator** is each task's own verifier (sandbox-shell), resolved
+  per-task by :class:`rllm.hooks.SandboxTaskHooks`. For r2egym it runs the
+  image's own ``/testbed/run_tests.sh`` and checks pytest-output equality
+  against the row's expected output; for the Verified split it runs the
+  task's bundled ``tests/test.sh``. The verifier writes a reward that rLLM
+  reads back.
 
-So ``train.py`` only wires the two datasets into :class:`AgentTrainer`;
-everything else is configured by Hydra overrides on the command line
-(see ``train_tinker.sh`` / ``train_verl.sh`` for working defaults).
+Because we pass an ``agent_flow`` (and no explicit ``evaluator``/``hooks``),
+:class:`AgentTrainer` runs the **rLLM-native SandboxedAgentFlow path**
+(``AgentFlowEngine``) — sandboxes are created locally by ``SandboxTaskHooks``
+via a pluggable ``sandbox_backend`` (``docker`` | ``local`` | ``modal`` |
+``daytona``). This is NOT the remote-runtime / ``RemoteAgentFlowEngine`` path.
+
+The sandbox backend is selected by the ``SWE_SANDBOX_BACKEND`` env var
+(default ``modal``). For ``modal`` install ``pip install modal`` and run
+``modal token new``; for ``daytona`` install ``pip install daytona`` and set
+``DAYTONA_API_KEY``. Everything else is configured by Hydra overrides on the
+command line (see ``train_tinker.sh`` / ``train_verl.sh`` for working defaults).
 
 Usage (from rllm repo root)::
 
-    python cookbooks/swe-rl/train.py rllm/backend=tinker
+    SWE_SANDBOX_BACKEND=modal python cookbooks/swe-rl/train.py rllm/backend=tinker
 """
 
 from __future__ import annotations
+
+import os
 
 import hydra
 from omegaconf import DictConfig
 
 from rllm.data.dataset import DatasetRegistry
+from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
 from rllm.trainer import AgentTrainer
 
-TRAIN_DATASET = "rllm-swesmith"
+TRAIN_DATASET = "r2egym"
 VAL_DATASET = "swebench-verified"
+
+# Sandbox backend for the SandboxedAgentFlow path: docker | local | modal | daytona.
+SANDBOX_BACKEND = os.environ.get("SWE_SANDBOX_BACKEND", "modal")
+
+# Optional cap on the validation set size. SWE-bench Verified is 500 tasks;
+# validation runs ALL of them every time it fires, which is slow. Set
+# SWE_VAL_MAX=N to validate on the first N tasks instead (0/unset = all 500).
+SWE_VAL_MAX = int(os.environ.get("SWE_VAL_MAX", "0"))
 
 
 @hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
 def main(config: DictConfig) -> None:
     train_dataset = DatasetRegistry.load_dataset(TRAIN_DATASET, "train")
-    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "test")
+    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "default")
 
     if train_dataset is None:
         raise RuntimeError(f"Dataset '{TRAIN_DATASET}' not found. Run: rllm dataset pull {TRAIN_DATASET} (or: python cookbooks/swe-rl/prepare_data.py)")
     if val_dataset is None:
         raise RuntimeError(f"Dataset '{VAL_DATASET}' not found. Run: rllm dataset pull harbor:swebench-verified (or: python cookbooks/swe-rl/prepare_data.py)")
 
+    if SWE_VAL_MAX > 0 and SWE_VAL_MAX < len(val_dataset):
+        val_dataset = val_dataset.select(range(SWE_VAL_MAX))
+
+    # mini-swe-agent as a SandboxedAgentFlow. Passing ``agent_flow`` (with no
+    # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
+    # for the sandbox lifecycle + per-task verifier, and route rollouts through
+    # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
+    agent_flow = MiniSweAgentHarness(sandbox_backend=SANDBOX_BACKEND)
+
     trainer = AgentTrainer(
         backend=config.rllm.get("backend", "tinker"),
         config=config,
         train_dataset=train_dataset,
         val_dataset=val_dataset,
+        agent_flow=agent_flow,
+        sandbox_backend=SANDBOX_BACKEND,
     )
     trainer.train()
 

--- a/cookbooks/swe-rl/train.py
+++ b/cookbooks/swe-rl/train.py
@@ -2,10 +2,10 @@
 
 This cookbook deliberately ships no custom AgentFlow or evaluator:
 
-* The **agent** is the in-tree ``mini-swe-agent`` harness
-  (:class:`rllm.harnesses.mini_swe_agent.MiniSweAgentHarness`) — a
-  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow` that installs the
-  ``mini-swe-agent`` CLI inside each task's sandbox. The rLLM gateway
+* The **agent** is the in-tree ``terminus2`` harness
+  (:class:`rllm.harnesses.terminus2.Terminus2Harness`) — a
+  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow` that runs the
+  terminus2 CLI agent inside each task's sandbox. The rLLM gateway
   intercepts every LLM call, so the trainer sees full trajectories without
   the harness knowing it's being trained.
 * The **evaluator** is each task's own verifier (sandbox-shell), resolved
@@ -40,7 +40,7 @@ import hydra
 from omegaconf import DictConfig
 
 from rllm.data.dataset import DatasetRegistry
-from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
+from rllm.harnesses.terminus2 import Terminus2Harness
 from rllm.trainer import AgentTrainer
 
 TRAIN_DATASET = "r2egym"
@@ -68,11 +68,11 @@ def main(config: DictConfig) -> None:
     if SWE_VAL_MAX > 0 and SWE_VAL_MAX < len(val_dataset):
         val_dataset = val_dataset.select(range(SWE_VAL_MAX))
 
-    # mini-swe-agent as a SandboxedAgentFlow. Passing ``agent_flow`` (with no
+    # terminus2 as a SandboxedAgentFlow. Passing ``agent_flow`` (with no
     # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
     # for the sandbox lifecycle + per-task verifier, and route rollouts through
     # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
-    agent_flow = MiniSweAgentHarness(sandbox_backend=SANDBOX_BACKEND)
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
 
     trainer = AgentTrainer(
         backend=config.rllm.get("backend", "tinker"),

--- a/cookbooks/swe-rl/train.py
+++ b/cookbooks/swe-rl/train.py
@@ -1,0 +1,55 @@
+"""Train an SWE agent on rllm-swesmith, validate on SWE-bench Verified.
+
+This cookbook deliberately ships no custom AgentFlow or evaluator:
+
+* The **agent** is the in-tree ``mini-swe-agent`` harness — a CLI scaffold
+  installed inside each task's sandbox. The rLLM gateway intercepts every
+  LLM call, so the trainer sees full trajectories without the harness
+  knowing it's being trained.
+* The **evaluator** is each task's own ``tests/test.sh`` (sandbox-shell
+  verifier) — pytest for rllm-swesmith, the SWE-bench harness for the
+  Verified split. The verifier writes a reward to
+  ``/logs/verifier/reward.txt`` and rLLM reads it back.
+
+So ``train.py`` only wires the two datasets into :class:`AgentTrainer`;
+everything else is configured by Hydra overrides on the command line
+(see ``train_tinker.sh`` / ``train_verl.sh`` for working defaults).
+
+Usage (from rllm repo root)::
+
+    python cookbooks/swe-rl/train.py rllm/backend=tinker
+"""
+
+from __future__ import annotations
+
+import hydra
+from omegaconf import DictConfig
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.trainer import AgentTrainer
+
+TRAIN_DATASET = "rllm-swesmith"
+VAL_DATASET = "swebench-verified"
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config: DictConfig) -> None:
+    train_dataset = DatasetRegistry.load_dataset(TRAIN_DATASET, "train")
+    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "test")
+
+    if train_dataset is None:
+        raise RuntimeError(f"Dataset '{TRAIN_DATASET}' not found. Run: rllm dataset pull {TRAIN_DATASET} (or: python cookbooks/swe-rl/prepare_data.py)")
+    if val_dataset is None:
+        raise RuntimeError(f"Dataset '{VAL_DATASET}' not found. Run: rllm dataset pull harbor:swebench-verified (or: python cookbooks/swe-rl/prepare_data.py)")
+
+    trainer = AgentTrainer(
+        backend=config.rllm.get("backend", "tinker"),
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Train an SWE agent on rllm-swesmith, eval on SWE-bench Verified.
+#
+# Prerequisites:
+#   1. Install rllm with tinker extras:   uv pip install -e ".[tinker]"
+#   2. Install this cookbook:              uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                  python cookbooks/swe-rl/prepare_data.py
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 64 tasks rolled out in parallel; each rollout boots a Daytona sandbox
+#     and runs mini-swe-agent against it. The gateway routes every LLM call
+#     back to the trainer-hosted model.
+#   - 32K prompt window, 8K response budget per turn (mini-swe-agent runs
+#     many turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker.sh model.name=Qwen/Qwen3-8B training.group_size=4
+
+set -euo pipefail
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=32768 \
+    sampling.train.temperature=1.0 \
+    sampling.train.top_p=1.0 \
+    sampling.val.temperature=0.7 \
+    sampling.val.top_p=0.8 \
+    data.max_prompt_length=32768 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.remote_runtime.enabled=true \
+    rllm.remote_runtime.backend=harbor \
+    rllm.remote_runtime.harbor.agent=mini-swe-agent \
+    rllm.remote_runtime.harbor.environment_type=daytona \
+    rllm.remote_runtime.session_timeout=1800.0 \
+    rllm.gateway.port=9090 \
+    rllm.gateway.public_url=null \
+    rllm.gateway.sampling_params_priority=session \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='swesmith-mini-swe-agent-qwen3.5-9b' \
+    rllm.trainer.val_before_train=true \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=-1 \
+    "$@"

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -9,10 +9,10 @@
 # What this configures, in plain English:
 #   - Async GRPO with compact filtering (drop too-long rollouts before grad).
 #   - 64 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
-#     own SandboxedAgentFlow path, AgentFlowEngine) and runs mini-swe-agent
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2
 #     against it. The gateway routes every LLM call back to the trainer-hosted
 #     model. This is NOT the remote-runtime / RemoteAgentFlowEngine path.
-#   - 32K prompt window, 8K response budget per turn (mini-swe-agent runs
+#   - 32K prompt window, 8K response budget per turn (terminus2 runs
 #     many turns; the per-turn cap keeps the optimizer batch shape sane).
 #
 # Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
@@ -30,7 +30,7 @@ export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \
     rllm/backend=tinker \
-    model.name=Qwen/Qwen3.5-9B \
+    model.name=Qwen/Qwen3.5-4B \
     model.lora_rank=32 \
     training.group_size=8 \
     training.learning_rate=2e-5 \
@@ -55,12 +55,12 @@ python -u train.py \
     rllm.workflow.n_parallel_tasks=64 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
-    rllm.gateway.cumulative_token_mode=false \
+    rllm.gateway.cumulative_token_mode=true \
     rllm.gateway.renderer_family=qwen3.5 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \
     rllm.trainer.project_name='swe-rl' \
-    rllm.trainer.experiment_name='r2egym-mini-swe-agent-qwen3.5-9b' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3.5-4b' \
     rllm.trainer.val_before_train=false \
     rllm.trainer.test_freq=10 \
     rllm.trainer.save_freq=10 \

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -55,7 +55,7 @@ python -u train.py \
     rllm.workflow.n_parallel_tasks=64 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
-    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.cumulative_token_mode=false \
     rllm.gateway.renderer_family=qwen3.5 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Train an SWE agent on rllm-swesmith, eval on SWE-bench Verified.
+# Train an SWE agent on R2E-Gym, eval on SWE-bench Verified.
 #
 # Prerequisites:
 #   1. Install rllm with tinker extras:   uv pip install -e ".[tinker]"
@@ -8,16 +8,25 @@
 #
 # What this configures, in plain English:
 #   - Async GRPO with compact filtering (drop too-long rollouts before grad).
-#   - 64 tasks rolled out in parallel; each rollout boots a Daytona sandbox
-#     and runs mini-swe-agent against it. The gateway routes every LLM call
-#     back to the trainer-hosted model.
+#   - 64 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs mini-swe-agent
+#     against it. The gateway routes every LLM call back to the trainer-hosted
+#     model. This is NOT the remote-runtime / RemoteAgentFlowEngine path.
 #   - 32K prompt window, 8K response budget per turn (mini-swe-agent runs
 #     many turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
 #
 # Override anything by passing extra Hydra args after the script:
 #   bash train_tinker.sh model.name=Qwen/Qwen3-8B training.group_size=4
 
 set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \
     rllm/backend=tinker \
@@ -28,8 +37,8 @@ python -u train.py \
     training.max_length=32768 \
     rllm.rollout.train.temperature=1.0 \
     rllm.rollout.train.top_p=1.0 \
-    rllm.rollout.val.temperature=0.7 \
-    rllm.rollout.val.top_p=0.8 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
     data.max_prompt_length=32768 \
     data.max_response_length=8192 \
     data.train_batch_size=1 \
@@ -44,17 +53,13 @@ python -u train.py \
     rllm.async_training.trigger_parameter_sync_step=1 \
     rllm.async_training.partial_rollout=true \
     rllm.workflow.n_parallel_tasks=64 \
-    rllm.remote_runtime.enabled=true \
-    rllm.remote_runtime.backend=harbor \
-    rllm.remote_runtime.harbor.agent=mini-swe-agent \
-    rllm.remote_runtime.harbor.environment_type=daytona \
-    rllm.remote_runtime.session_timeout=1800.0 \
+    rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \
     rllm.trainer.project_name='swe-rl' \
-    rllm.trainer.experiment_name='swesmith-mini-swe-agent-qwen3.5-9b' \
-    rllm.trainer.val_before_train=true \
+    rllm.trainer.experiment_name='r2egym-mini-swe-agent-qwen3.5-9b' \
+    rllm.trainer.val_before_train=false \
     rllm.trainer.test_freq=10 \
     rllm.trainer.save_freq=-1 \
     "$@"

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -34,12 +34,12 @@ python -u train.py \
     model.lora_rank=32 \
     training.group_size=8 \
     training.learning_rate=2e-5 \
-    training.max_length=32768 \
+    training.max_length=65536 \
     rllm.rollout.train.temperature=1.0 \
     rllm.rollout.train.top_p=1.0 \
     rllm.rollout.val.temperature=1.0 \
     rllm.rollout.val.top_p=1.0 \
-    data.max_prompt_length=32768 \
+    data.max_prompt_length=57344 \
     data.max_response_length=8192 \
     data.train_batch_size=1 \
     data.val_batch_size=-1 \
@@ -55,11 +55,13 @@ python -u train.py \
     rllm.workflow.n_parallel_tasks=64 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \
     rllm.trainer.project_name='swe-rl' \
     rllm.trainer.experiment_name='r2egym-mini-swe-agent-qwen3.5-9b' \
     rllm.trainer.val_before_train=false \
     rllm.trainer.test_freq=10 \
-    rllm.trainer.save_freq=-1 \
+    rllm.trainer.save_freq=10 \
     "$@"

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -52,7 +52,7 @@ python -u train.py \
     rllm.async_training.staleness_threshold=0.5 \
     rllm.async_training.trigger_parameter_sync_step=1 \
     rllm.async_training.partial_rollout=true \
-    rllm.workflow.n_parallel_tasks=64 \
+    rllm.workflow.n_parallel_tasks=128 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
     rllm.gateway.cumulative_token_mode=true \

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -26,10 +26,10 @@ python -u train.py \
     training.group_size=8 \
     training.learning_rate=2e-5 \
     training.max_length=32768 \
-    sampling.train.temperature=1.0 \
-    sampling.train.top_p=1.0 \
-    sampling.val.temperature=0.7 \
-    sampling.val.top_p=0.8 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=0.7 \
+    rllm.rollout.val.top_p=0.8 \
     data.max_prompt_length=32768 \
     data.max_response_length=8192 \
     data.train_batch_size=1 \
@@ -50,8 +50,6 @@ python -u train.py \
     rllm.remote_runtime.harbor.environment_type=daytona \
     rllm.remote_runtime.session_timeout=1800.0 \
     rllm.gateway.port=9090 \
-    rllm.gateway.public_url=null \
-    rllm.gateway.sampling_params_priority=session \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \
     rllm.trainer.project_name='swe-rl' \

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -37,7 +37,7 @@ python -u train.py \
     rllm.rollout.val.top_p=1.0 \
     data.max_prompt_length=57344 \
     data.max_response_length=8192 \
-    data.train_batch_size=4 \
+    data.train_batch_size=16 \
     data.val_batch_size=-1 \
     rllm.compact_filtering.enable=true \
     rllm.algorithm.adv_estimator=grpo \
@@ -45,7 +45,7 @@ python -u train.py \
     rllm.workflow.n_parallel_tasks=64 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
-    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.cumulative_token_mode=false \
     rllm.gateway.renderer_family=qwen3.5 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the tinker backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_tinker.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous tinker recipe other cookbooks use (e.g. deepcoder).
+#
+# Differences from train_tinker.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Sandbox backend: SWE_SANDBOX_BACKEND (docker | local | modal | daytona; default
+# modal). Cap the eval set with SWE_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=4 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-mini-swe-agent-qwen3.5-9b-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -42,7 +42,7 @@ python -u train.py \
     rllm.compact_filtering.enable=true \
     rllm.algorithm.adv_estimator=grpo \
     rllm.algorithm.norm_adv_by_std_in_grpo=true \
-    rllm.workflow.n_parallel_tasks=64 \
+    rllm.workflow.n_parallel_tasks=128 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
     rllm.gateway.cumulative_token_mode=true \

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -26,7 +26,7 @@ export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \
     rllm/backend=tinker \
-    model.name=Qwen/Qwen3.5-9B \
+    model.name=Qwen/Qwen3.5-4B \
     model.lora_rank=32 \
     training.group_size=8 \
     training.learning_rate=2e-5 \
@@ -45,12 +45,12 @@ python -u train.py \
     rllm.workflow.n_parallel_tasks=64 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
-    rllm.gateway.cumulative_token_mode=false \
+    rllm.gateway.cumulative_token_mode=true \
     rllm.gateway.renderer_family=qwen3.5 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \
     rllm.trainer.project_name='swe-rl' \
-    rllm.trainer.experiment_name='r2egym-mini-swe-agent-qwen3.5-9b-sync' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3.5-4b-sync' \
     rllm.trainer.val_before_train=false \
     rllm.trainer.test_freq=10 \
     rllm.trainer.save_freq=10 \

--- a/cookbooks/swe-rl/train_verl.sh
+++ b/cookbooks/swe-rl/train_verl.sh
@@ -24,7 +24,7 @@ unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
-MODEL_PATH=Qwen/Qwen3.5-9B
+MODEL_PATH=Qwen/Qwen3.5-4B
 
 python -u train.py \
     rllm/backend=verl \
@@ -69,7 +69,7 @@ python -u train.py \
     rllm.gateway.port=9090 \
     trainer.logger="['console','wandb']" \
     trainer.project_name=swe-rl \
-    trainer.experiment_name=r2egym-mini-swe-agent-qwen3.5-9b-verl \
+    trainer.experiment_name=r2egym-terminus2-qwen3.5-4b-verl \
     trainer.val_before_train=true \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \

--- a/cookbooks/swe-rl/train_verl.sh
+++ b/cookbooks/swe-rl/train_verl.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Train an SWE agent on rllm-swesmith with the verl (distributed) backend.
+#
+# Prerequisites:
+#   1. Install rllm with verl extras:     uv pip install -e ".[verl]"
+#   2. Install megatron:                   bash scripts/install_megatron.sh <cu128|cu129|...>
+#   3. Install this cookbook:              uv pip install --no-deps -e cookbooks/swe-rl
+#   4. Pull the datasets:                  python cookbooks/swe-rl/prepare_data.py
+#
+# Verl runs vLLM rollouts + FSDP/Megatron training across N GPUs. Mini-swe-agent
+# still executes inside per-task sandboxes (Daytona by default); only the policy
+# rollout traffic flows through the gateway back to the verl-hosted vLLM engine.
+
+set -euo pipefail
+
+unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
+
+MODEL_PATH=Qwen/Qwen3.5-9B
+
+python -u train.py \
+    rllm/backend=verl \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.algorithm.use_rllm=true \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    data.max_prompt_length=32768 \
+    data.max_response_length=8192 \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    +actor_rollout_ref.model.lora.rank=32 \
+    +actor_rollout_ref.model.lora.alpha=32 \
+    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=40960 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    +actor_rollout_ref.rollout.max_model_len=40960 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.7 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.remote_runtime.enabled=true \
+    rllm.remote_runtime.backend=harbor \
+    rllm.remote_runtime.harbor.agent=mini-swe-agent \
+    rllm.remote_runtime.harbor.environment_type=daytona \
+    rllm.remote_runtime.session_timeout=1800.0 \
+    rllm.gateway.port=9090 \
+    trainer.logger="['console','wandb']" \
+    trainer.project_name=swe-rl \
+    trainer.experiment_name=swesmith-mini-swe-agent-qwen3.5-9b-verl \
+    trainer.val_before_train=true \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    "$@"

--- a/cookbooks/swe-rl/train_verl.sh
+++ b/cookbooks/swe-rl/train_verl.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Train an SWE agent on rllm-swesmith with the verl (distributed) backend.
+# Train an SWE agent on R2E-Gym with the verl (distributed) backend.
 #
 # Prerequisites:
 #   1. Install rllm with verl extras:     uv pip install -e ".[verl]"
@@ -8,12 +8,21 @@
 #   4. Pull the datasets:                  python cookbooks/swe-rl/prepare_data.py
 #
 # Verl runs vLLM rollouts + FSDP/Megatron training across N GPUs. Mini-swe-agent
-# still executes inside per-task sandboxes (Daytona by default); only the policy
-# rollout traffic flows through the gateway back to the verl-hosted vLLM engine.
+# still executes inside per-task sandboxes via rLLM's own SandboxedAgentFlow path
+# (AgentFlowEngine, not the remote Harbor runtime); only the policy rollout
+# traffic flows through the gateway back to the verl-hosted vLLM engine.
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
 
 set -euo pipefail
 
 unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 MODEL_PATH=Qwen/Qwen3.5-9B
 
@@ -56,15 +65,11 @@ python -u train.py \
     actor_rollout_ref.rollout.val_kwargs.do_sample=True \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
     rllm.workflow.n_parallel_tasks=64 \
-    rllm.remote_runtime.enabled=true \
-    rllm.remote_runtime.backend=harbor \
-    rllm.remote_runtime.harbor.agent=mini-swe-agent \
-    rllm.remote_runtime.harbor.environment_type=daytona \
-    rllm.remote_runtime.session_timeout=1800.0 \
+    rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
     trainer.logger="['console','wandb']" \
     trainer.project_name=swe-rl \
-    trainer.experiment_name=swesmith-mini-swe-agent-qwen3.5-9b-verl \
+    trainer.experiment_name=r2egym-mini-swe-agent-qwen3.5-9b-verl \
     trainer.val_before_train=true \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \

--- a/rllm/data/utils.py
+++ b/rllm/data/utils.py
@@ -16,12 +16,28 @@ def task_from_row(row: dict[str, Any], task_id: str) -> Task:
 
     Shared by the engine (per-task at rollout) and the sandbox warm-pool
     schedule so both derive the same ``env_key`` for a given row.
+
+    Harbor-sourced rows (r2egym, swebench-verified, swesmith, …) carry a
+    ``task_path`` pointing at the per-task directory. Root the Task there and
+    merge its ``task.toml`` + ``environment/Dockerfile`` metadata so per-task
+    verifier resolution and per-task image selection work on the sandbox path
+    — mirroring the eval CLI's ``_dict_rows_to_tasks``. Rows without
+    ``task_path`` keep ``dataset_dir=Path(".")`` and rely on a fixed evaluator.
     """
+    task_path = row.get("task_path")
+    metadata: dict[str, Any] = dict(row)
+    if task_path:
+        from rllm.tasks.loader import _merge_task_toml_metadata
+
+        dataset_dir = Path(task_path)
+        metadata = _merge_task_toml_metadata(dataset_dir, metadata)
+    else:
+        dataset_dir = Path(".")
     return Task(
         id=str(task_id),
         instruction=str(row.get("question", row.get("instruction", ""))),
-        metadata=row,
-        dataset_dir=Path("."),
+        metadata=metadata,
+        dataset_dir=dataset_dir,
     )
 
 

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -17,6 +17,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from rllm.engine.rollout.tinker_engine import TinkerEngine
+from rllm.workflows import TerminationEvent, TerminationReason
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,33 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         if tools:
             kwargs["tools"] = tools
 
-        model_output = await engine.get_model_response(messages, **kwargs)
+        try:
+            model_output = await engine.get_model_response(messages, **kwargs)
+        except TerminationEvent as e:
+            # The engine signals an unrecoverable per-call limit (e.g. the
+            # prompt crossed max_prompt_length). For CLI harnesses the agent
+            # loop runs inside the sandbox, so the ONLY way to stop it is the
+            # HTTP response — propagating this as a 500 makes the harness's
+            # LLM client retry the (still-too-long) call until the harness
+            # run-timeout SIGKILLs it, stalling the whole group. Instead,
+            # return the OpenAI-standard ``context_length_exceeded`` 400:
+            # litellm/openai SDKs map it to a NON-retryable
+            # ContextWindowExceededError, so the in-sandbox agent raises and
+            # the rollout returns immediately with the turns so far.
+            from fastapi import HTTPException
+
+            is_prompt_limit = e.reason == TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": f"Rollout terminated: {e.reason}. The conversation exceeded the model's prompt window.",
+                        "type": "invalid_request_error",
+                        "code": "context_length_exceeded" if is_prompt_limit else "rollout_terminated",
+                        "param": "messages",
+                    }
+                },
+            ) from e
 
         response_text = model_output.content or model_output.text or ""
         prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else []

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -42,6 +42,32 @@ def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
     return result
 
 
+def _termination_http_error(reason: TerminationReason) -> Exception:
+    """Map a ``TerminationEvent`` to a non-retryable OpenAI-style 400.
+
+    For CLI harnesses the agent loop runs inside the sandbox, so the only way
+    to stop it is the HTTP response — a 500 makes the LLM client retry the
+    (still-too-long) call until the harness run-timeout SIGKILLs it, stalling
+    the whole group. ``context_length_exceeded`` maps to a NON-retryable
+    ContextWindowExceededError in litellm/openai SDKs, so the agent raises and
+    the rollout returns immediately with the turns so far.
+    """
+    from fastapi import HTTPException
+
+    is_prompt_limit = reason == TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED
+    return HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": f"Rollout terminated: {reason}. The conversation exceeded the model's prompt window.",
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded" if is_prompt_limit else "rollout_terminated",
+                "param": "messages",
+            }
+        },
+    )
+
+
 async def _token_prompt_completion(
     engine: TinkerEngine,
     request_body: dict[str, Any],
@@ -123,7 +149,10 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         # path the HTTP backend uses for the same feature.
         prompt = request_body.get("prompt")
         if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
-            return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+            try:
+                return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+            except TerminationEvent as e:
+                raise _termination_http_error(e.reason) from e
 
         messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
@@ -134,30 +163,7 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         try:
             model_output = await engine.get_model_response(messages, **kwargs)
         except TerminationEvent as e:
-            # The engine signals an unrecoverable per-call limit (e.g. the
-            # prompt crossed max_prompt_length). For CLI harnesses the agent
-            # loop runs inside the sandbox, so the ONLY way to stop it is the
-            # HTTP response — propagating this as a 500 makes the harness's
-            # LLM client retry the (still-too-long) call until the harness
-            # run-timeout SIGKILLs it, stalling the whole group. Instead,
-            # return the OpenAI-standard ``context_length_exceeded`` 400:
-            # litellm/openai SDKs map it to a NON-retryable
-            # ContextWindowExceededError, so the in-sandbox agent raises and
-            # the rollout returns immediately with the turns so far.
-            from fastapi import HTTPException
-
-            is_prompt_limit = e.reason == TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": {
-                        "message": f"Rollout terminated: {e.reason}. The conversation exceeded the model's prompt window.",
-                        "type": "invalid_request_error",
-                        "code": "context_length_exceeded" if is_prompt_limit else "rollout_terminated",
-                        "param": "messages",
-                    }
-                },
-            ) from e
+            raise _termination_http_error(e.reason) from e
 
         response_text = model_output.content or model_output.text or ""
         prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else []

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -58,7 +58,25 @@ if ! command -v mini-swe-agent >/dev/null 2>&1; then
         fi
     fi
     if ! command -v uv >/dev/null 2>&1; then
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+        # Sandbox->GitHub egress (astral.sh redirects to
+        # release-assets.githubusercontent.com) intermittently resets the
+        # connection on cloud backends (Modal/Daytona). Without a retry a
+        # single ``curl: (35/56) Connection reset by peer`` aborts the whole
+        # install under ``set -e`` and the rollout scores 0. Retry a few times
+        # with backoff before giving up.
+        uv_installed=0
+        for attempt in 1 2 3 4 5; do
+            if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+                uv_installed=1
+                break
+            fi
+            echo "uv install attempt ${attempt} failed; retrying in $((attempt * 3))s" >&2
+            sleep $((attempt * 3))
+        done
+        if [ "$uv_installed" -ne 1 ]; then
+            echo "uv install failed after 5 attempts" >&2
+            exit 1
+        fi
     fi
     export PATH="$HOME/.local/bin:$PATH"
     # Pin a modern interpreter for the tool's ISOLATED venv. mini-swe-agent


### PR DESCRIPTION
## Summary

End-to-end agentic-RL recipe in `cookbooks/swe-rl/`: train an SWE agent on **R2E-Gym** (4,578 bug-fix tasks) and validate on **SWE-bench Verified** (500 real GitHub issues). Ships **no custom AgentFlow or evaluator** — it wires in-tree primitives:

- **Agent** = `rllm.harnesses.terminus2.Terminus2Harness`, a `SandboxedAgentFlow` that runs the agent CLI inside each task's sandbox; the rLLM gateway captures every LLM call.
- **Evaluator** = each task's own `tests/test.sh` (sandbox-shell verifier), resolved per-task by `SandboxTaskHooks` (`run_tests.sh` pytest-equality for r2egym; SWE-bench harness for Verified).

`train.py` passes the harness as `agent_flow` to `AgentTrainer`, which runs the **rLLM-native `SandboxedAgentFlow` path (`AgentFlowEngine`)** — not the remote-runtime path. Sandboxes are created locally by `SandboxTaskHooks` with a pluggable backend (`SWE_SANDBOX_BACKEND`, default `modal`).

Default recipe: **Qwen/Qwen3.5-4B** + LoRA-32, GRPO + compact filtering.

> Targets `terminal-rl` (depends on the R2E-Gym dataset PR #654 and the cumulative-token-mode PR #658, both merged there).

## What's included

**Cookbook**
- `train.py` — loads r2egym/swebench-verified, passes `Terminus2Harness` as `agent_flow`. `SWE_SANDBOX_BACKEND` + `SWE_VAL_MAX` env knobs.
- `train_tinker.sh` — async GRPO (single-machine LoRA).
- `train_tinker_sync.sh` — synchronous (on-policy) variant, simpler for debugging.
- `train_verl.sh` — distributed vLLM + FSDP recipe.
- `prepare_data.py`, `README.md`, `test.py`, `pyproject.toml`.

**Supporting rLLM fixes (needed for the training path)**
- `rllm/data/utils.py`: `task_from_row` roots the `Task` at the row's `task_path` and merges `task.toml`/Dockerfile metadata — so per-task verifier + image resolution work on the **training** path (fixes "No verifier configured").
- `rllm/gateway/tinker_adapter.py`: translate `TerminationEvent` → non-retryable `400 context_length_exceeded` so an over-length in-sandbox agent stops immediately instead of retrying until the run-timeout SIGKILL (which was stalling async group completion).
- `rllm/harnesses/mini_swe_agent.py`: retry the in-sandbox `uv` install (flaky Modal→GitHub egress).

## Test plan

- [x] `pytest cookbooks/swe-rl/test.py` → passing (catalog wiring, harness import, train.py import).
- [x] `bash -n` on all three train scripts.
- [x] Live Modal run on the SandboxedAgentFlow path: sandbox → agent → per-task verifier → reward, with rollouts completing and rewards computed.
- [x] Full multi-step training run on Qwen3.5-4B + terminus2 (in progress).

## Notes
- `cumulative_token_mode` is enabled in the tinker scripts (`renderer_family=qwen3.5`); it's a no-op for harnesses/turns the renderer's bridge can't extend, so it only helps where applicable.
- Eval of self-hosted models that emit tool calls in a non-standard format needs the matching tool-call parser at the **serving** layer (e.g. vLLM `--tool-call-parser`); the eval proxy is a transparent forwarder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)