### PR TITLE
fix(config): preserve ui_api_key on model swap

### DIFF
--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -440,17 +440,30 @@ def save_config(config: RllmConfig) -> str:
     Creates parent directories as needed and sets file permissions to 0o600
     (owner read/write only) since the file contains API keys.
 
+    Merges into any existing file so unrelated keys (e.g. ``ui_api_key``
+    written by ``rllm login``) survive provider/model changes instead of
+    being clobbered.
+
     Returns the path that was written.
     """
     path = _config_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    data: dict[str, object] = {
-        "provider": config.provider,
-        "model": config.model,
-        "api_keys": dict(config.api_keys),
-    }
+    data: dict[str, object] = {}
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                data = loaded
+        except (json.JSONDecodeError, OSError):
+            data = {}
+    data["provider"] = config.provider
+    data["model"] = config.model
+    data["api_keys"] = dict(config.api_keys)
     if config.base_url:
         data["base_url"] = config.base_url
+    else:
+        data.pop("base_url", None)
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")

--- a/tests/eval/test_eval_config.py
+++ b/tests/eval/test_eval_config.py
@@ -148,6 +148,20 @@ class TestLoadSaveConfig:
             data = json.load(f)
         assert "base_url" not in data
 
+    def test_save_preserves_unrelated_keys(self, tmp_rllm_home):
+        """save_config must not clobber keys it doesn't own (e.g. ui_api_key from `rllm login`)."""
+        config_path = os.path.join(tmp_rllm_home, "config.json")
+        os.makedirs(tmp_rllm_home, exist_ok=True)
+        with open(config_path, "w") as f:
+            json.dump({"provider": "openai", "api_keys": {"openai": "k1"}, "model": "m1", "ui_api_key": "rllm_abc"}, f)
+        # A provider/model swap should leave the UI token intact.
+        save_config(RllmConfig(provider="tinker", api_keys={"tinker": "tml-xyz"}, model="m2"))
+        with open(config_path) as f:
+            data = json.load(f)
+        assert data["ui_api_key"] == "rllm_abc"
+        assert data["provider"] == "tinker"
+        assert data["model"] == "m2"
+
 
 class TestConstants:
     def test_openai_in_supported_providers(self):


### PR DESCRIPTION
## Problem
`rllm model swap`/`setup` silently logs you out of the rLLM UI.

`~/.rllm/config.json` is shared between two writers:
- `save_ui_config()` (from `rllm login`) writes `ui_api_key` and **merges** into the existing file.
- `save_config()` (from `rllm model`) rebuilt the file from scratch with only `provider`/`model`/`api_keys`/`base_url`, **clobbering `ui_api_key`**.

So any provider/model swap (e.g. refreshing a Tinker key) wipes the UI token, and subsequent evals stop reporting to the UI — with no error.

## Fix
`save_config()` now reads the existing file and merges its owned fields in (mirroring `save_ui_config()`), so unrelated keys survive. Empty `base_url` is now removed rather than left stale.

## Test
Adds `test_save_preserves_unrelated_keys` (seeds a config with `ui_api_key`, swaps provider/model, asserts the token survives). Full `tests/eval/test_eval_config.py` suite: 36 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)