### PR TITLE
feat(engine): show running avg reward on the eval progress bar

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -426,9 +426,18 @@ class AgentFlowEngine:
 
         results: list[Episode | None] = [None] * len(tasks)
         with tqdm(total=len(tasks), desc="Generating trajectories") as pbar:
+            n_done = 0
+            reward_sum = 0.0
             for future in asyncio.as_completed(futures):
                 task_id, rollout_idx, result_idx, episode = await future
                 results[result_idx] = episode
+                # Surface a running average reward on the progress bar so the
+                # current score is visible live (not just per-rollout lines).
+                if episode is not None:
+                    rewards = [t.reward for t in episode.trajectories if t.reward is not None]
+                    reward_sum += (sum(rewards) / len(rewards)) if rewards else (1.0 if episode.is_correct else 0.0)
+                    n_done += 1
+                    pbar.set_postfix(avg_reward=f"{reward_sum / n_done:.3f}")
                 pbar.update(1)
 
         ordered_results: list[Episode] = results  # type: ignore[assignment]


### PR DESCRIPTION
## What
Show a running **average reward** on the `AgentFlowEngine` progress bar, so the current score is visible live during a run instead of having to eyeball the per-rollout `Rollout completed. Rewards: [...]` lines or wait for `results.json`.

```
Generating trajectories:  45%|██▋ | 120/267 [2:18<...] avg_reward=0.433
```

## Change
One spot — the `tqdm` loop in `rllm/engine/agentflow_engine.py` that consumes completed rollouts. It now accumulates a cumulative mean reward and surfaces it via `pbar.set_postfix`:

- Averages `trajectory.reward`; falls back to `is_correct` (0/1) for error/empty episodes.
- **Display-only** — no change to rollout execution, scoring, or results.

## Why
On long eval runs (hundreds of rollouts over hours) there was no live readout of how the model is scoring. This makes the running pass-rate visible at a glance.
