### PR TITLE
fix(engine): populate Step.output in trace_record_to_step

### DIFF
--- a/rllm/engine/trace_converter.py
+++ b/rllm/engine/trace_converter.py
@@ -66,6 +66,7 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
         chat_completions=chat_completions,
         model_output=model_output,
         model_response=content,
+        output=content,
         thought=reasoning,
         metadata=trace.metadata,
         weight_version=trace.weight_version,


### PR DESCRIPTION
## Summary

- `trace_record_to_step()` sets `model_response=content` but omits `output`, leaving it as `None`
- During enrichment (`enrich_episode_with_traces`), the training Step replaces the agent's original Step — only `action`/`reward`/`done` are copied, so `output` is lost
- Evaluators checking `step.output` (e.g. substring-match) always see `None` → all rewards = 0.0
- **Fix**: add `output=content` alongside `model_response` (one line)

Supersedes #662 (which accidentally included unrelated commits).

## Test plan

- [x] Verified on Koala H200×8 with Qwen3.5-9B sandbox_code training: rewards went from all-zero to non-zero after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)