### PR TITLE
feat(eval): default sampling params + surface Fireworks deployments in the picker

### DIFF
--- a/rllm/cli/_sampling.py
+++ b/rllm/cli/_sampling.py
@@ -147,14 +147,21 @@ def _flags(temperature: float | None, top_p: float | None, max_tokens: int | Non
     return SamplingConfig.from_obj(d)
 
 
+# Default sampling params applied to every ``rllm eval`` run unless the user
+# overrides them — surfaced in the eval header's Sampling row and
+# gateway-enforced. Mirrors the cookbook training rollout so eval samples the
+# model the same way it was trained.
+_EVAL_DEFAULT_SAMPLING = SamplingConfig(temperature=1.0, top_p=1.0)
+
+
 def resolve_eval_sampling(
     sampling_params: str | None,
     temperature: float | None = None,
     top_p: float | None = None,
     max_tokens: int | None = None,
 ) -> SamplingConfig:
-    """Resolve the SamplingConfig for ``rllm eval`` (string/@file, overridden by flags)."""
-    return _parse(sampling_params).merged(_flags(temperature, top_p, max_tokens))
+    """Resolve the SamplingConfig for ``rllm eval``: defaults < string/@file < flags."""
+    return _EVAL_DEFAULT_SAMPLING.merged(_parse(sampling_params)).merged(_flags(temperature, top_p, max_tokens))
 
 
 def resolve_train_sampling(

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -46,11 +46,14 @@ def _apply_sandbox_overrides(agent, agent_metadata: dict | None) -> None:
 # Agent knobs surfaced in the eval header, in display order. Each entry is
 # (attribute, label, formatter); a flow that doesn't expose an attribute (or
 # leaves it ``None``) simply omits that pair, so this works across harnesses.
+# NB: temperature is intentionally omitted — sampling params (temperature,
+# top_p, …) are shown in the gateway-enforced "Sampling" row, which is
+# authoritative; listing the harness's requested temperature here too just
+# duplicated it with a (usually different, since the gateway wins) value.
 _AGENT_CONFIG_SPECS = (
     ("max_turns", "max turns", str),
     ("max_steps", "max steps", str),
     ("max_concurrent", "max concurrent", str),
-    ("temperature", "temperature", lambda v: f"{v:g}"),
     ("run_timeout", "run timeout", lambda v: f"{v}s"),
     ("install_timeout", "install timeout", lambda v: f"{v}s"),
 )

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -402,13 +402,19 @@ def fetch_fireworks_models(api_key: str | None = None) -> list[str]:
 
 
 def fetch_fireworks_deployed_models(api_key: str | None = None) -> list[str]:
-    """Return the caller's actively deployed model IDs (best-effort).
+    """Return the caller's runnable dedicated-deployment IDs (best-effort).
 
-    Discovers the caller's account ID(s) via ``GET /v1/accounts``, then lists
-    each account's ``deployedModels`` that are in state ``DEPLOYED`` — i.e.
-    models currently serving inference on a dedicated deployment (not merely
-    uploaded). These can be sampled with no further setup. The shared public
-    ``fireworks`` namespace is excluded (see :func:`fetch_fireworks_models`).
+    Discovers the caller's account ID(s) via ``GET /v1/accounts``, then collects
+    two complementary sources (the shared public ``fireworks`` namespace is
+    excluded — see :func:`fetch_fireworks_models`):
+
+    * ``deployedModels`` in state ``DEPLOYED`` — a custom/fine-tuned model bound
+      to a deployment; addressed for inference by its ``model`` id.
+    * ``deployments`` in state ``READY`` — a dedicated deployment of a base
+      model has no ``deployedModel`` entry (``model`` is null) and is addressed
+      for inference by its own ``accounts/<acct>/deployments/<id>`` name. Without
+      this, base-model deployments are invisible to the picker even though
+      that's the exact id evals run against.
 
     Returns an empty list on any failure so callers can degrade gracefully.
     """
@@ -421,6 +427,9 @@ def fetch_fireworks_deployed_models(api_key: str | None = None) -> list[str]:
             for dm in _fireworks_paged(f"accounts/{account}/deployedModels", key, "deployedModels"):
                 if dm.get("state") == "DEPLOYED" and dm.get("model"):
                     names.append(dm["model"])
+            for dep in _fireworks_paged(f"accounts/{account}/deployments", key, "deployments"):
+                if dep.get("state") == "READY" and dep.get("name"):
+                    names.append(dep["name"])
         return sorted(set(names))
     except Exception:
         return []

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -88,7 +88,10 @@ class Terminus2Harness(BaseCliHarness):
     harbor_version: str = "0.3.0"
     terminus_python: str = "3.12"
     parser_name: str = "json"  # "json" or "xml"
-    temperature: float = 0.7
+    # Temperature the agent requests; in `rllm eval`/training the gateway
+    # enforces its own sampling params on top (default 1.0), so this is the
+    # value used only when sampling isn't gateway-enforced. Kept at 1.0 to match.
+    temperature: float = 1.0
     # Per-rollout turn cap. ``None`` = don't impose one — let Harbor's own
     # (effectively unbounded) default apply, so the agent isn't artificially
     # cut short; the per-rollout run timeout (RLLM_HARNESS_RUN_TIMEOUT_S) still
@@ -270,7 +273,7 @@ async def _main():
     # as its own (effectively unbounded) default.
     _max_turns = os.environ.get("RLLM_TERMINUS_MAX_TURNS")
     max_turns = int(_max_turns) if _max_turns else None
-    temperature = float(os.environ.get("RLLM_TERMINUS_TEMPERATURE", "0.7"))
+    temperature = float(os.environ.get("RLLM_TERMINUS_TEMPERATURE", "1.0"))
     record = os.environ.get("RLLM_TERMINUS_RECORD", "0") == "1"
     logs_dir = Path(os.environ.get("RLLM_TERMINUS_LOGS_DIR", "/tmp/terminus2/logs"))
     logs_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/cli/test_sampling_resolution.py
+++ b/tests/cli/test_sampling_resolution.py
@@ -12,12 +12,15 @@ BASE = {"temperature": 1.0, "top_p": 1.0, "top_k": -1, "max_tokens": 2048}
 # -- eval: single config, empty base, always validation ---------------------
 
 
-def test_eval_empty_by_default():
-    assert resolve_eval_sampling(None).is_empty
+def test_eval_default_sampling():
+    # Eval seeds temperature=1.0, top_p=1.0 (mirrors the cookbook training rollout).
+    assert resolve_eval_sampling(None).as_dict() == {"temperature": 1.0, "top_p": 1.0}
 
 
 def test_eval_string_only():
-    assert resolve_eval_sampling("temperature=0.3,top_k=20").as_dict() == {"temperature": 0.3, "top_k": 20}
+    # User params override the defaults (temperature) and add new keys (top_k);
+    # the unspecified default (top_p) stays.
+    assert resolve_eval_sampling("temperature=0.3,top_k=20").as_dict() == {"temperature": 0.3, "top_p": 1.0, "top_k": 20}
 
 
 def test_eval_flags_beat_string():
@@ -31,7 +34,7 @@ def test_eval_standalone_flags_only():
 def test_eval_flat_file(tmp_path):
     p = tmp_path / "sp.yaml"
     p.write_text("temperature: 0.42\npresence_penalty: 0.3\n")
-    assert resolve_eval_sampling(f"@{p}").as_dict() == {"temperature": 0.42, "presence_penalty": 0.3}
+    assert resolve_eval_sampling(f"@{p}").as_dict() == {"temperature": 0.42, "top_p": 1.0, "presence_penalty": 0.3}
 
 
 def test_eval_nonmapping_file_raises(tmp_path):


### PR DESCRIPTION
Follow-up to #679 — two CLI UX fixes on the Fireworks eval path. Independent of #679 (no file overlap); both target `terminal-rl`.

## 1. Eval sampling defaults + de-duplicated header

The eval header showed `temperature` **twice** with conflicting values: the **Config** row printed the harness's *requested* temperature (`0.7`) while the gateway-enforced **Sampling** row printed the actual override (`1.0`).

- `rllm eval` now seeds **`temperature=1.0, top_p=1.0`** (mirrors the cookbook training rollout) — overridable by `--sampling-params` / `--temperature` / `--top-p`, and always shown in the gateway-enforced **Sampling** row.
- Removed `temperature` from the **Config** panel; the Sampling row is the single source of truth.
- `Terminus2Harness.temperature` 0.7 → 1.0 (and the driver fallback) so nothing lingers at 0.7 when sampling isn't gateway-enforced.

Header before → after:
```
- Config     max concurrent 64  ·  temperature 0.7  ·  run timeout 3600s  ·  install timeout 600s
- Sampling   {'temperature': 1.0} (gateway-enforced)
+ Config     max concurrent 64  ·  run timeout 3600s  ·  install timeout 600s
+ Sampling   {'temperature': 1.0, 'top_p': 1.0} (gateway-enforced)
```

**Scope note:** this default applies to **every** `rllm eval` run (not just terminus2), so anything that relied on greedy/`temp=0` eval must now pass `--temperature 0` explicitly. `resolve_train_sampling` is untouched.

## 2. Surface dedicated Fireworks deployments in the `rllm setup` picker

`fetch_fireworks_deployed_models()` only queried the `deployedModels` endpoint (populated when a custom/fine-tuned model is *bound* to a deployment). A **dedicated deployment of a base model** has no `deployedModel` entry and is addressed for inference by its own `accounts/<acct>/deployments/<id>` name — exactly what evals run against. Those were invisible to the picker.

Live probe of `rllm-project`: `deployedModels` → 0 items; `deployments` → 2 `READY` (`gpdl1exc`, `xgmmo430`). The fetch now also lists `READY` deployments by id, so both appear (flagged "(your deployment)"). Verified against the live API.

## Tests
- Updated the 3 `test_sampling_resolution.py` cases that encoded the old "eval defaults to empty" contract; full `tests/cli` + `tests/eval` (491) pass.
- Excludes other in-progress `terminal-rl` working-tree edits (`train_*.sh`, `fireworks_engine.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
