### PR TITLE
Support Fireworks on SWE-RL

### DIFF
--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -86,6 +86,24 @@ bash cookbooks/swe-rl/train_verl.sh
 
 vLLM rollouts + FSDP/Megatron training. Sandboxes still run mini-swe-agent — only the trainer hosting changes.
 
+### Fireworks (managed, LoRA)
+
+```bash
+uv pip install -e ".[fireworks]"
+export FIREWORKS_API_KEY=...
+bash cookbooks/swe-rl/train_fireworks.sh
+```
+
+Same async GRPO + compact-filtering recipe as `train_tinker.sh`, but the trainer
+job and inference deployment are provisioned on Fireworks at startup and torn
+down on shutdown. Defaults to `accounts/fireworks/models/qwen3p5-9b` + LoRA rank
+32 on the `qwen3p5-9b-256k-lora` training shape (Fireworks ships a 3.5-9B LoRA
+shape but no 3.5-4B; swap `model.name` / `model.tokenizer_model` /
+`fireworks_config.policy_trainer_shape_id` together to change it — see
+[`docs/backends/fireworks.mdx`](../../docs/backends/fireworks.mdx) for the
+model/shape catalog). The synchronous (on-policy) variant is
+`train_fireworks_sync.sh`.
+
 ## Evaluation (no training)
 
 ```bash
@@ -118,6 +136,8 @@ by `SandboxTaskHooks`. Pick a backend via the `SWE_SANDBOX_BACKEND` env var:
 | `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
 | `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Modal sandboxes |
 | `train_tinker_sync.sh` | Tinker backend — synchronous (on-policy) variant, simpler for testing |
+| `train_fireworks.sh` | Fireworks backend — Qwen3.5-9B LoRA, GRPO + async, managed trainer/deployment |
+| `train_fireworks_sync.sh` | Fireworks backend — synchronous (on-policy) variant, simpler for testing |
 | `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
 | `test.py` | Catalog wiring + harness import smoke tests |
 | `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -47,6 +47,7 @@ python -u train.py \
     model.tokenizer_model=Qwen/Qwen3.5-9B \
     model.lora_rank=32 \
     fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    fireworks_config.rollout_deployment_replica_count=4 \
     training.group_size=8 \
     training.learning_rate=2e-5 \
     training.max_length=65536 \

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -58,6 +58,10 @@ python -u train.py \
     data.max_response_length=8192 \
     data.train_batch_size=1 \
     data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=1 \
+    rllm.data.val_batch_size=-1 \
     rllm.compact_filtering.enable=true \
     rllm.algorithm.adv_estimator=grpo \
     rllm.algorithm.norm_adv_by_std_in_grpo=true \

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym, eval on SWE-bench Verified — Fireworks backend.
+#
+# Prerequisites:
+#   1. Install rllm with fireworks extras:  uv pip install -e ".[fireworks]"
+#   2. Install this cookbook:                uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                    python cookbooks/swe-rl/prepare_data.py
+#   4. Set your API key:                     export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 128 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2
+#     against it. The gateway routes every LLM call back to the Fireworks-hosted
+#     deployment. This is NOT the remote-runtime / RemoteAgentFlowEngine path.
+#   - 32K prompt window, 8K response budget per turn (terminus2 runs
+#     many turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B the README names as the base model rather than the tinker recipe's
+# 4B. To change it, swap model.name / model.tokenizer_model /
+# fireworks_config.policy_trainer_shape_id together (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks.sh training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3p5-9b-fireworks' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -48,6 +48,7 @@ python -u train.py \
     model.tokenizer_model=Qwen/Qwen3.5-9B \
     model.lora_rank=32 \
     fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    fireworks_config.rollout_deployment_replica_count=4 \
     training.group_size=8 \
     training.learning_rate=2e-5 \
     training.max_length=65536 \

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the Fireworks backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_fireworks.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous fireworks recipe other cookbooks use (e.g. deepcoder).
+#
+# Prerequisites:
+#   1. Install rllm with fireworks extras:  uv pip install -e ".[fireworks]"
+#   2. Install this cookbook:                uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                    python cookbooks/swe-rl/prepare_data.py
+#   4. Set your API key:                     export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# Differences from train_fireworks.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B the README names as the base model rather than the tinker recipe's
+# 4B. To change it, swap model.name / model.tokenizer_model /
+# fireworks_config.policy_trainer_shape_id together (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend: SWE_SANDBOX_BACKEND (docker | local | modal | daytona; default
+# modal). Cap the eval set with SWE_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3p5-9b-fireworks-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -59,6 +59,10 @@ python -u train.py \
     data.max_response_length=8192 \
     data.train_batch_size=16 \
     data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=16 \
+    rllm.data.val_batch_size=-1 \
     rllm.compact_filtering.enable=true \
     rllm.algorithm.adv_estimator=grpo \
     rllm.algorithm.norm_adv_by_std_in_grpo=true \

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -4,7 +4,7 @@ Two classes share most of the lifecycle (uvicorn-on-thread or subprocess,
 trace store, session API). They differ in how upstream workers are
 registered and what request-body injection the middleware applies.
 
-* :class:`GatewayManager` — training. Workers come from a verl/tinker
+* :class:`GatewayManager` — training. Workers come from a verl/tinker/fireworks
   rollout engine via :meth:`start(rollout_engine)`. Injects ``logprobs``
   and ``return_token_ids`` into request bodies (vLLM needs both for the
   loss math downstream).
@@ -207,11 +207,11 @@ class GatewayManager:
         """Start the gateway and register inference workers.
 
         For VerlEngine: registers the existing vLLM server addresses.
-        For TinkerEngine: creates an in-process handler (no sidecar needed).
+        For TinkerEngine / FireworksEngine: creates an in-process handler (no sidecar needed).
         """
         engine_cls = type(rollout_engine).__name__
 
-        if engine_cls == "TinkerEngine":
+        if engine_cls in ("TinkerEngine", "FireworksEngine"):
             # In-process handler — no HTTP backend, no worker registration
             from rllm.gateway.tinker_adapter import create_tinker_handler
 
@@ -227,6 +227,7 @@ class GatewayManager:
             for url in worker_urls:
                 worker_id = self.client.add_worker(url=url)
                 logger.info("Registered worker %s -> %s", worker_id, url)
+        
         else:
             logger.warning("Unknown engine type %s — no workers registered", engine_cls)
 

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -159,8 +159,8 @@ class GatewayManager:
         from rllm.gateway.tunnel import parse_tunnel
 
         self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
-        # The gateway always pins ``body.model`` to whatever the trainer is serving
-        self.model: str | None = config.get("model", {}).get("name", None)
+        _model_cfg = config.get("model", {})
+        self.model: str | None = _model_cfg.get("tokenizer_model") or _model_cfg.get("name", None)
 
         # Cumulative token mode: drift-free multi-turn token forwarding. The
         # gateway loads the tokenizer from the served model path. renderers

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -227,7 +227,7 @@ class GatewayManager:
             for url in worker_urls:
                 worker_id = self.client.add_worker(url=url)
                 logger.info("Registered worker %s -> %s", worker_id, url)
-        
+
         else:
             logger.warning("Unknown engine type %s — no workers registered", engine_cls)
 


### PR DESCRIPTION
## Summary

Adds a **Fireworks** managed-backend training path to the `swe-rl` cookbook, alongside the existing Tinker and Verl recipes. The trainer job and inference deployment are provisioned on Fireworks at startup and torn down on shutdown; the same async-GRPO + compact-filtering recipe is reused, only the trainer/inference hosting changes.

## What's included

- **`cookbooks/swe-rl/train_fireworks.sh`** — Fireworks backend, async GRPO + compact filtering. Qwen3.5-9B + LoRA-32 on the `qwen3p5-9b-256k-lora` training shape, 128 parallel rollouts, 32K prompt / 8K per-turn response budget. Rollout deployment runs **4 replicas** (`fireworks_config.rollout_deployment_replica_count=4`).
- **`cookbooks/swe-rl/train_fireworks_sync.sh`** — synchronous (on-policy) variant for easier testing/debugging (no `async_training.*`; `train_batch_size` is the real per-step task count). Same 4-replica rollout deployment.
- **`cookbooks/swe-rl/README.md`** — new "Fireworks (managed, LoRA)" section + entries in the file-map table.
- **`rllm/gateway/manager.py`** — gateway support for `FireworksEngine`:
  - `start()` routes `FireworksEngine` through the in-process (Tinker-style) handler — no HTTP sidecar / worker registration.
  - `body.model` now prefers `model.tokenizer_model` over `model.name` when present, so the gateway loads the correct tokenizer for cumulative-token mode.

## Notes

- Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this recipe uses the 9B base (vs. the Tinker recipe's 4B). Swap `model.name` / `model.tokenizer_model` / `fireworks_config.policy_trainer_shape_id` together to change it — see `docs/backends/fireworks.mdx`.
- Sandbox backend is selected via `SWE_SANDBOX_BACKEND` (docker | local | modal | daytona; default modal), same as the other recipes.

## Testing

- `ruff format --check` and `ruff check` pass on `rllm/gateway/manager.py`.

---

Supersedes #664 (original work by @1stprinciple, preserved as commit co-author). Rebased onto `terminal-rl` with the ruff formatting fix applied.
