### PR TITLE
fix(verl): port fully-async/separated rollout path to verl 0.8.0

### DIFF
--- a/rllm/trainer/verl/async_agent_loop.py
+++ b/rllm/trainer/verl/async_agent_loop.py
@@ -1,118 +1,37 @@
-from __future__ import annotations
+"""Fully-async / separated-mode rollout classes.
 
-import asyncio
-from typing import Any
+rLLM used to hand-roll the fully-async + partial-rollout rollout machinery here,
+subclassing verl's pre-0.8 experimental ``AsyncLLMServerManager`` / ``AgentLoopWorker``.
+verl 0.8.0 removed those APIs and upstreamed the very same machinery (same class
+names, same partial-rollout ``generate`` loop) into
+``verl.experimental.fully_async_policy.fully_async_rollouter``, rebuilt on the new
+``LLMServerClient`` / ``LLMServerManager`` architecture:
 
-import ray
-import torch
-from omegaconf import DictConfig
-from verl.experimental.agent_loop.agent_loop import (
-    AgentLoopManager,
-    AgentLoopWorker,
-    AsyncLLMServerManager,
-    TokenOutput,
+* ``FullyAsyncLLMServerClient`` — ``LLMServerClient`` whose ``generate`` resumes an
+  aborted (preempted) rollout when ``async_training.partial_rollout`` is enabled.
+  This replaces the old ``FullyAsyncLLMServerManager(AsyncLLMServerManager)`` and is
+  the object handed to ``VerlEngine`` as ``server_manager``.
+* ``FullyAsyncLLMServerManager`` — ``LLMServerManager`` that owns/launches the rollout
+  replicas (hybrid + standalone). In 0.8.0 the *manager* owns the servers, not the
+  ``AgentLoopManager``; mint the client via ``get_client(client_cls=FullyAsyncLLMServerClient)``.
+* ``FullyAsyncAgentLoopManager`` — ``AgentLoopManager`` with ``generate_sequences_single``
+  / ``_select_best_worker`` (the per-worker dispatch rLLM relies on).
+
+The dedicated ``FullyAsyncAgentLoopWorker`` is gone: partial-rollout now lives in the
+*client*, so the stock ``AgentLoopWorker`` (which takes the client) is sufficient.
+
+We simply re-export the upstream implementations so the rest of rLLM keeps a stable
+import path.
+"""
+
+from verl.experimental.fully_async_policy.fully_async_rollouter import (
+    FullyAsyncAgentLoopManager,
+    FullyAsyncLLMServerClient,
+    FullyAsyncLLMServerManager,
 )
-from verl.protocol import DataProto
-from verl.single_controller.ray import RayResourcePool, RayWorkerGroup
-from verl.utils.ray_utils import auto_await
-from verl.utils.rollout_trace import rollout_trace_op
 
-
-class FullyAsyncLLMServerManager(AsyncLLMServerManager):
-    @rollout_trace_op
-    async def generate(
-        self,
-        request_id,
-        *,
-        prompt_ids: list[int],
-        sampling_params: dict[str, Any],
-        image_data: list[Any] | None = None,
-        video_data: list[Any] | None = None,
-    ) -> TokenOutput:
-        limit_key = None
-        if "max_tokens" in sampling_params:
-            limit_key = "max_tokens"
-        elif "max_new_tokens" in sampling_params:
-            limit_key = "max_new_tokens"
-        original_max_tokens = sampling_params.get(limit_key) if limit_key else None
-
-        final_output = TokenOutput(token_ids=[], log_probs=[], num_preempted=0)
-        min_global_steps, max_global_steps = None, None
-
-        while True:
-            output = await super().generate(
-                request_id=request_id,
-                prompt_ids=prompt_ids + final_output.token_ids,
-                sampling_params=sampling_params,
-                image_data=image_data,
-                video_data=video_data,
-            )
-
-            final_output.token_ids.extend(output.token_ids)
-            if output.log_probs is not None:
-                final_output.log_probs.extend(output.log_probs)
-            if output.routed_experts is not None:
-                if final_output.routed_experts is None:
-                    final_output.routed_experts = output.routed_experts
-                else:
-                    final_output.routed_experts = torch.cat([final_output.routed_experts, output.routed_experts], dim=0)
-            if output.num_preempted is not None:
-                final_output.num_preempted += output.num_preempted
-            final_output.stop_reason = output.stop_reason
-
-            global_steps = output.extra_fields.get("global_steps", None)
-            if min_global_steps is None:
-                min_global_steps = global_steps
-            max_global_steps = global_steps
-
-            if original_max_tokens is not None:
-                sampling_params[limit_key] = original_max_tokens - len(final_output.token_ids)
-                if len(final_output.token_ids) >= original_max_tokens:
-                    final_output.stop_reason = "length"
-                    break
-
-            if output.stop_reason not in ("aborted", "abort") or not self.config.async_training.partial_rollout:
-                break
-
-        final_output.extra_fields["global_steps"] = global_steps
-        final_output.extra_fields["min_global_steps"] = min_global_steps
-        final_output.extra_fields["max_global_steps"] = max_global_steps
-        return final_output
-
-
-@ray.remote
-class FullyAsyncAgentLoopWorker(AgentLoopWorker):
-    def __init__(
-        self,
-        config: DictConfig,
-        servers: list[tuple[str, ray.actor.ActorHandle]],
-        load_balancer_handle: ray.actor.ActorHandle,
-        reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
-    ):
-        self.server_manager = FullyAsyncLLMServerManager(config, servers, load_balancer_handle)
-        super().__init__(config, servers, load_balancer_handle, reward_loop_worker_handles)
-
-
-class FullyAsyncAgentLoopManager(AgentLoopManager):
-    def __init__(
-        self,
-        config: DictConfig,
-        worker_group: RayWorkerGroup = None,
-        rollout_resource_pool: RayResourcePool = None,
-        reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
-    ):
-        self.agent_loop_workers_class = FullyAsyncAgentLoopWorker
-        super().__init__(config, worker_group, rollout_resource_pool, reward_loop_worker_handles)
-
-    @auto_await
-    async def generate_sequences_single(self, prompts: DataProto) -> DataProto:
-        worker = self._select_best_worker()
-        output_future = worker.generate_sequences.remote(prompts)
-        return await asyncio.wrap_future(output_future.future())
-
-    def _select_best_worker(self):
-        if not hasattr(self, "_worker_index"):
-            self._worker_index = 0
-        worker = self.agent_loop_workers[self._worker_index]
-        self._worker_index = (self._worker_index + 1) % len(self.agent_loop_workers)
-        return worker
+__all__ = [
+    "FullyAsyncAgentLoopManager",
+    "FullyAsyncLLMServerClient",
+    "FullyAsyncLLMServerManager",
+]

--- a/rllm/trainer/verl/verl_backend.py
+++ b/rllm/trainer/verl/verl_backend.py
@@ -214,7 +214,7 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         Rollout servers are launched by FullyAsyncAgentLoopManager in standalone
         mode (worker_group=None), using config.actor_rollout_ref.rollout.nnodes/n_gpus_per_node.
         """
-        from rllm.trainer.verl.async_agent_loop import FullyAsyncAgentLoopManager
+        from rllm.trainer.verl.async_agent_loop import FullyAsyncAgentLoopManager, FullyAsyncLLMServerClient, FullyAsyncLLMServerManager
 
         config = self.config
         wg_kwargs = build_wg_kwargs(config, self.device_name)
@@ -262,17 +262,25 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         if self.ref_in_actor:
             self.ref_policy_wg = self.actor_rollout_wg
 
-        # Standalone rollout servers (no worker_group; resources from rollout.nnodes/n_gpus_per_node)
-        self.async_rollout_manager = FullyAsyncAgentLoopManager.create(
+        # verl 0.8.0: the LLMServerManager (not the AgentLoopManager) owns/launches the
+        # rollout replicas. Standalone servers => worker_group=None (resources come from
+        # rollout.nnodes/n_gpus_per_node). The AgentLoopManager then drives them via a
+        # partial-rollout client minted from the manager.
+        self.llm_server_manager = FullyAsyncLLMServerManager.create(
             config=config,
             worker_group=None,
+            rollout_resource_pool=None,
+        )
+        self.async_rollout_manager = FullyAsyncAgentLoopManager.create(
+            config=config,
+            llm_client=self.llm_server_manager.get_client(client_cls=FullyAsyncLLMServerClient),
         )
 
         ckpt_cfg = omega_conf_to_dataclass(config.actor_rollout_ref.rollout.checkpoint_engine)
         self.checkpoint_manager = CheckpointEngineManager(
             config=ckpt_cfg,
             trainer=self.actor_rollout_wg,
-            replicas=self.async_rollout_manager.rollout_replicas,
+            replicas=self.llm_server_manager.get_replicas(),
         )
 
     # =========================================================================
@@ -321,28 +329,22 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         else:
             logger.warning("RayWorkerGroup.set_loss_fn not available — skipping custom loss injection")
 
+        # Both paths obtain the rollout client from the LLMServerManager; the separated
+        # path uses the partial-rollout-aware client so preempted rollouts can resume.
         if self.is_separated:
-            from rllm.trainer.verl.async_agent_loop import FullyAsyncLLMServerManager
+            from rllm.trainer.verl.async_agent_loop import FullyAsyncLLMServerClient
 
-            servers = zip(self.async_rollout_manager.server_addresses, self.async_rollout_manager.server_handles, strict=True)
-            server_manager = FullyAsyncLLMServerManager(self.config, servers=servers, load_balancer_handle=self.async_rollout_manager.global_load_balancer)
-
-            self.rollout_engine = VerlEngine(
-                config=self.config,
-                server_manager=server_manager,
-                tokenizer=self.tokenizer,
-                processor=self.processor,
-            )
+            server_client = self.llm_server_manager.get_client(client_cls=FullyAsyncLLMServerClient)
         else:
             server_client = self.llm_server_manager.get_client()
 
-            self.rollout_engine = VerlEngine(
-                config=self.config,
-                server_manager=server_client,
-                tokenizer=self.tokenizer,
-                processor=self.processor,
-            )
-            self.rollout_engine.server_addresses = self.llm_server_manager.get_addresses()
+        self.rollout_engine = VerlEngine(
+            config=self.config,
+            server_manager=server_client,
+            tokenizer=self.tokenizer,
+            processor=self.processor,
+        )
+        self.rollout_engine.server_addresses = self.llm_server_manager.get_addresses()
 
         self.algorithm_config = kwargs.get("algorithm_config")
 

--- a/rllm/trainer/verl/verl_backend.py
+++ b/rllm/trainer/verl/verl_backend.py
@@ -361,6 +361,20 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             )
             if async_cfg.get("partial_rollout", False) and self.config.rllm.get("remote_runtime", {}).get("enabled", False):
                 raise ValueError("VerlBackend: async_training.partial_rollout is not supported with remote_runtime; set it to false.")
+            # Separated mode does trainer->rollout weight sync via verl's 'nccl' checkpoint
+            # engine, which imports cupy. verl's checkpoint_engine/__init__ swallows a missing
+            # cupy in a silent try/except, so the failure otherwise surfaces only as a confusing
+            # "ValueError: Checkpoint engine nccl not registered" deep in actor_init_model.
+            # Fail fast here with an actionable message instead.
+            try:
+                import cupy  # noqa: F401
+            except ImportError as e:
+                raise RuntimeError(
+                    "Separated/async training (rllm.async_training.enable=true) requires cupy for "
+                    "verl's 'nccl' checkpoint engine (trainer->rollout weight sync). Install the wheel "
+                    "matching your CUDA toolkit: `pip install cupy-cuda12x` (CUDA 12.x) or "
+                    "`pip install cupy-cuda13x` (CUDA 13.x)."
+                ) from e
         if self.config.rllm.stepwise_advantage.mode != "broadcast":
             # automatically set the stepwise_advantage_mode to "broadcast", the warning is already shown in AlgorithmConfig.from_config
             self.config.rllm.stepwise_advantage.mode = "broadcast"


### PR DESCRIPTION
## Summary

Follow-up to #671 (verl 0.8.0 upgrade). Ports the **fully-async / separated rollout path** to verl 0.8.0. `rllm/trainer/verl/async_agent_loop.py` subclassed verl's pre-0.8 experimental `AsyncLLMServerManager` / `AgentLoopWorker`, which verl 0.8.0 **removed** — so any run with `rllm.async_training.enable=true` `ImportError`s at import time. verl 0.8.0 upstreamed the *identical* fully-async + partial-rollout machinery (same class names, same partial-rollout `generate` loop) into `verl.experimental.fully_async_policy.fully_async_rollouter`, rebuilt on the new `LLMServerClient` / `LLMServerManager` API — so we re-export those instead of maintaining a removed-API fork, and rewire the backend to the new ownership model.

## Type of change

- [x] Fix
- [x] Refactor

## What changed

- **`async_agent_loop.py`** — replace the hand-rolled `FullyAsyncLLMServerManager(AsyncLLMServerManager)` / `FullyAsyncAgentLoopWorker` / `FullyAsyncAgentLoopManager` with re-exports of verl 0.8.0's upstreamed `FullyAsyncLLMServerClient`, `FullyAsyncLLMServerManager`, `FullyAsyncAgentLoopManager`.
- **`verl_backend.py` `_init_separated_workers`** — in 0.8.0 the **`LLMServerManager` owns/launches the rollout replicas** (not the `AgentLoopManager`). Create a `FullyAsyncLLMServerManager` (standalone: `worker_group=None`), then `FullyAsyncAgentLoopManager.create(config, llm_client=mgr.get_client(client_cls=FullyAsyncLLMServerClient))`. Checkpoint replicas now come from `llm_server_manager.get_replicas()` (was `async_rollout_manager.rollout_replicas`).
- **`verl_backend.py` rollout-engine wiring** — the separated and colocated branches now differ only by client class: separated uses the partial-rollout-aware `FullyAsyncLLMServerClient`, colocated uses the default. Drops the old `zip(server_addresses, server_handles)` + `global_load_balancer` plumbing (the client encapsulates load balancing now).
- The dedicated `FullyAsyncAgentLoopWorker` is **dropped** — partial-rollout moved into the *client*, so the stock `AgentLoopWorker` suffices.

## Validation

- [x] `python -m py_compile` on both files
- [x] Import-checked the full separated-path chain under verl 0.8.0 (`async_agent_loop`, `VerlBackend`, `VerlTaskRunner`); confirmed the re-exports are correct `LLMServerClient` / `LLMServerManager` subclasses.
- [ ] **Not run end-to-end.** A live separated-mode run (`rllm.async_training.enable=true`) needs separate trainer/rollout GPU pools and wasn't exercised. **Please validate a real separated run before merge.**

Validation details:
- The standard **colocated** path is unaffected and was validated end-to-end on the 0.8.0 stack (3 GRPO steps + math500 `pass@1 0.884` on 8×H100, via #671).

## Breaking changes / migration notes

- None for the colocated path. The separated path's import-time crash is fixed; behavior should match the pre-0.8 implementation since verl upstreamed the same logic.

## Related issues / PRs

- Stacked on / depends on #671 (verl 0.8.0 upgrade). Base branch is `verl_0.8`.

## Note for reviewers

The remaining risk is the exact `FullyAsyncLLMServerManager.create(worker_group=None, rollout_resource_pool=None)` arg shape for standalone vs hybrid replicas, and that no other separated-path code references the dropped `async_rollout_manager.{rollout_replicas,server_addresses,server_handles,global_load_balancer}` attrs (grep confirms only the three rewired sites used them). A separated-mode smoke run is the real gate.
