### PR TITLE
fix(deps): pin fireworks-training-cookbook to a compatible commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ tinker = [
 
 fireworks = [
     "fireworks-ai[training]==1.2.0a79 ; python_version >= '3.11'",
-    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
+    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@bba676c6d00bd595f9453e0b2165b7457a01e0d5#subdirectory=training ; python_version >= '3.11'",
 ]
 
 opentelemetry = [


### PR DESCRIPTION
The cookbook git dep tracked HEAD, which raised its fireworks-ai floor to >=1.2.0a83 and conflicted with our pinned fireworks-ai[training]==1.2.0a79, breaking 'uv sync'. Pin the cookbook to bba676c (fw-ai/cookbook #515, requires >=1.2.0a70) so a79 still satisfies it — no SDK bump.

## Summary

<!-- What changed, and why does it matter? Keep this to 2-6 sentences. -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- 
- 
- 

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
