### PR TITLE
feat(fireworks): per-trajectory session affinity

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -198,7 +198,11 @@ class ReverseProxy:
         t0 = time.perf_counter()
 
         if self.local_handler is not None:
-            # In-process path: call handler directly, no HTTP
+            # In-process path: call handler directly, no HTTP.
+            # Forward the rollout session id so affinity-aware engines (Fireworks)
+            # can pin a trajectory's turns to one replica for prefix-cache reuse.
+            if session_id:
+                request_body["rllm_session_id"] = session_id
             response_body = await self.local_handler(request_body)
             status_code = 200
         else:
@@ -320,6 +324,8 @@ class ReverseProxy:
         if self.local_handler is not None:
             # In-process path (Tinker): sample directly from the pre-tokenized
             # prompt; no HTTP worker, no re-tokenization.
+            if session_id:
+                completions_body["rllm_session_id"] = session_id
             response_body = await self.local_handler(completions_body)
             status_code = 200
         else:
@@ -535,6 +541,8 @@ class ReverseProxy:
         """
         assert self.local_handler is not None
         t0 = time.perf_counter()
+        if session_id:
+            completions_body["rllm_session_id"] = session_id
         response_body = await self.local_handler(completions_body)
         latency_ms = (time.perf_counter() - t0) * 1000
 

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -52,9 +52,6 @@ _TRANSIENT_ERROR_MARKERS = (
 )
 
 
-# How often to log a rolling Fireworks prompt-cache-hit summary (per engine).
-_CACHE_LOG_EVERY = 50
-
 # Per-request inference headers (e.g. Fireworks session-affinity) injected into
 # DeploymentSampler requests. ``DeploymentSampler.async_completions_stream`` only
 # forwards body params and a fixed set of client-level headers, so there is no
@@ -191,13 +188,6 @@ class FireworksEngine(TinkerEngine):
         self.router_replay = router_replay
         self.sampling_client = sampler
 
-        # Rolling Fireworks prompt-cache accounting (logged every
-        # ``_CACHE_LOG_EVERY`` completions). Low hit-ratio ⇒ session affinity not
-        # routing a trajectory's turns to the same replica.
-        self._cache_cached_tokens = 0
-        self._cache_prompt_tokens = 0
-        self._cache_calls = 0
-
     # ------------------------------------------------------------------
     # Token-in / token-out override
     # ------------------------------------------------------------------
@@ -303,9 +293,9 @@ class FireworksEngine(TinkerEngine):
         # Fireworks routes requests carrying the same session id to the same
         # replica, so its per-replica prompt-prefix KV is reused across a
         # trajectory's turns. Set once per turn from the trajectory id.
-        affinity_headers = None
+        session_headers = None
         if session_id:
-            affinity_headers = {
+            session_headers = {
                 "x-multi-turn-session-id": str(session_id),
                 "x-session-affinity": str(session_id),
             }
@@ -314,7 +304,7 @@ class FireworksEngine(TinkerEngine):
             prompt_ids,
             max_tokens,
             sampling_params,
-            affinity_headers=affinity_headers,
+            session_headers=session_headers,
         )
 
         choice = raw["choices"][0]
@@ -355,49 +345,23 @@ class FireworksEngine(TinkerEngine):
     # Internal retry helper
     # ------------------------------------------------------------------
 
-    def _record_prompt_cache(self, server_metrics, metrics_dict: dict | None) -> None:
-        """Accumulate Fireworks prompt-cache stats; log a rolling summary.
-
-        ``cached_prompt_tokens`` / ``prompt_tokens`` are only present on
-        dedicated deployments (``None`` on serverless), so this is a no-op
-        otherwise. Adds a per-call ``prompt_cache_hit_ratio`` to ``metrics_dict``
-        and logs a rolling hit-ratio every ``_CACHE_LOG_EVERY`` completions.
-        """
-        if server_metrics is None or not getattr(server_metrics, "prompt_tokens", None):
-            return
-        cached = getattr(server_metrics, "cached_prompt_tokens", None) or 0
-        prompt = server_metrics.prompt_tokens
-        if metrics_dict is not None:
-            metrics_dict["prompt_cache_hit_ratio"] = cached / prompt
-        self._cache_cached_tokens += cached
-        self._cache_prompt_tokens += prompt
-        self._cache_calls += 1
-        if self._cache_calls % _CACHE_LOG_EVERY == 0 and self._cache_prompt_tokens:
-            logger.info(
-                "Fireworks prompt cache: hit_ratio=%.3f (cached=%d / prompt=%d over %d completions)",
-                self._cache_cached_tokens / self._cache_prompt_tokens,
-                self._cache_cached_tokens,
-                self._cache_prompt_tokens,
-                self._cache_calls,
-            )
-
     async def _completions_with_retry(
         self,
         prompt_ids: list[int],
         max_tokens: int,
         sampling_kwargs: dict[str, Any],
-        affinity_headers: dict[str, str] | None = None,
+        session_headers: dict[str, str] | None = None,
     ) -> tuple[dict[str, Any], dict | None]:
         """Call ``DeploymentSampler.async_completions_stream`` with transient-error retries.
 
-        ``affinity_headers``, when given, are merged into the request's HTTP
+        ``session_headers``, when given, are merged into the request's HTTP
         headers (via the ``_inference_headers`` patch) so Fireworks routes this
         request to the trajectory's pinned replica. Returns
         (response_dict, server_metrics_dict)."""
 
         for attempt in range(_MAX_SAMPLE_ATTEMPTS):
             try:
-                token = _per_request_headers.set(affinity_headers) if affinity_headers else None
+                token = _per_request_headers.set(session_headers) if session_headers else None
                 try:
                     result, server_metrics = await self.sampling_client.async_completions_stream(
                         prompt=prompt_ids,
@@ -415,7 +379,6 @@ class FireworksEngine(TinkerEngine):
                 completion_ids = (choice.get("raw_output") or {}).get("completion_token_ids") or []
                 if not completion_ids:
                     raise _EmptyCompletionIdsError("Fireworks response included empty completion_token_ids")
-                self._record_prompt_cache(server_metrics, metrics_dict)
                 return result, metrics_dict
             except Exception as exc:
                 err = str(exc)

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -18,6 +18,7 @@ is inherited from ``TinkerEngine``.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import dataclasses
 import logging
 from typing import Any
@@ -49,6 +50,42 @@ _TRANSIENT_ERROR_MARKERS = (
     "_SSETruncationError",
     "closed the SSE stream mid-generation",
 )
+
+
+# How often to log a rolling Fireworks prompt-cache-hit summary (per engine).
+_CACHE_LOG_EVERY = 50
+
+# Per-request inference headers (e.g. Fireworks session-affinity) injected into
+# DeploymentSampler requests. ``DeploymentSampler.async_completions_stream`` only
+# forwards body params and a fixed set of client-level headers, so there is no
+# per-call header hook; we patch ``_inference_headers`` to merge whatever the
+# current async context stashed here. A ContextVar is async-safe — each rollout
+# task carries its own copy, so concurrent trajectories don't clobber each
+# other's session-affinity key.
+_per_request_headers: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar("rllm_fw_request_headers", default=None)
+
+
+def _install_inference_header_patch() -> None:
+    """Patch ``DeploymentSampler._inference_headers`` to merge per-request headers.
+
+    Idempotent: re-imports / repeated calls are no-ops.
+    """
+    orig = DeploymentSampler._inference_headers
+    if getattr(orig, "_rllm_session_affinity_patch", False):
+        return
+
+    def _inference_headers(self):  # noqa: ANN001 - matches SDK signature
+        headers = orig(self)
+        extra = _per_request_headers.get()
+        if extra:
+            headers = {**headers, **extra}
+        return headers
+
+    _inference_headers._rllm_session_affinity_patch = True  # type: ignore[attr-defined]
+    DeploymentSampler._inference_headers = _inference_headers
+
+
+_install_inference_header_patch()
 
 
 class _EmptyCompletionIdsError(RuntimeError):
@@ -85,6 +122,11 @@ class FireworksEngine(TinkerEngine):
     ``/inference/v1/completions`` endpoint, so ``TinkerTokenInput`` and
     ``TinkerTokenOutput`` are fully supported.
     """
+
+    # Signals the gateway handler to forward a per-trajectory ``rllm_session_id``
+    # so this engine can set Fireworks session-affinity headers (prefix-cache
+    # reuse across a rollout's turns). Other engines ignore the session id.
+    supports_session_affinity = True
 
     def __init__(
         self,
@@ -148,6 +190,13 @@ class FireworksEngine(TinkerEngine):
         self.sample_timeout = sample_timeout
         self.router_replay = router_replay
         self.sampling_client = sampler
+
+        # Rolling Fireworks prompt-cache accounting (logged every
+        # ``_CACHE_LOG_EVERY`` completions). Low hit-ratio ⇒ session affinity not
+        # routing a trajectory's turns to the same replica.
+        self._cache_cached_tokens = 0
+        self._cache_prompt_tokens = 0
+        self._cache_calls = 0
 
     # ------------------------------------------------------------------
     # Token-in / token-out override
@@ -237,6 +286,10 @@ class FireworksEngine(TinkerEngine):
         requested_max_tokens = sampling_params.pop("max_tokens", requested_max_tokens)
         max_tokens = self._prepare_max_tokens(requested_max_tokens, input_length)
 
+        # Per-trajectory session id (gateway forwards it for affinity); it must
+        # NOT leak into the request body, so pop it before building sampling params.
+        session_id = kwargs.pop("rllm_session_id", None)
+
         for key in ("temperature", "top_p", "top_k", "user", "reasoning_effort"):
             if key in kwargs:
                 sampling_params[key] = kwargs.pop(key)
@@ -247,10 +300,21 @@ class FireworksEngine(TinkerEngine):
         if self.router_replay:
             sampling_params["include_routing_matrix"] = True
 
+        # Fireworks routes requests carrying the same session id to the same
+        # replica, so its per-replica prompt-prefix KV is reused across a
+        # trajectory's turns. Set once per turn from the trajectory id.
+        affinity_headers = None
+        if session_id:
+            affinity_headers = {
+                "x-multi-turn-session-id": str(session_id),
+                "x-session-affinity": str(session_id),
+            }
+
         raw, server_metrics = await self._completions_with_retry(
             prompt_ids,
             max_tokens,
             sampling_params,
+            affinity_headers=affinity_headers,
         )
 
         choice = raw["choices"][0]
@@ -291,31 +355,67 @@ class FireworksEngine(TinkerEngine):
     # Internal retry helper
     # ------------------------------------------------------------------
 
+    def _record_prompt_cache(self, server_metrics, metrics_dict: dict | None) -> None:
+        """Accumulate Fireworks prompt-cache stats; log a rolling summary.
+
+        ``cached_prompt_tokens`` / ``prompt_tokens`` are only present on
+        dedicated deployments (``None`` on serverless), so this is a no-op
+        otherwise. Adds a per-call ``prompt_cache_hit_ratio`` to ``metrics_dict``
+        and logs a rolling hit-ratio every ``_CACHE_LOG_EVERY`` completions.
+        """
+        if server_metrics is None or not getattr(server_metrics, "prompt_tokens", None):
+            return
+        cached = getattr(server_metrics, "cached_prompt_tokens", None) or 0
+        prompt = server_metrics.prompt_tokens
+        if metrics_dict is not None:
+            metrics_dict["prompt_cache_hit_ratio"] = cached / prompt
+        self._cache_cached_tokens += cached
+        self._cache_prompt_tokens += prompt
+        self._cache_calls += 1
+        if self._cache_calls % _CACHE_LOG_EVERY == 0 and self._cache_prompt_tokens:
+            logger.info(
+                "Fireworks prompt cache: hit_ratio=%.3f (cached=%d / prompt=%d over %d completions)",
+                self._cache_cached_tokens / self._cache_prompt_tokens,
+                self._cache_cached_tokens,
+                self._cache_prompt_tokens,
+                self._cache_calls,
+            )
+
     async def _completions_with_retry(
         self,
         prompt_ids: list[int],
         max_tokens: int,
         sampling_kwargs: dict[str, Any],
+        affinity_headers: dict[str, str] | None = None,
     ) -> tuple[dict[str, Any], dict | None]:
         """Call ``DeploymentSampler.async_completions_stream`` with transient-error retries.
 
-        Returns (response_dict, server_metrics_dict)."""
+        ``affinity_headers``, when given, are merged into the request's HTTP
+        headers (via the ``_inference_headers`` patch) so Fireworks routes this
+        request to the trajectory's pinned replica. Returns
+        (response_dict, server_metrics_dict)."""
 
         for attempt in range(_MAX_SAMPLE_ATTEMPTS):
             try:
-                result, server_metrics = await self.sampling_client.async_completions_stream(
-                    prompt=prompt_ids,
-                    max_tokens=max_tokens,
-                    raw_output=True,
-                    logprobs=True,
-                    http_timeout=self.sample_timeout,
-                    **sampling_kwargs,
-                )
+                token = _per_request_headers.set(affinity_headers) if affinity_headers else None
+                try:
+                    result, server_metrics = await self.sampling_client.async_completions_stream(
+                        prompt=prompt_ids,
+                        max_tokens=max_tokens,
+                        raw_output=True,
+                        logprobs=True,
+                        http_timeout=self.sample_timeout,
+                        **sampling_kwargs,
+                    )
+                finally:
+                    if token is not None:
+                        _per_request_headers.reset(token)
                 metrics_dict = {k: v for k, v in dataclasses.asdict(server_metrics).items() if v is not None} if server_metrics else None
                 choice = (result.get("choices") or [{}])[0]
                 completion_ids = (choice.get("raw_output") or {}).get("completion_token_ids") or []
                 if not completion_ids:
                     raise _EmptyCompletionIdsError("Fireworks response included empty completion_token_ids")
+                self._record_prompt_cache(server_metrics, metrics_dict)
                 return result, metrics_dict
             except Exception as exc:
                 err = str(exc)

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -140,6 +140,13 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         if request_body.get("max_completion_tokens") is not None:
             sampling_kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
 
+        # Per-trajectory session id (injected by the gateway) — forwarded only to
+        # engines that use it for inference session affinity (Fireworks prefix-cache
+        # reuse across a rollout's turns). Popped so it never reaches a chat body.
+        session_id = request_body.pop("rllm_session_id", None)
+        if session_id and getattr(engine, "supports_session_affinity", False):
+            sampling_kwargs["rllm_session_id"] = session_id
+
         # Cumulative-token-mode path: the gateway rewrites turn 2+ to a
         # completions-style request whose ``prompt`` is raw token IDs built by
         # ``renderers.bridge_to_next_turn`` (= prior turns' prompt+completion


### PR DESCRIPTION
Fireworks reuses a replica's prompt-prefix KV only when a trajectory's turns route to the same replica (keyed on a session id via request headers). The rollout path set no such header, so multi-turn requests scattered across replicas and re-prefilled the (growing) prompt every turn.

## Session affinity
- Gateway threads the per-rollout session id into the in-process handler body (`rllm_session_id`) at all local-handler call sites.
- `tinker_adapter` forwards it only to engines advertising `supports_session_affinity` (Fireworks), so the tinker path is unchanged.
- `FireworksEngine` builds `session_headers` (`x-multi-turn-session-id` / `x-session-affinity`) per request. Since `DeploymentSampler.async_completions_stream` has no per-call header hook, `_inference_headers` is monkeypatched to merge headers stashed in an async-safe `ContextVar` set around each call.

Automatic — no config change. Verify prompt-cache reuse from the Fireworks console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
