### PR TITLE
chore(sandbox): raise default sandbox concurrency from 4 to 64

### DIFF
--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -584,7 +584,7 @@ def _load_or_pull_dataset(name: str, split: str, catalog: dict, catalog_entry_ov
     type=click.Choice(["docker", "local", "modal", "daytona", "e2b", "runloop", "gke", "apple-container"], case_sensitive=False),
     help="Sandbox backend for SandboxedAgentFlow harnesses (default: per-task or docker). Remote backends auto-spawn a cloudflared tunnel for the gateway.",
 )
-@click.option("--sandbox-concurrency", "sandbox_concurrency", default=None, type=int, help="Override max concurrent sandboxes (default: agent's max_concurrent — usually 4).")
+@click.option("--sandbox-concurrency", "sandbox_concurrency", default=None, type=int, help="Override max concurrent sandboxes (default: agent's max_concurrent — usually 64).")
 # Sampling options (resolved into rollout.{train,val}; gateway-enforced)
 @click.option("--sampling-params", "sampling_params", default=None, help=_SAMPLING_PARAMS_HELP)
 @click.option("--temperature", default=None, type=float, help="Sampling temperature for train+val (shortcut for --sampling-params temperature=...).")

--- a/rllm/harnesses/aider.py
+++ b/rllm/harnesses/aider.py
@@ -65,7 +65,6 @@ class AiderHarness(BaseCliHarness):
 
     name = "aider"
     sandbox_backend = "docker"
-    max_concurrent = 4
     stdout_log_path = "/tmp/aider.log"
 
     def install_script(self) -> str:

--- a/rllm/harnesses/bash.py
+++ b/rllm/harnesses/bash.py
@@ -48,7 +48,6 @@ class BashHarness(SandboxedAgentFlow):
 
     name = "bash"
     sandbox_backend = "docker"
-    max_concurrent = 4
 
     def run(self, task: Task, config, *, env) -> Episode:
         from openai import OpenAI

--- a/rllm/harnesses/claude_code.py
+++ b/rllm/harnesses/claude_code.py
@@ -102,7 +102,6 @@ class ClaudeCodeHarness(BaseCliHarness):
 
     name = "claude-code"
     sandbox_backend = "docker"
-    max_concurrent = 4
     stdout_log_path = "/tmp/claude-code.log"
 
     def install_script(self) -> str:

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -58,8 +58,6 @@ class BaseCliHarness(SandboxedAgentFlow):
     sandbox_backend: str = "docker"
     # Default container image. Tasks usually override via per-task images.
     image: str = "python:3.11-slim"
-    # Concurrency hint for the eval runner.
-    max_concurrent: int = 4
     # Container user the CLI runs as. ``None`` uses the image default.
     agent_user: str | None = None
     # Path inside the sandbox where the CLI's stdout is teed.

--- a/rllm/harnesses/codex.py
+++ b/rllm/harnesses/codex.py
@@ -71,7 +71,6 @@ class CodexHarness(BaseCliHarness):
 
     name = "codex"
     sandbox_backend = "docker"
-    max_concurrent = 4
     stdout_log_path = "/tmp/codex.log"
 
     def install_script(self) -> str:

--- a/rllm/harnesses/kimi_cli.py
+++ b/rllm/harnesses/kimi_cli.py
@@ -66,7 +66,6 @@ class KimiCliHarness(BaseCliHarness):
 
     name = "kimi-cli"
     sandbox_backend = "docker"
-    max_concurrent = 4
     stdout_log_path = "/tmp/kimi-cli.log"
 
     def install_script(self) -> str:

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -79,7 +79,6 @@ class MiniSweAgentHarness(BaseCliHarness):
 
     name = "mini-swe-agent"
     sandbox_backend = "docker"
-    max_concurrent = 4
     stdout_log_path = "/tmp/mini-swe-agent.log"
 
     def install_script(self) -> str:

--- a/rllm/harnesses/opencode.py
+++ b/rllm/harnesses/opencode.py
@@ -67,7 +67,6 @@ class OpenCodeHarness(BaseCliHarness):
 
     name = "opencode"
     sandbox_backend = "docker"
-    max_concurrent = 4
     stdout_log_path = "/tmp/opencode.log"
 
     # Provider name we register the gateway under inside opencode.json.

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -39,7 +39,6 @@ class OracleHarness(SandboxedAgentFlow):
 
     name = "oracle"
     sandbox_backend = "docker"
-    max_concurrent = 4
 
     # Mirror Harbor's ``env_paths.solution_dir`` convention so anyone
     # comparing the two implementations doesn't trip on path drift.

--- a/rllm/harnesses/qwen_code.py
+++ b/rllm/harnesses/qwen_code.py
@@ -56,7 +56,6 @@ class QwenCodeHarness(BaseCliHarness):
 
     name = "qwen-code"
     sandbox_backend = "docker"
-    max_concurrent = 4
     stdout_log_path = "/tmp/qwen-code.log"
 
     def install_script(self) -> str:

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -82,7 +82,6 @@ class Terminus2Harness(BaseCliHarness):
     name = "terminus2"
     # Default to Modal for this integration; override via --sandbox-backend.
     sandbox_backend = "modal"
-    max_concurrent = 4
     stdout_log_path = "/tmp/terminus2.log"
 
     # ---- Terminus-2 knobs (overridable via agent kwargs / configure) ----

--- a/rllm/harnesses/zeroclaw.py
+++ b/rllm/harnesses/zeroclaw.py
@@ -75,7 +75,6 @@ class ZeroClawHarness(BaseCliHarness):
 
     name = "zeroclaw"
     sandbox_backend = "docker"  # overridden to "daytona" via --sandbox-backend
-    max_concurrent = 8
     stdout_log_path = "/tmp/zeroclaw.log"
 
     def install_script(self) -> str:

--- a/rllm/integrations/harbor/runtime.py
+++ b/rllm/integrations/harbor/runtime.py
@@ -39,7 +39,7 @@ class HarborRuntime:
     """
 
     # Used by run_dataset / Runner to cap concurrency.
-    max_concurrent: int = 4
+    max_concurrent: int = 64
 
     def __init__(
         self,

--- a/rllm/sandbox/sandboxed_flow.py
+++ b/rllm/sandbox/sandboxed_flow.py
@@ -36,7 +36,11 @@ class SandboxedAgentFlow(ABC):
     llm_inside_env: bool = False
     sandbox_backend: str = "docker"
     image: str = "python:3.11-slim"
-    max_concurrent: int = 4
+    # Default cap on concurrent sandboxes. The eval/train runner clamps
+    # effective concurrency to this value, so it is the single source of
+    # truth for sandboxed flows. Subclasses override only to deviate;
+    # ``--sandbox-concurrency`` overrides it per-run.
+    max_concurrent: int = 64
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():


### PR DESCRIPTION
## What

Raise the default sandbox concurrency from **4** to **64**, defined as a single source of truth on the base `SandboxedAgentFlow`.

## Why

The eval/train runner caps effective concurrency at the agent flow's `max_concurrent`:

```python
# rllm/eval/runner.py
effective_concurrency = concurrency
if hasattr(agent_flow, "max_concurrent"):
    effective_concurrency = min(effective_concurrency, agent_flow.max_concurrent)
```

Sandboxed agents defaulted to `max_concurrent = 4`, so `rllm eval`/`rllm train` with a sandbox backend ran at 4 concurrent sandboxes regardless of `--concurrency` (default 64). This raises the default so a sandbox backend uses 64 out of the box.

## How

- Bump the default **once** on `SandboxedAgentFlow.max_concurrent` (4 → 64).
- Drop the redundant per-harness `max_concurrent` restatements so each sandboxed harness inherits the base default — one value instead of the same number scattered across every harness file. This also folds in `zeroclaw` (previously 8).
- `react` and the Harbor runtime are separate (non-`SandboxedAgentFlow`) classes and keep their own explicit values (64).
- Update the stale `--sandbox-concurrency` help text ("usually 4" → "usually 64").

`--sandbox-concurrency N` still overrides per-run.

## Verification

- Inheritance resolves correctly: `Bash/Codex/Oracle/BaseCliHarness/ZeroClaw` → 64.
- `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)