### PR TITLE
feat(cookbooks): add MigrationBench agent example (AWS AgentCore Runtime + verl)

### DIFF
--- a/cookbooks/migrationbench/.env.example
+++ b/cookbooks/migrationbench/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and fill in. The train script sources this file.
+# Deployed AgentCore agent runtime ARN (from agentcore-rl-toolkit deploy step)
+AGENTCORE_AGENT_ARN=arn:aws:bedrock-agentcore:<region>:<account>:runtime/<name>
+# Output bucket where the agent writes rollout results (rewards, etc.); rLLM polls it
+AGENTCORE_S3_BUCKET=<output-bucket>

--- a/cookbooks/migrationbench/README.md
+++ b/cookbooks/migrationbench/README.md
@@ -1,0 +1,88 @@
+# MigrationBench Agent (AWS AgentCore Runtime)
+
+Train a Java 8→17 migration agent on [MigrationBench](https://github.com/amazon-science/MigrationBench) with rLLM. The agent runs **inside an AWS Bedrock AgentCore Runtime** (a serverless remote runtime), not in-process — rLLM drives rollouts over the network and trains the policy locally with the **verl** backend.
+
+## Overview
+
+The agent code lives in the [agentcore-rl-toolkit](https://github.com/awslabs/agentcore-rl-toolkit) repo, not here. You build and deploy it from there ([`examples/strands_migration_agent`](https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent)), which produces the inputs this cookbook needs:
+
+- **An AgentCore agent runtime ARN** — the deployed container where the agent loop to perform migrations is hosted.
+- **A data S3 bucket** — holds the prepared MigrationBench repo tarballs and their `metadata.json`, written by the toolkit's `preprocess.py`. The container downloads repos from here at runtime, and `prepare_migrationbench_data.py` reads its metadata to register the dataset.
+- **An output S3 bucket** — where the agent writes rollout results (rewards, etc.); rLLM polls it for each rollout. This can be a different bucket from the data bucket.
+
+This cookbook only handles the rLLM side: registering the dataset from the data bucket's metadata and launching verl training against the remote runtime. The repo tarballs stay in S3 and are pulled at runtime by the container.
+
+```
+agentcore-rl-toolkit (separate repo)         rLLM (this cookbook)
+──────────────────────────────────          ─────────────────────────
+build + deploy agent  ──► agent ARN ─────►   train_…_verl.sh  (drive rollouts + train)
+preprocess.py         ──► data bucket ───►   prepare_migrationbench_data.py  (register dataset)
+                          output bucket ◄──  agent writes rewards; rLLM polls
+```
+
+> **Note:** this example supports **verl only** (distributed multi-GPU). It is tested on a single 8×B200 node with verl 0.8.0 / Qwen3-Coder-30B-A3B-Instruct (LoRA).
+
+## Installation
+
+```bash
+# rLLM + verl backend (vLLM) + AgentCore runtime client
+uv pip install -e ".[verl,agentcore]"
+
+# Megatron deps for the verl training backend
+bash scripts/install_megatron.sh <cu129|cu130|...>
+```
+
+## Prerequisites (agentcore-rl-toolkit)
+
+Clone the toolkit, then preprocess the dataset and build/deploy the agent. Follow the
+[strands_migration_agent README](https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent):
+
+```bash
+git clone https://github.com/awslabs/agentcore-rl-toolkit
+cd agentcore-rl-toolkit/examples/strands_migration_agent
+
+# Upload prepared MigrationBench repos + metadata to your data bucket
+python preprocess.py --s3-bucket-name <data-bucket>
+
+# Build + deploy the agent container (see the example README) → records the agent runtime ARN
+```
+
+When this finishes you have the **agent runtime ARN**, the **data bucket**, and an **output bucket** — the only inputs the rest of this cookbook needs. Run the remaining steps from this cookbook folder (`cd cookbooks/migrationbench`); the train script sources `.env` from the current directory. Copy the example and fill it in:
+
+```bash
+cp .env.example .env
+# edit .env:
+#   AGENTCORE_AGENT_ARN=arn:aws:bedrock-agentcore:<region>:<account>:runtime/<name>
+#   AGENTCORE_S3_BUCKET=<output-bucket>
+```
+
+## Dataset
+
+Run from this cookbook folder (`cd cookbooks/migrationbench`):
+
+```bash
+python prepare_migrationbench_data.py --s3-bucket-name <data-bucket>
+```
+
+This downloads only the small `metadata.json` files from `s3://<data-bucket>/tars/{train,test}/`, then registers `migration_bench/{train,test}` with the rLLM `DatasetRegistry`:
+
+- **Train** — repos under `tars/train/` with `num_test_cases > 0`.
+- **Test** — all repos under `tars/test/`.
+
+## Training
+
+From this cookbook folder (`cd cookbooks/migrationbench`):
+
+```bash
+bash train_agentcore_migrationbench_verl.sh
+```
+
+The script sources `.env` for the agent ARN and output bucket, then runs verl with `rllm.remote_runtime.backend=agentcore` so rollouts execute in the deployed container. Tune `MODEL_PATH`, parallelism (`TP`/`EP`/`CP`), batch sizes, and `trainer.n_gpus_per_node`/`nnodes` in the script to match your hardware.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `prepare_migrationbench_data.py` | Register `migration_bench/{train,test}` from the data bucket's metadata |
+| `train_agentcore_migrationbench_verl.py` | Python API training entrypoint (Hydra config, verl backend) |
+| `train_agentcore_migrationbench_verl.sh` | Launch verl training against the AgentCore Runtime |

--- a/cookbooks/migrationbench/prepare_migrationbench_data.py
+++ b/cookbooks/migrationbench/prepare_migrationbench_data.py
@@ -1,0 +1,166 @@
+"""Prepare MigrationBench dataset for rLLM training with AgentCore runtime.
+
+Prerequisite: run the strands_migration_agent preprocess step first to upload the
+MigrationBench repos to S3. We upload the repos rather than loading them from
+GitHub at training time so the dataset remains available even if an upstream
+repo is deleted or made private.
+
+    https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent
+
+    cd <agentcore-rl-toolkit>/examples/strands_migration_agent
+    python preprocess.py --s3-bucket-name <your-bucket>
+
+This script then downloads only the tiny metadata.json files (~241 bytes each)
+from that same bucket to filter by num_test_cases, and registers train/test
+splits with the rLLM DatasetRegistry. The actual repo tarballs stay in S3 and
+are pulled at runtime by the AgentCore container.
+
+Train: repos from s3://<bucket>/tars/train/ with num_test_cases > 0
+Test:  all repos from s3://<bucket>/tars/test/
+
+Usage (from this cookbook folder, cd cookbooks/migrationbench):
+    python prepare_migrationbench_data.py --s3-bucket-name <your-bucket>
+"""
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from rllm.data.dataset import DatasetRegistry
+
+DATASET_NAME = "migration_bench"
+PROMPT_TEMPLATE = "Please help migrate this repo: {repo_path}. There are {num_tests} test cases in it."
+
+
+def list_s3_folders(s3_bucket: str, s3_prefix: str) -> list[str]:
+    """List immediate sub-folder names under an S3 prefix."""
+    result = subprocess.run(
+        ["aws", "s3", "ls", f"s3://{s3_bucket}/{s3_prefix}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    folders = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.strip().split()
+        if parts[0] == "PRE":
+            folders.append(parts[1].rstrip("/"))
+    return folders
+
+
+def download_all_metadata(s3_bucket: str, s3_prefix: str, folders: list[str], dest_dir: Path) -> None:
+    """Download metadata.json for all folders in parallel."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    commands = "\n".join(f"aws s3 cp s3://{s3_bucket}/{s3_prefix}{f}/metadata.json {dest_dir}/{f}.json --quiet" for f in folders)
+    subprocess.run(
+        ["xargs", "-P", "32", "-I", "{}", "bash", "-c", "{}"],
+        input=commands,
+        text=True,
+        check=False,
+    )
+
+
+def build_records(s3_bucket: str, metadata_dir: Path, s3_prefix: str, filter_positive_tests: bool) -> list[dict]:
+    """Load metadata and build dataset records."""
+    records = []
+    for f in sorted(metadata_dir.glob("*.json")):
+        try:
+            with open(f) as fh:
+                meta = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if filter_positive_tests and meta.get("num_test_cases", 0) <= 0:
+            continue
+
+        folder_name = f.stem
+        repo = meta.get("repo", folder_name)
+
+        records.append(
+            {
+                "prompt": PROMPT_TEMPLATE,
+                "repo_uri": f"s3://{s3_bucket}/{s3_prefix}{folder_name}/{folder_name}.tar.gz",
+                "metadata_uri": f"s3://{s3_bucket}/{s3_prefix}{folder_name}/metadata.json",
+                "require_maximal_migration": False,
+                "data_source": "migration_bench",
+                "num_test_cases": meta.get("num_test_cases", 0),
+                "num_loc": meta.get("num_loc", 0),
+                "repo": repo,
+            }
+        )
+    return records
+
+
+def print_stats(records: list[dict], split: str):
+    """Print summary statistics."""
+    test_counts = [r["num_test_cases"] for r in records]
+    pos = [t for t in test_counts if t > 0]
+
+    print(f"\n  {split.upper()}: {len(records)} repos")
+    if not pos:
+        return
+
+    buckets = [(1, 5), (6, 10), (11, 20), (21, 50), (51, 100), (101, 500), (501, float("inf"))]
+    for lo, hi in buckets:
+        label = f"{lo}-{int(hi)}" if hi != float("inf") else f"{lo}+"
+        count = sum(1 for t in pos if lo <= t <= hi)
+        if count:
+            print(f"    tests {label:<10} {count:>5} ({count / len(pos) * 100:.1f}%)")
+
+    neg = sum(1 for t in test_counts if t <= 0)
+    if neg:
+        print(f"    tests <= 0 (filtered): {neg}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--s3-bucket-name", required=True)
+    args = parser.parse_args()
+    s3_bucket = args.s3_bucket_name
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        # Train
+        print("Fetching train metadata...")
+        train_folders = list_s3_folders(s3_bucket, "tars/train/")
+        print(f"  {len(train_folders)} repos found")
+        download_all_metadata(s3_bucket, "tars/train/", train_folders, tmpdir / "train")
+        train_records = build_records(s3_bucket, tmpdir / "train", "tars/train/", filter_positive_tests=True)
+        print_stats(train_records, "train")
+
+        # Test
+        print("\nFetching test metadata...")
+        test_folders = list_s3_folders(s3_bucket, "tars/test/")
+        print(f"  {len(test_folders)} repos found")
+        download_all_metadata(s3_bucket, "tars/test/", test_folders, tmpdir / "test")
+        test_records = build_records(s3_bucket, tmpdir / "test", "tars/test/", filter_positive_tests=False)
+        print_stats(test_records, "test")
+
+    # Register
+    print("\nRegistering datasets...")
+    DatasetRegistry.register_dataset(
+        name=DATASET_NAME,
+        data=train_records,
+        split="train",
+        source="AmazonScience/migration-bench-java-full",
+        description=f"Java 8→17 migration benchmark, train ({len(train_records)} repos with tests > 0)",
+        category="code",
+    )
+    DatasetRegistry.register_dataset(
+        name=DATASET_NAME,
+        data=test_records,
+        split="test",
+        source="AmazonScience/migration-bench-java-selected",
+        description=f"Java 8→17 migration benchmark, test ({len(test_records)} repos)",
+        category="code",
+    )
+    print(f"  {DATASET_NAME}/train: {len(train_records)} examples")
+    print(f"  {DATASET_NAME}/test:  {len(test_records)} examples")
+    print(f'\nLoad with: DatasetRegistry.load_dataset("{DATASET_NAME}", "train")')
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/migrationbench/train_agentcore_migrationbench_verl.py
+++ b/cookbooks/migrationbench/train_agentcore_migrationbench_verl.py
@@ -1,0 +1,37 @@
+"""Train a migration agent on MigrationBench using Verl backend + AgentCore remote runtime.
+
+The agent runs inside an AgentCore container and migrates Java 8→17 repos.
+Build/deploy the agent and upload the dataset to S3 by following:
+    https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent
+
+Usage (from this cookbook folder, cd cookbooks/migrationbench):
+    # 1. Build + deploy the agent and upload data (see strands_migration_agent README).
+    # 2. Register the dataset locally from the data S3 bucket:
+    python prepare_migrationbench_data.py --s3-bucket-name <your-bucket>
+
+    # 3. Then train:
+    bash train_agentcore_migrationbench_verl.sh
+"""
+
+import hydra
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.trainer import AgentTrainer
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config):
+    train_dataset = DatasetRegistry.load_dataset("migration_bench", "train")
+    test_dataset = DatasetRegistry.load_dataset("migration_bench", "test")
+
+    trainer = AgentTrainer(
+        backend="verl",
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=test_dataset,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/migrationbench/train_agentcore_migrationbench_verl.sh
+++ b/cookbooks/migrationbench/train_agentcore_migrationbench_verl.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Requires megatron deps: bash scripts/install_megatron.sh
+
+# This script is tested on a single B200 machine with 8 GPUs with veRL 0.8.0
+set -eux
+
+# Load environment variables (AGENTCORE_AGENT_ARN, AGENTCORE_S3_BUCKET)
+set -a && source .env && set +a
+
+export VLLM_ALLREDUCE_USE_SYMM_MEM=0
+# flashinfer TRT-LLM MoE kernel is not compatible with weight sync in veRL 0.8.0;
+# it also requires TP <= 2 for Qwen3-Coder-30B-A3B-Instruct due to block dim
+export VLLM_USE_FLASHINFER_MOE_FP16=0
+
+MODEL_PATH=Qwen/Qwen3-Coder-30B-A3B-Instruct
+
+MAX_CONTEXT_LENGTH=131072
+MAX_PROMPT_LENGTH=122880
+MAX_RESPONSE_LENGTH=8192
+
+TP=2
+EP=2
+CP=2
+MAX_TOKENS_PER_GPU=$((MAX_CONTEXT_LENGTH / CP))
+
+# LoRA configuration
+LORA_RANK=64
+LORA_ALPHA=128
+
+# TP=4 for inference gives the most KV cache
+python train_agentcore_migrationbench_verl.py \
+    rllm/backend=verl \
+    model_engine=megatron \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.algorithm.rollout_correction.bypass_mode=false \
+    rllm.algorithm.rollout_correction.tis_mode=token \
+    rllm.algorithm.rollout_correction.tis_cap=2.0 \
+    data.train_batch_size=32 \
+    data.val_batch_size=128 \
+    data.max_prompt_length=$MAX_PROMPT_LENGTH \
+    data.max_response_length=$MAX_RESPONSE_LENGTH \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    actor_rollout_ref.model.lora.rank=$LORA_RANK \
+    actor_rollout_ref.model.lora.alpha=$LORA_ALPHA \
+    actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-5 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=32 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_dynamic_bsz=true \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$MAX_TOKENS_PER_GPU \
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=1 \
+    actor_rollout_ref.actor.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=$TP \
+    actor_rollout_ref.actor.megatron.context_parallel_size=$CP \
+    actor_rollout_ref.actor.megatron.sequence_parallel=true \
+    actor_rollout_ref.actor.megatron.use_dist_checkpointing=False \
+    actor_rollout_ref.actor.megatron.use_mbridge=True \
+    actor_rollout_ref.actor.megatron.vanilla_mbridge=False \
+    actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full \
+    actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform \
+    actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1 \
+    actor_rollout_ref.actor.megatron.param_offload=false \
+    actor_rollout_ref.actor.megatron.optimizer_offload=true \
+    actor_rollout_ref.actor.megatron.grad_offload=true \
+    ++actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_cpu_offload=True \
+    ++actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_offload_fraction=1.0 \
+    ++actor_rollout_ref.actor.optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-sum \
+    actor_rollout_ref.actor.checkpoint.save_contents='["model"]' \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=4 \
+    actor_rollout_ref.rollout.data_parallel_size=1 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=true \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=$MAX_TOKENS_PER_GPU \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=qwen3_coder \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.70 \
+    actor_rollout_ref.rollout.max_model_len=$MAX_CONTEXT_LENGTH \
+    actor_rollout_ref.rollout.max_num_batched_tokens=16384 \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.7 \
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.8 \
+    actor_rollout_ref.rollout.val_kwargs.top_k=20 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=true \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=$MAX_TOKENS_PER_GPU \
+    actor_rollout_ref.ref.megatron.param_offload=true \
+    actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=1 \
+    actor_rollout_ref.ref.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=$TP \
+    actor_rollout_ref.ref.megatron.context_parallel_size=$CP \
+    actor_rollout_ref.ref.megatron.sequence_parallel=true \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger="['console','wandb']" \
+    trainer.project_name=agentcore-migration-bench \
+    trainer.experiment_name="coder-30b-tis${EXPERIMENT_SUFFIX:-}" \
+    trainer.val_before_train=true \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=15 \
+    trainer.test_freq=15 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    rllm.remote_runtime.enabled=true \
+    rllm.remote_runtime.backend=agentcore \
+    rllm.remote_runtime.agentcore.agent_runtime_arn=$AGENTCORE_AGENT_ARN \
+    rllm.remote_runtime.agentcore.s3_bucket=$AGENTCORE_S3_BUCKET \
+    rllm.remote_runtime.agentcore.tps_limit=10 \
+    rllm.remote_runtime.session_timeout=1800 \
+    rllm.workflow.n_parallel_tasks=512 \
+    rllm.episode_logging.log_episodes=true

--- a/docs/cookbooks/migrationbench.mdx
+++ b/docs/cookbooks/migrationbench.mdx
@@ -1,0 +1,83 @@
+---
+title: MigrationBench
+description: Train a Java 8→17 migration agent that runs inside an AWS Bedrock AgentCore Runtime, with verl driving rollouts over the network
+---
+
+This cookbook trains a Java 8→17 code-migration agent on [MigrationBench](https://github.com/amazon-science/MigrationBench). Unlike the other cookbooks, the agent does **not** run in-process as an `AgentFlow` plugin — it runs inside an [AWS Bedrock AgentCore Runtime](/agent-runtimes/agentcore) container built and deployed from the [agentcore-rl-toolkit](https://github.com/awslabs/agentcore-rl-toolkit) repo. rLLM drives rollouts over the network and trains the policy locally with the **verl** backend.
+
+Because the agent lives in an external container, there is no `pip install -e cookbooks/<name>` plugin and no `rllm eval/train` CLI entry point. The cookbook in [`cookbooks/migrationbench/`](https://github.com/rllm-org/rllm/tree/main/cookbooks/migrationbench) only handles the rLLM side: registering the dataset from S3 metadata and launching verl training against the remote runtime.
+
+## Pattern
+
+| Aspect | Value |
+|---|---|
+| Loop shape | Multi-turn coding agent, running inside an AgentCore Runtime container |
+| Dataset | `migration_bench` — MigrationBench Java repos, registered from S3 metadata |
+| Runtime | AWS Bedrock AgentCore Runtime (remote, auto-scaling microVMs) |
+| Backend | verl only (distributed multi-GPU) |
+| Reward shape | Agent runs `mvn` build/tests in-container, writes the reward to S3; rLLM polls it |
+| Model (reference) | Qwen3-Coder-30B-A3B-Instruct (LoRA), tested on a single 8×B200 node with verl 0.8.0 |
+
+## Prerequisites
+
+The agent code, container build, and dataset upload all live in the toolkit. Build and deploy the agent by following the [strands_migration_agent example](https://github.com/awslabs/agentcore-rl-toolkit/tree/main/examples/strands_migration_agent). That produces the three inputs this cookbook needs:
+
+- **An AgentCore agent runtime ARN** — the deployed container that performs the migrations.
+- **A data S3 bucket** — holds the prepared MigrationBench repo tarballs and their `metadata.json`, written by the toolkit's `preprocess.py`. The container downloads repos from here at runtime, and `prepare_migrationbench_data.py` reads its metadata to register the dataset.
+- **An output S3 bucket** — where the agent writes rollout results (rewards, etc.); rLLM polls it each rollout. May differ from the data bucket.
+
+<Steps>
+  <Step title="Install rLLM with the verl and agentcore extras">
+    ```bash
+    # rLLM + verl backend (vLLM) + AgentCore runtime client
+    uv pip install -e ".[verl,agentcore]"
+
+    # Megatron deps for the verl training backend
+    bash scripts/install_megatron.sh <cu128|cu129|...>
+    ```
+  </Step>
+
+  <Step title="Deploy the agent and upload data (agentcore-rl-toolkit)">
+    ```bash
+    git clone https://github.com/awslabs/agentcore-rl-toolkit
+    cd agentcore-rl-toolkit/examples/strands_migration_agent
+
+    # Upload prepared MigrationBench repos + metadata to your data bucket
+    python preprocess.py --s3-bucket-name <data-bucket>
+
+    # Build + deploy the agent container (see the example README) → records the agent runtime ARN
+    ```
+  </Step>
+
+  <Step title="Configure the environment">
+    Run the remaining steps from the cookbook folder (`cd cookbooks/migrationbench`); the train script sources `.env` from the current directory. Copy the example and fill it in:
+
+    ```bash
+    cp .env.example .env
+    # edit .env:
+    #   AGENTCORE_AGENT_ARN=arn:aws:bedrock-agentcore:<region>:<account>:runtime/<name>
+    #   AGENTCORE_S3_BUCKET=<output-bucket>
+    ```
+  </Step>
+
+  <Step title="Register the dataset">
+    ```bash
+    python prepare_migrationbench_data.py --s3-bucket-name <data-bucket>
+    ```
+
+    This downloads only the small `metadata.json` files from `s3://<data-bucket>/tars/{train,test}/`, then registers `migration_bench/{train,test}` with the rLLM `DatasetRegistry`:
+
+    - **Train** — repos under `tars/train/` with `num_test_cases > 0`.
+    - **Test** — all repos under `tars/test/`.
+  </Step>
+
+  <Step title="Run training">
+    ```bash
+    bash train_agentcore_migrationbench_verl.sh
+    ```
+
+    The script sources `.env` for the agent ARN and output bucket, then runs verl with `rllm.remote_runtime.backend=agentcore` so rollouts execute in the deployed container. Tune `MODEL_PATH`, parallelism (`TP`/`EP`/`CP`), batch sizes, and `trainer.n_gpus_per_node`/`nnodes` in the script to match your hardware.
+  </Step>
+</Steps>
+
+See the [AWS Bedrock AgentCore](/agent-runtimes/agentcore) page for how the remote runtime, the model gateway, and S3 fit together during training.

--- a/docs/cookbooks/overview.mdx
+++ b/docs/cookbooks/overview.mdx
@@ -25,6 +25,7 @@ Each cookbook is a plain async function that calls an OpenAI-compatible endpoint
 | [`geo3k`](/cookbooks/geo3k) | VLM single-turn | Multimodal geometry on the Geometry3K dataset. |
 | [`solver_judge_flow`](/cookbooks/solver_judge_flow) | Multi-agent | Solver–judge pattern on the countdown task. |
 | [`terminal_bench`](/cookbooks/terminal_bench) | CLI-only, sandboxed harness | Evaluates Harbor's Terminus-2 terminal agent on all 89 Terminal-Bench 2.0 tasks via Modal sandboxes, snapshots, and pass@k. No plugin to install — the whole run is `rllm` CLI commands. |
+| [`migrationbench`](/cookbooks/migrationbench) | Remote AgentCore runtime, sandboxed harness | Trains a Java 8→17 migration agent that runs inside an AWS Bedrock AgentCore Runtime. The agent ships from [agentcore-rl-toolkit](https://github.com/awslabs/agentcore-rl-toolkit); rLLM drives rollouts over the network. |
 
 Click into any row for the deep-dive page — install flow, dataset, eval and train commands, and key code snippets. The full source, including the launch scripts, lives at [`cookbooks/`](https://github.com/rllm-org/rllm/tree/main/cookbooks) on GitHub.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -136,7 +136,8 @@
               "cookbooks/finqa",
               "cookbooks/geo3k",
               "cookbooks/solver_judge_flow",
-              "cookbooks/terminal_bench"
+              "cookbooks/terminal_bench",
+              "cookbooks/migrationbench"
             ]
           }
         ]


### PR DESCRIPTION
Cookbook for MigrationBench + AgentCore.