### PR TITLE
feat(gateway): cumulative token mode for the in-process (Tinker) path

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -568,7 +568,17 @@ class ReverseProxy:
             def _sse(data: str) -> str:
                 return f"data: {data}\n\n"
 
-            yield _sse(json.dumps({"id": chat_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}))
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+                    }
+                )
+            )
             yield _sse(
                 json.dumps(
                     _sanitize_chunk(
@@ -583,7 +593,18 @@ class ReverseProxy:
                     )
                 )
             )
-            yield _sse(json.dumps({"id": chat_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}], "usage": usage}))
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+                        "usage": usage,
+                    }
+                )
+            )
             yield _sse("[DONE]")
 
         return StreamingResponse(event_generator(), media_type="text/event-stream", status_code=200)

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -309,29 +309,40 @@ class ReverseProxy:
         token_ids: list[int],
         originally_requested_logprobs: bool = False,
     ) -> Response:
-        """Non-streaming cumulative turn: send non-streaming to vLLM, return JSON."""
+        """Non-streaming cumulative turn: send pre-tokenized prompt, return JSON.
+
+        Routes to the in-process ``local_handler`` (e.g. Tinker) when present,
+        otherwise POSTs ``/v1/completions`` to a vLLM worker. Both return a
+        completions-style body carrying ``prompt_token_ids`` + ``token_ids``.
+        """
         t0 = time.perf_counter()
 
-        worker = self.router.route(session_id)
-        url = self._build_url(worker.api_url, "/v1/completions", "")
-        headers = self._forward_headers(request)
-        raw_body = json.dumps(completions_body).encode()
-        try:
-            resp = await self._send_with_retry(
-                method="POST",
-                url=url,
-                content=raw_body,
-                headers=headers,
-            )
-            content = resp.content
-            status_code = resp.status_code
-        finally:
-            self.router.release(worker.url)
+        if self.local_handler is not None:
+            # In-process path (Tinker): sample directly from the pre-tokenized
+            # prompt; no HTTP worker, no re-tokenization.
+            response_body = await self.local_handler(completions_body)
+            status_code = 200
+        else:
+            worker = self.router.route(session_id)
+            url = self._build_url(worker.api_url, "/v1/completions", "")
+            headers = self._forward_headers(request)
+            raw_body = json.dumps(completions_body).encode()
+            try:
+                resp = await self._send_with_retry(
+                    method="POST",
+                    url=url,
+                    content=raw_body,
+                    headers=headers,
+                )
+                content = resp.content
+                status_code = resp.status_code
+            finally:
+                self.router.release(worker.url)
 
-        try:
-            response_body = json.loads(content)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            response_body = {}
+            try:
+                response_body = json.loads(content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                response_body = {}
 
         latency_ms = (time.perf_counter() - t0) * 1000
 
@@ -375,6 +386,11 @@ class ReverseProxy:
         token_ids: list[int],
     ) -> StreamingResponse:
         """Streaming cumulative turn: stream from vLLM, translate chunks to chat format."""
+        if self.local_handler is not None:
+            # In-process backends (Tinker) don't stream; synthesize an SSE
+            # stream from a single pre-tokenized completion call.
+            return await self._handle_cumulative_streaming_local(request, request_body, completions_body, session_id, acc, token_ids)
+
         completions_body["stream"] = True
 
         worker = self.router.route(session_id)
@@ -501,6 +517,76 @@ class ReverseProxy:
             media_type="text/event-stream",
             status_code=resp.status_code,
         )
+
+    async def _handle_cumulative_streaming_local(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        completions_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        token_ids: list[int],
+    ) -> StreamingResponse:
+        """Cumulative streaming via the in-process handler (fake-streaming).
+
+        The local handler returns a full completion in one shot; we ingest its
+        token IDs into the accumulator, translate to chat format, and emit it as
+        a synthesized SSE stream (role → content+tokens → finish → [DONE]).
+        """
+        assert self.local_handler is not None
+        t0 = time.perf_counter()
+        response_body = await self.local_handler(completions_body)
+        latency_ms = (time.perf_counter() - t0) * 1000
+
+        prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
+        completion_token_ids = extract_completion_token_ids(response_body)
+        acc.ingest_turn(prompt_token_ids, completion_token_ids)
+        acc.update_prefix(request_body.get("messages", []))
+
+        choices = response_body.get("choices") or []
+        content = choices[0].pop("text", "") if choices else ""
+        finish_reason = (choices[0].get("finish_reason") if choices else None) or "stop"
+        completion_logprobs = choices[0].get("logprobs") if choices else None
+
+        if session_id and response_body:
+            chat_body = dict(response_body)
+            chat_body["object"] = "chat.completion"
+            if chat_body.get("choices"):
+                chat_body["choices"][0]["message"] = {"role": "assistant", "content": content}
+            trace = build_trace_record(session_id, request_body, chat_body, latency_ms, weight_version=request.state.weight_version)
+            await self._persist(trace)
+
+        chat_id = response_body.get("id", "chatcmpl-local")
+        created = response_body.get("created", int(time.time()))
+        model = response_body.get("model", "")
+        usage = response_body.get("usage", {})
+
+        def _sanitize_chunk(chunk: dict[str, Any]) -> dict[str, Any]:
+            return strip_vllm_fields(chunk) if self.strip_vllm else chunk
+
+        async def event_generator():
+            def _sse(data: str) -> str:
+                return f"data: {data}\n\n"
+
+            yield _sse(json.dumps({"id": chat_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}))
+            yield _sse(
+                json.dumps(
+                    _sanitize_chunk(
+                        {
+                            "id": chat_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None, "token_ids": completion_token_ids, "logprobs": completion_logprobs}],
+                            "prompt_token_ids": prompt_token_ids,
+                        }
+                    )
+                )
+            )
+            yield _sse(json.dumps({"id": chat_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}], "usage": usage}))
+            yield _sse("[DONE]")
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream", status_code=200)
 
     # ------------------------------------------------------------------
     # Streaming (SSE)

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
@@ -1,0 +1,136 @@
+"""Cumulative token mode over the in-process ``local_handler`` (e.g. Tinker).
+
+The HTTP-worker path is covered by ``test_cumulative_token_mode.py``. These
+tests cover the local-handler branch added so backends without a vLLM
+``/v1/completions`` worker (Tinker runs in-process) get the same drift-free
+prefix-extension: turn 2+ samples directly from pre-tokenized prompt IDs built
+by the renderer, and the accumulator ingests the result.
+
+Tests drive the proxy methods directly (no HTTP server) via ``asyncio.run`` to
+avoid a pytest-asyncio dependency.
+"""
+
+import asyncio
+import json
+
+from rllm_model_gateway.proxy import ReverseProxy
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+
+class _State:
+    weight_version = 0
+
+
+class _Request:
+    """Minimal stand-in: the cumulative-local paths only read request.state."""
+
+    state = _State()
+
+
+def _make_proxy(local_handler):
+    """ReverseProxy wired for the local cumulative path (no router/worker)."""
+    return ReverseProxy(
+        router=None,
+        store=MemoryTraceStore(),
+        sync_traces=True,
+        local_handler=local_handler,
+        cumulative_token_mode=True,
+        renderer=None,  # accumulator state is set directly in these tests
+    )
+
+
+def _completion_handler(record):
+    """Fake Tinker token-path handler: echoes ``prompt`` as prompt_token_ids,
+    returns a fixed 2-token completion. Records the body it was called with."""
+
+    async def handler(body):
+        record.append(body)
+        return {
+            "id": "cmpl-x",
+            "object": "text_completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "next action",
+                    "token_ids": [91, 92],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2]},
+                }
+            ],
+            "prompt_token_ids": body["prompt"],
+            "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
+        }
+
+    return handler
+
+
+def test_cumulative_local_non_streaming_ingests_and_translates():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])  # turn 1: prompt + completion already captured
+    bridged = [1, 2, 3, 4, 5, 6, 7]  # what the renderer would produce for turn 2
+
+    completions_body = {"prompt": bridged, "add_special_tokens": False, "model": "q"}
+    resp = asyncio.run(
+        proxy._handle_cumulative_non_streaming(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            completions_body,
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    # The local handler was called with the pre-tokenized prompt, not messages.
+    assert record and record[0]["prompt"] == bridged
+    assert "messages" not in record[0]
+
+    # Response is translated back to chat format for the agent.
+    body = json.loads(resp.body)
+    assert resp.status_code == 200
+    assert body["object"] == "chat.completion"
+    assert body["choices"][0]["message"] == {"role": "assistant", "content": "next action"}
+
+    # Accumulator advanced: prefix-extension holds (bridged starts with prev prompt+completion).
+    assert acc.turn_count == 2
+    assert acc.prev_prompt_ids == bridged
+    assert acc.prev_completion_ids == [91, 92]
+    assert acc.cumulative_ids[: len([1, 2, 3, 4, 5])] == [1, 2, 3, 4, 5]
+
+
+def test_cumulative_local_streaming_emits_sse_and_ingests():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    bridged = [1, 2, 3, 4, 5, 6, 7]
+
+    resp = asyncio.run(
+        proxy._handle_cumulative_streaming_local(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            {"prompt": bridged},
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    chunks = []
+
+    async def drain():
+        async for c in resp.body_iterator:
+            chunks.append(c if isinstance(c, str) else c.decode())
+
+    asyncio.run(drain())
+
+    assert any('"role": "assistant"' in c for c in chunks)
+    assert any('"next action"' in c for c in chunks)
+    assert chunks[-1].strip().endswith("[DONE]")
+    # Same ingest as non-streaming.
+    assert acc.turn_count == 2 and acc.prev_completion_ids == [91, 92]

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -41,6 +41,56 @@ def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
     return result
 
 
+async def _token_prompt_completion(
+    engine: TinkerEngine,
+    request_body: dict[str, Any],
+    prompt_ids: list[int],
+    sampling_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Sample from a pre-tokenized prompt (cumulative-token mode).
+
+    Bypasses message rendering entirely: ``prompt_ids`` is fed straight to the
+    engine's token-input sampler. Returns a **completions-style** response dict
+    (``choices[0].text`` + ``token_ids``, root ``prompt_token_ids``,
+    ``logprobs.token_logprobs``) — the exact shape the gateway's cumulative-turn
+    handler extracts token IDs from and translates back to chat format.
+    """
+    token_output = await engine.get_token_output_from_token_input(prompt_ids, **sampling_kwargs)
+    model_output = engine.assemble_model_output(prompt_ids, token_output)
+
+    # Text the agent sees as the assistant turn (same precedence as the chat path).
+    text = model_output.content or model_output.text or ""
+    out_prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else list(prompt_ids)
+    completion_ids = list(model_output.completion_ids) if model_output.completion_ids else []
+    logprobs = model_output.logprobs or []
+    finish_reason = model_output.finish_reason or "stop"
+    prompt_len = model_output.prompt_length or len(out_prompt_ids)
+    completion_len = model_output.completion_length or len(completion_ids)
+
+    return {
+        "id": f"cmpl-{uuid.uuid4().hex[:12]}",
+        "object": "text_completion",
+        "created": int(time.time()),
+        "model": request_body.get("model", getattr(engine, "model_name", "default")),
+        "choices": [
+            {
+                "index": 0,
+                "text": text,
+                "token_ids": completion_ids,
+                "finish_reason": finish_reason,
+                "logprobs": {"token_logprobs": logprobs},
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_len,
+            "completion_tokens": completion_len,
+            "total_tokens": prompt_len + completion_len,
+        },
+        "prompt_token_ids": out_prompt_ids,
+        "weight_version": getattr(model_output, "weight_version", None),
+    }
+
+
 def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
     """Return an async handler that calls TinkerEngine in-process.
 
@@ -50,22 +100,35 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
     """
 
     async def handler(request_body: dict[str, Any]) -> dict[str, Any]:
+        # Sampling params shared by the chat and pre-tokenized paths.
+        sampling_kwargs: dict[str, Any] = {}
+        if request_body.get("temperature") is not None:
+            sampling_kwargs["temperature"] = request_body["temperature"]
+        if request_body.get("top_p") is not None:
+            sampling_kwargs["top_p"] = request_body["top_p"]
+        if request_body.get("top_k") is not None:
+            sampling_kwargs["top_k"] = request_body["top_k"]
+        if request_body.get("max_tokens") is not None:
+            sampling_kwargs["max_tokens"] = request_body["max_tokens"]
+        if request_body.get("max_completion_tokens") is not None:
+            sampling_kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
+
+        # Cumulative-token-mode path: the gateway rewrites turn 2+ to a
+        # completions-style request whose ``prompt`` is raw token IDs built by
+        # ``renderers.bridge_to_next_turn`` (= prior turns' prompt+completion
+        # tokens + the new messages). Sample straight from those tokens — no
+        # re-render, no re-tokenization — so the sequence the optimizer trains on
+        # is byte-for-byte what was generated. Mirrors the vLLM /v1/completions
+        # path the HTTP backend uses for the same feature.
+        prompt = request_body.get("prompt")
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+
         messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
-
-        kwargs: dict[str, Any] = {}
+        kwargs = dict(sampling_kwargs)
         if tools:
             kwargs["tools"] = tools
-        if request_body.get("temperature") is not None:
-            kwargs["temperature"] = request_body["temperature"]
-        if request_body.get("top_p") is not None:
-            kwargs["top_p"] = request_body["top_p"]
-        if request_body.get("top_k") is not None:
-            kwargs["top_k"] = request_body["top_k"]
-        if request_body.get("max_tokens") is not None:
-            kwargs["max_tokens"] = request_body["max_tokens"]
-        if request_body.get("max_completion_tokens") is not None:
-            kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
 
         model_output = await engine.get_model_response(messages, **kwargs)
 

--- a/tests/test_tinker_adapter_cumulative.py
+++ b/tests/test_tinker_adapter_cumulative.py
@@ -1,0 +1,91 @@
+"""Tinker adapter: pre-tokenized prompt path for cumulative token mode.
+
+When the gateway runs in ``cumulative_token_mode``, turn 2+ arrives at the
+in-process handler as a completions-style request whose ``prompt`` is raw token
+IDs (built by ``renderers.bridge_to_next_turn``). The handler must sample
+straight from those tokens — bypassing message rendering — and return a
+completions-style body the gateway can extract token IDs from.
+
+Uses a fake engine so no Tinker service / model is required.
+"""
+
+import asyncio
+
+from rllm.gateway.tinker_adapter import create_tinker_handler
+
+
+class _ModelOutput:
+    text = "ls -la"
+    content = "ls -la"
+    reasoning = ""
+    tool_calls = []
+    prompt_ids = [1, 2, 3, 4]
+    completion_ids = [10, 11]
+    logprobs = [-0.1, -0.2]
+    prompt_length = 4
+    completion_length = 2
+    finish_reason = "stop"
+
+
+class _FakeEngine:
+    model_name = "qwen"
+
+    def __init__(self):
+        self.token_input = None
+        self.messages = None
+
+    async def get_token_output_from_token_input(self, token_input, **kwargs):
+        self.token_input = token_input
+        self.sampling_kwargs = kwargs
+        return "sampled"
+
+    def assemble_model_output(self, token_input, token_output):
+        return _ModelOutput()
+
+    async def get_model_response(self, messages, **kwargs):
+        self.messages = messages
+        return _ModelOutput()
+
+
+def test_token_prompt_path_samples_from_tokens():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"prompt": [1, 2, 3, 4], "temperature": 0.7, "model": "qwen"}))
+
+    # Sampled directly from the token IDs — message rendering bypassed.
+    assert engine.token_input == [1, 2, 3, 4]
+    assert engine.messages is None
+    assert engine.sampling_kwargs.get("temperature") == 0.7
+
+    # Completions-style body the gateway's cumulative handler understands.
+    assert resp["object"] == "text_completion"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+    assert resp["choices"][0]["text"] == "ls -la"
+    assert resp["choices"][0]["token_ids"] == [10, 11]
+    assert resp["choices"][0]["logprobs"]["token_logprobs"] == [-0.1, -0.2]
+
+
+def test_chat_path_unchanged_by_token_branch():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"messages": [{"role": "user", "content": "hi"}], "model": "qwen"}))
+
+    assert engine.messages == [{"role": "user", "content": "hi"}]
+    assert engine.token_input is None  # token path not taken
+    assert resp["object"] == "chat.completion"
+    assert resp["choices"][0]["message"]["content"] == "ls -la"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+
+
+def test_non_int_prompt_falls_through_to_chat():
+    """A string ``prompt`` (or none) must not trigger the token path."""
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    # No messages and a string prompt: should still go down the chat path
+    # (messages defaulting to []), not the token path.
+    asyncio.run(handler({"prompt": "hello", "messages": [{"role": "user", "content": "hi"}]}))
+    assert engine.token_input is None
+    assert engine.messages == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## What

Extends `cumulative_token_mode` — the drift-free multi-turn token-forwarding feature — to the **in-process `local_handler` (Tinker)** path. Until now it only worked for the HTTP-proxy (vLLM/verl) backend; Tinker rollouts re-rendered + re-tokenized the full conversation every turn.

## Why

In multi-turn RL, re-tokenizing a rendered string each turn can split tokens differently than the concatenation of the tokens actually *sampled* in prior turns, so the sequence the optimizer trains on can drift from what was generated. The HTTP path already avoids this by rewriting turn 2+ to `/v1/completions` with raw token IDs from `renderers.bridge_to_next_turn` (the Prime Intellect [`renderers`](https://github.com/PrimeIntellect-ai/renderers) package). The cumulative handlers, however, always routed to an HTTP worker — so Tinker (in-process, no vLLM worker) never got it.

## How

The accumulator (`TokenAccumulator`) and the `renderers` bridge are already backend-agnostic; the only gaps were the handler and the routing:

- **`rllm/gateway/tinker_adapter.py`** — the handler now detects a pre-tokenized `prompt` (`list[int]`) and samples straight from it via the engine's existing `get_token_output_from_token_input` + `assemble_model_output`, returning a completions-style body (`prompt_token_ids` + `choices[].token_ids`) — exactly the shape the gateway's cumulative handler extracts token IDs from. The chat (`messages`) path is untouched.
- **`rllm-model-gateway/.../proxy.py`** — `_handle_cumulative_non_streaming` routes to `local_handler` when present (no HTTP worker); new `_handle_cumulative_streaming_local` synthesizes an SSE stream from the single in-process completion (mirrors the existing `_handle_streaming_local`), with the same token ingest.

Net effect: Tinker rollouts get the same prefix-extension guarantee verl has — turn N's prompt tokens are byte-for-byte the prior turns' prompt+completion tokens.

## Tests (no Tinker service / model needed)

- `tests/test_tinker_adapter_cumulative.py` — token-prompt path samples from tokens (bypassing rendering); chat path unchanged; non-int `prompt` falls through.
- `rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py` — proxy local cumulative non-streaming + streaming: ingests bridged prompt + completion, translates back to chat.
- Existing cumulative/accumulator suites (28 tests) still pass.

## Notes / follow-ups

- Gated entirely by the existing `cumulative_token_mode` flag (default `false`); the default chat path is unchanged.
- The cumulative→chat translation forwards the assistant **text** content (sufficient for text-action agents like mini-swe-agent). Preserving `tool_calls`/`reasoning` structurally through the cumulative path is a possible follow-up.
- Not yet validated against a live Tinker run — verified at the unit/integration level (the prefix-extension invariant and ingest). A short live run to confirm turn-2 prompt IDs equal turn-1 prompt+completion IDs is the recommended next step before relying on it in training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)