### PR TITLE
fix(sandbox): [environment].replay_dockerfile toggle + fix RUN-continuation mangling

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -196,15 +196,37 @@ def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, 
     return create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend), **backend_kwargs)
 
 
+def _should_replay_dockerfile(task: Task) -> bool:
+    """Whether to replay the Dockerfile's ``RUN`` steps on non-docker backends.
+
+    Two task conventions are supported via ``[environment].replay_dockerfile``:
+
+    * **SWE-bench style** (default, ``true``): the configured ``docker_image``
+      is a *base*; the Dockerfile's ``RUN`` steps (e.g. ``uv``, needed by the
+      grader) are not in that image and must be replayed on top.
+    * **Terminal-bench / Harbor style** (``false``): the configured
+      ``docker_image`` is the *fully built* task image, so replaying its ``RUN``
+      steps double-applies the build (``git clone ... already exists``, missing
+      ``COPY``'d files, etc.). These tasks set
+      ``[environment]\nreplay_dockerfile = false`` to boot the image as-is.
+    """
+    env = task.metadata.get("environment", {}) or {}
+    return bool(env.get("replay_dockerfile", True))
+
+
 def _replay_dockerfile(task: Task, sandbox: Sandbox, backend: str) -> None:
     """Replay the Dockerfile RUN steps on a live sandbox (stage C).
 
     Non-docker backends pull the Dockerfile's FROM base instead of building
     it, so the RUN steps (e.g. swebench's ``uv``, needed by the grader) must
     be replayed. Best-effort: a failed step shouldn't abort the task. Docker
-    builds the image, so its RUN steps already ran — skip.
+    builds the image, so its RUN steps already ran — skip. Tasks that boot a
+    fully-built image opt out via ``[environment].replay_dockerfile = false``
+    (see :func:`_should_replay_dockerfile`).
     """
     if backend == "docker":
+        return
+    if not _should_replay_dockerfile(task):
         return
     for cmd in _dockerfile_run_commands(task):
         _safe_exec(sandbox, cmd, timeout=900)
@@ -249,9 +271,13 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
 
 
 def _dockerfile_run_commands(task: Task) -> list[str]:
-    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps (joining
-    ``\\``-continuations). Non-``RUN`` directives — ``COPY``/``ADD`` etc. — are
-    skipped; only ``RUN`` is replayable on a live sandbox.
+    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps.
+
+    ``\\``-continuations are joined into a single logical command with a space
+    (matching shell line-continuation semantics) so multi-line ``RUN`` steps
+    stay valid when re-executed via ``bash -c``. Non-``RUN`` directives —
+    ``COPY``/``ADD`` etc. — are skipped; only ``RUN`` is replayable on a live
+    sandbox.
     """
     dockerfile = task.task_dir / "environment" / "Dockerfile"
     if not dockerfile.exists():
@@ -275,7 +301,7 @@ def _dockerfile_run_commands(task: Task) -> list[str]:
                 if i >= len(lines):
                     break
                 parts.append(lines[i])
-            cmd = "\n".join(parts).strip()
+            cmd = " ".join(part.strip() for part in parts).strip()
             if cmd:
                 commands.append(cmd)
         i += 1

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -349,9 +349,7 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
     img = Image.base(_resolve_image(task, "daytona"))
     # Honor [environment].replay_dockerfile: fully-built task images opt out so
     # their RUN steps aren't double-applied on top of the prebuilt image.
-    run_commands = (
-        [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
-    )
+    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
     if install_script:
         run_commands.append(_as_single_run_line(install_script))
     if run_commands:

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -327,7 +327,13 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
     """
     from daytona import CreateSnapshotParams, Daytona, DaytonaNotFoundError, Image, Resources
 
-    from rllm.eval._resolution import _as_single_run_line, _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
+    from rllm.eval._resolution import (
+        _as_single_run_line,
+        _dockerfile_run_commands,
+        _resolve_image,
+        _sandbox_resource_kwargs,
+        _should_replay_dockerfile,
+    )
 
     client = Daytona()
     try:
@@ -341,7 +347,11 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
         pass
 
     img = Image.base(_resolve_image(task, "daytona"))
-    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)]
+    # Honor [environment].replay_dockerfile: fully-built task images opt out so
+    # their RUN steps aren't double-applied on top of the prebuilt image.
+    run_commands = (
+        [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
+    )
     if install_script:
         run_commands.append(_as_single_run_line(install_script))
     if run_commands:

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -322,7 +322,12 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     (stored as a diff from the base). A failed install fails the build — a
     snapshot keyed on the install must actually contain it.
     """
-    from rllm.eval._resolution import _create_base_sandbox, _dockerfile_run_commands, _replay_dockerfile
+    from rllm.eval._resolution import (
+        _create_base_sandbox,
+        _dockerfile_run_commands,
+        _replay_dockerfile,
+        _should_replay_dockerfile,
+    )
 
     if prior_ref and not force and _modal_ref_alive(prior_ref):
         logger.info("modal snapshot %s already live (%s) — reusing", key, prior_ref)
@@ -333,7 +338,8 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     # full bound), plus the install bound and pull/capture slack. With the
     # 30-min default, two hung steps killed the sandbox mid-build.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
-    build_timeout = max(_DEFAULT_TIMEOUT, 900 * len(_dockerfile_run_commands(task)) + install_budget + 600)
+    n_replay = len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0
+    build_timeout = max(_DEFAULT_TIMEOUT, 900 * n_replay + install_budget + 600)
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
     try:
         _replay_dockerfile(task, sb, "modal")

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -70,9 +70,10 @@ def env_key(backend: str, base_image: str, run_commands: list[str], install_scri
 
 def env_key_for(task: Task, backend: str, install_script: str = "") -> str:
     """Fingerprint a task's environment via the shared image/RUN resolution."""
-    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image
+    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _should_replay_dockerfile
 
-    return env_key(backend, _resolve_image(task, backend), _dockerfile_run_commands(task), install_script)
+    run_commands = _dockerfile_run_commands(task) if _should_replay_dockerfile(task) else []
+    return env_key(backend, _resolve_image(task, backend), run_commands, install_script)
 
 
 def install_script_for(agent_flow: object) -> str:

--- a/tests/eval/test_dockerfile_replay.py
+++ b/tests/eval/test_dockerfile_replay.py
@@ -1,0 +1,92 @@
+"""Tests for Dockerfile RUN-replay handling in :mod:`rllm.eval._resolution`.
+
+Covers two fixes:
+
+* ``_dockerfile_run_commands`` joins ``\\``-continuations into a single valid
+  shell command (so multi-line ``RUN`` steps don't become invalid ``bash``).
+* ``_should_replay_dockerfile`` honors ``[environment].replay_dockerfile``:
+  default ``True`` (SWE-bench: replay RUN steps on a base image), ``False`` for
+  fully-built terminal-bench/Harbor images (boot as-is, no double-apply).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rllm.eval._resolution import _dockerfile_run_commands, _should_replay_dockerfile
+from rllm.tasks.loader import _load_task_from_dir
+from rllm.types import Task
+
+
+def _task_with_dockerfile(tmp_path: Path, dockerfile: str, metadata: dict | None = None) -> Task:
+    env = tmp_path / "environment"
+    env.mkdir(parents=True, exist_ok=True)
+    (env / "Dockerfile").write_text(dockerfile)
+    return Task(id="t", instruction="", metadata=metadata or {}, dataset_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _dockerfile_run_commands: continuation join + COPY skipping
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_run_joins_with_space_not_newline(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\n"
+        "RUN apt-get update && apt-get install -y \\\n"
+        "    python3-pip \\\n"
+        "    && rm -rf /var/lib/apt/lists/*\n",
+    )
+    cmds = _dockerfile_run_commands(task)
+    assert cmds == ["apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*"]
+    # The old bug joined with "\n", which bash rejects ("syntax error near '&&'").
+    assert "\n" not in cmds[0]
+
+
+def test_copy_directives_are_skipped(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\n"
+        "COPY input_files/data.json /app/data.json\n"
+        "RUN echo hi\n"
+        "ADD x.tar /app/\n",
+    )
+    assert _dockerfile_run_commands(task) == ["echo hi"]
+
+
+def test_single_line_run_unchanged(tmp_path):
+    task = _task_with_dockerfile(tmp_path, "FROM ubuntu:24.04\nRUN pip3 install ansible-core==2.16.3\n")
+    assert _dockerfile_run_commands(task) == ["pip3 install ansible-core==2.16.3"]
+
+
+# ---------------------------------------------------------------------------
+# _should_replay_dockerfile: the [environment].replay_dockerfile toggle
+# ---------------------------------------------------------------------------
+
+
+def test_replay_defaults_true_when_unset():
+    assert _should_replay_dockerfile(Task(id="t", instruction="", metadata={}, dataset_dir=Path("."))) is True
+    task = Task(id="t", instruction="", metadata={"environment": {"docker_image": "base"}}, dataset_dir=Path("."))
+    assert _should_replay_dockerfile(task) is True
+
+
+def test_replay_disabled_when_flag_false():
+    task = Task(
+        id="t",
+        instruction="",
+        metadata={"environment": {"docker_image": "prebuilt", "replay_dockerfile": False}},
+        dataset_dir=Path("."),
+    )
+    assert _should_replay_dockerfile(task) is False
+
+
+def test_replay_flag_read_from_task_toml(tmp_path):
+    """End-to-end: [environment].replay_dockerfile in task.toml reaches metadata."""
+    (tmp_path / "environment").mkdir()
+    (tmp_path / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\nRUN echo hi\n")
+    (tmp_path / "task.toml").write_text(
+        '[environment]\ndocker_image = "org/img:t"\nreplay_dockerfile = false\n'
+    )
+    task = _load_task_from_dir(tmp_path, dataset_dir=tmp_path)
+    assert _should_replay_dockerfile(task) is False

--- a/tests/eval/test_dockerfile_replay.py
+++ b/tests/eval/test_dockerfile_replay.py
@@ -33,10 +33,7 @@ def _task_with_dockerfile(tmp_path: Path, dockerfile: str, metadata: dict | None
 def test_multiline_run_joins_with_space_not_newline(tmp_path):
     task = _task_with_dockerfile(
         tmp_path,
-        "FROM ubuntu:24.04\n"
-        "RUN apt-get update && apt-get install -y \\\n"
-        "    python3-pip \\\n"
-        "    && rm -rf /var/lib/apt/lists/*\n",
+        "FROM ubuntu:24.04\nRUN apt-get update && apt-get install -y \\\n    python3-pip \\\n    && rm -rf /var/lib/apt/lists/*\n",
     )
     cmds = _dockerfile_run_commands(task)
     assert cmds == ["apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*"]
@@ -47,10 +44,7 @@ def test_multiline_run_joins_with_space_not_newline(tmp_path):
 def test_copy_directives_are_skipped(tmp_path):
     task = _task_with_dockerfile(
         tmp_path,
-        "FROM ubuntu:24.04\n"
-        "COPY input_files/data.json /app/data.json\n"
-        "RUN echo hi\n"
-        "ADD x.tar /app/\n",
+        "FROM ubuntu:24.04\nCOPY input_files/data.json /app/data.json\nRUN echo hi\nADD x.tar /app/\n",
     )
     assert _dockerfile_run_commands(task) == ["echo hi"]
 
@@ -85,8 +79,6 @@ def test_replay_flag_read_from_task_toml(tmp_path):
     """End-to-end: [environment].replay_dockerfile in task.toml reaches metadata."""
     (tmp_path / "environment").mkdir()
     (tmp_path / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\nRUN echo hi\n")
-    (tmp_path / "task.toml").write_text(
-        '[environment]\ndocker_image = "org/img:t"\nreplay_dockerfile = false\n'
-    )
+    (tmp_path / "task.toml").write_text('[environment]\ndocker_image = "org/img:t"\nreplay_dockerfile = false\n')
     task = _load_task_from_dir(tmp_path, dataset_dir=tmp_path)
     assert _should_replay_dockerfile(task) is False


### PR DESCRIPTION
## Summary

Fixes #655. On non-docker backends (`modal`/`daytona`), rLLM replays a task's `environment/Dockerfile` `RUN` steps on top of the booted image. That path has two defects this PR addresses.

### 1. Continuation mangling (bug)

`_dockerfile_run_commands` stripped the trailing `\` from continued `RUN` lines and rejoined them with `\n`, turning one logical shell command into invalid multi-line input. Re-exec'd via `bash -c` it fails with:

```
bash: -c: line 2: syntax error near unexpected token `&&'
```

Now joined with a single space (matching shell line-continuation semantics).

### 2. Double-apply on prebuilt images (the terminal-bench case)

The replay assumes the configured `docker_image` is a *base* that still needs the `RUN` steps (SWE-bench convention: pull base, replay `uv` install, etc.). Terminal-bench / Harbor tasks instead boot a *fully-built* per-task image, so replaying the `RUN` steps re-runs the build → `git clone ... already exists`, `No such file` for `COPY`'d/`rm`'d files, redundant `apt-get`, …

This PR adds an opt-out, **`[environment].replay_dockerfile`**:

- `true` (**default**) — unchanged SWE-bench behavior (replay `RUN` on a base image).
- `false` — boot the prebuilt image as-is, no replay.

Honored consistently across: the resolution cold path (`_replay_dockerfile`), the daytona snapshot build, the modal snapshot build (+ its build-timeout sizing), and the snapshot env-key fingerprint.

```toml
# task.toml — terminal-bench / Harbor style (fully-built image)
[environment]
docker_image = "org/optimbench-tb:my-task"
replay_dockerfile = false
```

## Tests

`tests/eval/test_dockerfile_replay.py` — continuation join, `COPY` skipping, single-line passthrough, default-`true`, flag-`false`, and the `task.toml` → metadata path. All green.

## Notes

- `--sandbox-backend docker` was already correct (native build, no replay) and is unaffected.
- Default stays `true`, so SWE-bench and other base-image tasks are unchanged; terminal-bench tasks opt in by adding `replay_dockerfile = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
