### PR TITLE
Support Fireworks on SWE-RL

### DIFF
--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -1,0 +1,132 @@
+# SWE-RL
+
+End-to-end agentic-RL recipe for software engineering: train on [R2E-Gym](https://huggingface.co/datasets/R2E-Gym/R2E-Gym-Subset) (R2E-Gym Subset, 4,578 bug-fix tasks across 12 Python repos), validate on [SWE-bench Verified](https://www.swebench.com/) (500 real GitHub issues). The agent harness is [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent); the base model is `Qwen/Qwen3.5-9B`.
+
+This cookbook deliberately ships **no custom AgentFlow and no custom evaluator** — it's a thin wrapper around primitives that already live in `rllm/`. The flow is `mini-swe-agent` running as a CLI inside per-task sandboxes, and the evaluator is each task's own `tests/test.sh`. Both `r2egym` and `harbor:swebench-verified` ship that verifier with the dataset.
+
+## Architecture
+
+```
+AgentTrainer.train()
+  │
+  ├── for each task: launch a sandbox (Modal / Daytona / Docker)
+  │       │
+  │       └── mini-swe-agent --yolo --task=<problem_statement>
+  │             │   (multi-turn shell loop; each LLM call → gateway)
+  │             │
+  │             └── rLLM gateway routes to the trainer-hosted policy,
+  │                  capturing the full trajectory (prompt + response
+  │                  tokens + sampling params per turn).
+  │
+  └── verifier: tests/test.sh inside the sandbox
+        │   run_tests.sh for r2egym;  SWE-bench harness for verified.
+        │
+        └── writes /logs/verifier/reward.txt  →  RL reward signal
+```
+
+The trainer never parses tool calls or model outputs directly. The agent harness owns the action loop; the gateway owns the trajectory; the in-sandbox verifier owns the reward. This is the same setup as `examples/harbor_swe/` — the cookbook packages it as a versioned, installable recipe.
+
+## Installation
+
+```bash
+uv pip install -e ".[tinker]"                       # rllm + tinker backend
+uv pip install --no-deps -e cookbooks/swe-rl        # this cookbook (registers prepare_data)
+```
+
+`mini-swe-agent` is installed automatically into each task sandbox on first run — no host-side install required.
+
+## Datasets
+
+```bash
+python cookbooks/swe-rl/prepare_data.py
+# or, faster smoke run:
+python cookbooks/swe-rl/prepare_data.py --train-limit 50 --val-limit 20
+```
+
+This pulls:
+
+| Dataset | Role | Source | Verifier |
+|---|---|---|---|
+| `r2egym` | train (4,578) | `R2E-Gym/R2E-Gym-Subset` | in-sandbox `run_tests.sh`, pytest-output equality (`tests/test.sh`) |
+| `harbor:swebench-verified` | eval (500) | `princeton-nlp/SWE-bench_Verified` | official SWE-bench harness (F2P / P2P) |
+
+Both materialize as Harbor-format task directories (`task.toml`, `instruction.md`, `environment/Dockerfile`, `tests/test.sh`).
+
+## Training
+
+### Tinker (single-machine, LoRA)
+
+```bash
+bash cookbooks/swe-rl/train_tinker.sh
+```
+
+Defaults: Qwen/Qwen3.5-9B + LoRA rank 32, GRPO with compact filtering, 64 parallel Modal sandboxes, async rollout/training. Override anything via Hydra:
+
+```bash
+SWE_SANDBOX_BACKEND=docker bash cookbooks/swe-rl/train_tinker.sh \
+    model.name=Qwen/Qwen3-8B \
+    rllm.workflow.n_parallel_tasks=32
+```
+
+For a simpler on-policy loop (generate a full batch, then one optimizer step — easier to debug), use the synchronous variant:
+
+```bash
+bash cookbooks/swe-rl/train_tinker_sync.sh
+```
+
+It drops `async_training` and uses a real `data.train_batch_size` (default 4; effective batch = `train_batch_size × group_size`).
+
+### Verl (distributed GPU)
+
+```bash
+uv pip install -e ".[verl]"
+bash scripts/install_megatron.sh <cu128|cu129|...>
+bash cookbooks/swe-rl/train_verl.sh
+```
+
+vLLM rollouts + FSDP/Megatron training. Sandboxes still run mini-swe-agent — only the trainer hosting changes.
+
+## Evaluation (no training)
+
+```bash
+rllm eval harbor:swebench-verified \
+    --agent mini-swe-agent \
+    --model Qwen/Qwen3.5-9B \
+    --base-url http://localhost:8000/v1 \
+    --max-examples 20
+```
+
+Per-task results land in `~/.rllm/eval_results/`; aggregated resolve rate is printed at the end. `rllm view` opens the per-task trajectory UI.
+
+## Sandbox backend
+
+Training uses rLLM's own `SandboxedAgentFlow` path (`AgentFlowEngine`) — not the
+remote Harbor runtime. `mini-swe-agent` runs inside one sandbox per task, created
+by `SandboxTaskHooks`. Pick a backend via the `SWE_SANDBOX_BACKEND` env var:
+
+| Backend | Setup | Notes |
+|---|---|---|
+| `modal` | `pip install modal` + `modal token new` | Default for training — per-task billing, scales to many parallel sandboxes. |
+| `daytona` | `pip install daytona` + `DAYTONA_API_KEY` | Cloud sandboxes; scales to thousands in parallel. |
+| `docker` | local | Fastest iteration; needs the Docker daemon and ~20 GB free disk. |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `prepare_data.py` | Pulls `r2egym` (train) and `harbor:swebench-verified` (eval) |
+| `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
+| `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Modal sandboxes |
+| `train_tinker_sync.sh` | Tinker backend — synchronous (on-policy) variant, simpler for testing |
+| `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
+| `test.py` | Catalog wiring + harness import smoke tests |
+| `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |
+
+## Why no custom flow or evaluator?
+
+Other cookbooks in this repo (`finqa`, `math`, `deepcoder`, …) ship a custom AgentFlow because their workloads either fit in a single LLM turn or need bespoke tool wiring. SWE doesn't — the existing in-tree primitives already cover it:
+
+- **`rllm.harnesses.mini_swe_agent`** is the agent. It exposes the `mini-swe-agent` CLI as an rLLM harness (installs in-sandbox on first run; reads the gateway URL from the env; logs to `/tmp/mini-swe-agent.log`).
+- **Per-task `tests/test.sh`** is the evaluator. The sandbox-shell verifier kind (`rllm.eval.script_evaluator`) reads `/logs/verifier/reward.txt` and returns it as the RL reward. For `harbor:swebench-verified`, that script invokes the official SWE-bench harness; for `r2egym`, it runs the image's own `/testbed/run_tests.sh` and scores 1.0 iff the pytest output matches the row's expected output.
+
+The only thing this cookbook adds on top is the recipe: dataset pairing, sampling/optimizer hyperparams, and the `mini-swe-agent` harness selection. Forking `train_tinker.sh` is the place to start customizing.

--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -86,6 +86,24 @@ bash cookbooks/swe-rl/train_verl.sh
 
 vLLM rollouts + FSDP/Megatron training. Sandboxes still run mini-swe-agent — only the trainer hosting changes.
 
+### Fireworks (managed, LoRA)
+
+```bash
+uv pip install -e ".[fireworks]"
+export FIREWORKS_API_KEY=...
+bash cookbooks/swe-rl/train_fireworks.sh
+```
+
+Same async GRPO + compact-filtering recipe as `train_tinker.sh`, but the trainer
+job and inference deployment are provisioned on Fireworks at startup and torn
+down on shutdown. Defaults to `accounts/fireworks/models/qwen3p5-9b` + LoRA rank
+32 on the `qwen3p5-9b-256k-lora` training shape (Fireworks ships a 3.5-9B LoRA
+shape but no 3.5-4B; swap `model.name` / `model.tokenizer_model` /
+`fireworks_config.policy_trainer_shape_id` together to change it — see
+[`docs/backends/fireworks.mdx`](../../docs/backends/fireworks.mdx) for the
+model/shape catalog). The synchronous (on-policy) variant is
+`train_fireworks_sync.sh`.
+
 ## Evaluation (no training)
 
 ```bash
@@ -118,6 +136,8 @@ by `SandboxTaskHooks`. Pick a backend via the `SWE_SANDBOX_BACKEND` env var:
 | `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
 | `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Modal sandboxes |
 | `train_tinker_sync.sh` | Tinker backend — synchronous (on-policy) variant, simpler for testing |
+| `train_fireworks.sh` | Fireworks backend — Qwen3.5-9B LoRA, GRPO + async, managed trainer/deployment |
+| `train_fireworks_sync.sh` | Fireworks backend — synchronous (on-policy) variant, simpler for testing |
 | `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
 | `test.py` | Catalog wiring + harness import smoke tests |
 | `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |

--- a/cookbooks/swe-rl/prepare_data.py
+++ b/cookbooks/swe-rl/prepare_data.py
@@ -1,0 +1,66 @@
+"""Pull the train + eval datasets for the swe-rl cookbook.
+
+Both are sandbox-format benchmarks (per-task ``environment/Dockerfile`` +
+``tests/test.sh`` verifier). The training set is rLLM's native
+``r2egym`` (R2E-Gym Subset, 4,578 bug-fix tasks across 12 Python repos,
+each shipped as a per-instance Docker image graded by the image's own
+``/testbed/run_tests.sh``). The eval set is ``harbor:swebench-verified``
+(500 real-world GitHub issues, evaluated against the official SWE-bench
+harness inside the sandbox).
+
+This script is a thin wrapper around ``rllm dataset pull`` so the
+cookbook can be used end-to-end with a single command. Re-runs are
+no-ops once the on-disk benchmark directory exists.
+
+Usage::
+
+    python cookbooks/swe-rl/prepare_data.py
+    # or, smoke run with a small training cap (rebuilds the benchmark dir):
+    python cookbooks/swe-rl/prepare_data.py --train-limit 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+TRAIN_DATASET = "r2egym"
+VAL_DATASET = "harbor:swebench-verified"
+
+
+def _pull(name: str, limit: int | None = None) -> None:
+    cmd = [sys.executable, "-m", "rllm.cli.main", "dataset", "pull", name]
+    if limit is not None:
+        cmd += ["--limit", str(limit)]
+    print(f"[swe-rl] $ {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--train-limit",
+        type=int,
+        default=None,
+        help="Cap training tasks (default: full ~4.6K). Useful for smoke runs.",
+    )
+    ap.add_argument(
+        "--val-limit",
+        type=int,
+        default=None,
+        help="Cap eval tasks (default: full 500).",
+    )
+    args = ap.parse_args()
+
+    _pull(TRAIN_DATASET, limit=args.train_limit)
+    _pull(VAL_DATASET, limit=args.val_limit)
+
+    print(
+        f"\n[swe-rl] Done. Train: {TRAIN_DATASET}   Eval: {VAL_DATASET}\n        Run `bash cookbooks/swe-rl/train_tinker.sh` to train.",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/swe-rl/pyproject.toml
+++ b/cookbooks/swe-rl/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "swe-rl"
+version = "0.1.0"
+description = "End-to-end SWE-RL recipe: train on R2E-Gym, eval on SWE-bench Verified"
+requires-python = ">=3.10"
+dependencies = ["rllm"]
+
+[tool.setuptools]
+py-modules = ["prepare_data"]

--- a/cookbooks/swe-rl/test.py
+++ b/cookbooks/swe-rl/test.py
@@ -1,0 +1,67 @@
+"""Smoke tests for the swe-rl cookbook.
+
+These tests don't boot sandboxes, run agents, or train. They only
+verify the wiring: the dataset names resolve in the catalog, the
+``mini-swe-agent`` harness is importable, and ``train.py`` can be
+imported without side effects.
+
+Run::
+
+    pytest cookbooks/swe-rl/test.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+# -- Dataset catalog entries --------------------------------------------------
+
+
+def _load_catalog() -> dict:
+    registry_path = Path(__file__).resolve().parents[2] / "rllm" / "registry" / "datasets.json"
+    return json.loads(registry_path.read_text())
+
+
+def test_train_dataset_in_catalog():
+    """r2egym must be registered as a sandbox dataset using mini-swe-agent."""
+    catalog = _load_catalog()
+    entry = catalog["datasets"]["r2egym"]
+    assert entry["category"] == "code"
+    assert entry["default_agent"] == "mini-swe-agent"
+    assert "train" in entry["splits"]
+
+
+def test_val_dataset_resolvable():
+    """SWE-bench Verified must be reachable either as the native row dataset
+    (``swebench_verified``) or as the Harbor sandbox dataset
+    (``harbor:swebench-verified``)."""
+    catalog = _load_catalog()
+    assert "swebench_verified" in catalog["datasets"], "native swebench_verified entry missing from registry"
+
+
+# -- Harness wiring -----------------------------------------------------------
+
+
+def test_mini_swe_agent_harness_importable():
+    """``mini-swe-agent`` is the harness this cookbook drives; it must import."""
+    mod = importlib.import_module("rllm.harnesses.mini_swe_agent")
+    assert hasattr(mod, "MiniSweAgentHarness")
+    assert mod.MiniSweAgentHarness.name == "mini-swe-agent"
+
+
+# -- Train script -------------------------------------------------------------
+
+
+def test_train_module_imports():
+    """``train.py`` must be importable without triggering Hydra or starting training."""
+    import sys
+
+    script_dir = Path(__file__).resolve().parent
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))
+    mod = importlib.import_module("train")
+    assert mod.TRAIN_DATASET == "r2egym"
+    assert mod.VAL_DATASET == "swebench-verified"
+    assert callable(mod.main)

--- a/cookbooks/swe-rl/train.py
+++ b/cookbooks/swe-rl/train.py
@@ -1,0 +1,89 @@
+"""Train an SWE agent on R2E-Gym, validate on SWE-bench Verified.
+
+This cookbook deliberately ships no custom AgentFlow or evaluator:
+
+* The **agent** is the in-tree ``terminus2`` harness
+  (:class:`rllm.harnesses.terminus2.Terminus2Harness`) — a
+  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow` that runs the
+  terminus2 CLI agent inside each task's sandbox. The rLLM gateway
+  intercepts every LLM call, so the trainer sees full trajectories without
+  the harness knowing it's being trained.
+* The **evaluator** is each task's own verifier (sandbox-shell), resolved
+  per-task by :class:`rllm.hooks.SandboxTaskHooks`. For r2egym it runs the
+  image's own ``/testbed/run_tests.sh`` and checks pytest-output equality
+  against the row's expected output; for the Verified split it runs the
+  task's bundled ``tests/test.sh``. The verifier writes a reward that rLLM
+  reads back.
+
+Because we pass an ``agent_flow`` (and no explicit ``evaluator``/``hooks``),
+:class:`AgentTrainer` runs the **rLLM-native SandboxedAgentFlow path**
+(``AgentFlowEngine``) — sandboxes are created locally by ``SandboxTaskHooks``
+via a pluggable ``sandbox_backend`` (``docker`` | ``local`` | ``modal`` |
+``daytona``). This is NOT the remote-runtime / ``RemoteAgentFlowEngine`` path.
+
+The sandbox backend is selected by the ``SWE_SANDBOX_BACKEND`` env var
+(default ``modal``). For ``modal`` install ``pip install modal`` and run
+``modal token new``; for ``daytona`` install ``pip install daytona`` and set
+``DAYTONA_API_KEY``. Everything else is configured by Hydra overrides on the
+command line (see ``train_tinker.sh`` / ``train_verl.sh`` for working defaults).
+
+Usage (from rllm repo root)::
+
+    SWE_SANDBOX_BACKEND=modal python cookbooks/swe-rl/train.py rllm/backend=tinker
+"""
+
+from __future__ import annotations
+
+import os
+
+import hydra
+from omegaconf import DictConfig
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.harnesses.terminus2 import Terminus2Harness
+from rllm.trainer import AgentTrainer
+
+TRAIN_DATASET = "r2egym"
+VAL_DATASET = "swebench-verified"
+
+# Sandbox backend for the SandboxedAgentFlow path: docker | local | modal | daytona.
+SANDBOX_BACKEND = os.environ.get("SWE_SANDBOX_BACKEND", "modal")
+
+# Optional cap on the validation set size. SWE-bench Verified is 500 tasks;
+# validation runs ALL of them every time it fires, which is slow. Set
+# SWE_VAL_MAX=N to validate on the first N tasks instead (0/unset = all 500).
+SWE_VAL_MAX = int(os.environ.get("SWE_VAL_MAX", "0"))
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config: DictConfig) -> None:
+    train_dataset = DatasetRegistry.load_dataset(TRAIN_DATASET, "train")
+    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "default")
+
+    if train_dataset is None:
+        raise RuntimeError(f"Dataset '{TRAIN_DATASET}' not found. Run: rllm dataset pull {TRAIN_DATASET} (or: python cookbooks/swe-rl/prepare_data.py)")
+    if val_dataset is None:
+        raise RuntimeError(f"Dataset '{VAL_DATASET}' not found. Run: rllm dataset pull harbor:swebench-verified (or: python cookbooks/swe-rl/prepare_data.py)")
+
+    if SWE_VAL_MAX > 0 and SWE_VAL_MAX < len(val_dataset):
+        val_dataset = val_dataset.select(range(SWE_VAL_MAX))
+
+    # terminus2 as a SandboxedAgentFlow. Passing ``agent_flow`` (with no
+    # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
+    # for the sandbox lifecycle + per-task verifier, and route rollouts through
+    # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
+
+    trainer = AgentTrainer(
+        backend=config.rllm.get("backend", "tinker"),
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        agent_flow=agent_flow,
+        sandbox_backend=SANDBOX_BACKEND,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -58,6 +58,10 @@ python -u train.py \
     data.max_response_length=8192 \
     data.train_batch_size=1 \
     data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=1 \
+    rllm.data.val_batch_size=-1 \
     rllm.compact_filtering.enable=true \
     rllm.algorithm.adv_estimator=grpo \
     rllm.algorithm.norm_adv_by_std_in_grpo=true \

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym, eval on SWE-bench Verified — Fireworks backend.
+#
+# Prerequisites:
+#   1. Install rllm with fireworks extras:  uv pip install -e ".[fireworks]"
+#   2. Install this cookbook:                uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                    python cookbooks/swe-rl/prepare_data.py
+#   4. Set your API key:                     export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 128 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2
+#     against it. The gateway routes every LLM call back to the Fireworks-hosted
+#     deployment. This is NOT the remote-runtime / RemoteAgentFlowEngine path.
+#   - 32K prompt window, 8K response budget per turn (terminus2 runs
+#     many turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B the README names as the base model rather than the tinker recipe's
+# 4B. To change it, swap model.name / model.tokenizer_model /
+# fireworks_config.policy_trainer_shape_id together (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks.sh training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3p5-9b-fireworks' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the Fireworks backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_fireworks.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous fireworks recipe other cookbooks use (e.g. deepcoder).
+#
+# Prerequisites:
+#   1. Install rllm with fireworks extras:  uv pip install -e ".[fireworks]"
+#   2. Install this cookbook:                uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                    python cookbooks/swe-rl/prepare_data.py
+#   4. Set your API key:                     export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# Differences from train_fireworks.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B the README names as the base model rather than the tinker recipe's
+# 4B. To change it, swap model.name / model.tokenizer_model /
+# fireworks_config.policy_trainer_shape_id together (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend: SWE_SANDBOX_BACKEND (docker | local | modal | daytona; default
+# modal). Cap the eval set with SWE_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3p5-9b-fireworks-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -59,6 +59,10 @@ python -u train.py \
     data.max_response_length=8192 \
     data.train_batch_size=16 \
     data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=16 \
+    rllm.data.val_batch_size=-1 \
     rllm.compact_filtering.enable=true \
     rllm.algorithm.adv_estimator=grpo \
     rllm.algorithm.norm_adv_by_std_in_grpo=true \

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym, eval on SWE-bench Verified.
+#
+# Prerequisites:
+#   1. Install rllm with tinker extras:   uv pip install -e ".[tinker]"
+#   2. Install this cookbook:              uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                  python cookbooks/swe-rl/prepare_data.py
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 64 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2
+#     against it. The gateway routes every LLM call back to the trainer-hosted
+#     model. This is NOT the remote-runtime / RemoteAgentFlowEngine path.
+#   - 32K prompt window, 8K response budget per turn (terminus2 runs
+#     many turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker.sh model.name=Qwen/Qwen3-8B training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-4B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3.5-4b' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the tinker backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_tinker.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous tinker recipe other cookbooks use (e.g. deepcoder).
+#
+# Differences from train_tinker.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Sandbox backend: SWE_SANDBOX_BACKEND (docker | local | modal | daytona; default
+# modal). Cap the eval set with SWE_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-4B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3.5-4b-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_verl.sh
+++ b/cookbooks/swe-rl/train_verl.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the verl (distributed) backend.
+#
+# Prerequisites:
+#   1. Install rllm with verl extras:     uv pip install -e ".[verl]"
+#   2. Install megatron:                   bash scripts/install_megatron.sh <cu128|cu129|...>
+#   3. Install this cookbook:              uv pip install --no-deps -e cookbooks/swe-rl
+#   4. Pull the datasets:                  python cookbooks/swe-rl/prepare_data.py
+#
+# Verl runs vLLM rollouts + FSDP/Megatron training across N GPUs. Mini-swe-agent
+# still executes inside per-task sandboxes via rLLM's own SandboxedAgentFlow path
+# (AgentFlowEngine, not the remote Harbor runtime); only the policy rollout
+# traffic flows through the gateway back to the verl-hosted vLLM engine.
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+
+set -euo pipefail
+
+unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+MODEL_PATH=Qwen/Qwen3.5-4B
+
+python -u train.py \
+    rllm/backend=verl \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.algorithm.use_rllm=true \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    data.max_prompt_length=32768 \
+    data.max_response_length=8192 \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    +actor_rollout_ref.model.lora.rank=32 \
+    +actor_rollout_ref.model.lora.alpha=32 \
+    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=40960 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    +actor_rollout_ref.rollout.max_model_len=40960 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.7 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    trainer.logger="['console','wandb']" \
+    trainer.project_name=swe-rl \
+    trainer.experiment_name=r2egym-terminus2-qwen3.5-4b-verl \
+    trainer.val_before_train=true \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    "$@"

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -309,29 +309,40 @@ class ReverseProxy:
         token_ids: list[int],
         originally_requested_logprobs: bool = False,
     ) -> Response:
-        """Non-streaming cumulative turn: send non-streaming to vLLM, return JSON."""
+        """Non-streaming cumulative turn: send pre-tokenized prompt, return JSON.
+
+        Routes to the in-process ``local_handler`` (e.g. Tinker) when present,
+        otherwise POSTs ``/v1/completions`` to a vLLM worker. Both return a
+        completions-style body carrying ``prompt_token_ids`` + ``token_ids``.
+        """
         t0 = time.perf_counter()
 
-        worker = self.router.route(session_id)
-        url = self._build_url(worker.api_url, "/v1/completions", "")
-        headers = self._forward_headers(request)
-        raw_body = json.dumps(completions_body).encode()
-        try:
-            resp = await self._send_with_retry(
-                method="POST",
-                url=url,
-                content=raw_body,
-                headers=headers,
-            )
-            content = resp.content
-            status_code = resp.status_code
-        finally:
-            self.router.release(worker.url)
+        if self.local_handler is not None:
+            # In-process path (Tinker): sample directly from the pre-tokenized
+            # prompt; no HTTP worker, no re-tokenization.
+            response_body = await self.local_handler(completions_body)
+            status_code = 200
+        else:
+            worker = self.router.route(session_id)
+            url = self._build_url(worker.api_url, "/v1/completions", "")
+            headers = self._forward_headers(request)
+            raw_body = json.dumps(completions_body).encode()
+            try:
+                resp = await self._send_with_retry(
+                    method="POST",
+                    url=url,
+                    content=raw_body,
+                    headers=headers,
+                )
+                content = resp.content
+                status_code = resp.status_code
+            finally:
+                self.router.release(worker.url)
 
-        try:
-            response_body = json.loads(content)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            response_body = {}
+            try:
+                response_body = json.loads(content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                response_body = {}
 
         latency_ms = (time.perf_counter() - t0) * 1000
 
@@ -375,6 +386,11 @@ class ReverseProxy:
         token_ids: list[int],
     ) -> StreamingResponse:
         """Streaming cumulative turn: stream from vLLM, translate chunks to chat format."""
+        if self.local_handler is not None:
+            # In-process backends (Tinker) don't stream; synthesize an SSE
+            # stream from a single pre-tokenized completion call.
+            return await self._handle_cumulative_streaming_local(request, request_body, completions_body, session_id, acc, token_ids)
+
         completions_body["stream"] = True
 
         worker = self.router.route(session_id)
@@ -501,6 +517,97 @@ class ReverseProxy:
             media_type="text/event-stream",
             status_code=resp.status_code,
         )
+
+    async def _handle_cumulative_streaming_local(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        completions_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        token_ids: list[int],
+    ) -> StreamingResponse:
+        """Cumulative streaming via the in-process handler (fake-streaming).
+
+        The local handler returns a full completion in one shot; we ingest its
+        token IDs into the accumulator, translate to chat format, and emit it as
+        a synthesized SSE stream (role → content+tokens → finish → [DONE]).
+        """
+        assert self.local_handler is not None
+        t0 = time.perf_counter()
+        response_body = await self.local_handler(completions_body)
+        latency_ms = (time.perf_counter() - t0) * 1000
+
+        prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
+        completion_token_ids = extract_completion_token_ids(response_body)
+        acc.ingest_turn(prompt_token_ids, completion_token_ids)
+        acc.update_prefix(request_body.get("messages", []))
+
+        choices = response_body.get("choices") or []
+        content = choices[0].pop("text", "") if choices else ""
+        finish_reason = (choices[0].get("finish_reason") if choices else None) or "stop"
+        completion_logprobs = choices[0].get("logprobs") if choices else None
+
+        if session_id and response_body:
+            chat_body = dict(response_body)
+            chat_body["object"] = "chat.completion"
+            if chat_body.get("choices"):
+                chat_body["choices"][0]["message"] = {"role": "assistant", "content": content}
+            trace = build_trace_record(session_id, request_body, chat_body, latency_ms, weight_version=request.state.weight_version)
+            await self._persist(trace)
+
+        chat_id = response_body.get("id", "chatcmpl-local")
+        created = response_body.get("created", int(time.time()))
+        model = response_body.get("model", "")
+        usage = response_body.get("usage", {})
+
+        def _sanitize_chunk(chunk: dict[str, Any]) -> dict[str, Any]:
+            return strip_vllm_fields(chunk) if self.strip_vllm else chunk
+
+        async def event_generator():
+            def _sse(data: str) -> str:
+                return f"data: {data}\n\n"
+
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+                    }
+                )
+            )
+            yield _sse(
+                json.dumps(
+                    _sanitize_chunk(
+                        {
+                            "id": chat_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None, "token_ids": completion_token_ids, "logprobs": completion_logprobs}],
+                            "prompt_token_ids": prompt_token_ids,
+                        }
+                    )
+                )
+            )
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+                        "usage": usage,
+                    }
+                )
+            )
+            yield _sse("[DONE]")
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream", status_code=200)
 
     # ------------------------------------------------------------------
     # Streaming (SSE)

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
@@ -1,0 +1,136 @@
+"""Cumulative token mode over the in-process ``local_handler`` (e.g. Tinker).
+
+The HTTP-worker path is covered by ``test_cumulative_token_mode.py``. These
+tests cover the local-handler branch added so backends without a vLLM
+``/v1/completions`` worker (Tinker runs in-process) get the same drift-free
+prefix-extension: turn 2+ samples directly from pre-tokenized prompt IDs built
+by the renderer, and the accumulator ingests the result.
+
+Tests drive the proxy methods directly (no HTTP server) via ``asyncio.run`` to
+avoid a pytest-asyncio dependency.
+"""
+
+import asyncio
+import json
+
+from rllm_model_gateway.proxy import ReverseProxy
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+
+class _State:
+    weight_version = 0
+
+
+class _Request:
+    """Minimal stand-in: the cumulative-local paths only read request.state."""
+
+    state = _State()
+
+
+def _make_proxy(local_handler):
+    """ReverseProxy wired for the local cumulative path (no router/worker)."""
+    return ReverseProxy(
+        router=None,
+        store=MemoryTraceStore(),
+        sync_traces=True,
+        local_handler=local_handler,
+        cumulative_token_mode=True,
+        renderer=None,  # accumulator state is set directly in these tests
+    )
+
+
+def _completion_handler(record):
+    """Fake Tinker token-path handler: echoes ``prompt`` as prompt_token_ids,
+    returns a fixed 2-token completion. Records the body it was called with."""
+
+    async def handler(body):
+        record.append(body)
+        return {
+            "id": "cmpl-x",
+            "object": "text_completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "next action",
+                    "token_ids": [91, 92],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2]},
+                }
+            ],
+            "prompt_token_ids": body["prompt"],
+            "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
+        }
+
+    return handler
+
+
+def test_cumulative_local_non_streaming_ingests_and_translates():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])  # turn 1: prompt + completion already captured
+    bridged = [1, 2, 3, 4, 5, 6, 7]  # what the renderer would produce for turn 2
+
+    completions_body = {"prompt": bridged, "add_special_tokens": False, "model": "q"}
+    resp = asyncio.run(
+        proxy._handle_cumulative_non_streaming(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            completions_body,
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    # The local handler was called with the pre-tokenized prompt, not messages.
+    assert record and record[0]["prompt"] == bridged
+    assert "messages" not in record[0]
+
+    # Response is translated back to chat format for the agent.
+    body = json.loads(resp.body)
+    assert resp.status_code == 200
+    assert body["object"] == "chat.completion"
+    assert body["choices"][0]["message"] == {"role": "assistant", "content": "next action"}
+
+    # Accumulator advanced: prefix-extension holds (bridged starts with prev prompt+completion).
+    assert acc.turn_count == 2
+    assert acc.prev_prompt_ids == bridged
+    assert acc.prev_completion_ids == [91, 92]
+    assert acc.cumulative_ids[: len([1, 2, 3, 4, 5])] == [1, 2, 3, 4, 5]
+
+
+def test_cumulative_local_streaming_emits_sse_and_ingests():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    bridged = [1, 2, 3, 4, 5, 6, 7]
+
+    resp = asyncio.run(
+        proxy._handle_cumulative_streaming_local(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            {"prompt": bridged},
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    chunks = []
+
+    async def drain():
+        async for c in resp.body_iterator:
+            chunks.append(c if isinstance(c, str) else c.decode())
+
+    asyncio.run(drain())
+
+    assert any('"role": "assistant"' in c for c in chunks)
+    assert any('"next action"' in c for c in chunks)
+    assert chunks[-1].strip().endswith("[DONE]")
+    # Same ingest as non-streaming.
+    assert acc.turn_count == 2 and acc.prev_completion_ids == [91, 92]

--- a/rllm/data/utils.py
+++ b/rllm/data/utils.py
@@ -16,12 +16,28 @@ def task_from_row(row: dict[str, Any], task_id: str) -> Task:
 
     Shared by the engine (per-task at rollout) and the sandbox warm-pool
     schedule so both derive the same ``env_key`` for a given row.
+
+    Harbor-sourced rows (r2egym, swebench-verified, swesmith, …) carry a
+    ``task_path`` pointing at the per-task directory. Root the Task there and
+    merge its ``task.toml`` + ``environment/Dockerfile`` metadata so per-task
+    verifier resolution and per-task image selection work on the sandbox path
+    — mirroring the eval CLI's ``_dict_rows_to_tasks``. Rows without
+    ``task_path`` keep ``dataset_dir=Path(".")`` and rely on a fixed evaluator.
     """
+    task_path = row.get("task_path")
+    metadata: dict[str, Any] = dict(row)
+    if task_path:
+        from rllm.tasks.loader import _merge_task_toml_metadata
+
+        dataset_dir = Path(task_path)
+        metadata = _merge_task_toml_metadata(dataset_dir, metadata)
+    else:
+        dataset_dir = Path(".")
     return Task(
         id=str(task_id),
         instruction=str(row.get("question", row.get("instruction", ""))),
-        metadata=row,
-        dataset_dir=Path("."),
+        metadata=metadata,
+        dataset_dir=dataset_dir,
     )
 
 

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -196,15 +196,37 @@ def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, 
     return create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend), **backend_kwargs)
 
 
+def _should_replay_dockerfile(task: Task) -> bool:
+    """Whether to replay the Dockerfile's ``RUN`` steps on non-docker backends.
+
+    Two task conventions are supported via ``[environment].replay_dockerfile``:
+
+    * **SWE-bench style** (default, ``true``): the configured ``docker_image``
+      is a *base*; the Dockerfile's ``RUN`` steps (e.g. ``uv``, needed by the
+      grader) are not in that image and must be replayed on top.
+    * **Terminal-bench / Harbor style** (``false``): the configured
+      ``docker_image`` is the *fully built* task image, so replaying its ``RUN``
+      steps double-applies the build (``git clone ... already exists``, missing
+      ``COPY``'d files, etc.). These tasks set
+      ``[environment]\nreplay_dockerfile = false`` to boot the image as-is.
+    """
+    env = task.metadata.get("environment", {}) or {}
+    return bool(env.get("replay_dockerfile", True))
+
+
 def _replay_dockerfile(task: Task, sandbox: Sandbox, backend: str) -> None:
     """Replay the Dockerfile RUN steps on a live sandbox (stage C).
 
     Non-docker backends pull the Dockerfile's FROM base instead of building
     it, so the RUN steps (e.g. swebench's ``uv``, needed by the grader) must
     be replayed. Best-effort: a failed step shouldn't abort the task. Docker
-    builds the image, so its RUN steps already ran — skip.
+    builds the image, so its RUN steps already ran — skip. Tasks that boot a
+    fully-built image opt out via ``[environment].replay_dockerfile = false``
+    (see :func:`_should_replay_dockerfile`).
     """
     if backend == "docker":
+        return
+    if not _should_replay_dockerfile(task):
         return
     for cmd in _dockerfile_run_commands(task):
         _safe_exec(sandbox, cmd, timeout=900)
@@ -249,9 +271,13 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
 
 
 def _dockerfile_run_commands(task: Task) -> list[str]:
-    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps (joining
-    ``\\``-continuations). Non-``RUN`` directives — ``COPY``/``ADD`` etc. — are
-    skipped; only ``RUN`` is replayable on a live sandbox.
+    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps.
+
+    ``\\``-continuations are joined into a single logical command with a space
+    (matching shell line-continuation semantics) so multi-line ``RUN`` steps
+    stay valid when re-executed via ``bash -c``. Non-``RUN`` directives —
+    ``COPY``/``ADD`` etc. — are skipped; only ``RUN`` is replayable on a live
+    sandbox.
     """
     dockerfile = task.task_dir / "environment" / "Dockerfile"
     if not dockerfile.exists():
@@ -275,7 +301,7 @@ def _dockerfile_run_commands(task: Task) -> list[str]:
                 if i >= len(lines):
                     break
                 parts.append(lines[i])
-            cmd = "\n".join(parts).strip()
+            cmd = " ".join(part.strip() for part in parts).strip()
             if cmd:
                 commands.append(cmd)
         i += 1

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -440,17 +440,30 @@ def save_config(config: RllmConfig) -> str:
     Creates parent directories as needed and sets file permissions to 0o600
     (owner read/write only) since the file contains API keys.
 
+    Merges into any existing file so unrelated keys (e.g. ``ui_api_key``
+    written by ``rllm login``) survive provider/model changes instead of
+    being clobbered.
+
     Returns the path that was written.
     """
     path = _config_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    data: dict[str, object] = {
-        "provider": config.provider,
-        "model": config.model,
-        "api_keys": dict(config.api_keys),
-    }
+    data: dict[str, object] = {}
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                data = loaded
+        except (json.JSONDecodeError, OSError):
+            data = {}
+    data["provider"] = config.provider
+    data["model"] = config.model
+    data["api_keys"] = dict(config.api_keys)
     if config.base_url:
         data["base_url"] = config.base_url
+    else:
+        data.pop("base_url", None)
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -4,7 +4,7 @@ Two classes share most of the lifecycle (uvicorn-on-thread or subprocess,
 trace store, session API). They differ in how upstream workers are
 registered and what request-body injection the middleware applies.
 
-* :class:`GatewayManager` — training. Workers come from a verl/tinker
+* :class:`GatewayManager` — training. Workers come from a verl/tinker/fireworks
   rollout engine via :meth:`start(rollout_engine)`. Injects ``logprobs``
   and ``return_token_ids`` into request bodies (vLLM needs both for the
   loss math downstream).
@@ -207,11 +207,11 @@ class GatewayManager:
         """Start the gateway and register inference workers.
 
         For VerlEngine: registers the existing vLLM server addresses.
-        For TinkerEngine: creates an in-process handler (no sidecar needed).
+        For TinkerEngine / FireworksEngine: creates an in-process handler (no sidecar needed).
         """
         engine_cls = type(rollout_engine).__name__
 
-        if engine_cls == "TinkerEngine":
+        if engine_cls in ("TinkerEngine", "FireworksEngine"):
             # In-process handler — no HTTP backend, no worker registration
             from rllm.gateway.tinker_adapter import create_tinker_handler
 
@@ -227,6 +227,7 @@ class GatewayManager:
             for url in worker_urls:
                 worker_id = self.client.add_worker(url=url)
                 logger.info("Registered worker %s -> %s", worker_id, url)
+        
         else:
             logger.warning("Unknown engine type %s — no workers registered", engine_cls)
 

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -159,8 +159,8 @@ class GatewayManager:
         from rllm.gateway.tunnel import parse_tunnel
 
         self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
-        # The gateway always pins ``body.model`` to whatever the trainer is serving
-        self.model: str | None = config.get("model", {}).get("name", None)
+        _model_cfg = config.get("model", {})
+        self.model: str | None = _model_cfg.get("tokenizer_model") or _model_cfg.get("name", None)
 
         # Cumulative token mode: drift-free multi-turn token forwarding. The
         # gateway loads the tokenizer from the served model path. renderers

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -17,6 +17,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from rllm.engine.rollout.tinker_engine import TinkerEngine
+from rllm.workflows import TerminationEvent, TerminationReason
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,32 @@ def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
             }
         )
     return result
+
+
+def _termination_http_error(reason: TerminationReason) -> Exception:
+    """Map a ``TerminationEvent`` to a non-retryable OpenAI-style 400.
+
+    For CLI harnesses the agent loop runs inside the sandbox, so the only way
+    to stop it is the HTTP response — a 500 makes the LLM client retry the
+    (still-too-long) call until the harness run-timeout SIGKILLs it, stalling
+    the whole group. ``context_length_exceeded`` maps to a NON-retryable
+    ContextWindowExceededError in litellm/openai SDKs, so the agent raises and
+    the rollout returns immediately with the turns so far.
+    """
+    from fastapi import HTTPException
+
+    is_prompt_limit = reason == TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED
+    return HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": f"Rollout terminated: {reason}. The conversation exceeded the model's prompt window.",
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded" if is_prompt_limit else "rollout_terminated",
+                "param": "messages",
+            }
+        },
+    )
 
 
 async def _token_prompt_completion(
@@ -122,7 +149,10 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         # path the HTTP backend uses for the same feature.
         prompt = request_body.get("prompt")
         if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
-            return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+            try:
+                return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+            except TerminationEvent as e:
+                raise _termination_http_error(e.reason) from e
 
         messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
@@ -130,7 +160,10 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         if tools:
             kwargs["tools"] = tools
 
-        model_output = await engine.get_model_response(messages, **kwargs)
+        try:
+            model_output = await engine.get_model_response(messages, **kwargs)
+        except TerminationEvent as e:
+            raise _termination_http_error(e.reason) from e
 
         response_text = model_output.content or model_output.text or ""
         prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else []

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -41,6 +41,56 @@ def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
     return result
 
 
+async def _token_prompt_completion(
+    engine: TinkerEngine,
+    request_body: dict[str, Any],
+    prompt_ids: list[int],
+    sampling_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Sample from a pre-tokenized prompt (cumulative-token mode).
+
+    Bypasses message rendering entirely: ``prompt_ids`` is fed straight to the
+    engine's token-input sampler. Returns a **completions-style** response dict
+    (``choices[0].text`` + ``token_ids``, root ``prompt_token_ids``,
+    ``logprobs.token_logprobs``) — the exact shape the gateway's cumulative-turn
+    handler extracts token IDs from and translates back to chat format.
+    """
+    token_output = await engine.get_token_output_from_token_input(prompt_ids, **sampling_kwargs)
+    model_output = engine.assemble_model_output(prompt_ids, token_output)
+
+    # Text the agent sees as the assistant turn (same precedence as the chat path).
+    text = model_output.content or model_output.text or ""
+    out_prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else list(prompt_ids)
+    completion_ids = list(model_output.completion_ids) if model_output.completion_ids else []
+    logprobs = model_output.logprobs or []
+    finish_reason = model_output.finish_reason or "stop"
+    prompt_len = model_output.prompt_length or len(out_prompt_ids)
+    completion_len = model_output.completion_length or len(completion_ids)
+
+    return {
+        "id": f"cmpl-{uuid.uuid4().hex[:12]}",
+        "object": "text_completion",
+        "created": int(time.time()),
+        "model": request_body.get("model", getattr(engine, "model_name", "default")),
+        "choices": [
+            {
+                "index": 0,
+                "text": text,
+                "token_ids": completion_ids,
+                "finish_reason": finish_reason,
+                "logprobs": {"token_logprobs": logprobs},
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_len,
+            "completion_tokens": completion_len,
+            "total_tokens": prompt_len + completion_len,
+        },
+        "prompt_token_ids": out_prompt_ids,
+        "weight_version": getattr(model_output, "weight_version", None),
+    }
+
+
 def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
     """Return an async handler that calls TinkerEngine in-process.
 
@@ -50,22 +100,35 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
     """
 
     async def handler(request_body: dict[str, Any]) -> dict[str, Any]:
+        # Sampling params shared by the chat and pre-tokenized paths.
+        sampling_kwargs: dict[str, Any] = {}
+        if request_body.get("temperature") is not None:
+            sampling_kwargs["temperature"] = request_body["temperature"]
+        if request_body.get("top_p") is not None:
+            sampling_kwargs["top_p"] = request_body["top_p"]
+        if request_body.get("top_k") is not None:
+            sampling_kwargs["top_k"] = request_body["top_k"]
+        if request_body.get("max_tokens") is not None:
+            sampling_kwargs["max_tokens"] = request_body["max_tokens"]
+        if request_body.get("max_completion_tokens") is not None:
+            sampling_kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
+
+        # Cumulative-token-mode path: the gateway rewrites turn 2+ to a
+        # completions-style request whose ``prompt`` is raw token IDs built by
+        # ``renderers.bridge_to_next_turn`` (= prior turns' prompt+completion
+        # tokens + the new messages). Sample straight from those tokens — no
+        # re-render, no re-tokenization — so the sequence the optimizer trains on
+        # is byte-for-byte what was generated. Mirrors the vLLM /v1/completions
+        # path the HTTP backend uses for the same feature.
+        prompt = request_body.get("prompt")
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+
         messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
-
-        kwargs: dict[str, Any] = {}
+        kwargs = dict(sampling_kwargs)
         if tools:
             kwargs["tools"] = tools
-        if request_body.get("temperature") is not None:
-            kwargs["temperature"] = request_body["temperature"]
-        if request_body.get("top_p") is not None:
-            kwargs["top_p"] = request_body["top_p"]
-        if request_body.get("top_k") is not None:
-            kwargs["top_k"] = request_body["top_k"]
-        if request_body.get("max_tokens") is not None:
-            kwargs["max_tokens"] = request_body["max_tokens"]
-        if request_body.get("max_completion_tokens") is not None:
-            kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
 
         model_output = await engine.get_model_response(messages, **kwargs)
 

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -58,7 +58,25 @@ if ! command -v mini-swe-agent >/dev/null 2>&1; then
         fi
     fi
     if ! command -v uv >/dev/null 2>&1; then
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+        # Sandbox->GitHub egress (astral.sh redirects to
+        # release-assets.githubusercontent.com) intermittently resets the
+        # connection on cloud backends (Modal/Daytona). Without a retry a
+        # single ``curl: (35/56) Connection reset by peer`` aborts the whole
+        # install under ``set -e`` and the rollout scores 0. Retry a few times
+        # with backoff before giving up.
+        uv_installed=0
+        for attempt in 1 2 3 4 5; do
+            if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+                uv_installed=1
+                break
+            fi
+            echo "uv install attempt ${attempt} failed; retrying in $((attempt * 3))s" >&2
+            sleep $((attempt * 3))
+        done
+        if [ "$uv_installed" -ne 1 ]; then
+            echo "uv install failed after 5 attempts" >&2
+            exit 1
+        fi
     fi
     export PATH="$HOME/.local/bin:$PATH"
     # Pin a modern interpreter for the tool's ISOLATED venv. mini-swe-agent

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -327,7 +327,13 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
     """
     from daytona import CreateSnapshotParams, Daytona, DaytonaNotFoundError, Image, Resources
 
-    from rllm.eval._resolution import _as_single_run_line, _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
+    from rllm.eval._resolution import (
+        _as_single_run_line,
+        _dockerfile_run_commands,
+        _resolve_image,
+        _sandbox_resource_kwargs,
+        _should_replay_dockerfile,
+    )
 
     client = Daytona()
     try:
@@ -341,7 +347,9 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
         pass
 
     img = Image.base(_resolve_image(task, "daytona"))
-    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)]
+    # Honor [environment].replay_dockerfile: fully-built task images opt out so
+    # their RUN steps aren't double-applied on top of the prebuilt image.
+    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
     if install_script:
         run_commands.append(_as_single_run_line(install_script))
     if run_commands:

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -322,7 +322,12 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     (stored as a diff from the base). A failed install fails the build — a
     snapshot keyed on the install must actually contain it.
     """
-    from rllm.eval._resolution import _create_base_sandbox, _dockerfile_run_commands, _replay_dockerfile
+    from rllm.eval._resolution import (
+        _create_base_sandbox,
+        _dockerfile_run_commands,
+        _replay_dockerfile,
+        _should_replay_dockerfile,
+    )
 
     if prior_ref and not force and _modal_ref_alive(prior_ref):
         logger.info("modal snapshot %s already live (%s) — reusing", key, prior_ref)
@@ -333,7 +338,8 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     # full bound), plus the install bound and pull/capture slack. With the
     # 30-min default, two hung steps killed the sandbox mid-build.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
-    build_timeout = max(_DEFAULT_TIMEOUT, 900 * len(_dockerfile_run_commands(task)) + install_budget + 600)
+    n_replay = len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0
+    build_timeout = max(_DEFAULT_TIMEOUT, 900 * n_replay + install_budget + 600)
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
     try:
         _replay_dockerfile(task, sb, "modal")

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -70,9 +70,10 @@ def env_key(backend: str, base_image: str, run_commands: list[str], install_scri
 
 def env_key_for(task: Task, backend: str, install_script: str = "") -> str:
     """Fingerprint a task's environment via the shared image/RUN resolution."""
-    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image
+    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _should_replay_dockerfile
 
-    return env_key(backend, _resolve_image(task, backend), _dockerfile_run_commands(task), install_script)
+    run_commands = _dockerfile_run_commands(task) if _should_replay_dockerfile(task) else []
+    return env_key(backend, _resolve_image(task, backend), run_commands, install_script)
 
 
 def install_script_for(agent_flow: object) -> str:

--- a/tests/eval/test_dockerfile_replay.py
+++ b/tests/eval/test_dockerfile_replay.py
@@ -1,0 +1,84 @@
+"""Tests for Dockerfile RUN-replay handling in :mod:`rllm.eval._resolution`.
+
+Covers two fixes:
+
+* ``_dockerfile_run_commands`` joins ``\\``-continuations into a single valid
+  shell command (so multi-line ``RUN`` steps don't become invalid ``bash``).
+* ``_should_replay_dockerfile`` honors ``[environment].replay_dockerfile``:
+  default ``True`` (SWE-bench: replay RUN steps on a base image), ``False`` for
+  fully-built terminal-bench/Harbor images (boot as-is, no double-apply).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rllm.eval._resolution import _dockerfile_run_commands, _should_replay_dockerfile
+from rllm.tasks.loader import _load_task_from_dir
+from rllm.types import Task
+
+
+def _task_with_dockerfile(tmp_path: Path, dockerfile: str, metadata: dict | None = None) -> Task:
+    env = tmp_path / "environment"
+    env.mkdir(parents=True, exist_ok=True)
+    (env / "Dockerfile").write_text(dockerfile)
+    return Task(id="t", instruction="", metadata=metadata or {}, dataset_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _dockerfile_run_commands: continuation join + COPY skipping
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_run_joins_with_space_not_newline(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\nRUN apt-get update && apt-get install -y \\\n    python3-pip \\\n    && rm -rf /var/lib/apt/lists/*\n",
+    )
+    cmds = _dockerfile_run_commands(task)
+    assert cmds == ["apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*"]
+    # The old bug joined with "\n", which bash rejects ("syntax error near '&&'").
+    assert "\n" not in cmds[0]
+
+
+def test_copy_directives_are_skipped(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\nCOPY input_files/data.json /app/data.json\nRUN echo hi\nADD x.tar /app/\n",
+    )
+    assert _dockerfile_run_commands(task) == ["echo hi"]
+
+
+def test_single_line_run_unchanged(tmp_path):
+    task = _task_with_dockerfile(tmp_path, "FROM ubuntu:24.04\nRUN pip3 install ansible-core==2.16.3\n")
+    assert _dockerfile_run_commands(task) == ["pip3 install ansible-core==2.16.3"]
+
+
+# ---------------------------------------------------------------------------
+# _should_replay_dockerfile: the [environment].replay_dockerfile toggle
+# ---------------------------------------------------------------------------
+
+
+def test_replay_defaults_true_when_unset():
+    assert _should_replay_dockerfile(Task(id="t", instruction="", metadata={}, dataset_dir=Path("."))) is True
+    task = Task(id="t", instruction="", metadata={"environment": {"docker_image": "base"}}, dataset_dir=Path("."))
+    assert _should_replay_dockerfile(task) is True
+
+
+def test_replay_disabled_when_flag_false():
+    task = Task(
+        id="t",
+        instruction="",
+        metadata={"environment": {"docker_image": "prebuilt", "replay_dockerfile": False}},
+        dataset_dir=Path("."),
+    )
+    assert _should_replay_dockerfile(task) is False
+
+
+def test_replay_flag_read_from_task_toml(tmp_path):
+    """End-to-end: [environment].replay_dockerfile in task.toml reaches metadata."""
+    (tmp_path / "environment").mkdir()
+    (tmp_path / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\nRUN echo hi\n")
+    (tmp_path / "task.toml").write_text('[environment]\ndocker_image = "org/img:t"\nreplay_dockerfile = false\n')
+    task = _load_task_from_dir(tmp_path, dataset_dir=tmp_path)
+    assert _should_replay_dockerfile(task) is False

--- a/tests/eval/test_eval_config.py
+++ b/tests/eval/test_eval_config.py
@@ -148,6 +148,20 @@ class TestLoadSaveConfig:
             data = json.load(f)
         assert "base_url" not in data
 
+    def test_save_preserves_unrelated_keys(self, tmp_rllm_home):
+        """save_config must not clobber keys it doesn't own (e.g. ui_api_key from `rllm login`)."""
+        config_path = os.path.join(tmp_rllm_home, "config.json")
+        os.makedirs(tmp_rllm_home, exist_ok=True)
+        with open(config_path, "w") as f:
+            json.dump({"provider": "openai", "api_keys": {"openai": "k1"}, "model": "m1", "ui_api_key": "rllm_abc"}, f)
+        # A provider/model swap should leave the UI token intact.
+        save_config(RllmConfig(provider="tinker", api_keys={"tinker": "tml-xyz"}, model="m2"))
+        with open(config_path) as f:
+            data = json.load(f)
+        assert data["ui_api_key"] == "rllm_abc"
+        assert data["provider"] == "tinker"
+        assert data["model"] == "m2"
+
 
 class TestConstants:
     def test_openai_in_supported_providers(self):

--- a/tests/test_tinker_adapter_cumulative.py
+++ b/tests/test_tinker_adapter_cumulative.py
@@ -1,0 +1,91 @@
+"""Tinker adapter: pre-tokenized prompt path for cumulative token mode.
+
+When the gateway runs in ``cumulative_token_mode``, turn 2+ arrives at the
+in-process handler as a completions-style request whose ``prompt`` is raw token
+IDs (built by ``renderers.bridge_to_next_turn``). The handler must sample
+straight from those tokens — bypassing message rendering — and return a
+completions-style body the gateway can extract token IDs from.
+
+Uses a fake engine so no Tinker service / model is required.
+"""
+
+import asyncio
+
+from rllm.gateway.tinker_adapter import create_tinker_handler
+
+
+class _ModelOutput:
+    text = "ls -la"
+    content = "ls -la"
+    reasoning = ""
+    tool_calls = []
+    prompt_ids = [1, 2, 3, 4]
+    completion_ids = [10, 11]
+    logprobs = [-0.1, -0.2]
+    prompt_length = 4
+    completion_length = 2
+    finish_reason = "stop"
+
+
+class _FakeEngine:
+    model_name = "qwen"
+
+    def __init__(self):
+        self.token_input = None
+        self.messages = None
+
+    async def get_token_output_from_token_input(self, token_input, **kwargs):
+        self.token_input = token_input
+        self.sampling_kwargs = kwargs
+        return "sampled"
+
+    def assemble_model_output(self, token_input, token_output):
+        return _ModelOutput()
+
+    async def get_model_response(self, messages, **kwargs):
+        self.messages = messages
+        return _ModelOutput()
+
+
+def test_token_prompt_path_samples_from_tokens():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"prompt": [1, 2, 3, 4], "temperature": 0.7, "model": "qwen"}))
+
+    # Sampled directly from the token IDs — message rendering bypassed.
+    assert engine.token_input == [1, 2, 3, 4]
+    assert engine.messages is None
+    assert engine.sampling_kwargs.get("temperature") == 0.7
+
+    # Completions-style body the gateway's cumulative handler understands.
+    assert resp["object"] == "text_completion"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+    assert resp["choices"][0]["text"] == "ls -la"
+    assert resp["choices"][0]["token_ids"] == [10, 11]
+    assert resp["choices"][0]["logprobs"]["token_logprobs"] == [-0.1, -0.2]
+
+
+def test_chat_path_unchanged_by_token_branch():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"messages": [{"role": "user", "content": "hi"}], "model": "qwen"}))
+
+    assert engine.messages == [{"role": "user", "content": "hi"}]
+    assert engine.token_input is None  # token path not taken
+    assert resp["object"] == "chat.completion"
+    assert resp["choices"][0]["message"]["content"] == "ls -la"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+
+
+def test_non_int_prompt_falls_through_to_chat():
+    """A string ``prompt`` (or none) must not trigger the token path."""
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    # No messages and a string prompt: should still go down the chat path
+    # (messages defaulting to []), not the token path.
+    asyncio.run(handler({"prompt": "hello", "messages": [{"role": "user", "content": "hi"}]}))
+    assert engine.token_input is None
+    assert engine.messages == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## Summary

Adds a **Fireworks** managed-backend training path to the `swe-rl` cookbook, alongside the existing Tinker and Verl recipes. The trainer job and inference deployment are provisioned on Fireworks at startup and torn down on shutdown; the same async-GRPO + compact-filtering recipe is reused, only the trainer/inference hosting changes.

## What's included

- **`cookbooks/swe-rl/train_fireworks.sh`** — Fireworks backend, async GRPO + compact filtering. Qwen3.5-9B + LoRA-32 on the `qwen3p5-9b-256k-lora` training shape, 128 parallel rollouts, 32K prompt / 8K per-turn response budget.
- **`cookbooks/swe-rl/train_fireworks_sync.sh`** — synchronous (on-policy) variant for easier testing/debugging (no `async_training.*`; `train_batch_size` is the real per-step task count).
- **`cookbooks/swe-rl/README.md`** — new "Fireworks (managed, LoRA)" section + entries in the file-map table.
- **`rllm/gateway/manager.py`** — gateway support for `FireworksEngine`:
  - `start()` routes `FireworksEngine` through the in-process (Tinker-style) handler — no HTTP sidecar / worker registration.
  - `body.model` now prefers `model.tokenizer_model` over `model.name` when present, so the gateway loads the correct tokenizer for cumulative-token mode.

## Notes

- Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this recipe uses the 9B base (vs. the Tinker recipe's 4B). Swap `model.name` / `model.tokenizer_model` / `fireworks_config.policy_trainer_shape_id` together to change it — see `docs/backends/fireworks.mdx`.
- Sandbox backend is selected via `SWE_SANDBOX_BACKEND` (docker | local | modal | daytona; default modal), same as the other recipes.

## Testing

- `ruff format --check` and `ruff check` pass on `rllm/gateway/manager.py`.
