### PR TITLE
feat(harness): configurable rollout limits + terminal-rl config tuning

### DIFF
--- a/cookbooks/swe-rl/train.py
+++ b/cookbooks/swe-rl/train.py
@@ -54,6 +54,13 @@ SANDBOX_BACKEND = os.environ.get("SWE_SANDBOX_BACKEND", "modal")
 # SWE_VAL_MAX=N to validate on the first N tasks instead (0/unset = all 500).
 SWE_VAL_MAX = int(os.environ.get("SWE_VAL_MAX", "0"))
 
+# Per-rollout turn cap for the terminus2 agent. Unset = no artificial cap
+# (Harbor's own default); the per-rollout RLLM_HARNESS_RUN_TIMEOUT_S still
+# bounds wall-clock. The train_*.sh scripts default this to 100; set
+# TERMINUS_MAX_TURNS=N to override (empty/0 = uncapped).
+_terminus_max_turns = os.environ.get("TERMINUS_MAX_TURNS")
+TERMINUS_MAX_TURNS = int(_terminus_max_turns) if _terminus_max_turns and int(_terminus_max_turns) > 0 else None
+
 
 @hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
 def main(config: DictConfig) -> None:
@@ -72,7 +79,7 @@ def main(config: DictConfig) -> None:
     # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
     # for the sandbox lifecycle + per-task verifier, and route rollouts through
     # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
-    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND, max_turns=TERMINUS_MAX_TURNS)
 
     trainer = AgentTrainer(
         backend=config.rllm.get("backend", "tinker"),

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -39,6 +39,8 @@
 set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -40,6 +40,8 @@ set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
 export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -26,6 +26,8 @@
 set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
 export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_verl.sh
+++ b/cookbooks/swe-rl/train_verl.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 MODEL_PATH=Qwen/Qwen3.5-4B

--- a/cookbooks/terminal-rl/train.py
+++ b/cookbooks/terminal-rl/train.py
@@ -58,6 +58,13 @@ SANDBOX_BACKEND = os.environ.get("TERMINAL_SANDBOX_BACKEND", "modal")
 # TB_VAL_MAX=N to validate on the first N tasks instead (0/unset = all).
 TB_VAL_MAX = int(os.environ.get("TB_VAL_MAX", "0"))
 
+# Per-rollout turn cap for the terminus2 agent. Unset = no artificial cap
+# (Harbor's own default); the per-rollout RLLM_HARNESS_RUN_TIMEOUT_S still
+# bounds wall-clock. The train_*.sh scripts default this to 100; set
+# TERMINUS_MAX_TURNS=N to override (empty/0 = uncapped).
+_terminus_max_turns = os.environ.get("TERMINUS_MAX_TURNS")
+TERMINUS_MAX_TURNS = int(_terminus_max_turns) if _terminus_max_turns and int(_terminus_max_turns) > 0 else None
+
 
 @hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
 def main(config: DictConfig) -> None:
@@ -76,7 +83,7 @@ def main(config: DictConfig) -> None:
     # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
     # for the sandbox lifecycle + per-task verifier, and route rollouts through
     # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
-    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND, max_turns=TERMINUS_MAX_TURNS)
 
     trainer = AgentTrainer(
         backend=config.rllm.get("backend", "tinker"),

--- a/cookbooks/terminal-rl/train_fireworks.sh
+++ b/cookbooks/terminal-rl/train_fireworks.sh
@@ -47,6 +47,8 @@
 set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
@@ -62,16 +64,16 @@ python -u train.py \
     fireworks_config.rollout_deployment_replica_count=6 \
     training.group_size=8 \
     training.learning_rate=2e-5 \
-    training.max_length=65536 \
+    training.max_length=131072 \
     rllm.rollout.train.temperature=1.0 \
     rllm.rollout.train.top_p=1.0 \
     rllm.rollout.val.temperature=1.0 \
     rllm.rollout.val.top_p=1.0 \
-    data.max_prompt_length=57344 \
+    data.max_prompt_length=122880 \
     data.max_response_length=8192 \
     data.train_batch_size=1 \
     data.val_batch_size=-1 \
-    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_prompt_length=122880 \
     rllm.data.max_response_length=8192 \
     rllm.data.train_batch_size=1 \
     rllm.data.val_batch_size=-1 \
@@ -81,13 +83,13 @@ python -u train.py \
     rllm.async_training.enable=true \
     rllm.async_training.mini_batch_size=16 \
     rllm.async_training.fwd_bwd_group_size=1 \
-    rllm.async_training.staleness_threshold=1.0 \
+    rllm.async_training.staleness_threshold=0.5 \
     rllm.async_training.trigger_parameter_sync_step=1 \
     rllm.async_training.partial_rollout=true \
     rllm.workflow.n_parallel_tasks=192 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
-    rllm.gateway.cumulative_token_mode=false \
+    rllm.gateway.cumulative_token_mode=true \
     rllm.gateway.renderer_family=qwen3.5 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \

--- a/cookbooks/terminal-rl/train_fireworks_sync.sh
+++ b/cookbooks/terminal-rl/train_fireworks_sync.sh
@@ -41,6 +41,8 @@ set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
 export TB_VAL_MAX="${TB_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_tinker.sh
+++ b/cookbooks/terminal-rl/train_tinker.sh
@@ -28,6 +28,8 @@
 set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_tinker_sync.sh
+++ b/cookbooks/terminal-rl/train_tinker_sync.sh
@@ -23,6 +23,8 @@ set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
 export TB_VAL_MAX="${TB_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_verl.sh
+++ b/cookbooks/terminal-rl/train_verl.sh
@@ -23,6 +23,8 @@ set -euo pipefail
 unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -575,6 +575,17 @@ def _run_eval(
 @click.option("--temperature", default=None, type=float, help="Sampling temperature (shortcut for --sampling-params temperature=...).")
 @click.option("--top-p", "top_p", default=None, type=float, help="Nucleus sampling top_p (shortcut for --sampling-params top_p=...).")
 @click.option("--max-tokens", "max_tokens", default=None, type=int, help="Max generated tokens per call (shortcut for --sampling-params max_tokens=...).")
+@click.option(
+    "--agent-timeout",
+    "agent_timeout",
+    default=None,
+    type=int,
+    metavar="SECONDS",
+    help=(
+        "Per-rollout agent wall-clock timeout in seconds for sandboxed CLI harnesses (e.g. terminus2). "
+        "Default 3600. Sandbox lifetimes are sized to outlast this, so the environment isn't torn down mid-rollout."
+    ),
+)
 def eval_cmd(
     benchmark: str,
     agent_name: str | None,
@@ -598,6 +609,7 @@ def eval_cmd(
     temperature: float | None,
     top_p: float | None,
     max_tokens: int | None,
+    agent_timeout: int | None,
 ):
     """Evaluate a model on a benchmark dataset."""
     from rllm.cli._sampling import resolve_eval_sampling
@@ -671,6 +683,17 @@ def eval_cmd(
         agent_metadata["sandbox_backend"] = sandbox_backend
     if sandbox_concurrency is not None:
         agent_metadata["sandbox_concurrency"] = sandbox_concurrency
+    if agent_timeout is not None:
+        if agent_timeout < 1:
+            fail("--agent-timeout must be >= 1 second.")
+        # Consumed by BaseCliHarness.configure() → sets the harness run_timeout.
+        agent_metadata["agent_timeout"] = agent_timeout
+        # Also publish it as the canonical env knob so the Modal backend derives
+        # a sandbox lifetime with headroom over it (else a raised timeout would
+        # still be reaped at the default lifetime).
+        import os
+
+        os.environ["RLLM_HARNESS_RUN_TIMEOUT_S"] = str(agent_timeout)
 
     parsed_indices = parse_index_spec(task_indices) if task_indices is not None else None
 

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -64,7 +64,22 @@ class BaseCliHarness(SandboxedAgentFlow):
     stdout_log_path: str = "/tmp/agent-stdout.log"
     # Per-call timeouts (seconds). Tasks may override via metadata.
     install_timeout: int = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)  # set env var: export RLLM_HARNESS_INSTALL_TIMEOUT_S=xxx
-    run_timeout: int = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 1800)  # set env var: export RLLM_HARNESS_RUN_TIMEOUT_S=xxx
+    run_timeout: int = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600)  # set env var: export RLLM_HARNESS_RUN_TIMEOUT_S=xxx
+
+    def configure(self, overrides: dict) -> dict:
+        """Consume CLI overrides this harness understands, then defer to the base.
+
+        ``agent_timeout`` (seconds) caps a single rollout's wall-clock — it's the
+        timeout handed to the in-sandbox ``exec``. ``rllm eval --agent-timeout``
+        routes here. Backends with a hard sandbox lifetime (e.g. Modal, see
+        ``modal_backend._default_sandbox_timeout``) size it to exceed this so the
+        environment can't be reaped before the agent's own timeout fires.
+        """
+        leftovers = super().configure(overrides)
+        timeout = leftovers.pop("agent_timeout", None)
+        if timeout is not None:
+            self.run_timeout = int(timeout)
+        return leftovers
 
     # ---------------------------------------------------------------------
     # Sandbox helpers

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -89,7 +89,11 @@ class Terminus2Harness(BaseCliHarness):
     terminus_python: str = "3.12"
     parser_name: str = "json"  # "json" or "xml"
     temperature: float = 0.7
-    max_turns: int = 50
+    # Per-rollout turn cap. ``None`` = don't impose one — let Harbor's own
+    # (effectively unbounded) default apply, so the agent isn't artificially
+    # cut short; the per-rollout run timeout (RLLM_HARNESS_RUN_TIMEOUT_S) still
+    # bounds wall-clock. Set a value (e.g. via the train_*.sh scripts) to cap.
+    max_turns: int | None = None
     # Asciinema recording needs an extra dep and a writable trial dir; off by
     # default since rLLM scores from the verifier, not the cast.
     record_terminal_session: bool = False
@@ -118,12 +122,14 @@ class Terminus2Harness(BaseCliHarness):
             "RLLM_TERMINUS_API_BASE": gateway_url,
             "RLLM_TERMINUS_WORKDIR": str(task.metadata.get("workdir") or ""),
             "RLLM_TERMINUS_PARSER": self.parser_name,
-            "RLLM_TERMINUS_MAX_TURNS": str(self.max_turns),
             "RLLM_TERMINUS_TEMPERATURE": str(self.temperature),
             "RLLM_TERMINUS_RECORD": "1" if self.record_terminal_session else "0",
             "RLLM_TERMINUS_INSTRUCTION_FILE": _INSTRUCTION_PATH,
             "RLLM_TERMINUS_LOGS_DIR": _LOGS_DIR,
         }
+        # Only pass a turn cap when one is set; absent var = no artificial limit.
+        if self.max_turns is not None:
+            env["RLLM_TERMINUS_MAX_TURNS"] = str(self.max_turns)
         return env
 
     def write_configs(
@@ -260,7 +266,10 @@ async def _main():
     api_base = os.environ.get("RLLM_TERMINUS_API_BASE") or None
     workdir = os.environ.get("RLLM_TERMINUS_WORKDIR") or None
     parser = os.environ.get("RLLM_TERMINUS_PARSER", "json")
-    max_turns = int(os.environ.get("RLLM_TERMINUS_MAX_TURNS", "50"))
+    # Unset/empty = no artificial cap; Harbor's Terminus2 treats max_turns=None
+    # as its own (effectively unbounded) default.
+    _max_turns = os.environ.get("RLLM_TERMINUS_MAX_TURNS")
+    max_turns = int(_max_turns) if _max_turns else None
     temperature = float(os.environ.get("RLLM_TERMINUS_TEMPERATURE", "0.7"))
     record = os.environ.get("RLLM_TERMINUS_RECORD", "0") == "1"
     logs_dir = Path(os.environ.get("RLLM_TERMINUS_LOGS_DIR", "/tmp/terminus2/logs"))

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -26,9 +26,28 @@ from rllm.sandbox.protocol import SnapshotNotFound
 
 logger = logging.getLogger(__name__)
 
-# Default sandbox lifetime: 30 minutes (Modal default is 5 min). Raise via the
-# env var for workloads whose single rollout can exceed it (e.g. long builds).
-_DEFAULT_TIMEOUT = env_int("RLLM_MODAL_SANDBOX_TIMEOUT_S", 30 * 60)
+# Headroom the sandbox lifetime keeps *beyond* the agent run timeout + install,
+# to cover the post-run verifier, teardown, and scheduling slack.
+_SANDBOX_LIFETIME_HEADROOM_S = 10 * 60
+
+
+def _default_sandbox_timeout() -> int:
+    """Default Modal sandbox lifetime (seconds) — must outlast a full rollout.
+
+    The lifetime clock starts at ``Sandbox.create()``, *before* the cold-path
+    install, the agent run, and the verifier. If it doesn't exceed their sum the
+    container is reaped mid-rollout (exit 137 + "Sandbox already shut down").
+    So derive it from the agent run-timeout knob with headroom for install +
+    verify + teardown. ``RLLM_MODAL_SANDBOX_TIMEOUT_S`` overrides outright.
+    (Modal's own default is only 5 min.)
+    """
+    explicit = env_int("RLLM_MODAL_SANDBOX_TIMEOUT_S", 0)
+    if explicit > 0:
+        return explicit
+    run_timeout = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600)
+    install_timeout = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)
+    return run_timeout + install_timeout + _SANDBOX_LIFETIME_HEADROOM_S
+
 
 # Modal caps an exec's total argv at 64 KiB (ARG_MAX); payloads above this go
 # through a chunked temp-file path instead of being inlined in the command.
@@ -84,7 +103,7 @@ class ModalSandbox:
 
         self.name = name
         self._image_spec = image
-        self._timeout = kwargs.pop("timeout", _DEFAULT_TIMEOUT)
+        self._timeout = kwargs.pop("timeout", None) or _default_sandbox_timeout()
         self._app_name = kwargs.pop("app_name", "rllm-sandbox")
 
         # A stored snapshot ref is a bare Modal image id ("im-…", no registry/tag);
@@ -335,11 +354,12 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
 
     # Size the build sandbox's lifetime to the worst-case replay: each RUN is
     # bounded at 900s (a step that hangs against a prebuilt image burns its
-    # full bound), plus the install bound and pull/capture slack. With the
-    # 30-min default, two hung steps killed the sandbox mid-build.
+    # full bound), plus the install bound and pull/capture slack — floored at
+    # the rollout default. Without this floor, two hung steps killed the
+    # sandbox mid-build.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
     n_replay = len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0
-    build_timeout = max(_DEFAULT_TIMEOUT, 900 * n_replay + install_budget + 600)
+    build_timeout = max(_default_sandbox_timeout(), 900 * n_replay + install_budget + 600)
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
     try:
         _replay_dockerfile(task, sb, "modal")


### PR DESCRIPTION
Makes per-rollout limits for sandboxed CLI harnesses (terminus2) configurable instead of hardcoded, and stops rollouts from being cut short — both by the turn cap and by the Modal sandbox being reaped mid-run.

## Why
- The terminus2 turn cap was hardcoded at 50 in the harness; the operational value should live in the training scripts.
- Default agent timeout (1800s) **equalled** the default Modal sandbox lifetime (1800s), and the lifetime clock starts at `Sandbox.create()` — before install + agent run + verify. So long rollouts hit the lifetime ceiling first and were SIGKILLed: `exit 137` + `NotFoundError("Sandbox ... already shut down")`.

## Framework (`550193b2`)
- **terminus2**: `max_turns` defaults to `None` (no artificial cap — Harbor's own default) instead of 50; `RLLM_TERMINUS_MAX_TURNS` is emitted only when set, and the in-sandbox driver treats an absent value as uncapped.
- **BaseCliHarness**: per-rollout `run_timeout` default `1800 → 3600`s; `configure()` now consumes an `agent_timeout` override.
- **eval CLI**: new `--agent-timeout SECONDS` (routed through `configure()`, also published as `RLLM_HARNESS_RUN_TIMEOUT_S`).
- **modal_backend**: sandbox lifetime is now `run_timeout + install_timeout + headroom`, so it always outlasts a full rollout. `RLLM_MODAL_SANDBOX_TIMEOUT_S` still overrides outright.

## Cookbooks (`733958a7`)
- terminal-rl & swe-rl `train.py`: read the `TERMINUS_MAX_TURNS` env knob (empty/0 = uncapped) and pass it to `Terminus2Harness`.
- all `train_*.sh`: default `TERMINUS_MAX_TURNS=100` (overridable per run) — the operational cap lives in the scripts, not the harness.
- terminal-rl/train_fireworks.sh: grow the context window for longer rollouts (`max_length` 64k→128k, `max_prompt_length` 56k→120k), enable `gateway.cumulative_token_mode`, lower async `staleness_threshold` to 0.5.

## Defaults / compatibility
Train scripts that already pin `RLLM_HARNESS_RUN_TIMEOUT_S` / `RLLM_MODAL_SANDBOX_TIMEOUT_S` are unaffected (explicit values still win). The new defaults only change paths that set neither — notably `rllm eval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
