### PR TITLE
Eval reliability: concurrent-eval proxy ports, sandbox isolation, proxy resilience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ tinker = [
 ]
 
 fireworks = [
-    "fireworks-ai[training]==1.2.0a79 ; python_version >= '3.11'",
+    "fireworks-ai[training]==1.2.0a83 ; python_version >= '3.11'",
     "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
 ]
 

--- a/rllm-model-gateway/src/rllm_model_gateway/session_router.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/session_router.py
@@ -181,7 +181,10 @@ class SessionRouter:
     async def start_health_checks(self) -> None:
         if self._health_task is not None:
             return
-        self._http = httpx.AsyncClient(timeout=httpx.Timeout(5.0))
+        # 20s (not 5s): under a concurrency spike the single proxy worker can be
+        # slow to answer /health while busy forwarding requests; a 5s timeout
+        # marked it dead → "No healthy workers available" → failed turns.
+        self._http = httpx.AsyncClient(timeout=httpx.Timeout(20.0))
         self._health_task = asyncio.create_task(self._health_loop())
 
     async def stop_health_checks(self) -> None:

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -578,6 +578,9 @@ def _run_eval(
 @click.option("--agent", "agent_name", default=None, help="Agent scaffold: registry name or module:object path.")
 @click.option("--evaluator", "evaluator_name", default=None, help="Evaluator: registry name or module:class path.")
 @click.option("--base-url", default=None, help="OpenAI-compatible API endpoint URL. If omitted, a proxy is auto-started using 'rllm setup' config.")
+@click.option(
+    "--proxy-port", "proxy_port", default=None, type=int, help="Pin the auto-started LiteLLM proxy to this port. Default: a free port is picked automatically (so concurrent eval jobs don't collide)."
+)
 @click.option("--model", default=None, help="Model name to evaluate. Defaults to configured model from 'rllm setup'.")
 @click.option("--split", default=None, help="Dataset split (default: from catalog eval_split).")
 @click.option("--concurrency", default=64, type=int, help="Number of parallel requests.")
@@ -629,6 +632,7 @@ def eval_cmd(
     agent_name: str | None,
     evaluator_name: str | None,
     base_url: str | None,
+    proxy_port: int | None,
     model: str | None,
     split: str | None,
     concurrency: int,
@@ -704,6 +708,7 @@ def eval_cmd(
                 provider=config.provider,
                 model_name=model,
                 api_key=config.api_key,
+                proxy_port=proxy_port,
             )
             with Status(f"[dim]Starting LiteLLM proxy for [bold]{config.provider}/{model}[/bold]...[/]", console=console):
                 try:

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -395,6 +395,7 @@ class AgentFlowEngine:
         tasks: list[dict | Task],
         task_ids: list[str] | None = None,
         is_validation: bool = False,
+        on_episode_complete=None,
         **kwargs,
     ) -> list[Episode]:
         """Run AgentFlows on a list of tasks; return enriched Episodes.
@@ -429,10 +430,33 @@ class AgentFlowEngine:
         n_correct = 0
         reward_sum = 0.0
         n_scored = 0
+        n_empty_rollouts = 0  # canary: rollouts whose LLM completions are all empty (upstream down)
         with tqdm(total=len(tasks), desc="Generating trajectories") as pbar:
             for future in asyncio.as_completed(futures):
                 task_id, rollout_idx, result_idx, episode = await future
                 results[result_idx] = episode
+                # Stream each enriched+scored episode as it finishes (eval:
+                # progressive UI upload + local write) instead of a burst at the
+                # end — keeps the UI live and avoids a giant end-of-run flush.
+                if on_episode_complete is not None and episode is not None:
+                    try:
+                        on_episode_complete(result_idx, episode)
+                    except Exception:
+                        logger.debug("on_episode_complete callback error", exc_info=True)
+                # Canary: a rollout whose LLM completions are ALL empty means the
+                # upstream returned nothing (dead litellm proxy, gateway "no healthy
+                # workers", or the model itself). Surface it loudly — otherwise the
+                # run silently produces garbage (every rollout scores 0).
+                if episode is not None:
+                    _steps = [s for t in (episode.trajectories or []) for s in (t.steps or [])]
+                    if _steps and all(not (s.model_response or "").strip() for s in _steps):
+                        n_empty_rollouts += 1
+                        colorful_print(
+                            f"[{task_id}:{rollout_idx}] ⚠️  EMPTY COMPLETIONS: all {len(_steps)} LLM calls "
+                            f"returned 0 tokens — upstream likely DOWN (dead litellm proxy :4000 / gateway "
+                            f"no-healthy-workers / model). [{n_empty_rollouts} empty rollouts so far]",
+                            fg="red",
+                        )
                 done = pbar.n + 1
                 if episode is not None and episode.is_correct:
                     n_correct += 1

--- a/rllm/env.py
+++ b/rllm/env.py
@@ -19,6 +19,27 @@ parsing (and the ``RLLM_`` naming convention) lives in one place.
 from __future__ import annotations
 
 import os
+import re
+
+_RUN_ID: str | None = None
+
+
+def rllm_run_id() -> str:
+    """Stable per-process run identifier stamped onto cloud sandboxes.
+
+    Used as the Modal App name suffix and a sandbox tag so a single run's
+    sandboxes are greppable and terminable on a *shared* account (where you
+    can't just kill every ``rllm-*`` sandbox because others' runs use them).
+
+    Set ``RLLM_RUN_ID`` to a memorable value (e.g. ``alice-tb2-0621``);
+    otherwise a random 8-char id is generated once per process. Sanitized to
+    Modal's label charset (``[a-zA-Z0-9_.-]``).
+    """
+    global _RUN_ID
+    if _RUN_ID is None:
+        raw = re.sub(r"[^a-zA-Z0-9_.-]", "-", os.environ.get("RLLM_RUN_ID", "")).strip("-")
+        _RUN_ID = raw or os.urandom(4).hex()
+    return _RUN_ID
 
 
 def env_str(name: str, default: str) -> str:

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -95,6 +95,7 @@ class _ProxyManagerBase:
         if self._proxy_process is None:
             return
 
+        self._shutting_down = True  # tell the monitor this exit is expected
         logger.info("Shutting down proxy subprocess...")
         self._proxy_process.terminate()
         try:
@@ -202,7 +203,7 @@ class EvalProxyManager(_ProxyManagerBase):
         logger.info("Starting proxy subprocess: %s", " ".join(cmd))
         self._proxy_process = subprocess.Popen(
             cmd,
-            stdout=subprocess.DEVNULL,
+            stdout=stderr_file,  # capture stdout too (litellm logs + crash output) so a death leaves a trail
             stderr=stderr_file,
             env=env,
             preexec_fn=set_limits,
@@ -220,7 +221,34 @@ class EvalProxyManager(_ProxyManagerBase):
 
         atexit.register(self.shutdown_proxy)
         logger.info("Proxy subprocess ready (PID: %s)", self._proxy_process.pid)
+        self._start_proxy_monitor()
         return snapshot_path
+
+    def _start_proxy_monitor(self) -> None:
+        """Watch the proxy subprocess; if it dies mid-run, scream loudly with its
+        captured output. Otherwise the gateway silently routes to a dead worker
+        and every subsequent rollout returns empty completions (scoring 0) with
+        no visible cause — exactly the failure that's been impossible to debug.
+        """
+        import threading
+
+        proc = self._proxy_process
+        if proc is None:
+            return
+
+        def _monitor() -> None:
+            rc = proc.wait()  # blocks until the proxy process exits
+            if getattr(self, "_shutting_down", False):
+                return  # expected teardown at end of run
+            tail = self._read_stderr_tail(max_lines=60)
+            logger.error(
+                "\n🚨🚨🚨 LITELLM PROXY DIED MID-RUN (exit code %s) 🚨🚨🚨\n"
+                "Every subsequent LLM call now returns EMPTY and all remaining rollouts "
+                "score 0. THIS is why the run is failing. Proxy stdout/stderr tail:\n%s\n",
+                rc, tail or "(nothing captured — likely SIGKILL / OOM / external kill)",
+            )
+
+        threading.Thread(target=_monitor, daemon=True, name="rllm-proxy-monitor").start()
 
     def _wait_for_proxy(self, timeout: float = 30.0) -> None:
         if self._proxy_process is None:

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -4,9 +4,12 @@ The caller controls the proxy lifecycle::
 
     pm = EvalProxyManager(provider="openai", model_name="gpt-4o", api_key="sk-...")
     pm.start_proxy_subprocess(pm.build_proxy_config())
-    base_url = pm.get_proxy_url()  # http://127.0.0.1:4000/v1
+    base_url = pm.get_proxy_url()  # http://127.0.0.1:<auto-port>/v1
     # ... run eval ...
     pm.shutdown_proxy()
+
+By default the proxy binds a free port (so concurrent ``rllm eval`` jobs each
+get their own and don't collide); pass ``proxy_port=`` to pin a specific one.
 
 This proxy is the bridge to commercial providers during ``rllm eval``. For
 training and for vLLM-backed eval, requests go through ``rllm-model-gateway``
@@ -19,6 +22,7 @@ import atexit
 import logging
 import os
 import resource
+import socket
 import subprocess
 import sys
 import tempfile
@@ -34,6 +38,22 @@ logger = logging.getLogger(__name__)
 
 _NUM_RETRIES = env_int("RLLM_EVAL_PROXY_NUM_RETRIES", 3)  # set env var: export RLLM_EVAL_PROXY_NUM_RETRIES=xxx
 _STARTUP_TIMEOUT_S = env_float("RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S", 30.0)  # set env var: export RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S=xxx
+# Retries for the rare TOCTOU race where an auto-picked free port is taken
+# between selection and the subprocess binding it (matters for concurrent
+# `rllm eval` launches, each auto-starting its own proxy).
+_PORT_BIND_RETRIES = env_int("RLLM_EVAL_PROXY_PORT_BIND_RETRIES", 5)
+
+
+def _find_free_port() -> int:
+    """Ask the OS for a free TCP port on the loopback interface.
+
+    Mirrors ``rllm.gateway.manager._find_free_port`` — used so every
+    auto-started eval proxy binds a distinct port instead of the fixed 4000,
+    letting multiple ``rllm eval`` jobs run concurrently without colliding.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
 
 class _ProxyManagerBase:
@@ -42,11 +62,15 @@ class _ProxyManagerBase:
     def __init__(
         self,
         proxy_host: str = "127.0.0.1",
-        proxy_port: int = 4000,
+        proxy_port: int | None = None,
         admin_token: str | None = None,
     ) -> None:
         self.proxy_host = proxy_host
-        self.proxy_port = proxy_port
+        # ``proxy_port=None`` (the default) auto-picks a free port so concurrent
+        # ``rllm eval`` jobs don't collide on the old hardcoded 4000. Pass an
+        # explicit port to pin it (e.g. for debugging a single run).
+        self._port_auto = proxy_port is None
+        self.proxy_port = proxy_port if proxy_port is not None else _find_free_port()
         self.admin_token = admin_token
         self._proxy_process: subprocess.Popen | None = None
 
@@ -118,7 +142,7 @@ class EvalProxyManager(_ProxyManagerBase):
         model_name: str,
         api_key: str,
         proxy_host: str = "127.0.0.1",
-        proxy_port: int = 4000,
+        proxy_port: int | None = None,
     ) -> None:
         super().__init__(proxy_host=proxy_host, proxy_port=proxy_port)
         self.provider = provider
@@ -168,16 +192,6 @@ class EvalProxyManager(_ProxyManagerBase):
         if not snapshot_path or not os.path.exists(snapshot_path):
             raise RuntimeError("Config snapshot not available. Cannot start proxy.")
 
-        cmd = [
-            sys.executable,
-            "-m",
-            "rllm.eval._litellm_server",
-            "--host",
-            self.proxy_host,
-            "--port",
-            str(self.proxy_port),
-        ]
-
         env = os.environ.copy()
         try:
             import certifi
@@ -196,28 +210,49 @@ class EvalProxyManager(_ProxyManagerBase):
             except (ValueError, OSError):
                 pass
 
-        # Capture stderr to a temp file so we can show errors on failure
-        stderr_file = tempfile.NamedTemporaryFile(mode="w", prefix="rllm_proxy_", suffix=".log", delete=False)
-        self._stderr_path = stderr_file.name
+        # An auto-picked free port can be grabbed by another process between
+        # selection and bind (concurrent eval launches), so retry on a fresh
+        # port. A pinned port gets a single attempt — the user asked for that
+        # exact port, so surface the failure instead of silently moving.
+        max_attempts = _PORT_BIND_RETRIES if self._port_auto else 1
+        for attempt in range(1, max_attempts + 1):
+            cmd = [
+                sys.executable,
+                "-m",
+                "rllm.eval._litellm_server",
+                "--host",
+                self.proxy_host,
+                "--port",
+                str(self.proxy_port),
+            ]
 
-        logger.info("Starting proxy subprocess: %s", " ".join(cmd))
-        self._proxy_process = subprocess.Popen(
-            cmd,
-            stdout=stderr_file,  # capture stdout too (litellm logs + crash output) so a death leaves a trail
-            stderr=stderr_file,
-            env=env,
-            preexec_fn=set_limits,
-        )
+            # Fresh stderr capture per attempt so a death leaves a readable trail.
+            stderr_file = tempfile.NamedTemporaryFile(mode="w", prefix="rllm_proxy_", suffix=".log", delete=False)
+            self._stderr_path = stderr_file.name
 
-        try:
-            self._wait_for_proxy(timeout=_STARTUP_TIMEOUT_S)
-            logger.info("Proxy server started, sending configuration...")
-            self.reload_proxy_config(config=config)
-            logger.info("Proxy configuration loaded successfully")
-        except Exception:
-            self._report_proxy_failure()
-            self.shutdown_proxy()
-            raise
+            logger.info("Starting proxy subprocess (attempt %d/%d): %s", attempt, max_attempts, " ".join(cmd))
+            self._proxy_process = subprocess.Popen(
+                cmd,
+                stdout=stderr_file,  # capture stdout too (litellm logs + crash output) so a death leaves a trail
+                stderr=stderr_file,
+                env=env,
+                preexec_fn=set_limits,
+            )
+
+            try:
+                self._wait_for_proxy(timeout=_STARTUP_TIMEOUT_S)
+                logger.info("Proxy server started, sending configuration...")
+                self.reload_proxy_config(config=config)
+                logger.info("Proxy configuration loaded successfully")
+                break
+            except Exception:
+                self._report_proxy_failure()
+                self.shutdown_proxy()
+                if attempt >= max_attempts:
+                    raise
+                old_port = self.proxy_port
+                self.proxy_port = _find_free_port()
+                logger.warning("Proxy startup failed on port %s; retrying on %s", old_port, self.proxy_port)
 
         atexit.register(self.shutdown_proxy)
         logger.info("Proxy subprocess ready (PID: %s)", self._proxy_process.pid)
@@ -245,7 +280,8 @@ class EvalProxyManager(_ProxyManagerBase):
                 "\n🚨🚨🚨 LITELLM PROXY DIED MID-RUN (exit code %s) 🚨🚨🚨\n"
                 "Every subsequent LLM call now returns EMPTY and all remaining rollouts "
                 "score 0. THIS is why the run is failing. Proxy stdout/stderr tail:\n%s\n",
-                rc, tail or "(nothing captured — likely SIGKILL / OOM / external kill)",
+                rc,
+                tail or "(nothing captured — likely SIGKILL / OOM / external kill)",
             )
 
         threading.Thread(target=_monitor, daemon=True, name="rllm-proxy-monitor").start()

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -135,7 +135,7 @@ async def run_dataset(
         # downstream consumer wants it) is stable; the engine's session uid
         # becomes f"{task.id}:0" which matches training's convention.
         task_ids = [getattr(t, "id", None) or str(idx) for idx, t in enumerate(tasks)]
-        episodes = await engine.execute_tasks(tasks, task_ids=task_ids, is_validation=True)
+        episodes = await engine.execute_tasks(tasks, task_ids=task_ids, is_validation=True, on_episode_complete=on_episode_complete)
     finally:
         if warm_queue is not None:
             warm_queue.shutdown()
@@ -169,11 +169,9 @@ async def run_dataset(
         if episode.trajectories and episode.trajectories[0].reward is not None:
             reward = float(episode.trajectories[0].reward)
 
-        if on_episode_complete is not None:
-            try:
-                on_episode_complete(idx, episode)
-            except Exception:
-                logger.debug("on_episode_complete callback error", exc_info=True)
+        # NOTE: on_episode_complete is now invoked *streaming* inside
+        # engine.execute_tasks (as each rollout finishes), not here — so UI
+        # uploads + local writes happen progressively instead of in a burst.
 
         items.append(
             EvalItem(

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -22,7 +22,7 @@ import threading
 import time
 import weakref
 
-from rllm.env import env_float, env_int
+from rllm.env import env_float, env_int, rllm_run_id
 from rllm.sandbox.protocol import SandboxCommandTimeout, SnapshotNotFound
 
 logger = logging.getLogger(__name__)
@@ -163,7 +163,11 @@ class ModalSandbox:
         self.name = name
         self._image_spec = image
         self._timeout = kwargs.pop("timeout", None) or _default_sandbox_timeout()
-        self._app_name = kwargs.pop("app_name", "rllm-sandbox")
+        # Per-run App name so a run's sandboxes are isolated on a shared Modal
+        # account: `modal app stop rllm-sandbox-<run_id>` kills only this run's
+        # sandboxes (set RLLM_RUN_ID; else a random per-process id). Pass an
+        # explicit app_name to override.
+        self._app_name = kwargs.pop("app_name", None) or f"rllm-sandbox-{rllm_run_id()}"
 
         # A stored snapshot ref is a bare Modal image id ("im-…", no registry/tag);
         # the ":" / "/" guard keeps real docker images off the from_id path.
@@ -183,6 +187,11 @@ class ModalSandbox:
                 modal_image = image  # already a modal.Image
 
             create_kwargs: dict = {"app": self._app, "image": modal_image, "timeout": self._timeout}
+            # name = per-task label (visible in `modal sandbox list`); tags carry
+            # the run id so you can filter/terminate a run's sandboxes:
+            #   modal.Sandbox.list(tags={"rllm_run_id": "<id>"})  -> .terminate()
+            create_kwargs["name"] = self.name[:64]
+            create_kwargs["tags"] = {"rllm_run_id": rllm_run_id()}
             for key in ("secrets", "volumes", "workdir", "gpu", "cpu", "memory"):
                 if key in kwargs:
                     create_kwargs[key] = kwargs.pop(key)

--- a/rllm/utils/tracking.py
+++ b/rllm/utils/tracking.py
@@ -32,6 +32,11 @@ from typing import Any
 from rllm.env import env_float
 
 _UI_HTTP_TIMEOUT_S = env_float("RLLM_UI_HTTP_TIMEOUT_S", 5.0)  # set env var: export RLLM_UI_HTTP_TIMEOUT_S=xxx
+# Max seconds to drain the episode-upload queue on finish(). Episodes are
+# enqueued in a burst at the end of an eval, so a short cap silently drops
+# uploads (the UI ends up empty while local files are fine). Raise for runs
+# with many/large episodes (e.g. terminus2). set: export RLLM_UI_DRAIN_TIMEOUT_S=xxx
+_UI_DRAIN_TIMEOUT_S = env_float("RLLM_UI_DRAIN_TIMEOUT_S", 600.0)
 
 
 def concat_dict_to_str(dict: dict, step):
@@ -638,9 +643,9 @@ class UILogger:
         # processes queued episodes.
         if hasattr(self, "_worker_thread"):
             self._queue.put(None)  # sentinel: worker exits after draining
-            self._worker_thread.join(timeout=30)
+            self._worker_thread.join(timeout=_UI_DRAIN_TIMEOUT_S)
             if self._worker_thread.is_alive():
-                self.logger.warning("UILogger worker thread did not finish within 30s")
+                self.logger.warning("UILogger worker thread did not finish within %.0fs", _UI_DRAIN_TIMEOUT_S)
                 self._worker_stop.set()  # force-stop only if join timed out
 
         # Stop heartbeat thread


### PR DESCRIPTION
Syncs `signalrush:terminal-rl` into upstream `terminal-rl`.

### Commits in this PR (head not in base)
- `fix(eval)`: **auto-pick a free port for the eval proxy so concurrent `rllm eval` jobs don't collide** — the auto-started LiteLLM proxy hardcoded port 4000; two concurrent jobs collided on it, and the loser's startup probe could see the winner's proxy and clobber its routing via `/admin/reload`. `EvalProxyManager` now binds a free port by default (with retry-on-bind-race), and a new `--proxy-port` pins it when needed. The gateway layer was already free-port, so 4000 was the only collision point.
- `fix(gateway)`: raise worker health-check timeout 5s → 20s
- `build(deps)`: bump fireworks-ai to 1.2.0a83
- `feat(eval)`: proxy-death monitor, empty-completion canary, streaming UI uploads
- `feat(sandbox/modal)`: isolate each run's sandboxes by run id
- `fix(eval)`: terminal-bench reliability — sandbox lifetime, retry, live metrics, prompt-cache affinity

### Validation (proxy free-port change)
- All 11 `tests/eval/test_eval_proxy.py` pass.
- Two `EvalProxyManager` defaults → distinct free ports (never 4000), both started via the real `start_proxy_subprocess`, routed to a Fireworks deployment, clean shutdown.
- `rllm eval --help` shows `--proxy-port`; pinned ports respected.

> ⚠️ Note: base `terminal-rl` has advanced and the last commit here (terminal-bench reliability) appears to already be upstream under a different hash — may need a rebase to drop the duplicate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
