### PR TITLE
feat(cli): show agent/model config in the eval header panel

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -43,6 +43,40 @@ def _apply_sandbox_overrides(agent, agent_metadata: dict | None) -> None:
         logger.warning("--%s has no effect for agent %s", flag.replace("_", "-"), type(agent).__name__)
 
 
+# Agent knobs surfaced in the eval header, in display order. Each entry is
+# (attribute, label, formatter); a flow that doesn't expose an attribute (or
+# leaves it ``None``) simply omits that pair, so this works across harnesses.
+_AGENT_CONFIG_SPECS = (
+    ("max_turns", "max turns", str),
+    ("max_steps", "max steps", str),
+    ("max_concurrent", "max concurrent", str),
+    ("temperature", "temperature", lambda v: f"{v:g}"),
+    ("run_timeout", "run timeout", lambda v: f"{v}s"),
+    ("install_timeout", "install timeout", lambda v: f"{v}s"),
+)
+
+
+def _agent_config_rows(agent) -> list[tuple[str, str]]:
+    """Build the ``Config`` panel row from the loaded flow's effective knobs.
+
+    Reads the curated attributes off the agent instance (max turns, temperature,
+    timeouts, …) and renders each present one as a ``key value`` chip — dim key,
+    bold value — with chips separated by a dim ``·``. Spaces *within* a chip are
+    non-breaking (`` ``) so a pair never splits across a line wrap; wraps
+    fall on the separators instead. Returns an empty list when the flow exposes
+    none of the knobs.
+    """
+    chips = []
+    for attr, label, fmt in _AGENT_CONFIG_SPECS:
+        value = getattr(agent, attr, None)
+        if value is not None:
+            key = label.replace(" ", " ")
+            chips.append(f"[dim]{key}[/] [val]{fmt(value)}[/]")
+    if not chips:
+        return []
+    return [("Config", "  [dim]·[/]  ".join(chips))]
+
+
 def _dict_rows_to_tasks(rows: list[dict]) -> list[Task]:
     """Wrap dict-rows from a catalog dataset as Task objects.
 
@@ -363,6 +397,7 @@ def _run_eval(
         ("Benchmark", f"[val]{benchmark}[/]  [dim]({split}, {len(dataset)} examples)[/]"),
         ("Model", f"[val]{model}[/]"),
         ("Agent", agent_text),
+        *_agent_config_rows(agent),
         ("Evaluator", f"[dim]{evaluator_display}[/]"),
     ]
     if not use_snapshot:


### PR DESCRIPTION
## What
Adds a **`Config`** row to the `rllm eval` startup panel, surfacing the loaded flow's *effective* rollout knobs next to the existing Benchmark / Model / Agent / Evaluator rows.

```
│   Agent      terminus2  Run Harbor's Terminus-2 terminal agent inside the sandbox  │
│   Config     max concurrent 64  ·  temperature 0.7  ·  run timeout 3600s  ·         │
│              install timeout 600s                                                   │
│   Evaluator  per-task (rllm runtime on harbor task)                                 │
```

## Why
The header showed *what* was running but none of the rollout limits. When debugging a run (e.g. terminus2 on terminal-bench) it's useful to see the turn/timeout/temperature config at a glance without grepping the harness — especially now that these are configurable (`--agent-timeout`, env vars) and the sandbox lifetime derives from them.

## How
- `_AGENT_CONFIG_SPECS` — curated `(attr, label, formatter)` list in display order: `max_turns`, `max_steps`, `max_concurrent`, `temperature`, `run_timeout`, `install_timeout`.
- `_agent_config_rows(agent)` — reads each knob off the agent instance via `getattr(..., None)`; renders present ones as dim-key / bold-value chips joined by a dim `·`. Spaces *within* a chip are non-breaking (` `) so a pair like `run timeout 3600s` never splits across a line wrap — wraps fall on the separators instead.
- Spliced between the `Agent` and `Evaluator` rows.

## Graceful degradation
A flow that doesn't expose a knob simply omits that chip; an agent exposing none gets no `Config` row at all. Verified across the loaded `terminus2` flow — with `max_turns=None` (uncapped) on this branch, that chip is correctly dropped while `run timeout 3600s` shows through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)