### PR TITLE
fix(eval): terminal-bench reliability — sandbox lifetime, retry, live metrics, prompt-cache affinity

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -209,7 +209,7 @@ class ReverseProxy:
             # HTTP proxy path
             worker = self.router.route(session_id)
             url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
-            headers = self._forward_headers(request)
+            headers = self._forward_headers(request, session_id)
             try:
                 resp = await self._send_with_retry(
                     method=request.method,
@@ -331,7 +331,7 @@ class ReverseProxy:
         else:
             worker = self.router.route(session_id)
             url = self._build_url(worker.api_url, "/v1/completions", "")
-            headers = self._forward_headers(request)
+            headers = self._forward_headers(request, session_id)
             raw_body = json.dumps(completions_body).encode()
             try:
                 resp = await self._send_with_retry(
@@ -401,7 +401,7 @@ class ReverseProxy:
 
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, "/v1/completions", "")
-        headers = self._forward_headers(request)
+        headers = self._forward_headers(request, session_id)
         raw_body = json.dumps(completions_body).encode()
 
         assert self._http is not None
@@ -634,7 +634,7 @@ class ReverseProxy:
 
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
-        headers = self._forward_headers(request)
+        headers = self._forward_headers(request, session_id)
 
         assert self._http is not None
         upstream = self._http.stream(
@@ -915,5 +915,13 @@ class ReverseProxy:
         return url
 
     @staticmethod
-    def _forward_headers(request: Request) -> dict[str, str]:
-        return {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+    def _forward_headers(request: Request, session_id: str | None = None) -> dict[str, str]:
+        headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+        # Pin a trajectory's turns to one replica so Fireworks reuses its
+        # prompt-prefix KV (caching is per-replica). The training path sets these
+        # via the rollout engine; the HTTP path (eval) does it here. No-op for
+        # non-Fireworks upstreams; setdefault lets a client pin its own value.
+        if session_id:
+            headers.setdefault("x-session-affinity", str(session_id))
+            headers.setdefault("x-multi-turn-session-id", str(session_id))
+        return headers

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -425,20 +425,25 @@ class AgentFlowEngine:
             futures.append(self.process_task_with_retry(task, task_id, rollout_idx, idx, is_validation=is_validation))
 
         results: list[Episode | None] = [None] * len(tasks)
+        # Running tallies for a live accuracy/reward readout on the progress bar.
+        n_correct = 0
+        reward_sum = 0.0
+        n_scored = 0
         with tqdm(total=len(tasks), desc="Generating trajectories") as pbar:
-            n_done = 0
-            reward_sum = 0.0
             for future in asyncio.as_completed(futures):
                 task_id, rollout_idx, result_idx, episode = await future
                 results[result_idx] = episode
-                # Surface a running average reward on the progress bar so the
-                # current score is visible live (not just per-rollout lines).
-                if episode is not None:
-                    rewards = [t.reward for t in episode.trajectories if t.reward is not None]
-                    reward_sum += (sum(rewards) / len(rewards)) if rewards else (1.0 if episode.is_correct else 0.0)
-                    n_done += 1
-                    pbar.set_postfix(avg_reward=f"{reward_sum / n_done:.3f}")
+                done = pbar.n + 1
+                if episode is not None and episode.is_correct:
+                    n_correct += 1
+                if episode is not None and episode.trajectories and episode.trajectories[0].reward is not None:
+                    reward_sum += float(episode.trajectories[0].reward)
+                    n_scored += 1
                 pbar.update(1)
+                postfix = f"acc {n_correct}/{done}={100.0 * n_correct / done:.1f}%"
+                if n_scored:
+                    postfix += f" reward={reward_sum / n_scored:.3f}"
+                pbar.set_postfix_str(postfix)
 
         ordered_results: list[Episode] = results  # type: ignore[assignment]
 

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -248,6 +248,8 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
     OOM-kills compile-heavy graders (e.g. ``go test ./...``). Modal takes memory
     in MB; Daytona takes memory/disk in GB. Docker/local ignore the values.
     """
+    from rllm.env import env_int
+
     env = task.metadata.get("environment", {}) or {}
     cpus, mem_mb, disk_mb = env.get("cpus"), env.get("memory_mb"), env.get("storage_mb")
     kw: dict = {}
@@ -256,6 +258,15 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
             kw["cpu"] = float(cpus)
         if mem_mb:
             kw["memory"] = int(mem_mb)
+        # Size the sandbox lifetime to this task's own budget so the box always
+        # outlives the agent + verifier it hosts (both run here). A flat global
+        # default could be shorter than agent+verifier and reap the box mid-run
+        # ("Sandbox already shut down"). max() keeps an explicit override as a floor.
+        agent_t = float(task.metadata.get("agent_timeout") or env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600))
+        verifier_t = float(task.metadata.get("verifier_timeout") or 600.0)
+        install_t = float(env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600))
+        per_task_floor = int(agent_t + verifier_t + install_t + 600)  # +600s teardown/scheduling slack
+        kw["timeout"] = max(per_task_floor, env_int("RLLM_MODAL_SANDBOX_TIMEOUT_S", 0))
     elif backend == "daytona":
         if cpus:
             kw["cpu"] = int(cpus)

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -108,7 +108,10 @@ async def run_dataset(
         gateway=gateway,
         model=model,
         n_parallel_tasks=effective_concurrency,
-        retry_limit=1,  # eval doesn't retry on flow errors
+        # One retry: rollout errors are usually transient infra (sandbox reaped,
+        # flaky create, install blip), not flow bugs. Without it they become
+        # permanent zeros that depress the score; only errored tasks re-run.
+        retry_limit=2,
         raise_on_error=False,  # capture per-task errors as error Episodes
         hooks=hooks,
         val_sampling_params=sampling_params or None,  # eval is always validation

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -34,7 +34,7 @@ import uuid
 from abc import abstractmethod
 
 from rllm.env import env_int
-from rllm.sandbox.protocol import Sandbox
+from rllm.sandbox.protocol import Sandbox, SandboxCommandTimeout
 from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
 from rllm.types import AgentConfig, Task
 
@@ -307,6 +307,10 @@ class BaseCliHarness(SandboxedAgentFlow):
 
         try:
             self._exec_agent(sandbox, cmd, timeout=timeout, env=env_vars)
+        except SandboxCommandTimeout as e:
+            # Expected, not a failure: the agent spent its whole time budget; the
+            # captured steps are still scored by the verifier. INFO, not WARNING.
+            logger.info("%s reached its time budget: %s", type(self).__name__, e)
         except Exception as e:
             # Surface as a warning for operator visibility; the engine
             # still gets None and the gateway traces (if any LLM calls

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -19,10 +19,11 @@ import logging
 import os
 import tarfile
 import threading
+import time
 import weakref
 
-from rllm.env import env_int
-from rllm.sandbox.protocol import SnapshotNotFound
+from rllm.env import env_float, env_int
+from rllm.sandbox.protocol import SandboxCommandTimeout, SnapshotNotFound
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,64 @@ _B64_ARGV_LIMIT = 50_000
 # atexit-tracked sandboxes; terminated on process exit to avoid leaks.
 _LIVE_SANDBOXES: weakref.WeakSet = weakref.WeakSet()
 _LIVE_LOCK = threading.Lock()
+
+
+class _CreateRateLimiter:
+    """Process-global token bucket pacing ``Sandbox.create()``.
+
+    Modal's create cap is a **token bucket**, not a flat cap: it absorbs an
+    initial burst, then refills at the rate its ``RESOURCE_EXHAUSTED`` error
+    advertises (~5/s). That shape is why a batch of ~192 concurrent creates can
+    sail through while ~256 trips it — the burst fits the bucket, then the extra
+    creates outrun the refill and Modal's client spends the batch in
+    retry/backoff (the repeated rate-limit warnings).
+
+    This mirrors that bucket on our side, gating every create through the one
+    chokepoint (:meth:`ModalSandbox.__init__`): up to ``burst`` go through
+    immediately, after which creates are paced at ``rate``/s. Tuned under
+    Modal's envelope, the startup burst is absorbed and only the long tail is
+    throttled — so creates queue locally instead of failing-and-retrying, with
+    little added latency for batches within the burst.
+
+    Thread-safe; token accounting is serialized under the lock while the wait
+    sleeps outside it, so concurrent callers self-correct on the next loop and
+    never collectively exceed ``rate``. Scope is per-process, which matches the
+    AgentFlowEngine path (all creates happen in the driver process).
+    """
+
+    def __init__(self, rate: float, burst: float) -> None:
+        self._rate = rate
+        self._capacity = max(1.0, burst)
+        self._tokens = self._capacity
+        self._last = time.monotonic()
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        if self._rate <= 0:  # disabled — e.g. account limit was raised
+            return
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                self._tokens = min(self._capacity, self._tokens + (now - self._last) * self._rate)
+                self._last = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                wait = (1.0 - self._tokens) / self._rate
+            time.sleep(wait)
+
+
+# Defaults sit inside the envelope observed live: a burst of ~192 concurrent
+# creates is fine, ~256 trips the limit, and the error advertises a ~5/s
+# refill. So allow a 150 burst (comfortably under the 192 that worked) and
+# refill at 4/s (under the stated 5/s) as a backstop for the long tail.
+# Steady-state create rate is usually far below the refill anyway (rollouts
+# free slots only as tasks finish), so in practice this just smooths startup.
+# Tune RLLM_MODAL_SANDBOX_CREATE_BURST / _RPS for your account; set _RPS=0 to
+# disable entirely (e.g. once Modal raises your limit).
+_CREATE_RATE_RPS = env_float("RLLM_MODAL_SANDBOX_CREATE_RPS", 4.0)
+_CREATE_BURST = env_float("RLLM_MODAL_SANDBOX_CREATE_BURST", 150.0)
+_CREATE_LIMITER = _CreateRateLimiter(_CREATE_RATE_RPS, _CREATE_BURST)
 
 
 def _terminate_all_live() -> None:
@@ -128,6 +187,8 @@ class ModalSandbox:
                 if key in kwargs:
                     create_kwargs[key] = kwargs.pop(key)
 
+            # Pace creates under Modal's account-wide rate cap (see _CreateRateLimiter).
+            _CREATE_LIMITER.acquire()
             self._sandbox = modal.Sandbox.create(**create_kwargs)
         except modal.exception.NotFoundError as e:
             if from_snapshot:
@@ -158,6 +219,7 @@ class ModalSandbox:
         if timeout is not None:
             exec_kwargs["timeout"] = int(timeout)
 
+        start = time.monotonic()
         process = self._sandbox.exec("bash", "-c", command, **exec_kwargs)
 
         stdout = process.stdout.read()
@@ -166,8 +228,21 @@ class ModalSandbox:
         # Wait for the process to complete and get exit code
         process.wait()
         exit_code = process.returncode
+        elapsed = time.monotonic() - start
 
         if exit_code != 0:
+            # A timeout SIGKILL surfaces as a negative returncode; flag it so an
+            # agent that simply spent its time budget isn't reported as a failure.
+            timed_out = timeout is not None and exit_code < 0 and elapsed >= timeout * 0.95
+            if timed_out:
+                logger.warning(
+                    "Command hit its %ds timeout in sandbox %s (killed after %.0fs): %s",
+                    int(timeout),
+                    self.name,
+                    elapsed,
+                    command[:200],
+                )
+                raise SandboxCommandTimeout(f"Command hit its {int(timeout)}s timeout in sandbox {self.name} (killed after {elapsed:.0f}s)")
             logger.warning(
                 "Command failed in sandbox %s: %s\nstderr: %s",
                 self.name,

--- a/rllm/sandbox/protocol.py
+++ b/rllm/sandbox/protocol.py
@@ -13,6 +13,14 @@ class SnapshotNotFound(Exception):
     """
 
 
+class SandboxCommandTimeout(RuntimeError):
+    """Raised by a backend's ``exec`` when a command is killed for exceeding its
+    own ``timeout``. Distinct from a genuine non-zero exit so callers can treat
+    "the agent spent its whole time budget" as expected, not a failure.
+    Subclasses ``RuntimeError`` so existing handlers keep catching it.
+    """
+
+
 @runtime_checkable
 class Sandbox(Protocol):
     """Protocol for sandbox backends (Docker, Local, Modal, etc.)."""


### PR DESCRIPTION
## Problem

Terminal-bench (`terminal-bench@2.0`) eval on Modal scored **~30–33%** vs the official Terminus-2 **~40%**, with flaky `Command failed` warnings. The gap was **infra, not model quality**.

Analysis of three complete 89-task runs: 29/27/29 pass, and **5/6/13 tasks per run auto-zeroed** as 0-step `ERROR` episodes — a *different* set each run (flaky), concentrated in high-`agent_timeout` tasks.

**Root cause:** the Modal sandbox lifetime was derived from a *global* env var (a flat 4800s), while the agent runs for the *per-task* `agent_timeout` (600–12000s) and the verifier then runs in the **same box**. 14 of 89 tasks have `agent+verifier > 4800s`, so the box was reaped before the verifier's exec → *"Sandbox already shut down"* → the whole episode became a bare 0-step `ERROR` (all agent work discarded). With `retry_limit=1` (no retry), each was a permanent zero.

## Changes

- **`eval/_resolution.py`** — size the Modal sandbox per-task: `max(RLLM_MODAL_SANDBOX_TIMEOUT_S, agent_timeout + verifier_timeout + install + slack)`. The box always outlives the agent + verifier; an explicit override only *raises* the ceiling.
- **`eval/runner.py`** — eval `retry_limit` 1 → 2, so a transient infra failure gets one retry instead of a permanent zero (matches the official Harbor harness). Only the few errored tasks re-run.
- **`engine/agentflow_engine.py`** — live running accuracy/reward on the progress bar (`acc N/done=% reward=…`), so the score is visible *as* the eval runs.
- **`sandbox/protocol.py` + `modal_backend.py`** — classify an exec killed at its own `timeout` as a new `SandboxCommandTimeout` (a `RuntimeError` subclass) instead of a generic `Command failed (exit -1)`. **`cli_harness.py`** catches it and logs at INFO (*"reached its time budget"*) — an agent spending its full per-task budget is expected (the verifier still scores partial state), not a failure.
- **`rllm-model-gateway/proxy.py`** — inject `x-session-affinity` / `x-multi-turn-session-id` from the rollout session id on the **HTTP forwarding path**, so multi-turn eval trajectories reuse Fireworks' per-replica prompt cache. Previously only the in-process training path set affinity; eval (the HTTP path) sent none, so 50–100-turn terminus2 rollouts re-prefilled the growing prompt on a fresh replica every turn.

## Validation

- All harness/eval/gateway unit tests pass (`tests/harnesses`, `tests/eval`, gateway proxy logic). Pre-existing failures are unrelated (`verl`/`tinker`/`pytest_asyncio` not installed in this env).
- Per-task lifetime sizing verified: short 900s tasks shrink 4800→3000s; sam-cell-seg → 15600s; build-pov-ray → 25200s. A stale override only raises the ceiling.
- Affinity-header injection verified: headers present with a session id, absent without, client-set values preserved, hop-by-hop still stripped.

## Notes / scope

- `modal_backend.py` also carries a **pre-existing** `_CreateRateLimiter` (Modal create-rate pacing) that shares the new `import time`; it's bundled here only because it lives in the same file and is also eval-reliability related.
- Excludes other in-progress working-tree edits on `terminal-rl` (the `train_*.sh` config tuning and `fireworks_engine.py`).
- Follow-up worth checking: Fireworks prompt caching also needs a **stable prompt prefix** — confirm the terminus2 system prompt keeps dynamic content (timestamps) at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
