### PR TITLE
feat(config): live Fireworks model catalog + deployed account models

### DIFF
--- a/rllm/cli/_ui.py
+++ b/rllm/cli/_ui.py
@@ -227,6 +227,10 @@ def _select_model(provider: str, existing, api_key: str | None = None) -> str:
     from rllm.eval.config import PROVIDER_MODELS
 
     models = PROVIDER_MODELS.get(provider, [])
+    # Display labels, one per entry in ``models``. Defaults to the model IDs
+    # themselves; a provider branch may override to annotate entries (e.g.
+    # Fireworks marks account models that need a dedicated deployment).
+    labels: list[str] | None = None
 
     if provider == "tinker":
         from rllm.eval.config import fetch_tinker_models
@@ -239,6 +243,21 @@ def _select_model(provider: str, existing, api_key: str | None = None) -> str:
         else:
             console.print("  [dim]Could not fetch live catalog — showing curated list (or enter a tinker:// path manually).[/]")
 
+    if provider == "fireworks":
+        from rllm.eval.config import fetch_fireworks_deployed_models, fetch_fireworks_models
+
+        with console.status("[dim]Fetching Fireworks model catalog...[/]"):
+            serverless = fetch_fireworks_models(api_key)
+            deployed = fetch_fireworks_deployed_models(api_key)
+        if serverless or deployed:
+            # Both are runnable now: public serverless models, plus the
+            # account's own actively deployed models (flagged for provenance).
+            models = list(serverless) + list(deployed)
+            labels = list(serverless) + [f"{m}  (your deployment)" for m in deployed]
+            console.print(f"  [success]Loaded {len(serverless)} serverless + {len(deployed)} deployed models[/] [dim](you can also enter any accounts/.../models/... ID manually)[/]")
+        else:
+            console.print("  [dim]Could not fetch live catalog — showing curated list (or enter a model ID manually).[/]")
+
     # For custom provider or providers with no curated list, prompt for free-text
     if provider == "custom" or not models:
         default = existing.model if existing.model else ""
@@ -247,7 +266,11 @@ def _select_model(provider: str, existing, api_key: str | None = None) -> str:
             fail("Model is required.")
         return model
 
-    choices = list(models) + ["Other (enter manually)"]
+    # ``models`` holds the selectable IDs; ``labels`` holds what's shown (they
+    # differ when a provider annotates entries). Keep them index-aligned.
+    if labels is None:
+        labels = list(models)
+    choices = labels + ["Other (enter manually)"]
 
     cursor = 0
     if existing.model in models:
@@ -265,7 +288,7 @@ def _select_model(provider: str, existing, api_key: str | None = None) -> str:
         if not model:
             fail("Model is required.")
     else:
-        model = choices[idx]
+        model = models[idx]
 
     return model
 

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -17,6 +17,14 @@ from rllm import paths
 # https://tinker-docs.thinkingmachines.ai/tinker/compatible-apis/openai/
 TINKER_OAI_BASE_URL = "https://tinker.thinkingmachines.dev/services/tinker-prod/oai/api/v1"
 
+# Fireworks' control-plane model catalog. ``GET {base}/v1/accounts/fireworks/models``
+# lists the full public model library (~280 entries) with rich metadata
+# (``supportsServerless``, ``kind``, ``contextLength``). We filter this to
+# serverless chat LLMs. (The OpenAI-compatible ``/inference/v1/models`` endpoint
+# only returns a small curated subset, so it's not used here.) See
+# https://docs.fireworks.ai/api-reference/list-models
+FIREWORKS_CONTROL_BASE_URL = "https://api.fireworks.ai/v1"
+
 
 @dataclass
 class ProviderInfo:
@@ -149,11 +157,18 @@ PROVIDER_REGISTRY: list[ProviderInfo] = [
         label="Fireworks",
         litellm_prefix="fireworks_ai",
         env_key="FIREWORKS_API_KEY",
-        default_model="accounts/fireworks/models/llama4-maverick-instruct-basic",
+        default_model="accounts/fireworks/models/deepseek-v4-flash",
+        # Curated fallback shown when the live catalog can't be fetched
+        # (offline / no key). ``rllm model setup`` pulls the full, live list of
+        # serverless chat models from the control-plane catalog when possible.
         models=[
-            "accounts/fireworks/models/llama4-maverick-instruct-basic",
-            "accounts/fireworks/models/deepseek-r1",
-            "accounts/fireworks/models/qwen2p5-72b-instruct",
+            "accounts/fireworks/models/deepseek-v4-flash",
+            "accounts/fireworks/models/deepseek-v4-pro",
+            "accounts/fireworks/models/glm-5p2",
+            "accounts/fireworks/models/gpt-oss-120b",
+            "accounts/fireworks/models/gpt-oss-20b",
+            "accounts/fireworks/models/kimi-k2p6",
+            "accounts/fireworks/models/minimax-m3",
         ],
     ),
     ProviderInfo(
@@ -320,6 +335,95 @@ def fetch_tinker_models(api_key: str | None = None) -> list[str]:
             os.environ.pop("TINKER_API_KEY", None)
         else:
             os.environ["TINKER_API_KEY"] = prev
+
+
+def _fireworks_get(path: str, key: str, params: dict | None = None) -> dict:
+    """GET a Fireworks control-plane path and return the parsed JSON dict."""
+    import urllib.parse
+    import urllib.request
+
+    url = f"{FIREWORKS_CONTROL_BASE_URL}/{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {key}", "Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.load(resp)
+
+
+def _fireworks_paged(path: str, key: str, list_key: str) -> list[dict]:
+    """Return every item under a paged control-plane list endpoint.
+
+    ``path`` is e.g. ``accounts/fireworks/models``; ``list_key`` is the array
+    field in the response (e.g. ``models``, ``deployedModels``).
+    """
+    items: list[dict] = []
+    page_token = ""
+    # Bound the loop so a misbehaving cursor can't spin forever (200/page).
+    for _ in range(20):
+        params = {"pageSize": "200"}
+        if page_token:
+            params["pageToken"] = page_token
+        payload = _fireworks_get(path, key, params)
+        items.extend(payload.get(list_key, []))
+        page_token = payload.get("nextPageToken") or ""
+        if not page_token:
+            break
+    return items
+
+
+def _fireworks_account_ids(key: str) -> list[str]:
+    """Return the caller's account IDs, excluding the shared public namespace."""
+    accounts = _fireworks_get("accounts", key).get("accounts", [])
+    ids = [a["name"].split("/", 1)[1] for a in accounts if a.get("name", "").startswith("accounts/")]
+    return [i for i in ids if i != "fireworks"]
+
+
+def fetch_fireworks_models(api_key: str | None = None) -> list[str]:
+    """Return Fireworks' live serverless chat-model catalog (best-effort).
+
+    Pages through the control-plane ``accounts/fireworks/models`` endpoint and
+    keeps only models that are (a) serverless-available and (b) text base
+    models (``kind == "HF_BASE_MODEL"``) — i.e. the ones you can sample without
+    spinning up a dedicated deployment. IDs are returned in the
+    ``accounts/fireworks/models/<slug>`` form the inference engine and config
+    already use.
+
+    Returns an empty list on any failure (no API key, network error, bad
+    response) so callers can fall back to the curated static list.
+    """
+    key = api_key or os.environ.get("FIREWORKS_API_KEY", "")
+    if not key:
+        return []
+    try:
+        models = _fireworks_paged("accounts/fireworks/models", key, "models")
+        return sorted(m["name"] for m in models if m.get("supportsServerless") and m.get("kind") == "HF_BASE_MODEL" and m.get("name"))
+    except Exception:
+        return []
+
+
+def fetch_fireworks_deployed_models(api_key: str | None = None) -> list[str]:
+    """Return the caller's actively deployed model IDs (best-effort).
+
+    Discovers the caller's account ID(s) via ``GET /v1/accounts``, then lists
+    each account's ``deployedModels`` that are in state ``DEPLOYED`` — i.e.
+    models currently serving inference on a dedicated deployment (not merely
+    uploaded). These can be sampled with no further setup. The shared public
+    ``fireworks`` namespace is excluded (see :func:`fetch_fireworks_models`).
+
+    Returns an empty list on any failure so callers can degrade gracefully.
+    """
+    key = api_key or os.environ.get("FIREWORKS_API_KEY", "")
+    if not key:
+        return []
+    try:
+        names: list[str] = []
+        for account in _fireworks_account_ids(key):
+            for dm in _fireworks_paged(f"accounts/{account}/deployedModels", key, "deployedModels"):
+                if dm.get("state") == "DEPLOYED" and dm.get("model"):
+                    names.append(dm["model"])
+        return sorted(set(names))
+    except Exception:
+        return []
 
 
 def _config_path() -> str:


### PR DESCRIPTION
## What

Gives Fireworks a **live model catalog**, matching what Tinker already does (`fetch_tinker_models` → `get_server_capabilities`). Previously the Fireworks provider only had a hardcoded list of 3 now-stale models and no live lookup.

## Changes

- **`fetch_fireworks_models()`** — pages the control-plane `accounts/fireworks/models` endpoint and filters to **serverless chat LLMs** (`supportsServerless` + `kind == HF_BASE_MODEL`). The public catalog is ~283 models; only ~12 are serverless chat models.
- **`fetch_fireworks_deployed_models()`** — discovers the caller's account(s) via `GET /v1/accounts`, then lists `deployedModels` in state `DEPLOYED` — i.e. the account's own models that are **actively serving inference** (not merely uploaded checkpoints).
- **CLI (`rllm model setup`)** — merges both lists: public serverless + the account's deployed models, the latter labeled `(your deployment)`. The model-selection menu now decouples **display labels** from **selectable values** so annotations never leak into the stored model id (generic; other providers unaffected).
- Refreshed the curated fallback list and default to current serverless IDs. Both fetches are **best-effort** and fall back to the curated list on any failure (no key / offline / API error).

## Why deployed-only for account models

An account can hold many uploaded checkpoints that aren't runnable without a dedicated deployment. Listing only `DEPLOYED` models keeps the catalog honest about what can actually be sampled right now.

## Testing

- Verified live against a real `FIREWORKS_API_KEY`: `fetch_fireworks_models()` returns 12 serverless chat models; `fetch_fireworks_deployed_models()` returns `[]` for an account with no active deployments (correctly excluding 82 uploaded-but-undeployed checkpoints).
- Confirmed menu value/label split returns the clean model id, not the annotated label.
- `ruff check` passes; modules import cleanly.

Note: the `DEPLOYED`-state filter wasn't exercised against a live deployment (test account has none); field names come from Fireworks' published OpenAPI schema and the endpoint returns the expected envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)