### PR TITLE
feat(fireworks): fold ECHO env loss into the client loss path (single pass)

### DIFF
--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -1,0 +1,132 @@
+# SWE-RL
+
+End-to-end agentic-RL recipe for software engineering: train on [R2E-Gym](https://huggingface.co/datasets/R2E-Gym/R2E-Gym-Subset) (R2E-Gym Subset, 4,578 bug-fix tasks across 12 Python repos), validate on [SWE-bench Verified](https://www.swebench.com/) (500 real GitHub issues). The agent harness is [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent); the base model is `Qwen/Qwen3.5-9B`.
+
+This cookbook deliberately ships **no custom AgentFlow and no custom evaluator** — it's a thin wrapper around primitives that already live in `rllm/`. The flow is `mini-swe-agent` running as a CLI inside per-task sandboxes, and the evaluator is each task's own `tests/test.sh`. Both `r2egym` and `harbor:swebench-verified` ship that verifier with the dataset.
+
+## Architecture
+
+```
+AgentTrainer.train()
+  │
+  ├── for each task: launch a sandbox (Modal / Daytona / Docker)
+  │       │
+  │       └── mini-swe-agent --yolo --task=<problem_statement>
+  │             │   (multi-turn shell loop; each LLM call → gateway)
+  │             │
+  │             └── rLLM gateway routes to the trainer-hosted policy,
+  │                  capturing the full trajectory (prompt + response
+  │                  tokens + sampling params per turn).
+  │
+  └── verifier: tests/test.sh inside the sandbox
+        │   run_tests.sh for r2egym;  SWE-bench harness for verified.
+        │
+        └── writes /logs/verifier/reward.txt  →  RL reward signal
+```
+
+The trainer never parses tool calls or model outputs directly. The agent harness owns the action loop; the gateway owns the trajectory; the in-sandbox verifier owns the reward. This is the same setup as `examples/harbor_swe/` — the cookbook packages it as a versioned, installable recipe.
+
+## Installation
+
+```bash
+uv pip install -e ".[tinker]"                       # rllm + tinker backend
+uv pip install --no-deps -e cookbooks/swe-rl        # this cookbook (registers prepare_data)
+```
+
+`mini-swe-agent` is installed automatically into each task sandbox on first run — no host-side install required.
+
+## Datasets
+
+```bash
+python cookbooks/swe-rl/prepare_data.py
+# or, faster smoke run:
+python cookbooks/swe-rl/prepare_data.py --train-limit 50 --val-limit 20
+```
+
+This pulls:
+
+| Dataset | Role | Source | Verifier |
+|---|---|---|---|
+| `r2egym` | train (4,578) | `R2E-Gym/R2E-Gym-Subset` | in-sandbox `run_tests.sh`, pytest-output equality (`tests/test.sh`) |
+| `harbor:swebench-verified` | eval (500) | `princeton-nlp/SWE-bench_Verified` | official SWE-bench harness (F2P / P2P) |
+
+Both materialize as Harbor-format task directories (`task.toml`, `instruction.md`, `environment/Dockerfile`, `tests/test.sh`).
+
+## Training
+
+### Tinker (single-machine, LoRA)
+
+```bash
+bash cookbooks/swe-rl/train_tinker.sh
+```
+
+Defaults: Qwen/Qwen3.5-9B + LoRA rank 32, GRPO with compact filtering, 64 parallel Modal sandboxes, async rollout/training. Override anything via Hydra:
+
+```bash
+SWE_SANDBOX_BACKEND=docker bash cookbooks/swe-rl/train_tinker.sh \
+    model.name=Qwen/Qwen3-8B \
+    rllm.workflow.n_parallel_tasks=32
+```
+
+For a simpler on-policy loop (generate a full batch, then one optimizer step — easier to debug), use the synchronous variant:
+
+```bash
+bash cookbooks/swe-rl/train_tinker_sync.sh
+```
+
+It drops `async_training` and uses a real `data.train_batch_size` (default 4; effective batch = `train_batch_size × group_size`).
+
+### Verl (distributed GPU)
+
+```bash
+uv pip install -e ".[verl]"
+bash scripts/install_megatron.sh <cu128|cu129|...>
+bash cookbooks/swe-rl/train_verl.sh
+```
+
+vLLM rollouts + FSDP/Megatron training. Sandboxes still run mini-swe-agent — only the trainer hosting changes.
+
+## Evaluation (no training)
+
+```bash
+rllm eval harbor:swebench-verified \
+    --agent mini-swe-agent \
+    --model Qwen/Qwen3.5-9B \
+    --base-url http://localhost:8000/v1 \
+    --max-examples 20
+```
+
+Per-task results land in `~/.rllm/eval_results/`; aggregated resolve rate is printed at the end. `rllm view` opens the per-task trajectory UI.
+
+## Sandbox backend
+
+Training uses rLLM's own `SandboxedAgentFlow` path (`AgentFlowEngine`) — not the
+remote Harbor runtime. `mini-swe-agent` runs inside one sandbox per task, created
+by `SandboxTaskHooks`. Pick a backend via the `SWE_SANDBOX_BACKEND` env var:
+
+| Backend | Setup | Notes |
+|---|---|---|
+| `modal` | `pip install modal` + `modal token new` | Default for training — per-task billing, scales to many parallel sandboxes. |
+| `daytona` | `pip install daytona` + `DAYTONA_API_KEY` | Cloud sandboxes; scales to thousands in parallel. |
+| `docker` | local | Fastest iteration; needs the Docker daemon and ~20 GB free disk. |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `prepare_data.py` | Pulls `r2egym` (train) and `harbor:swebench-verified` (eval) |
+| `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
+| `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Modal sandboxes |
+| `train_tinker_sync.sh` | Tinker backend — synchronous (on-policy) variant, simpler for testing |
+| `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
+| `test.py` | Catalog wiring + harness import smoke tests |
+| `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |
+
+## Why no custom flow or evaluator?
+
+Other cookbooks in this repo (`finqa`, `math`, `deepcoder`, …) ship a custom AgentFlow because their workloads either fit in a single LLM turn or need bespoke tool wiring. SWE doesn't — the existing in-tree primitives already cover it:
+
+- **`rllm.harnesses.mini_swe_agent`** is the agent. It exposes the `mini-swe-agent` CLI as an rLLM harness (installs in-sandbox on first run; reads the gateway URL from the env; logs to `/tmp/mini-swe-agent.log`).
+- **Per-task `tests/test.sh`** is the evaluator. The sandbox-shell verifier kind (`rllm.eval.script_evaluator`) reads `/logs/verifier/reward.txt` and returns it as the RL reward. For `harbor:swebench-verified`, that script invokes the official SWE-bench harness; for `r2egym`, it runs the image's own `/testbed/run_tests.sh` and scores 1.0 iff the pytest output matches the row's expected output.
+
+The only thing this cookbook adds on top is the recipe: dataset pairing, sampling/optimizer hyperparams, and the `mini-swe-agent` harness selection. Forking `train_tinker.sh` is the place to start customizing.

--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -86,6 +86,24 @@ bash cookbooks/swe-rl/train_verl.sh
 
 vLLM rollouts + FSDP/Megatron training. Sandboxes still run mini-swe-agent — only the trainer hosting changes.
 
+### Fireworks (managed, LoRA)
+
+```bash
+uv pip install -e ".[fireworks]"
+export FIREWORKS_API_KEY=...
+bash cookbooks/swe-rl/train_fireworks.sh
+```
+
+Same async GRPO + compact-filtering recipe as `train_tinker.sh`, but the trainer
+job and inference deployment are provisioned on Fireworks at startup and torn
+down on shutdown. Defaults to `accounts/fireworks/models/qwen3p5-9b` + LoRA rank
+32 on the `qwen3p5-9b-256k-lora` training shape (Fireworks ships a 3.5-9B LoRA
+shape but no 3.5-4B; swap `model.name` / `model.tokenizer_model` /
+`fireworks_config.policy_trainer_shape_id` together to change it — see
+[`docs/backends/fireworks.mdx`](../../docs/backends/fireworks.mdx) for the
+model/shape catalog). The synchronous (on-policy) variant is
+`train_fireworks_sync.sh`.
+
 ## Evaluation (no training)
 
 ```bash
@@ -118,6 +136,8 @@ by `SandboxTaskHooks`. Pick a backend via the `SWE_SANDBOX_BACKEND` env var:
 | `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
 | `train_tinker.sh` | Tinker backend — Qwen3.5-9B LoRA, GRPO + async, Modal sandboxes |
 | `train_tinker_sync.sh` | Tinker backend — synchronous (on-policy) variant, simpler for testing |
+| `train_fireworks.sh` | Fireworks backend — Qwen3.5-9B LoRA, GRPO + async, managed trainer/deployment |
+| `train_fireworks_sync.sh` | Fireworks backend — synchronous (on-policy) variant, simpler for testing |
 | `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
 | `test.py` | Catalog wiring + harness import smoke tests |
 | `pyproject.toml` | Cookbook metadata (no entry points — the harness is in-tree) |

--- a/cookbooks/swe-rl/README.md
+++ b/cookbooks/swe-rl/README.md
@@ -104,6 +104,37 @@ shape but no 3.5-4B; swap `model.name` / `model.tokenizer_model` /
 model/shape catalog). The synchronous (on-policy) variant is
 `train_fireworks_sync.sh`.
 
+### ECHO (train on environment feedback)
+
+[ECHO](https://arxiv.org/abs/2605.24517) adds a cross-entropy loss on the
+environment-observation tokens (tool/terminal output) that the policy already
+conditions on but GRPO never trains. For a terminal/SWE agent this turns every
+rollout — including the many that fail — into dense supervision, at no extra
+rollout or forward-pass cost. It uses GRPO's advantages unchanged; the only
+difference is the extra loss term.
+
+Flip GRPO → ECHO with one override on any backend (verl / tinker / fireworks):
+
+```bash
+# tinker (async or sync), verl, or fireworks — same switch:
+bash cookbooks/swe-rl/train_tinker.sh    rllm.algorithm.adv_estimator=echo
+bash cookbooks/swe-rl/train_verl.sh      algorithm.adv_estimator=echo
+bash cookbooks/swe-rl/train_fireworks.sh rllm.algorithm.adv_estimator=echo
+```
+
+`adv_estimator=echo` defaults the env-loss weight λ to the paper's 0.05. Tune it
+explicitly with `rllm.algorithm.env_loss_coef=<λ>` (productive range 0.01–0.05;
+`0.0` reproduces plain GRPO). It is implemented as an `env_prediction`
+[auxiliary loss](../../design/auxiliary-losses.md); watch
+`actor/aux_env_prediction_loss` (verl) / `train/aux_*` (tinker, fireworks) to
+confirm the environment-prediction loss is falling.
+
+> On verl the env term shares GRPO's single forward pass (free, exact). On
+> tinker/fireworks (managed training services with fixed server-side loss
+> kernels) it is a second, gradient-accumulated `cross_entropy` pass over the
+> same rollouts — no extra rollouts, but one extra backward. λ may need
+> per-backend retuning since loss normalization differs across services.
+
 ## Evaluation (no training)
 
 ```bash

--- a/cookbooks/swe-rl/prepare_data.py
+++ b/cookbooks/swe-rl/prepare_data.py
@@ -1,0 +1,66 @@
+"""Pull the train + eval datasets for the swe-rl cookbook.
+
+Both are sandbox-format benchmarks (per-task ``environment/Dockerfile`` +
+``tests/test.sh`` verifier). The training set is rLLM's native
+``r2egym`` (R2E-Gym Subset, 4,578 bug-fix tasks across 12 Python repos,
+each shipped as a per-instance Docker image graded by the image's own
+``/testbed/run_tests.sh``). The eval set is ``harbor:swebench-verified``
+(500 real-world GitHub issues, evaluated against the official SWE-bench
+harness inside the sandbox).
+
+This script is a thin wrapper around ``rllm dataset pull`` so the
+cookbook can be used end-to-end with a single command. Re-runs are
+no-ops once the on-disk benchmark directory exists.
+
+Usage::
+
+    python cookbooks/swe-rl/prepare_data.py
+    # or, smoke run with a small training cap (rebuilds the benchmark dir):
+    python cookbooks/swe-rl/prepare_data.py --train-limit 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+TRAIN_DATASET = "r2egym"
+VAL_DATASET = "harbor:swebench-verified"
+
+
+def _pull(name: str, limit: int | None = None) -> None:
+    cmd = [sys.executable, "-m", "rllm.cli.main", "dataset", "pull", name]
+    if limit is not None:
+        cmd += ["--limit", str(limit)]
+    print(f"[swe-rl] $ {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--train-limit",
+        type=int,
+        default=None,
+        help="Cap training tasks (default: full ~4.6K). Useful for smoke runs.",
+    )
+    ap.add_argument(
+        "--val-limit",
+        type=int,
+        default=None,
+        help="Cap eval tasks (default: full 500).",
+    )
+    args = ap.parse_args()
+
+    _pull(TRAIN_DATASET, limit=args.train_limit)
+    _pull(VAL_DATASET, limit=args.val_limit)
+
+    print(
+        f"\n[swe-rl] Done. Train: {TRAIN_DATASET}   Eval: {VAL_DATASET}\n        Run `bash cookbooks/swe-rl/train_tinker.sh` to train.",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/swe-rl/pyproject.toml
+++ b/cookbooks/swe-rl/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "swe-rl"
+version = "0.1.0"
+description = "End-to-end SWE-RL recipe: train on R2E-Gym, eval on SWE-bench Verified"
+requires-python = ">=3.10"
+dependencies = ["rllm"]
+
+[tool.setuptools]
+py-modules = ["prepare_data"]

--- a/cookbooks/swe-rl/test.py
+++ b/cookbooks/swe-rl/test.py
@@ -1,0 +1,67 @@
+"""Smoke tests for the swe-rl cookbook.
+
+These tests don't boot sandboxes, run agents, or train. They only
+verify the wiring: the dataset names resolve in the catalog, the
+``mini-swe-agent`` harness is importable, and ``train.py`` can be
+imported without side effects.
+
+Run::
+
+    pytest cookbooks/swe-rl/test.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+# -- Dataset catalog entries --------------------------------------------------
+
+
+def _load_catalog() -> dict:
+    registry_path = Path(__file__).resolve().parents[2] / "rllm" / "registry" / "datasets.json"
+    return json.loads(registry_path.read_text())
+
+
+def test_train_dataset_in_catalog():
+    """r2egym must be registered as a sandbox dataset using mini-swe-agent."""
+    catalog = _load_catalog()
+    entry = catalog["datasets"]["r2egym"]
+    assert entry["category"] == "code"
+    assert entry["default_agent"] == "mini-swe-agent"
+    assert "train" in entry["splits"]
+
+
+def test_val_dataset_resolvable():
+    """SWE-bench Verified must be reachable either as the native row dataset
+    (``swebench_verified``) or as the Harbor sandbox dataset
+    (``harbor:swebench-verified``)."""
+    catalog = _load_catalog()
+    assert "swebench_verified" in catalog["datasets"], "native swebench_verified entry missing from registry"
+
+
+# -- Harness wiring -----------------------------------------------------------
+
+
+def test_mini_swe_agent_harness_importable():
+    """``mini-swe-agent`` is the harness this cookbook drives; it must import."""
+    mod = importlib.import_module("rllm.harnesses.mini_swe_agent")
+    assert hasattr(mod, "MiniSweAgentHarness")
+    assert mod.MiniSweAgentHarness.name == "mini-swe-agent"
+
+
+# -- Train script -------------------------------------------------------------
+
+
+def test_train_module_imports():
+    """``train.py`` must be importable without triggering Hydra or starting training."""
+    import sys
+
+    script_dir = Path(__file__).resolve().parent
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))
+    mod = importlib.import_module("train")
+    assert mod.TRAIN_DATASET == "r2egym"
+    assert mod.VAL_DATASET == "swebench-verified"
+    assert callable(mod.main)

--- a/cookbooks/swe-rl/train.py
+++ b/cookbooks/swe-rl/train.py
@@ -1,0 +1,89 @@
+"""Train an SWE agent on R2E-Gym, validate on SWE-bench Verified.
+
+This cookbook deliberately ships no custom AgentFlow or evaluator:
+
+* The **agent** is the in-tree ``terminus2`` harness
+  (:class:`rllm.harnesses.terminus2.Terminus2Harness`) — a
+  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow` that runs the
+  terminus2 CLI agent inside each task's sandbox. The rLLM gateway
+  intercepts every LLM call, so the trainer sees full trajectories without
+  the harness knowing it's being trained.
+* The **evaluator** is each task's own verifier (sandbox-shell), resolved
+  per-task by :class:`rllm.hooks.SandboxTaskHooks`. For r2egym it runs the
+  image's own ``/testbed/run_tests.sh`` and checks pytest-output equality
+  against the row's expected output; for the Verified split it runs the
+  task's bundled ``tests/test.sh``. The verifier writes a reward that rLLM
+  reads back.
+
+Because we pass an ``agent_flow`` (and no explicit ``evaluator``/``hooks``),
+:class:`AgentTrainer` runs the **rLLM-native SandboxedAgentFlow path**
+(``AgentFlowEngine``) — sandboxes are created locally by ``SandboxTaskHooks``
+via a pluggable ``sandbox_backend`` (``docker`` | ``local`` | ``modal`` |
+``daytona``). This is NOT the remote-runtime / ``RemoteAgentFlowEngine`` path.
+
+The sandbox backend is selected by the ``SWE_SANDBOX_BACKEND`` env var
+(default ``modal``). For ``modal`` install ``pip install modal`` and run
+``modal token new``; for ``daytona`` install ``pip install daytona`` and set
+``DAYTONA_API_KEY``. Everything else is configured by Hydra overrides on the
+command line (see ``train_tinker.sh`` / ``train_verl.sh`` for working defaults).
+
+Usage (from rllm repo root)::
+
+    SWE_SANDBOX_BACKEND=modal python cookbooks/swe-rl/train.py rllm/backend=tinker
+"""
+
+from __future__ import annotations
+
+import os
+
+import hydra
+from omegaconf import DictConfig
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.harnesses.terminus2 import Terminus2Harness
+from rllm.trainer import AgentTrainer
+
+TRAIN_DATASET = "r2egym"
+VAL_DATASET = "swebench-verified"
+
+# Sandbox backend for the SandboxedAgentFlow path: docker | local | modal | daytona.
+SANDBOX_BACKEND = os.environ.get("SWE_SANDBOX_BACKEND", "modal")
+
+# Optional cap on the validation set size. SWE-bench Verified is 500 tasks;
+# validation runs ALL of them every time it fires, which is slow. Set
+# SWE_VAL_MAX=N to validate on the first N tasks instead (0/unset = all 500).
+SWE_VAL_MAX = int(os.environ.get("SWE_VAL_MAX", "0"))
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config: DictConfig) -> None:
+    train_dataset = DatasetRegistry.load_dataset(TRAIN_DATASET, "train")
+    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "default")
+
+    if train_dataset is None:
+        raise RuntimeError(f"Dataset '{TRAIN_DATASET}' not found. Run: rllm dataset pull {TRAIN_DATASET} (or: python cookbooks/swe-rl/prepare_data.py)")
+    if val_dataset is None:
+        raise RuntimeError(f"Dataset '{VAL_DATASET}' not found. Run: rllm dataset pull harbor:swebench-verified (or: python cookbooks/swe-rl/prepare_data.py)")
+
+    if SWE_VAL_MAX > 0 and SWE_VAL_MAX < len(val_dataset):
+        val_dataset = val_dataset.select(range(SWE_VAL_MAX))
+
+    # terminus2 as a SandboxedAgentFlow. Passing ``agent_flow`` (with no
+    # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
+    # for the sandbox lifecycle + per-task verifier, and route rollouts through
+    # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
+
+    trainer = AgentTrainer(
+        backend=config.rllm.get("backend", "tinker"),
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        agent_flow=agent_flow,
+        sandbox_backend=SANDBOX_BACKEND,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/swe-rl/train.py
+++ b/cookbooks/swe-rl/train.py
@@ -54,6 +54,13 @@ SANDBOX_BACKEND = os.environ.get("SWE_SANDBOX_BACKEND", "modal")
 # SWE_VAL_MAX=N to validate on the first N tasks instead (0/unset = all 500).
 SWE_VAL_MAX = int(os.environ.get("SWE_VAL_MAX", "0"))
 
+# Per-rollout turn cap for the terminus2 agent. Unset = no artificial cap
+# (Harbor's own default); the per-rollout RLLM_HARNESS_RUN_TIMEOUT_S still
+# bounds wall-clock. The train_*.sh scripts default this to 100; set
+# TERMINUS_MAX_TURNS=N to override (empty/0 = uncapped).
+_terminus_max_turns = os.environ.get("TERMINUS_MAX_TURNS")
+TERMINUS_MAX_TURNS = int(_terminus_max_turns) if _terminus_max_turns and int(_terminus_max_turns) > 0 else None
+
 
 @hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
 def main(config: DictConfig) -> None:
@@ -72,7 +79,7 @@ def main(config: DictConfig) -> None:
     # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
     # for the sandbox lifecycle + per-task verifier, and route rollouts through
     # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
-    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND, max_turns=TERMINUS_MAX_TURNS)
 
     trainer = AgentTrainer(
         backend=config.rllm.get("backend", "tinker"),

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym, eval on SWE-bench Verified — Fireworks backend.
+#
+# Prerequisites:
+#   1. Install rllm with fireworks extras:  uv pip install -e ".[fireworks]"
+#   2. Install this cookbook:                uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                    python cookbooks/swe-rl/prepare_data.py
+#   4. Set your API key:                     export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 128 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2
+#     against it. The gateway routes every LLM call back to the Fireworks-hosted
+#     deployment. This is NOT the remote-runtime / RemoteAgentFlowEngine path.
+#   - 32K prompt window, 8K response budget per turn (terminus2 runs
+#     many turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B the README names as the base model rather than the tinker recipe's
+# 4B. To change it, swap model.name / model.tokenizer_model /
+# fireworks_config.policy_trainer_shape_id together (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks.sh training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    fireworks_config.rollout_deployment_replica_count=4 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=1 \
+    rllm.data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3p5-9b-fireworks' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_fireworks.sh
+++ b/cookbooks/swe-rl/train_fireworks.sh
@@ -39,6 +39,8 @@
 set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the Fireworks backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_fireworks.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous fireworks recipe other cookbooks use (e.g. deepcoder).
+#
+# Prerequisites:
+#   1. Install rllm with fireworks extras:  uv pip install -e ".[fireworks]"
+#   2. Install this cookbook:                uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                    python cookbooks/swe-rl/prepare_data.py
+#   4. Set your API key:                     export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# Differences from train_fireworks.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B the README names as the base model rather than the tinker recipe's
+# 4B. To change it, swap model.name / model.tokenizer_model /
+# fireworks_config.policy_trainer_shape_id together (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend: SWE_SANDBOX_BACKEND (docker | local | modal | daytona; default
+# modal). Cap the eval set with SWE_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    fireworks_config.rollout_deployment_replica_count=4 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=16 \
+    rllm.data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3p5-9b-fireworks-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_fireworks_sync.sh
+++ b/cookbooks/swe-rl/train_fireworks_sync.sh
@@ -40,6 +40,8 @@ set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
 export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym, eval on SWE-bench Verified.
+#
+# Prerequisites:
+#   1. Install rllm with tinker extras:   uv pip install -e ".[tinker]"
+#   2. Install this cookbook:              uv pip install --no-deps -e cookbooks/swe-rl
+#   3. Pull the datasets:                  python cookbooks/swe-rl/prepare_data.py
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 64 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2
+#     against it. The gateway routes every LLM call back to the trainer-hosted
+#     model. This is NOT the remote-runtime / RemoteAgentFlowEngine path.
+#   - 32K prompt window, 8K response budget per turn (terminus2 runs
+#     many turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker.sh model.name=Qwen/Qwen3-8B training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-4B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3.5-4b' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_tinker.sh
+++ b/cookbooks/swe-rl/train_tinker.sh
@@ -26,6 +26,8 @@
 set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the tinker backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_tinker.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous tinker recipe other cookbooks use (e.g. deepcoder).
+#
+# Differences from train_tinker.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Sandbox backend: SWE_SANDBOX_BACKEND (docker | local | modal | daytona; default
+# modal). Cap the eval set with SWE_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-4B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='swe-rl' \
+    rllm.trainer.experiment_name='r2egym-terminus2-qwen3.5-4b-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/swe-rl/train_tinker_sync.sh
+++ b/cookbooks/swe-rl/train_tinker_sync.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
 export SWE_VAL_MAX="${SWE_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 python -u train.py \

--- a/cookbooks/swe-rl/train_verl.sh
+++ b/cookbooks/swe-rl/train_verl.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
 
 export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 
 MODEL_PATH=Qwen/Qwen3.5-4B

--- a/cookbooks/swe-rl/train_verl.sh
+++ b/cookbooks/swe-rl/train_verl.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Train an SWE agent on R2E-Gym with the verl (distributed) backend.
+#
+# Prerequisites:
+#   1. Install rllm with verl extras:     uv pip install -e ".[verl]"
+#   2. Install megatron:                   bash scripts/install_megatron.sh <cu128|cu129|...>
+#   3. Install this cookbook:              uv pip install --no-deps -e cookbooks/swe-rl
+#   4. Pull the datasets:                  python cookbooks/swe-rl/prepare_data.py
+#
+# Verl runs vLLM rollouts + FSDP/Megatron training across N GPUs. Mini-swe-agent
+# still executes inside per-task sandboxes via rLLM's own SandboxedAgentFlow path
+# (AgentFlowEngine, not the remote Harbor runtime); only the policy rollout
+# traffic flows through the gateway back to the verl-hosted vLLM engine.
+#
+# Sandbox backend is chosen by SWE_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+
+set -euo pipefail
+
+unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
+
+export SWE_SANDBOX_BACKEND="${SWE_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+
+MODEL_PATH=Qwen/Qwen3.5-4B
+
+python -u train.py \
+    rllm/backend=verl \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.algorithm.use_rllm=true \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    data.max_prompt_length=32768 \
+    data.max_response_length=8192 \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    +actor_rollout_ref.model.lora.rank=32 \
+    +actor_rollout_ref.model.lora.alpha=32 \
+    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=40960 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    +actor_rollout_ref.rollout.max_model_len=40960 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.7 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    trainer.logger="['console','wandb']" \
+    trainer.project_name=swe-rl \
+    trainer.experiment_name=r2egym-terminus2-qwen3.5-4b-verl \
+    trainer.val_before_train=true \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    "$@"

--- a/cookbooks/terminal-rl/README.md
+++ b/cookbooks/terminal-rl/README.md
@@ -1,0 +1,244 @@
+# Terminal-RL
+
+End-to-end agentic-RL recipe for terminal agents: train on **a local set of
+Harbor-format terminal-agent tasks** that you provide (a `.tar.zst` of task
+directories) and validate on
+[Terminal-Bench](https://www.tbench.ai) pulled from the Harbor registry. The
+agent harness is Harbor's [Terminus-2](https://www.harborframework.com/docs/agents/terminus-2)
+(a tmux-driven mono-tool terminal agent); the base model is `Qwen/Qwen3.5-4B`.
+
+This cookbook ships **no custom AgentFlow and no custom evaluator** — it's a thin
+wrapper around primitives that already live in `rllm/`. The flow is Terminus-2
+running *inside* each task's sandbox, and the evaluator is each task's own
+`tests/test.sh`. Both the training tasks and the Terminal-Bench eval tasks ship
+that verifier with the dataset. This is the same machinery as the
+[Terminal-Bench eval cookbook](../../docs/cookbooks/terminal_bench.mdx), packaged
+as a versioned, installable *training* recipe (the sibling of `cookbooks/swe-rl`).
+
+## Architecture
+
+```
+AgentTrainer.train()
+  │
+  ├── for each task: launch a sandbox (Modal / Daytona / Docker)
+  │       │
+  │       └── terminus2 driver runs IN the sandbox
+  │             │   (multi-turn tmux loop; each LLM call → gateway)
+  │             │
+  │             └── rLLM gateway routes to the trainer-hosted policy,
+  │                  capturing the full trajectory (prompt + response
+  │                  tokens + sampling params per turn).
+  │
+  └── verifier: tests/test.sh inside the sandbox
+        │   writes 1.0 / 0.0 to /logs/verifier/reward.txt
+        │
+        └──  →  RL reward signal
+```
+
+The trainer never parses tool calls or model outputs directly. The agent harness
+owns the action loop; the gateway owns the trajectory; the in-sandbox verifier
+owns the reward.
+
+## Installation
+
+```bash
+uv pip install -e ".[tinker,harbor]"                  # rllm + tinker backend + harbor
+uv pip install --no-deps -e cookbooks/terminal-rl     # this cookbook (registers prepare_data)
+```
+
+The `harbor` extra lets the CLI resolve `harbor:` dataset names and ships the
+Terminus-2 agent code. Terminus-2 itself (an isolated Python 3.12 venv with
+`harbor` + tmux) is installed automatically into each task sandbox on first run —
+no host-side agent install required.
+
+## Datasets
+
+```bash
+python cookbooks/terminal-rl/prepare_data.py
+# or, faster smoke run:
+python cookbooks/terminal-rl/prepare_data.py --train-limit 50
+```
+
+This pulls:
+
+| Dataset | Role | Source | Verifier |
+|---|---|---|---|
+| `tb-opus-pass` | train | local tarball (set via `TB_TRAIN_TARBALL`) | in-sandbox `tests/test.sh` → `/logs/verifier/reward.txt` |
+| `terminal-bench@2.0` | eval (89) | `harbor:terminal-bench@2.0` | in-sandbox `tests/test.sh` → `/logs/verifier/reward.txt` |
+
+Both materialize as Harbor-format task rows (each row points at a task directory
+holding `task.toml`, `instruction.md`, prebuilt `docker_image`, and
+`tests/test.sh`). The training tarball is extracted once under the rLLM datasets
+dir and each task directory becomes one row.
+
+**Eval version.** `TB_EVAL_VERSION` selects the Terminal-Bench eval version
+(default `2.0`). The Harbor registry only publishes `2.0` today; once `2.1`
+lands, switch with a single env var — `prepare_data.py` and `train.py` both read
+it so the pulled and loaded dataset names stay in sync:
+
+```bash
+TB_EVAL_VERSION=2.1 python cookbooks/terminal-rl/prepare_data.py
+TB_EVAL_VERSION=2.1 bash cookbooks/terminal-rl/train_tinker.sh
+```
+
+Point `TB_TRAIN_TARBALL` at your training tarball (or pass `--tarball`); it
+extracts on first run and is a no-op thereafter.
+
+## Training
+
+### Tinker (single-machine, LoRA)
+
+```bash
+bash cookbooks/terminal-rl/train_tinker.sh
+```
+
+Defaults: Qwen/Qwen3.5-4B + LoRA rank 32, GRPO with compact filtering, 128
+parallel Modal sandboxes, async rollout/training. Override anything via Hydra:
+
+```bash
+TERMINAL_SANDBOX_BACKEND=docker bash cookbooks/terminal-rl/train_tinker.sh \
+    model.name=Qwen/Qwen3-8B \
+    rllm.workflow.n_parallel_tasks=32
+```
+
+For a simpler on-policy loop (generate a full batch, then one optimizer step —
+easier to debug), use the synchronous variant:
+
+```bash
+bash cookbooks/terminal-rl/train_tinker_sync.sh
+```
+
+It drops `async_training` and uses a real `data.train_batch_size` (default 16;
+effective batch = `train_batch_size × group_size`).
+
+### Verl (distributed GPU)
+
+```bash
+uv pip install -e ".[verl,harbor]"
+bash scripts/install_megatron.sh <cu128|cu129|...>
+bash cookbooks/terminal-rl/train_verl.sh
+```
+
+vLLM rollouts + FSDP/Megatron training. Sandboxes still run Terminus-2 — only the
+trainer hosting changes.
+
+### Fireworks (managed, LoRA)
+
+```bash
+uv pip install -e ".[fireworks,harbor]"
+export FIREWORKS_API_KEY=...
+bash cookbooks/terminal-rl/train_fireworks.sh
+```
+
+Same async GRPO + compact-filtering recipe as `train_tinker.sh`, but the trainer
+job and inference deployment are provisioned on Fireworks at startup and torn
+down on shutdown. Defaults to `accounts/fireworks/models/qwen3p5-9b` + LoRA rank
+32 on the `qwen3p5-9b-256k-lora` training shape (Fireworks ships a 3.5-9B LoRA
+shape but no 3.5-4B; swap `model.name` / `model.tokenizer_model` /
+`fireworks_config.policy_trainer_shape_id` together to change it — see
+[`docs/backends/fireworks.mdx`](../../docs/backends/fireworks.mdx)). The
+synchronous (on-policy) variant is `train_fireworks_sync.sh`.
+
+### ECHO (train on environment feedback)
+
+[ECHO](https://arxiv.org/abs/2605.24517) adds a cross-entropy loss on the
+environment-observation tokens (the terminal/tool output) that the policy
+already conditions on but GRPO never trains. A terminal agent is the ideal case
+for it: rollouts are dominated by terminal output, and Terminal-Bench is hard
+enough that many rollouts fail — ECHO turns every rollout, including the
+failures, into dense supervision at no extra rollout or forward-pass cost. It
+uses GRPO's advantages unchanged; the only difference is the extra loss term.
+
+Flip GRPO → ECHO with one override on any backend (verl / tinker / fireworks):
+
+```bash
+# tinker (async or sync), verl, or fireworks — same switch:
+bash cookbooks/terminal-rl/train_tinker.sh    rllm.algorithm.adv_estimator=echo
+bash cookbooks/terminal-rl/train_verl.sh      algorithm.adv_estimator=echo
+bash cookbooks/terminal-rl/train_fireworks.sh rllm.algorithm.adv_estimator=echo
+```
+
+`adv_estimator=echo` defaults the env-loss weight λ to the paper's 0.05. Tune it
+explicitly with `rllm.algorithm.env_loss_coef=<λ>` (productive range 0.01–0.05;
+`0.0` reproduces plain GRPO). It is implemented as an `env_prediction`
+[auxiliary loss](../../design/auxiliary-losses.md); watch
+`actor/aux_env_prediction_loss` (verl) / `train/aux_*` (tinker, fireworks) to
+confirm the environment-prediction loss is falling.
+
+> On verl the env term shares GRPO's single forward pass (free, exact). On
+> tinker/fireworks (managed training services with fixed server-side loss
+> kernels) it is a second, gradient-accumulated `cross_entropy` pass over the
+> same rollouts — no extra rollouts, but one extra backward. λ may need
+> per-backend retuning since loss normalization differs across services.
+
+## Evaluation (no training)
+
+```bash
+rllm eval harbor:terminal-bench@2.0 \
+    --agent terminus2 --sandbox-backend modal \
+    --max-tokens 4096 --temperature 0.7 \
+    --max-examples 20
+```
+
+Per-task results land in `~/.rllm/eval_results/`; aggregated resolve rate is
+printed at the end. `rllm view` opens the per-task trajectory UI. See the
+[Terminal-Bench eval cookbook](../../docs/cookbooks/terminal_bench.mdx) for the
+full benchmark run (snapshots, pass@k, sandbox lifetimes).
+
+## Sandbox backend
+
+Training uses rLLM's own `SandboxedAgentFlow` path (`AgentFlowEngine`) — not the
+remote Harbor runtime. Terminus-2 runs inside one sandbox per task, created by
+`SandboxTaskHooks`. Pick a backend via the `TERMINAL_SANDBOX_BACKEND` env var:
+
+| Backend | Setup | Notes |
+|---|---|---|
+| `modal` | `pip install modal` + `modal token new` | Default for training — per-task billing, scales to many parallel sandboxes. |
+| `daytona` | `pip install daytona` + `DAYTONA_API_KEY` | Cloud sandboxes; scales to thousands in parallel. |
+| `docker` | local | Fastest iteration; needs the Docker daemon and ~20 GB free disk. |
+
+The scripts set two timeouts that must stay ordered — **`RLLM_MODAL_SANDBOX_TIMEOUT_S`
+(sandbox lifetime, default 2400s / 40 min) > `RLLM_HARNESS_RUN_TIMEOUT_S` (agent
+run cap, default 1800s / 30 min)**. The agent cap is the knob that actually
+bounds a rollout's duration/cost; the sandbox lifetime is a *ceiling*, not a
+fixed duration — a sandbox is torn down as soon as its rollout + verifier
+finish, so a higher ceiling costs nothing for normal rollouts. The two clocks
+start at different points (sandbox lifetime at **boot**, agent cap after
+**setup**, ~1–3 min), and the per-task verifier can take up to 300s, so the
+lifetime needs that margin above the agent cap. If you make them equal (or the
+lifetime shorter), Modal reaps the longest rollouts *before* their verifier runs
+and you get a storm of `NotFoundError: Sandbox has already shut down` (plus
+`exit 137` on the command that was running when the axe fell) — those rollouts
+then error out and get dropped instead of scored.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `prepare_data.py` | Extracts your local training tarball (train), pulls `harbor:terminal-bench@<ver>` (eval) |
+| `train.py` | Loads the two datasets, hands them to `AgentTrainer` |
+| `train_tinker.sh` | Tinker backend — Qwen3.5-4B LoRA, GRPO + async, Modal sandboxes |
+| `train_tinker_sync.sh` | Tinker backend — synchronous (on-policy) variant, simpler for testing |
+| `train_fireworks.sh` | Fireworks backend — Qwen3.5-9B LoRA, GRPO + async, managed trainer/deployment |
+| `train_fireworks_sync.sh` | Fireworks backend — synchronous (on-policy) variant |
+| `train_verl.sh` | Verl backend — same recipe with vLLM + FSDP |
+| `test.py` | Harness/loader import + script-wiring smoke tests |
+| `pyproject.toml` | Cookbook metadata (registers `prepare_data`) |
+
+## Why no custom flow or evaluator?
+
+Other cookbooks in this repo (`finqa`, `math`, `deepcoder`, …) ship a custom
+AgentFlow because their workloads either fit in a single LLM turn or need bespoke
+tool wiring. A terminal agent doesn't — the existing in-tree primitives already
+cover it:
+
+- **`rllm.harnesses.terminus2`** is the agent. It runs Harbor's Terminus-2
+  *inside* the sandbox (installs an isolated Python 3.12 venv on first run; reads
+  the gateway URL from the env; drives a tmux session locally).
+- **Per-task `tests/test.sh`** is the evaluator. The sandbox-shell verifier kind
+  reads `/logs/verifier/reward.txt` and returns it as the RL reward. Every
+  Terminal-Bench task (train and eval) ships that script.
+
+The only thing this cookbook adds on top is the recipe: dataset pairing,
+sampling/optimizer hyperparams, and the `terminus2` harness selection. Forking
+`train_tinker.sh` is the place to start customizing.

--- a/cookbooks/terminal-rl/prepare_data.py
+++ b/cookbooks/terminal-rl/prepare_data.py
@@ -1,0 +1,160 @@
+"""Pull the train + eval datasets for the terminal-rl cookbook.
+
+Both are sandbox-format benchmarks (per-task ``environment/Dockerfile`` +
+``tests/test.sh`` verifier) in Harbor's directory-per-task layout. The two
+sides differ only in *where* the tasks come from:
+
+* **Train** — a local tarball of Harbor-format task directories that you
+  provide (path set via ``TB_TRAIN_TARBALL`` or ``--tarball``). The tarball is
+  extracted once under the rLLM datasets dir and each task directory is
+  converted into a flat row (``task_path`` + ``instruction``) and registered as
+  the ``tb-opus-pass`` dataset's ``train`` split. Each task carries its own
+  prebuilt ``docker_image`` and a ``tests/test.sh`` that writes
+  ``/logs/verifier/reward.txt`` — exactly the signal rLLM's per-task verifier
+  reads back.
+* **Eval** — ``harbor:terminal-bench@<version>`` pulled straight from the
+  Harbor registry (the same path the Terminal-Bench eval cookbook uses).
+  ``TB_EVAL_VERSION`` selects the version (default ``2.0``; the registry only
+  publishes ``2.0`` today, so set ``TB_EVAL_VERSION=2.1`` once it lands).
+
+Re-runs are cheap: extraction is skipped once the on-disk task tree exists,
+and the eval pull is a no-op once the tasks are cached locally.
+
+Usage::
+
+    python cookbooks/terminal-rl/prepare_data.py
+    # smoke run with a small training cap (still extracts the full tarball):
+    python cookbooks/terminal-rl/prepare_data.py --train-limit 50
+    # evaluate against a different Terminal-Bench version:
+    TB_EVAL_VERSION=2.1 python cookbooks/terminal-rl/prepare_data.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Registry name for the local training set.
+TRAIN_DATASET = "tb-opus-pass"
+TRAIN_SPLIT = "train"
+
+# Terminal-Bench eval version (Harbor registry). 2.0 is what the registry
+# publishes today; flip to 2.1 (or any published version) via TB_EVAL_VERSION.
+EVAL_VERSION = os.environ.get("TB_EVAL_VERSION", "2.0")
+EVAL_DATASET = f"terminal-bench@{EVAL_VERSION}"
+
+# Local training tarball (Harbor tasks). Override with TB_TRAIN_TARBALL.
+DEFAULT_TARBALL = os.path.expanduser(os.environ.get("TB_TRAIN_TARBALL", "~/terminal_train_tasks.tar.zst"))
+
+
+def _tasks_root() -> Path:
+    """Where the training tarball is extracted (under the rLLM datasets home)."""
+    from rllm import paths
+
+    return Path(paths.datasets_dir()) / TRAIN_DATASET / "tasks"
+
+
+def _extract_tarball(tarball: Path, dest: Path) -> Path:
+    """Extract the ``.tar.zst`` tarball into ``dest`` (idempotent).
+
+    Returns the directory whose immediate children are Harbor task dirs
+    (unwrapping a single top-level wrapper dir if the archive has one).
+    """
+    marker = dest / ".extracted"
+    if not marker.exists():
+        if not tarball.exists():
+            raise FileNotFoundError(f"Training tarball not found: {tarball}\nSet TB_TRAIN_TARBALL to its path, e.g. TB_TRAIN_TARBALL=/path/to/your_tasks.tar.zst")
+        dest.mkdir(parents=True, exist_ok=True)
+        print(f"[terminal-rl] Extracting {tarball} -> {dest} (one-time)...", flush=True)
+        # --use-compress-program=unzstd works without GNU tar's --zstd support
+        # and without a Python zstandard dependency.
+        subprocess.run(
+            ["tar", "--use-compress-program=unzstd", "-xf", str(tarball), "-C", str(dest)],
+            check=True,
+        )
+        marker.touch()
+    else:
+        print(f"[terminal-rl] Reusing extracted tasks at {dest}", flush=True)
+
+    # Unwrap a single top-level wrapper directory (if the tarball ships one);
+    # fall back to ``dest`` if the task dirs sit directly under it.
+    children = [d for d in dest.iterdir() if d.is_dir()]
+    if len(children) == 1 and not (children[0] / "task.toml").exists():
+        return children[0]
+    return dest
+
+
+def _register_train(tasks_root: Path, limit: int | None) -> int:
+    """Convert each Harbor task dir into a row and register the train split."""
+    from rllm.data import DatasetRegistry
+    from rllm.integrations.harbor.dataset_loader import harbor_task_to_row
+
+    task_dirs = sorted(d for d in tasks_root.iterdir() if d.is_dir() and (d / "task.toml").exists())
+    if not task_dirs:
+        raise RuntimeError(f"No Harbor task directories (task.toml) found under {tasks_root}")
+    if limit is not None:
+        task_dirs = task_dirs[:limit]
+
+    rows = [row for d in task_dirs if (row := harbor_task_to_row(d)) is not None]
+    if not rows:
+        raise RuntimeError(f"All {len(task_dirs)} task dirs under {tasks_root} were invalid/skipped")
+
+    DatasetRegistry.register_dataset(
+        name=TRAIN_DATASET,
+        data=rows,
+        split=TRAIN_SPLIT,
+        source=f"local:{Path(DEFAULT_TARBALL).name}",
+        description="Local terminal-agent tasks (Harbor format; per-task tests/test.sh verifier)",
+        category="agentic",
+    )
+    return len(rows)
+
+
+def _pull_eval() -> None:
+    """Pull the Terminal-Bench eval split from the Harbor registry."""
+    name = f"harbor:{EVAL_DATASET}"
+    cmd = [sys.executable, "-m", "rllm.cli.main", "dataset", "pull", name]
+    print(f"[terminal-rl] $ {' '.join(cmd)}", flush=True)
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            f"[terminal-rl] Failed to pull '{name}'. The Harbor registry currently "
+            f"publishes terminal-bench@2.0; if you requested a version it does not "
+            f"have, set TB_EVAL_VERSION to an available one (e.g. 2.0)."
+        ) from e
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--train-limit",
+        type=int,
+        default=None,
+        help="Cap training tasks (default: all ~12.6K). Useful for smoke runs.",
+    )
+    ap.add_argument(
+        "--tarball",
+        type=str,
+        default=DEFAULT_TARBALL,
+        help=f"Path to the training tarball (default: {DEFAULT_TARBALL}).",
+    )
+    args = ap.parse_args()
+
+    tasks_root = _extract_tarball(Path(args.tarball).expanduser(), _tasks_root())
+    n_train = _register_train(tasks_root, args.train_limit)
+    print(f"[terminal-rl] Registered {TRAIN_DATASET}/{TRAIN_SPLIT} ({n_train} tasks)", flush=True)
+
+    _pull_eval()
+
+    print(
+        f"\n[terminal-rl] Done. Train: {TRAIN_DATASET} ({n_train})   Eval: {EVAL_DATASET}\n        Run `bash cookbooks/terminal-rl/train_tinker.sh` to train.",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/terminal-rl/pyproject.toml
+++ b/cookbooks/terminal-rl/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "terminal-rl"
+version = "0.1.0"
+description = "End-to-end terminal-agent RL recipe: train on local terminal tasks, eval on Terminal-Bench"
+requires-python = ">=3.10"
+dependencies = ["rllm"]
+
+[tool.setuptools]
+py-modules = ["prepare_data"]

--- a/cookbooks/terminal-rl/test.py
+++ b/cookbooks/terminal-rl/test.py
@@ -1,0 +1,60 @@
+"""Smoke tests for the terminal-rl cookbook.
+
+These tests don't boot sandboxes, run agents, or train. They only verify the
+wiring: the terminus2 harness is importable, the Harbor task loader is
+reachable, and ``train.py`` / ``prepare_data.py`` import without side effects
+and expose the expected dataset names.
+
+Run::
+
+    pytest cookbooks/terminal-rl/test.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+_COOKBOOK_DIR = Path(__file__).resolve().parent
+
+
+def _import_cookbook_module(name: str):
+    if str(_COOKBOOK_DIR) not in sys.path:
+        sys.path.insert(0, str(_COOKBOOK_DIR))
+    return importlib.import_module(name)
+
+
+# -- Harness wiring -----------------------------------------------------------
+
+
+def test_terminus2_harness_importable():
+    """``terminus2`` is the harness this cookbook drives; it must import."""
+    mod = importlib.import_module("rllm.harnesses.terminus2")
+    assert hasattr(mod, "Terminus2Harness")
+    assert mod.Terminus2Harness.name == "terminus2"
+
+
+def test_harbor_loader_importable():
+    """The local training tarball is ingested via the Harbor task loader."""
+    mod = importlib.import_module("rllm.integrations.harbor.dataset_loader")
+    assert hasattr(mod, "harbor_task_to_row")
+
+
+# -- Cookbook scripts ---------------------------------------------------------
+
+
+def test_train_module_imports():
+    """``train.py`` must import without triggering Hydra or starting training."""
+    mod = _import_cookbook_module("train")
+    assert mod.TRAIN_DATASET == "tb-opus-pass"
+    assert mod.VAL_DATASET.startswith("terminal-bench@")
+    assert callable(mod.main)
+
+
+def test_prepare_data_module_imports():
+    """``prepare_data.py`` must import and expose its dataset names."""
+    mod = _import_cookbook_module("prepare_data")
+    assert mod.TRAIN_DATASET == "tb-opus-pass"
+    assert mod.EVAL_DATASET.startswith("terminal-bench@")
+    assert callable(mod.main)

--- a/cookbooks/terminal-rl/train.py
+++ b/cookbooks/terminal-rl/train.py
@@ -1,0 +1,93 @@
+"""Train a terminal agent on a local set of terminal-agent tasks, eval on
+Terminal-Bench.
+
+This cookbook deliberately ships no custom AgentFlow or evaluator:
+
+* The **agent** is the in-tree ``terminus2`` harness
+  (:class:`rllm.harnesses.terminus2.Terminus2Harness`) — a
+  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow` that runs Harbor's
+  Terminus-2 tmux/terminal agent inside each task's sandbox. The rLLM gateway
+  intercepts every LLM call, so the trainer sees full trajectories without the
+  harness knowing it's being trained.
+* The **evaluator** is each task's own verifier (sandbox-shell), resolved
+  per-task by :class:`rllm.hooks.SandboxTaskHooks`. Both the local training
+  tasks and the Terminal-Bench eval tasks ship a ``tests/test.sh`` that writes
+  ``1.0``/``0.0`` to ``/logs/verifier/reward.txt``; rLLM reads that back as the
+  RL reward.
+
+Because we pass an ``agent_flow`` (and no explicit ``evaluator``/``hooks``),
+:class:`AgentTrainer` runs the **rLLM-native SandboxedAgentFlow path**
+(``AgentFlowEngine``) — sandboxes are created locally by ``SandboxTaskHooks``
+via a pluggable ``sandbox_backend`` (``docker`` | ``local`` | ``modal`` |
+``daytona``). This is NOT the remote-runtime / ``RemoteAgentFlowEngine`` path.
+
+The sandbox backend is selected by the ``TERMINAL_SANDBOX_BACKEND`` env var
+(default ``modal``). For ``modal`` install ``pip install modal`` and run
+``modal token new``; for ``daytona`` install ``pip install daytona`` and set
+``DAYTONA_API_KEY``. Everything else is configured by Hydra overrides on the
+command line (see ``train_tinker.sh`` / ``train_verl.sh`` for working defaults).
+
+Usage (from rllm repo root)::
+
+    TERMINAL_SANDBOX_BACKEND=modal python cookbooks/terminal-rl/train.py rllm/backend=tinker
+"""
+
+from __future__ import annotations
+
+import os
+
+import hydra
+from omegaconf import DictConfig
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.harnesses.terminus2 import Terminus2Harness
+from rllm.trainer import AgentTrainer
+
+TRAIN_DATASET = "tb-opus-pass"
+
+# Terminal-Bench eval version (Harbor registry). Must match prepare_data.py;
+# both read TB_EVAL_VERSION so the pulled and loaded dataset names agree.
+EVAL_VERSION = os.environ.get("TB_EVAL_VERSION", "2.0")
+VAL_DATASET = f"terminal-bench@{EVAL_VERSION}"
+
+# Sandbox backend for the SandboxedAgentFlow path: docker | local | modal | daytona.
+SANDBOX_BACKEND = os.environ.get("TERMINAL_SANDBOX_BACKEND", "modal")
+
+# Optional cap on the validation set size. Terminal-Bench 2.0 is 89 tasks;
+# validation runs ALL of them every time it fires, which is slow. Set
+# TB_VAL_MAX=N to validate on the first N tasks instead (0/unset = all).
+TB_VAL_MAX = int(os.environ.get("TB_VAL_MAX", "0"))
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config: DictConfig) -> None:
+    train_dataset = DatasetRegistry.load_dataset(TRAIN_DATASET, "train")
+    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "default")
+
+    if train_dataset is None:
+        raise RuntimeError(f"Dataset '{TRAIN_DATASET}' not found. Run: python cookbooks/terminal-rl/prepare_data.py")
+    if val_dataset is None:
+        raise RuntimeError(f"Dataset '{VAL_DATASET}' not found. Run: rllm dataset pull harbor:{VAL_DATASET} (or: python cookbooks/terminal-rl/prepare_data.py)")
+
+    if TB_VAL_MAX > 0 and TB_VAL_MAX < len(val_dataset):
+        val_dataset = val_dataset.select(range(TB_VAL_MAX))
+
+    # terminus2 as a SandboxedAgentFlow. Passing ``agent_flow`` (with no
+    # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
+    # for the sandbox lifecycle + per-task verifier, and route rollouts through
+    # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
+
+    trainer = AgentTrainer(
+        backend=config.rllm.get("backend", "tinker"),
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        agent_flow=agent_flow,
+        sandbox_backend=SANDBOX_BACKEND,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/terminal-rl/train.py
+++ b/cookbooks/terminal-rl/train.py
@@ -58,6 +58,13 @@ SANDBOX_BACKEND = os.environ.get("TERMINAL_SANDBOX_BACKEND", "modal")
 # TB_VAL_MAX=N to validate on the first N tasks instead (0/unset = all).
 TB_VAL_MAX = int(os.environ.get("TB_VAL_MAX", "0"))
 
+# Per-rollout turn cap for the terminus2 agent. Unset = no artificial cap
+# (Harbor's own default); the per-rollout RLLM_HARNESS_RUN_TIMEOUT_S still
+# bounds wall-clock. The train_*.sh scripts default this to 100; set
+# TERMINUS_MAX_TURNS=N to override (empty/0 = uncapped).
+_terminus_max_turns = os.environ.get("TERMINUS_MAX_TURNS")
+TERMINUS_MAX_TURNS = int(_terminus_max_turns) if _terminus_max_turns and int(_terminus_max_turns) > 0 else None
+
 
 @hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
 def main(config: DictConfig) -> None:
@@ -76,7 +83,7 @@ def main(config: DictConfig) -> None:
     # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
     # for the sandbox lifecycle + per-task verifier, and route rollouts through
     # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
-    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND)
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND, max_turns=TERMINUS_MAX_TURNS)
 
     trainer = AgentTrainer(
         backend=config.rllm.get("backend", "tinker"),

--- a/cookbooks/terminal-rl/train_fireworks.sh
+++ b/cookbooks/terminal-rl/train_fireworks.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Train a terminal agent on a local terminal-agent task set, eval on
+# Terminal-Bench — Fireworks backend.
+#
+# Prerequisites:
+#   1. Install rllm with fireworks + harbor extras:  uv pip install -e ".[fireworks,harbor]"
+#   2. Install this cookbook:                        uv pip install --no-deps -e cookbooks/terminal-rl
+#   3. Pull the datasets:                            python cookbooks/terminal-rl/prepare_data.py
+#   4. Set your API key:                             export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 128 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2 against
+#     it. The gateway routes every LLM call back to the Fireworks-hosted
+#     deployment. This is NOT the remote-runtime path.
+#   - Cumulative token mode is OFF: each agent turn is its own training row
+#     (no prefix-merge), with the prior conversation re-rendered reasoning-free
+#     each turn (matches how the model is served). So training.max_length only
+#     needs to hold ONE turn = max_prompt_length + max_response_length.
+#   - 56K reasoning-free prompt window (~17 turns of history) + 8K response
+#     budget per turn = 64K total (responses run short in practice). Bump
+#     max_prompt_length (toward the 256K shape) or cap turns if your rollouts
+#     regularly exceed ~17 turns, else their tails get dropped by compact
+#     filtering.
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B rather than the tinker recipe's 4B. To change it, swap model.name /
+# model.tokenizer_model / fireworks_config.policy_trainer_shape_id together
+# (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend is chosen by TERMINAL_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks.sh training.group_size=4
+
+set -euo pipefail
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+# Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
+# above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
+# "Sandbox has already shut down" (NotFoundError) and exit-137 kills.
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    fireworks_config.rollout_deployment_replica_count=6 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=1 \
+    rllm.data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=echo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=1.0 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=192 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=false \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='terminal-rl' \
+    rllm.trainer.experiment_name='terminal-rl-terminus2-qwen3p5-9b-fireworks' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=50 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/terminal-rl/train_fireworks.sh
+++ b/cookbooks/terminal-rl/train_fireworks.sh
@@ -47,6 +47,8 @@
 set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
@@ -62,16 +64,16 @@ python -u train.py \
     fireworks_config.rollout_deployment_replica_count=6 \
     training.group_size=8 \
     training.learning_rate=2e-5 \
-    training.max_length=65536 \
+    training.max_length=131072 \
     rllm.rollout.train.temperature=1.0 \
     rllm.rollout.train.top_p=1.0 \
     rllm.rollout.val.temperature=1.0 \
     rllm.rollout.val.top_p=1.0 \
-    data.max_prompt_length=57344 \
+    data.max_prompt_length=122880 \
     data.max_response_length=8192 \
     data.train_batch_size=1 \
     data.val_batch_size=-1 \
-    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_prompt_length=122880 \
     rllm.data.max_response_length=8192 \
     rllm.data.train_batch_size=1 \
     rllm.data.val_batch_size=-1 \
@@ -81,13 +83,13 @@ python -u train.py \
     rllm.async_training.enable=true \
     rllm.async_training.mini_batch_size=16 \
     rllm.async_training.fwd_bwd_group_size=1 \
-    rllm.async_training.staleness_threshold=1.0 \
+    rllm.async_training.staleness_threshold=0.5 \
     rllm.async_training.trigger_parameter_sync_step=1 \
     rllm.async_training.partial_rollout=true \
     rllm.workflow.n_parallel_tasks=192 \
     rllm.workflow.raise_on_error=false \
     rllm.gateway.port=9090 \
-    rllm.gateway.cumulative_token_mode=false \
+    rllm.gateway.cumulative_token_mode=true \
     rllm.gateway.renderer_family=qwen3.5 \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.logger='[wandb]' \

--- a/cookbooks/terminal-rl/train_fireworks_sync.sh
+++ b/cookbooks/terminal-rl/train_fireworks_sync.sh
@@ -41,6 +41,8 @@ set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
 export TB_VAL_MAX="${TB_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_fireworks_sync.sh
+++ b/cookbooks/terminal-rl/train_fireworks_sync.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Train a terminal agent on a local terminal-agent task set with the Fireworks
+# backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_fireworks.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous fireworks recipe other cookbooks use (e.g. deepcoder).
+#
+# Prerequisites:
+#   1. Install rllm with fireworks + harbor extras:  uv pip install -e ".[fireworks,harbor]"
+#   2. Install this cookbook:                        uv pip install --no-deps -e cookbooks/terminal-rl
+#   3. Pull the datasets:                            python cookbooks/terminal-rl/prepare_data.py
+#   4. Set your API key:                             export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup (via the cookbook's training.provision API) and torn down on shutdown.
+#
+# Differences from train_fireworks.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Fireworks' public catalog ships a 3.5-9B LoRA shape but no 3.5-4B, so this
+# uses the 9B rather than the tinker recipe's 4B. To change it, swap model.name /
+# model.tokenizer_model / fireworks_config.policy_trainer_shape_id together
+# (see docs/backends/fireworks.mdx).
+#
+# Sandbox backend: TERMINAL_SANDBOX_BACKEND (docker | local | modal | daytona;
+# default modal). Cap the eval set with TB_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Qwen3.5 is a reasoning family; if the harness can't parse reasoning output,
+# disable it by appending: rollout_engine.reasoning_effort=none
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_fireworks_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export TB_VAL_MAX="${TB_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+# Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
+# above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
+# "Sandbox has already shut down" (NotFoundError) and exit-137 kills.
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    fireworks_config.rollout_deployment_replica_count=4 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=57344 \
+    rllm.data.max_response_length=8192 \
+    rllm.data.train_batch_size=16 \
+    rllm.data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='terminal-rl' \
+    rllm.trainer.experiment_name='terminal-rl-terminus2-qwen3p5-9b-fireworks-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/terminal-rl/train_tinker.sh
+++ b/cookbooks/terminal-rl/train_tinker.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Train a terminal agent on a local terminal-agent task set, eval on Terminal-Bench.
+#
+# Prerequisites:
+#   1. Install rllm with tinker + harbor extras:  uv pip install -e ".[tinker,harbor]"
+#   2. Install this cookbook:                     uv pip install --no-deps -e cookbooks/terminal-rl
+#   3. Pull the datasets:                         python cookbooks/terminal-rl/prepare_data.py
+#
+# What this configures, in plain English:
+#   - Async GRPO with compact filtering (drop too-long rollouts before grad).
+#   - 128 tasks rolled out in parallel; each rollout boots a sandbox (rLLM's
+#     own SandboxedAgentFlow path, AgentFlowEngine) and runs terminus2 (Harbor's
+#     Terminus-2 tmux agent) against it. The gateway routes every LLM call back
+#     to the trainer-hosted model. This is NOT the remote-runtime path.
+#   - 56K prompt window, 8K response budget per turn (terminus2 runs many
+#     turns; the per-turn cap keeps the optimizer batch shape sane).
+#
+# Sandbox backend is chosen by TERMINAL_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Rollouts are capped at
+# 30 min (RLLM_HARNESS_RUN_TIMEOUT_S); the Modal sandbox lifetime
+# (RLLM_MODAL_SANDBOX_TIMEOUT_S) sits above it so the capped rollout still gets
+# verified before the sandbox is reaped.
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker.sh model.name=Qwen/Qwen3-8B training.group_size=4
+
+set -euo pipefail
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+# Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
+# above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
+# "Sandbox has already shut down" (NotFoundError) and exit-137 kills.
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-4B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='terminal-rl' \
+    rllm.trainer.experiment_name='terminal-rl-terminus2-qwen3.5-4b' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/terminal-rl/train_tinker.sh
+++ b/cookbooks/terminal-rl/train_tinker.sh
@@ -28,6 +28,8 @@
 set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_tinker_sync.sh
+++ b/cookbooks/terminal-rl/train_tinker_sync.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Train a terminal agent on a local terminal-agent task set with the tinker
+# backend in SYNCHRONOUS mode.
+#
+# This is the simpler, on-policy variant of train_tinker.sh (which uses
+# fully-async GRPO). Each step generates a full batch of rollouts, then takes
+# one optimizer step — easier to reason about for testing/debugging. Mirrors
+# the synchronous tinker recipe other cookbooks use (e.g. deepcoder).
+#
+# Differences from train_tinker.sh:
+#   - No rllm.async_training.* (async disabled → synchronous generate→train).
+#   - data.train_batch_size is the real per-step task count (async forces it to 1).
+#   - The effective batch is train_batch_size x group_size rollouts per step.
+#
+# Sandbox backend: TERMINAL_SANDBOX_BACKEND (docker | local | modal | daytona;
+# default modal). Cap the eval set with TB_VAL_MAX. Per-rollout agent timeout:
+# RLLM_HARNESS_RUN_TIMEOUT_S.
+#
+# Override anything by passing extra Hydra args after the script:
+#   bash train_tinker_sync.sh data.train_batch_size=2 training.group_size=4
+
+set -euo pipefail
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export TB_VAL_MAX="${TB_VAL_MAX:-16}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+# Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
+# above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
+# "Sandbox has already shut down" (NotFoundError) and exit-137 kills.
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-4B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=57344 \
+    data.max_response_length=8192 \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='terminal-rl' \
+    rllm.trainer.experiment_name='terminal-rl-terminus2-qwen3.5-4b-sync' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/terminal-rl/train_tinker_sync.sh
+++ b/cookbooks/terminal-rl/train_tinker_sync.sh
@@ -23,6 +23,8 @@ set -euo pipefail
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
 export TB_VAL_MAX="${TB_VAL_MAX:-16}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_verl.sh
+++ b/cookbooks/terminal-rl/train_verl.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Train a terminal agent on a local terminal-agent task set with the verl
+# (distributed) backend.
+#
+# Prerequisites:
+#   1. Install rllm with verl + harbor extras:  uv pip install -e ".[verl,harbor]"
+#   2. Install megatron:                         bash scripts/install_megatron.sh <cu128|cu129|...>
+#   3. Install this cookbook:                    uv pip install --no-deps -e cookbooks/terminal-rl
+#   4. Pull the datasets:                        python cookbooks/terminal-rl/prepare_data.py
+#
+# Verl runs vLLM rollouts + FSDP/Megatron training across N GPUs. The terminus2
+# agent still executes inside per-task sandboxes via rLLM's own SandboxedAgentFlow
+# path (AgentFlowEngine, not the remote Harbor runtime); only the policy rollout
+# traffic flows through the gateway back to the verl-hosted vLLM engine.
+#
+# Sandbox backend is chosen by TERMINAL_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). modal needs `pip install modal` + `modal token new`;
+# daytona needs `pip install daytona` + DAYTONA_API_KEY. Per-rollout agent
+# timeout: RLLM_HARNESS_RUN_TIMEOUT_S.
+
+set -euo pipefail
+
+unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+# Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
+# above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
+# "Sandbox has already shut down" (NotFoundError) and exit-137 kills.
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+MODEL_PATH=Qwen/Qwen3.5-4B
+
+python -u train.py \
+    rllm/backend=verl \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.algorithm.use_rllm=true \
+    data.train_batch_size=16 \
+    data.val_batch_size=-1 \
+    data.max_prompt_length=32768 \
+    data.max_response_length=8192 \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    +actor_rollout_ref.model.lora.rank=32 \
+    +actor_rollout_ref.model.lora.alpha=32 \
+    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=40960 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    +actor_rollout_ref.rollout.max_model_len=40960 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.7 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9090 \
+    trainer.logger="['console','wandb']" \
+    trainer.project_name=terminal-rl \
+    trainer.experiment_name=terminal-rl-terminus2-qwen3.5-4b-verl \
+    trainer.val_before_train=true \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    "$@"

--- a/cookbooks/terminal-rl/train_verl.sh
+++ b/cookbooks/terminal-rl/train_verl.sh
@@ -23,6 +23,8 @@ set -euo pipefail
 unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
 
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+# Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/design/auxiliary-losses.md
+++ b/design/auxiliary-losses.md
@@ -1,0 +1,402 @@
+# Design: Auxiliary Losses in rLLM
+
+- **Status:** Prototype landed — migration steps 1–3 implemented on PR #668; steps 4–5 (SDAR's `AuxForward` + dynamic weights, escape hatch) pending.
+- **Related:** PR #668 (ECHO, arXiv:2605.24517) — the first client of this framework
+- **Scope:** the unified trainer (`UnifiedTrainer`) and its three backends — verl, tinker, fireworks
+
+> **Implementation status.** The framework is prototyped on PR #668:
+> `rllm/trainer/algorithms/aux_loss.py` (the `AuxiliaryLoss` spec, the
+> `register_aux_loss` registry, `EnvPredictionLoss`, and `build_aux_losses` with
+> the `env_loss_coef`/`adv_estimator=echo` back-compat sugar);
+> `rllm/trainer/tinker/aux_loss.py` (the shared managed datum builder); the verl
+> in-process executor in `CustomPPOLoss._apply_aux_losses`; and the tinker
+> (`_get_aux_loss_futures`) / fireworks (`_build_aux_datums`) managed executors.
+> ECHO is ported onto it as `env_prediction`. The `requires` field (AuxForward)
+> raises `NotImplementedError` until step 4. See `tests/unified_trainer/test_aux_loss.py`.
+
+## Summary
+
+A growing class of agent-RL algorithms keep GRPO as the optimization backbone and
+add a **token-level auxiliary loss** on top of it: ECHO (predict environment
+observations), SDAR (gated on-policy self-distillation), demonstration/SFT
+blending, on-policy distillation, entropy/exploration shaping, etc. Today each
+such algorithm has to be hand-wired into all three backends' loss paths
+separately.
+
+This doc proposes a single abstraction — `AuxiliaryLoss` — so that adding one of
+these algorithms is **one registered class plus config, with zero per-backend
+loss surgery**. We refactor ECHO onto it as the first reference client and show
+SDAR as the second.
+
+## Motivation
+
+ECHO (PR #668) is a ~10-line idea — "add a cross-entropy term on the observation
+tokens" — but landing it touched three backends with bespoke code:
+
+- `rllm/trainer/verl/verl_backend.py` → `CustomPPOLoss._add_env_loss`
+- `rllm/trainer/tinker/tinker_policy_trainer.py` → `_get_env_loss_futures` / `_build_env_datum`
+- `rllm/trainer/fireworks/fireworks_policy_trainer.py` → fold-and-pass in `forward_backward_from_trajectory_groups` + `optim_step`
+
+Each backend reimplements the *same* concept: select a token subset, weight the
+per-token log-probs, aggregate, and add the result to the policy loss. The
+ECHO-specific knob (`algorithm.env_loss_coef`) is likewise bespoke. The next
+algorithm of this family (SDAR, distillation, SFT-blend) would repeat the
+3-backend surgery and add another bespoke flag.
+
+The mechanism is general; only the *policy* was hard-coded. This doc factors the
+mechanism out.
+
+## Goals / non-goals
+
+**Goals**
+
+- One place to define a token-level auxiliary loss; backends pick it up generically.
+- ECHO and SDAR both expressible as small declarations, sharing all backend plumbing.
+- Honest, explicit handling of the verl ↔ managed-service (tinker/fireworks) asymmetry.
+- Default-off: existing GRPO runs are byte-for-byte unchanged.
+
+**Non-goals**
+
+- Replacing the *primary* policy loss machinery (`adv_estimator`, the verl
+  `POLICY_LOSS_REGISTRY`, tinker's `ppo`/`importance_sampling`). Aux losses are
+  added *on top* of the policy loss.
+- Forcing every conceivable loss into one mold. Losses outside the
+  "token-weighted log-prob / cross-entropy" family are supported only on verl,
+  via an escape hatch (see [Capability model](#capability-model)).
+
+## Background: the two layers
+
+An auxiliary loss decomposes into a data layer and a loss layer. Only the loss
+layer is genuinely backend-specific.
+
+| Layer | Responsibility | Backend-specific? |
+|---|---|---|
+| **Data** | derive per-token `(mask, target, weight-inputs)` from the merged rollout | **No** — both transforms already build the same interleaved `[A₀, obs₁, A₁, …]` row with a per-token action mask |
+| **Loss** | combine forward-pass outputs (log-probs, entropy) with those tensors → scalar; add to the policy loss | **Yes** — see below |
+
+The irreducible asymmetry in the loss layer:
+
+- **verl** — rLLM owns the actor loss (`CustomPPOLoss`, installed via `set_loss_fn`).
+  It receives the full micro-batch `data` and `model_output`, so an aux term can
+  be folded into the *single existing forward/backward pass* (free, exact).
+- **tinker / fireworks** — loss is computed by a fixed **server-side kernel**
+  (`ppo`, `grpo`, …). rLLM cannot append a term to that kernel, but it *can*
+  submit an **extra gradient-accumulated `cross_entropy` pass** over the same
+  rollouts. No extra rollouts; one extra backward.
+
+The enabling fact: **every member of the "weighted cross-entropy / log-prob over
+a token subset" family maps onto `cross_entropy` on managed backends and onto an
+in-pass masked sum on verl.** That family is large — env prediction (ECHO),
+gated self-distillation (SDAR), SFT/demonstration blending, on-policy
+distillation CE, masked-LM-style auxiliaries. Abstract *that family* and these
+algorithms become declarations.
+
+## The abstraction
+
+### 1. Named token masks (data layer)
+
+The shared transform attaches a small dict of named masks to each training row
+(DataProto for verl; datum metadata for tinker/fireworks), computed once:
+
+```python
+aux_masks = {
+    "action":      <1 on assistant/action tokens>,        # == response_mask today
+    "observation": <complement of action mask, non-pad>,  # ECHO's O
+    # "observation_env_only": <O excluding warning/chat-template tokens>,  # paper's O′
+}
+```
+
+This is where token-subset definitions live — including refinements like the
+paper's `O′` (env tokens excluding low-entropy warning/template tokens), defined
+once with tokenizer knowledge instead of re-derived per backend. Aux losses
+reference a mask **by name**.
+
+> Today ECHO re-derives `(responses != pad) & ~response_mask` at the verl loss
+> site and `1 - mask` in the tinker/fireworks datum builders. Those collapse into
+> the single `"observation"` entry here.
+
+### 2. The `AuxiliaryLoss` interface
+
+```python
+class AuxiliaryLoss:
+    """A token-level loss added to the policy loss: coef * Agg(weight_t · term_t)."""
+
+    mask: str                      # name of the token subset (from aux_masks)
+    target: str                    # "next_token" | "sampled_token" | a named target tensor
+    requires: list[AuxForward] = []  # extra forward pass(es) this loss needs (default: none)
+
+    def weight(self, ctx: AuxContext) -> Tensor:
+        """Per-token weight. Default: the static coefficient (ECHO)."""
+        return ctx.coef
+```
+
+- **`mask` / `target`** — which tokens, and what the per-token term predicts.
+  `next_token` ⇒ the term is `−log p_θ(x_{t+1})` (ECHO). `sampled_token` ⇒
+  `−log p_θ(y_t)` on the rollout's own tokens (SDAR).
+- **`weight(ctx)`** — per-token weight. Constant for ECHO; a dynamic, detached
+  function of forward-pass signals for SDAR. `ctx` exposes student log-probs,
+  student entropy (where available), the static `coef`, and the outputs of any
+  declared `requires`.
+- **`requires`** — declares extra forward passes the loss needs (e.g. SDAR's
+  teacher branch). Empty for ECHO, which reuses the existing pass.
+
+```python
+class AuxForward:
+    name: str                                  # key under ctx.aux[...]
+    build_context: Callable                    # (x, y_<t) -> modified input (e.g. inject skills)
+    needs: set[str] = {"logprobs"}             # "logprobs" | "entropy" | ...
+```
+
+### 3. The registry
+
+Mirrors the existing `register_rllm_adv_estimator` pattern in
+`rllm/trainer/algorithms/advantage.py`:
+
+```python
+AUX_LOSS_REGISTRY: dict[str, type[AuxiliaryLoss]] = {}
+
+def register_aux_loss(name: str):
+    def deco(cls): AUX_LOSS_REGISTRY[name] = cls; return cls
+    return deco
+```
+
+### 4. Config
+
+A list of specs instead of a bespoke flag:
+
+```yaml
+algorithm:
+  adv_estimator: grpo
+  aux_losses:
+    - type: env_prediction      # registered name
+      coef: 0.05
+    # - type: sdar
+    #   coef: 0.1
+    #   gate: gap
+```
+
+`adv_estimator=echo` stays as **sugar** that injects
+`aux_losses: [{type: env_prediction, coef: 0.05}]`, preserving the one-word
+switch from PR #668. Bonus: aux losses **stack**.
+
+## Executors
+
+Each backend implements one executor that interprets *any* `AuxiliaryLoss`. These
+are the current ECHO code, de-ECHO'd.
+
+### `InProcessAuxExecutor` (verl)
+
+Runs inside `CustomPPOLoss`, after `ppo_loss(...)`:
+
+```python
+def add(self, policy_loss, metrics, model_output, data, spec):
+    ctx = AuxContext.from_verl(model_output, data, spec, self.config)  # logprobs, entropy, aux_masks
+    for fwd in spec.requires:                       # e.g. SDAR teacher pass
+        ctx.aux[fwd.name] = self.run_forward(fwd, data)               # detached
+    w   = spec.weight(ctx)                          # [bs, resp_len]
+    lp  = ctx.logprobs_on(spec.target)              # next_token or sampled_token
+    term = agg_loss(loss_mat=-w * lp, loss_mask=ctx.mask(spec.mask),
+                    loss_agg_mode=self.config.loss_agg_mode, **self.config.global_batch_info)
+    return policy_loss + spec.coef * term, {**metrics, f"actor/aux_{spec.type}": term}
+```
+
+One forward/backward; aggregation reuses GRPO's `loss_agg_mode` + global-batch
+normalization (so `coef` is on the same scale as the policy gradient).
+
+### `ManagedPassAuxExecutor` (tinker, fireworks)
+
+Builds a `cross_entropy` datum and submits a gradient-accumulated pass:
+
+```python
+def datums(self, raw_datums, spec, ctx):
+    out = []
+    for d in raw_datums:
+        w = spec.weight(ctx.for_datum(d))          # client-side; uses forward()/AuxForward logprobs
+        if w.any():
+            out.append(Datum(model_input=d.model_input,
+                             loss_fn_inputs={"target_tokens": ctx.target(d, spec.target),
+                                             "weights": w * spec.coef * ctx.norm(d)}))
+    return out   # submitted via forward_backward(..., "cross_entropy"), accumulated before optim_step
+```
+
+The two managed backends differ only in **normalization**, which lives here once:
+
+- **tinker** — `optim_step` applies no normalization, so accumulation is a clean
+  additive sum; `norm = 1`.
+- **fireworks** — `GradAccNormalization` counts tokens/sequences across *all*
+  accumulated passes, which would rescale the policy gradient. The executor folds
+  the intended normalization into `weights`/advantages and forces
+  `GradAccNormalization.NONE` (exactly the logic currently inline in PR #668).
+
+The `AuxForward` (e.g. SDAR's teacher pass) is a `forward(...)` call on
+context-modified datums — *the same pattern fireworks already uses for proximal
+log-probs* (`_compute_proximal_logprobs`).
+
+### `AuxContext`
+
+The uniform view each executor builds and hands to `weight()` / target resolution:
+
+| field | verl | tinker / fireworks |
+|---|---|---|
+| `logprobs` (student, per token) | `model_output["log_probs"]` | rollout / `forward()` logprobs |
+| `entropy` (student, per token) | computed from logits in-pass | **only if** `forward` exposes it (see capability model) |
+| `mask(name)` | from `aux_masks` in `data` | from `aux_masks` in datum meta |
+| `aux[name]` | result of in-pass `AuxForward` | result of `forward()` `AuxForward` |
+| `coef`, `norm` | from spec / agg config | from spec / normalization fold |
+
+## Reference client 1 — ECHO
+
+ECHO collapses to a declaration; all three backends run it via their executor.
+
+```python
+@register_aux_loss("env_prediction")
+class EnvPredictionLoss(AuxiliaryLoss):
+    mask   = "observation"     # tokens GRPO never trains
+    target = "next_token"      # predict the actual environment output
+    # weight() inherits the default (constant coef); requires = [] (reuses the existing pass)
+```
+
+**Before → after:**
+
+| Before (PR #668) | After |
+|---|---|
+| `CustomPPOLoss._add_env_loss` (verl) | deleted → `InProcessAuxExecutor` |
+| `_get_env_loss_futures` / `_build_env_datum` / `_record_env_loss_metrics` (tinker) | deleted → `ManagedPassAuxExecutor` |
+| fold + env pass + `optim_step` NONE (fireworks) | deleted → `ManagedPassAuxExecutor` |
+| `algorithm.env_loss_coef` | `aux_losses: [{type: env_prediction, coef}]` (echo sugar keeps the flag) |
+
+Math is unchanged: the env term is `coef · mean_seq((1/|O|) Σ_{t∈O} −log p_θ(x_t))`
+(verified numerically in PR #668 across all three backends).
+
+## Reference client 2 — SDAR
+
+SDAR (arXiv:2605.15155, *Self-Distilled Agentic RL*) is GRPO + a **gated
+on-policy self-distillation** term. It looks unlike ECHO, but its *trainable*
+gradient is again a weighted cross-entropy on a token subset:
+
+$$\ell_t = g_t\big(\log\pi^+_\theta(y_t\mid s^+_t) - \log\pi_\theta(y_t\mid s_t)\big),\quad \text{grad}\propto -\,g_t\,\nabla_\theta\log\pi_\theta(y_t\mid s_t)$$
+
+(the gate `g_t` and the teacher term are detached). So SDAR needs exactly two
+things ECHO didn't: a **dynamic weight** (`g_t`) and an **auxiliary teacher
+forward pass** over a privileged context. Both are first-class in the interface:
+
+```python
+@register_aux_loss("sdar")
+class SDARLoss(AuxiliaryLoss):
+    mask   = "action"          # the student's own response tokens
+    target = "sampled_token"   # y_t, already in the rollout
+
+    requires = [AuxForward(name="teacher",
+                           build_context=inject_retrieved_skills,   # s⁺_t = (x, c⁺, y_<t)
+                           needs={"logprobs"})]
+
+    def weight(self, ctx):
+        gap = (ctx.aux["teacher"].logprobs - ctx.logprobs).detach()      # Δ_t
+        b = self.cfg.beta
+        if self.cfg.gate == "gap":     return sigmoid(b * gap)
+        if self.cfg.gate == "entropy": return sigmoid(b * ctx.entropy.detach())   # needs entropy
+        if self.cfg.gate == "soft_or":
+            e = ctx.entropy.detach()
+            return sigmoid(b * (1 - (1 - e) * (1 - gap)))
+```
+
+**Per backend:**
+
+- **verl** — the `teacher` `AuxForward` is a second in-process forward over the
+  skills-augmented `input_ids`; `weight()` reads student logprobs + entropy from
+  the main pass; the executor adds the gated CE. (One extra forward — SDAR is not
+  "free" like ECHO; the framework makes that explicit via `requires`.)
+- **tinker / fireworks** — the teacher pass is a `forward(...)` on teacher-context
+  datums → teacher logprobs; the gate is computed client-side; the
+  `ManagedPassAuxExecutor` submits a `cross_entropy` pass with `weights = g_t`.
+
+The only new data-layer hook is `inject_retrieved_skills` — the teacher-context
+builder — parallel to how the `observation` mask is built once.
+
+## Capability model
+
+The framework targets the weighted-CE/log-prob family. It must say clearly what
+each backend can express, and **raise rather than silently degrade**:
+
+| Capability | verl | tinker | fireworks |
+|---|---|---|---|
+| weighted CE on a named mask (ECHO) | ✅ in-pass | ✅ extra pass | ✅ extra pass |
+| dynamic weight from **sampled-token** logprobs (SDAR gap gating) | ✅ | ✅ (`forward`) | ✅ (`forward`) |
+| dynamic weight from **full-vocab entropy** (SDAR entropy / soft-OR) | ✅ in-pass | ⚠️ only if `forward` exposes entropy | ⚠️ only if `forward` exposes entropy |
+| arbitrary Python loss on logits (value head, contrastive) | ✅ escape hatch | ❌ kernel change | ❌ kernel change |
+
+Each `AuxForward` declares `needs` (e.g. `{"entropy"}`); a backend that can't
+satisfy it raises a clear error at config time
+(*"entropy gating unsupported on tinker/fireworks"*) instead of training on a
+wrong signal. This makes today's implicit limitation explicit.
+
+### Escape hatch (verl)
+
+For losses outside the CE family, verl keeps a raw callable — `CustomPPOLoss`
+already receives full `model_output` + `data`:
+
+```yaml
+aux_losses:
+  - type: custom
+    fn: my_pkg.losses:value_head_loss   # (model_output, data, ctx) -> (scalar, metrics)
+    coef: 0.1
+```
+
+Managed backends reject `type: custom` (no in-process loss control).
+
+## Migration / incremental plan
+
+1. **Data layer** ✅ — named token subsets (`action`, `observation`) are resolved
+   by each executor from the merged row's existing masks (no new tensor plumbing
+   in this prototype; the `aux_masks`-in-transform option, including the paper's
+   `O′`, remains a future refinement).
+2. **Registry + executors** ✅ — `AuxiliaryLoss`, `register_aux_loss`, and the two
+   executors landed; `algorithm.aux_losses` is wired into each backend.
+3. **Port ECHO** ✅ — reimplemented as `EnvPredictionLoss`; `adv_estimator=echo` /
+   `env_loss_coef` kept as sugar; bespoke ECHO code removed. PR #668's numerical
+   checks are preserved as executor-math regression tests.
+4. **Add `AuxForward` + dynamic `weight`** ⏳ — the SDAR-driven extensions; land
+   gap-gated SDAR as the second client + the capability checks. (`requires`
+   currently raises `NotImplementedError`.)
+5. **Escape hatch + entropy capability** ⏳ — `type: custom` on verl; entropy
+   output plumbing or explicit rejection on managed backends.
+
+Steps 1–3 are a pure refactor (ECHO behavior preserved); 4–5 are additive.
+
+## Testing strategy
+
+- **Executor unit tests** (no GPU): given synthetic `(logprobs, mask, weight)`,
+  assert each executor reproduces `coef · Agg(weight · term)` — reuse the PR #668
+  numerical checks (verl seq-mean-token-mean; tinker additive; fireworks
+  NONE-fold).
+- **Registry/config tests**: `aux_losses` parsing, `echo` sugar expansion,
+  capability errors (entropy gating on managed backends raises).
+- **Equivalence test**: `aux_losses: [{type: env_prediction, coef: 0.05}]`
+  produces the same loss as PR #668's `adv_estimator=echo` (guards the refactor).
+- **Default-off**: empty `aux_losses` ⇒ identical to plain GRPO.
+
+## Open questions
+
+- **Cross-backend `coef` calibration.** verl normalizes via `loss_agg_mode` +
+  global-batch info; managed backends fold normalization into weights. We aim for
+  the same nominal scale, but exact parity across server kernels isn't
+  guaranteed — document that `coef` may need light per-backend retuning, and
+  surface `aux_*` loss metrics for monitoring.
+- **Multiple `AuxForward`s sharing a pass.** If two aux losses both need the same
+  teacher context, dedupe the forward. Out of scope for v1.
+- **Entropy on managed backends.** Worth a small upstream ask (expose entropy
+  from `forward`) to unlock entropy/soft-OR gating beyond verl.
+- **Per-role aux losses.** `estimator_map`/`loss_fn_map` are per-role; aux losses
+  are global in v1. Generalize later if needed.
+
+## Appendix: why these reduce to the same executor
+
+- **ECHO** — `target = next_token`, constant weight ⇒
+  `coef · Agg_O(−log p_θ(x_t))` = length-normalized env cross-entropy.
+- **SDAR** — `target = sampled_token`, detached gate weight, teacher term
+  detached ⇒ trainable gradient `−Agg_A(g_t ∇ log p_θ(y_t))` = gated
+  cross-entropy on the student's own action tokens.
+
+Both are `coef · Agg_mask(weight_t · [−log p_θ(target_t)])`. The executor
+implements that one expression; algorithms only supply `mask`, `target`,
+`weight`, and any `requires`.

--- a/docs/core-concepts/rl-algorithms.mdx
+++ b/docs/core-concepts/rl-algorithms.mdx
@@ -1,450 +1,167 @@
 ---
-title: RL Algorithms
-description: Understanding PPO, GRPO, and other RL algorithms in rLLM for language agent training
+title: RL algorithms
+description: The RL algorithms rLLM supports — advantage estimators and auxiliary losses — and how to build your own.
 ---
 
-rLLM supports multiple reinforcement learning algorithms optimized for training language agents. This guide explains the algorithms, their advantages, and how to configure them.
+<Note>
+**Modules**: `rllm.trainer.algorithms.advantage` (advantage estimators) · `rllm.trainer.algorithms.aux_loss` (auxiliary losses) · `rllm.trainer.algorithms.config` (`AlgorithmConfig`)
+</Note>
 
-## Overview
+In rLLM an RL "algorithm" is assembled from two composable, backend-agnostic pieces, both configured under `rllm.algorithm`:
 
-RL algorithms in rLLM differ primarily in how they compute **advantages** - the signals that guide policy optimization. The advantage function $A(s,a)$ estimates how much better an action $a$ is compared to the average action in state $s$.
+1. An **advantage estimator** — turns per-trajectory rewards into advantages (the GRPO family).
+2. Zero or more **auxiliary losses** — extra loss terms on tokens the policy gradient ignores (for example ECHO's loss on environment-observation tokens).
 
-### Supported Algorithms
+The backend then applies a policy **loss function** (`ppo`, `importance_sampling`, …) using those advantages. The same registries feed all three training backends (**verl**, **tinker**, **fireworks**), so flipping algorithms is a one-line config change that works everywhere.
 
-- **GRPO (Group Relative Policy Optimization)**: Efficient algorithm using group-based baselines
-- **PPO (Proximal Policy Optimization)**: Industry-standard policy gradient method
-- **ReMax**: Reward maximization with KL regularization
-- **Custom**: Define your own advantage computation
+## How advantages are computed
 
-## GRPO (Group Relative Policy Optimization)
+Advantages are computed on `TrajectoryGroup`s, partitioned by `group_role`. The estimator hook is **scalar reward per trajectory in, scalar advantage per trajectory out** — the unified trainer broadcasts each trajectory's advantage across its response tokens. This single contract is what lets the same estimator code serve every backend.
 
-GRPO is rLLM's recommended algorithm for most use cases. It's efficient, stable, and doesn't require a value network.
-
-### How GRPO Works
-
-GRPO groups multiple rollouts for the same task and computes advantages relative to the group:
-
-```python
-# For each task, generate N rollouts
-trajectories = [
-    rollout(task, policy) for _ in range(N)
-]
-
-# Compute baseline from the group
-baseline = mean([traj.reward for traj in trajectories])
-# Or: baseline = max([traj.reward for traj in trajectories])
-
-# Compute advantages
-for traj in trajectories:
-    advantage = traj.reward - baseline
-    # Apply to each step in trajectory
-```
-
-### Mathematical Formulation
-
-For a task $x$, we generate $N$ trajectories $\{y_1, \ldots, y_N\}$ and compute:
-
-$$
-A_i = R(x, y_i) - b(\{R(x, y_j)\}_{j=1}^N)
-$$
-
-Where:
-- $R(x, y_i)$ is the reward for trajectory $y_i$
-- $b(\cdot)$ is the baseline function (mean or max)
-- $A_i$ is the advantage for trajectory $y_i$
-
-### Configuration
-
-```yaml
-algorithm:
-  advantage:
-    kl_ctrl:
-      type: "grpo"              # Use GRPO
-      coeff: 0.05               # KL coefficient
-  
-  # GRPO-specific settings
-  grpo:
-    baseline: "mean"            # or "max"
-```
-
-### Advantages
-
-<Tip>
-**No Value Network**: GRPO doesn't require training a value function, reducing complexity and compute.
-</Tip>
-
-<Tip>
-**Stable**: Group-based baselines provide stable advantage estimates even with sparse rewards.
-</Tip>
-
-<Tip>
-**Efficient**: Lower memory footprint than PPO (no value network state).
-</Tip>
-
-### When to Use GRPO
-
-GRPO works well when:
-- You can generate multiple rollouts per task (typical: 4-8)
-- Rewards are sparse or noisy
-- You want simpler training (no value network)
-- You're working with limited compute resources
-
-### Example Configuration
-
-```python
-@hydra.main(config_path="pkg://rllm.trainer.config", config_name="ppo_trainer", version_base=None)
-def main(config):
-    # Override to use GRPO
-    config.algorithm.advantage.kl_ctrl.type = "grpo"
-    config.algorithm.grpo.baseline = "mean"
-    config.actor_rollout_ref.rollout.n = 8  # 8 rollouts per task
-    
-    trainer = AgentTrainer(
-        agent_class=MyAgent,
-        env_class=MyEnv,
-        config=config,
-        ...
-    )
-    trainer.train()
-```
-
-## PPO (Proximal Policy Optimization)
-
-PPO is the industry-standard policy gradient algorithm. It uses a learned value function to estimate advantages.
-
-### How PPO Works
-
-PPO trains two networks:
-1. **Policy network** $\pi_\theta(a|s)$: The agent's policy
-2. **Value network** $V_\phi(s)$: Estimates expected return from state $s$
-
-Advantages are computed using Generalized Advantage Estimation (GAE):
-
-$$
-A_t = \sum_{l=0}^{\infty} (\gamma \lambda)^l \delta_{t+l}
-$$
-
-Where $\delta_t = r_t + \gamma V(s_{t+1}) - V(s_t)$ is the TD error.
-
-### Mathematical Formulation
-
-The PPO objective is:
-
-$$
-L^{\text{CLIP}}(\theta) = \mathbb{E}_t \left[ \min(r_t(\theta) A_t, \text{clip}(r_t(\theta), 1-\epsilon, 1+\epsilon) A_t) \right]
-$$
-
-Where:
-- $r_t(\theta) = \frac{\pi_\theta(a_t|s_t)}{\pi_{\theta_{\text{old}}}(a_t|s_t)}$ is the probability ratio
-- $\epsilon$ is the clip ratio (typically 0.2)
-- $A_t$ is the advantage estimate
-
-### Configuration
-
-```yaml
-algorithm:
-  advantage:
-    kl_ctrl:
-      type: "ppo"               # Use PPO
-      coeff: 0.05               # KL coefficient
-  
-  # PPO-specific settings
-  clip_ratio: 0.2               # Clip parameter ε
-  ppo_epochs: 4                 # Number of PPO epochs per update
-  ppo_mini_batch_size: 256      # Mini-batch size
-  gamma: 0.99                   # Discount factor
-  gae_lambda: 0.95              # GAE lambda parameter
-  value_loss_coeff: 0.5         # Value loss coefficient
-  entropy_coeff: 0.01           # Entropy bonus coefficient
-```
-
-### Advantages
-
-<Tip>
-**Sample Efficient**: Value network provides better advantage estimates, improving sample efficiency.
-</Tip>
-
-<Tip>
-**Dense Feedback**: Works well with dense, intermediate rewards.
-</Tip>
-
-<Tip>
-**Stable**: Clipping prevents large policy updates.
-</Tip>
-
-### When to Use PPO
-
-PPO works well when:
-- You have dense, intermediate rewards
-- You can't generate many rollouts per task
-- Sample efficiency is critical
-- You have compute for training a value network
-
-### Example Configuration
-
-```python
-@hydra.main(config_path="pkg://rllm.trainer.config", config_name="ppo_trainer", version_base=None)
-def main(config):
-    # PPO is the default in ppo_trainer.yaml
-    config.algorithm.advantage.kl_ctrl.type = "ppo"
-    config.algorithm.clip_ratio = 0.2
-    config.algorithm.ppo_epochs = 4
-    config.algorithm.gamma = 0.99
-    config.algorithm.gae_lambda = 0.95
-    
-    trainer = AgentTrainer(
-        agent_class=MyAgent,
-        env_class=MyEnv,
-        config=config,
-        ...
-    )
-    trainer.train()
-```
-
-## ReMax (Reward Maximization)
-
-ReMax is a simpler algorithm that directly maximizes rewards with KL regularization.
-
-### How ReMax Works
-
-ReMax uses the trajectory reward directly as the advantage:
-
-$$
-A_i = R(\tau_i)
-$$
-
-With KL regularization to prevent the policy from diverging too far from the reference policy:
-
-$$
-L(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ R(\tau) - \beta \cdot D_{\text{KL}}(\pi_\theta || \pi_{\text{ref}}) \right]
-$$
-
-### Configuration
-
-```yaml
-algorithm:
-  advantage:
-    kl_ctrl:
-      type: "remax"             # Use ReMax
-      coeff: 0.1                # KL coefficient β
-```
-
-### When to Use ReMax
-
-ReMax works well when:
-- You have very sparse rewards (only final outcome matters)
-- Task is simple (limited need for step-level credit assignment)
-- You want the simplest possible algorithm
-
-## Stepwise vs. Trajectory-Level Advantages
-
-rLLM supports two modes for applying advantages:
-
-### Trajectory-Level (Default)
+Select the estimator with `adv_estimator`:
 
 ```yaml
 rllm:
-  stepwise_advantage:
-    enable: false               # Trajectory-level
+  algorithm:
+    adv_estimator: grpo
+    norm_adv_by_std_in_grpo: true   # GRPO only; false = center by mean only
 ```
 
-Advantages are computed at the trajectory level and applied uniformly:
+See [Advantage estimator](/training/advantage-estimator) for the full data contract, per-role estimator maps, and what the scalar hook intentionally cannot express (GAE and other per-token / critic-based estimators — for those, see [Pre-computing advantage](/training/precompute-advantage)).
 
-```python
-# Compute advantage for entire trajectory
-advantage = trajectory.reward - baseline
+## Built-in advantage estimators
 
-# Apply to all tokens in the trajectory
-for token in trajectory.response_tokens:
-    token.advantage = advantage
+| Estimator | `adv_estimator` | What it computes |
+|---|---|---|
+| **GRPO** *(default)* | `grpo` | Center rewards within each group by the group mean; optionally divide by the group std (`norm_adv_by_std_in_grpo`, default `true`). No value network. |
+| **REINFORCE** | `reinforce` | No baseline — the reward *is* the advantage. |
+| **REINFORCE++ baseline** | `reinforce_plus_plus_baseline` | Per-group mean baseline, then whiten by the role-batch std. |
+| **PRPO** | `prpo` | Center and normalize across the **whole batch** (flatten all groups), not per-group. |
+| **RLOO** | `rloo` | Leave-one-out baseline per group: each trajectory is scored against the mean of the *others*. |
+| **ECHO** | `echo` | GRPO's advantage **unchanged**, plus an environment-observation auxiliary loss (see below). |
+
+All six live in one registry and run on every backend. (The verl backend can also be pointed at its native estimators, but the rLLM-native set above is the portable path.)
+
+## ECHO and auxiliary losses
+
+[ECHO](https://arxiv.org/abs/2605.24517) keeps GRPO's advantage exactly and **adds a cross-entropy auxiliary loss on the environment-observation tokens** (tool / terminal output) that the policy conditions on but the policy gradient never trains. For tool-use and terminal agents — where rollouts are dominated by observation tokens and many rollouts fail — this turns *every* rollout, including the failures, into dense supervision at no extra rollout cost.
+
+`adv_estimator=echo` defaults the env-loss weight λ to the paper's `0.05`. Tune it explicitly (productive range `0.01–0.05`; `0.0` reproduces plain GRPO):
+
+```bash
+# any backend — verl / tinker / fireworks
+... rllm.algorithm.adv_estimator=echo
+... rllm.algorithm.adv_estimator=echo rllm.algorithm.env_loss_coef=0.03
 ```
 
-**Use when**: Final outcome is what matters (e.g., math problem solved correctly)
+### The auxiliary-loss framework
 
-### Step-Level
+`env_loss_coef` is shorthand for the general `aux_losses` mechanism. An auxiliary loss is a **named** loss applied to a **token subset (a "mask")**. These two configs are equivalent:
 
 ```yaml
 rllm:
-  stepwise_advantage:
-    enable: true                # Step-level
+  algorithm:
+    env_loss_coef: 0.05                       # shorthand
+    # — or, the general form —
+    aux_losses:
+      - { type: env_prediction, coef: 0.05 }  # ECHO's loss, by name
 ```
 
-Advantages are computed separately for each step:
+`env_prediction` is the one built-in client (length-normalized cross-entropy on observation tokens). You can list several aux losses; each is added to the policy loss with its own `coef`.
+
+The **same config runs on every backend**, with different mechanics and cost:
+
+| Backend | How the aux term is applied | Metric to watch |
+|---|---|---|
+| **verl** | Folded into GRPO's single forward/backward pass — free and exact. | `actor/aux_env_prediction_loss` |
+| **tinker / fireworks** | A second, gradient-accumulated `cross_entropy` pass over the *same* rollouts — no extra rollouts, one extra backward. | `train/aux_*` |
+
+<Tip>
+Because loss normalization differs across managed services, λ (the `coef`) may need per-backend retuning. Watch the metric above to confirm the auxiliary loss is actually falling.
+</Tip>
+
+## Building custom RL algorithms
+
+Both extension points are registries — register a function or a class and reference it by name from config. **No backend code to touch.**
+
+### A custom advantage estimator
+
+Decorate a function with `@register_rllm_adv_estimator("name")`. It is scalar-per-trajectory in, scalar-per-trajectory out; `**kwargs` carries `traj_groups` when you need per-trajectory metadata.
 
 ```python
-# Compute advantage for each step
-for step in trajectory.steps:
-    step.advantage = step.reward - baseline
+import numpy as np
+from rllm.trainer.algorithms.advantage import register_rllm_adv_estimator
+
+@register_rllm_adv_estimator("batch_mean_baseline")
+def batch_mean_baseline(rewards, algorithm_config, **kwargs):
+    # rewards: list of 1-D arrays (one per TrajectoryGroup)
+    batch_mean = np.mean(np.concatenate(rewards)) if rewards else 0.0
+    adv = [group - batch_mean for group in rewards]
+    return adv, adv          # (advantages_by_group, returns_by_group)
 ```
-
-**Use when**: Intermediate rewards are meaningful (e.g., progressive task completion)
-
-<Warning>
-Step-level advantages require that `max_prompt_length` and `max_response_length` are enforced per-step, not per-trajectory. Set `enforce_max_prompt_length: true` in the execution engine.
-</Warning>
-
-## Compact Filtering
-
-rLLM can filter out invalid trajectories based on termination reason:
 
 ```yaml
 rllm:
-  compact_filtering:
-    enable: true
-    mask_max_prompt_length_exceeded: true
-    mask_max_response_length_exceeded: true
-    mask_env_done: false
-    mask_max_turns_exceeded: true
-    mask_timeout: true
-    mask_error: true
-    mask_unknown: true
+  algorithm:
+    adv_estimator: batch_mean_baseline
 ```
 
-Filtered trajectories have their `response_mask` set to 0, excluding them from training.
+The full contract, role-level estimator maps, and a complete worked example (porting OPO from verl) are in [Advantage estimator](/training/advantage-estimator).
 
-<Info>
-Compact filtering is useful for removing low-quality trajectories that hit limits or errors, improving training efficiency.
-</Info>
+### A custom auxiliary loss
 
-## Algorithm Comparison
-
-| Feature | GRPO | PPO | ReMax |
-|---------|------|-----|-------|
-| **Value Network** | No | Yes | No |
-| **Sample Efficiency** | Medium | High | Low |
-| **Compute Cost** | Low | High | Low |
-| **Stability** | High | Medium | Medium |
-| **Best For** | Sparse rewards, multi-rollout | Dense rewards, sample efficiency | Very sparse rewards, simplicity |
-| **Rollouts per Task** | 4-8 | 1-2 | 1-4 |
-| **Hyperparameter Sensitivity** | Low | Medium | Low |
-
-## Advanced: Custom Advantage Computation
-
-You can implement custom advantage computation:
+Subclass `AuxiliaryLoss`, choose a token mask, and register it. The default weighting is uniform (every masked token gets `coef`); override `weight(ctx)` to return a per-token tensor instead.
 
 ```python
-from rllm.trainer.verl.agent_ppo_trainer import AgentPPOTrainer
+from rllm.trainer.algorithms import register_aux_loss, AuxiliaryLoss, MASK_ACTION
 
-class CustomAdvantageTrainer(AgentPPOTrainer):
-    def compute_advantages(self, rollout_data):
-        """Custom advantage computation."""
-        
-        # Group trajectories by task
-        task_groups = defaultdict(list)
-        for traj in rollout_data:
-            task_id = traj.task_id
-            task_groups[task_id].append(traj)
-        
-        # Compute custom advantages
-        for task_id, trajectories in task_groups.items():
-            # Your custom logic here
-            rewards = [traj.reward for traj in trajectories]
-            
-            # Example: Use median as baseline
-            baseline = np.median(rewards)
-            
-            for traj in trajectories:
-                advantage = traj.reward - baseline
-                
-                # Apply advantage to all steps
-                for step in traj.steps:
-                    step.advantage = advantage
-        
-        return rollout_data
+@register_aux_loss("entropy_bonus")
+class EntropyBonus(AuxiliaryLoss):
+    mask = MASK_ACTION          # or MASK_OBSERVATION
+    # def weight(self, ctx):    # optional — return a per-token tensor; None = uniform `coef`
+    #     ...
 ```
 
-## Hyperparameter Tuning Guide
+```yaml
+rllm:
+  algorithm:
+    aux_losses:
+      - { type: entropy_bonus, coef: 0.01 }
+```
 
-### GRPO Tuning
+The same class runs on all three backends (verl folds it into the policy pass; tinker/fireworks add the extra cross-entropy pass). Dynamic per-token weights and auxiliary losses that need a *separate* model call (e.g. a teacher branch) are an in-progress extension — see the design note `design/auxiliary-losses.md`.
 
-<Steps>
-  <Step title="Rollouts per task">
-    Start with 4-8 rollouts. More rollouts = better baseline estimates but higher compute cost.
-  </Step>
-  
-  <Step title="Baseline function">
-    Try both `mean` and `max`. Mean is more stable, max can help with very sparse rewards.
-  </Step>
-  
-  <Step title="KL coefficient">
-    Start with 0.05. Increase if policy changes too fast, decrease if learning is too slow.
-  </Step>
-</Steps>
+<Note>
+Need a **per-token** advantage signal (GAE, reward-to-go, a custom detector) that the scalar estimator hook can't express? Compute it in your workflow and feed it through [`use_precomputed_advantage`](/training/precompute-advantage) to bypass the estimator entirely.
+</Note>
 
-### PPO Tuning
+## Configuration quick reference
 
-<Steps>
-  <Step title="Clip ratio">
-    Default 0.2 works well. Increase for more aggressive updates, decrease for more conservative.
-  </Step>
-  
-  <Step title="GAE lambda">
-    Start with 0.95. Closer to 1.0 = lower bias but higher variance.
-  </Step>
-  
-  <Step title="PPO epochs">
-    Start with 4. Too many epochs can lead to overfitting, too few can underfit.
-  </Step>
-  
-  <Step title="Mini-batch size">
-    Balance between compute efficiency and gradient variance. Typical: 64-256.
-  </Step>
-</Steps>
+All under `rllm.algorithm` ([full reference](/training/configuration)):
 
-### General Tips
+| Field | Default | Purpose |
+|---|---|---|
+| `adv_estimator` | `grpo` | Global advantage estimator (registry name). |
+| `norm_adv_by_std_in_grpo` | `true` | GRPO: divide centered rewards by group std (`false` = center only). |
+| `env_loss_coef` | `0.05` if `adv_estimator=echo`, else `0.0` | Shorthand for `aux_losses: [{type: env_prediction, coef: …}]`. |
+| `aux_losses` | `[]` | List of `{type, coef}` auxiliary-loss specs. |
+| `loss_fn` | backend default | Policy loss function (`ppo`, `importance_sampling`, …). |
 
-<Tip>
-**Learning Rate**: Start with 1e-6 for language models. rLLM uses small LRs to avoid catastrophic forgetting.
-</Tip>
+Per-role estimator overrides are set via `traj_group_adv_estimator_map` on the `AgentTrainer` constructor — see [Advantage estimator](/training/advantage-estimator).
 
-<Tip>
-**Batch Size**: Larger batches = more stable gradients but slower iteration. Typical: 128-512.
-</Tip>
-
-<Tip>
-**KL Coefficient**: Controls how much the policy can deviate from reference. Typical: 0.01-0.1.
-</Tip>
-
-<Warning>
-RL is sensitive to hyperparameters. Always start with defaults and change one thing at a time.
-</Warning>
-
-## Monitoring Algorithm Performance
-
-Key metrics to watch during training:
-
-### Reward Metrics
-- **mean_reward**: Average trajectory reward (should increase)
-- **max_reward**: Best trajectory reward (indicates ceiling)
-- **reward_std**: Reward variance (high variance = unstable)
-
-### Policy Metrics
-- **kl_divergence**: KL from reference policy (should stay small)
-- **policy_loss**: Policy gradient loss (should decrease)
-- **entropy**: Policy entropy (too low = policy collapse)
-
-### Training Metrics
-- **explained_variance** (PPO only): How well value network predicts returns (should be >0.5)
-- **value_loss** (PPO only): Value network loss (should decrease)
-- **gradient_norm**: Gradient magnitude (too high = unstable)
-
-<Info>
-If `kl_divergence` grows too large, increase `kl_ctrl.coeff`. If `entropy` drops to near 0, add `entropy_coeff` or reduce temperature.
-</Info>
-
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Training" icon="brain" href="/core-concepts/training">
-    Learn how to use these algorithms in training
+  <Card title="Advantage estimator" icon="function" href="/training/advantage-estimator">
+    The estimator hook contract, role-level maps, and the OPO worked example
   </Card>
-  <Card title="Cookbooks" icon="book" href="/cookbooks/overview">
-    See algorithms in action across the cookbook examples
+  <Card title="Configuration" icon="gear" href="/training/configuration">
+    Every `AlgorithmConfig` field
   </Card>
-  <Card title="Configuration" icon="gear" href="/core-concepts/rl-algorithms">
-    Detailed algorithm config reference
+  <Card title="Capability matrix" icon="table-cells" href="/training/capability-matrix">
+    Which algorithms and losses each backend supports
   </Card>
-  <Card title="Debugging" icon="bug" href="/guides/distributed-training">
-    Troubleshoot RL training issues
+  <Card title="Backends" icon="server" href="/backends/comparison">
+    verl vs tinker vs fireworks
   </Card>
 </CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,6 +114,7 @@
           {
             "group": "Advanced algorithms",
             "pages": [
+              "core-concepts/rl-algorithms",
               "training/capability-matrix",
               "training/advantage-estimator",
               "training/precompute-advantage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ tinker = [
 ]
 
 fireworks = [
-    "fireworks-ai[training]==1.2.0a79 ; python_version >= '3.11'",
+    "fireworks-ai[training]==1.2.0a83 ; python_version >= '3.11'",
     "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
 ]
 

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -198,7 +198,11 @@ class ReverseProxy:
         t0 = time.perf_counter()
 
         if self.local_handler is not None:
-            # In-process path: call handler directly, no HTTP
+            # In-process path: call handler directly, no HTTP.
+            # Forward the rollout session id so affinity-aware engines (Fireworks)
+            # can pin a trajectory's turns to one replica for prefix-cache reuse.
+            if session_id:
+                request_body["rllm_session_id"] = session_id
             response_body = await self.local_handler(request_body)
             status_code = 200
         else:
@@ -320,6 +324,8 @@ class ReverseProxy:
         if self.local_handler is not None:
             # In-process path (Tinker): sample directly from the pre-tokenized
             # prompt; no HTTP worker, no re-tokenization.
+            if session_id:
+                completions_body["rllm_session_id"] = session_id
             response_body = await self.local_handler(completions_body)
             status_code = 200
         else:
@@ -535,6 +541,8 @@ class ReverseProxy:
         """
         assert self.local_handler is not None
         t0 = time.perf_counter()
+        if session_id:
+            completions_body["rllm_session_id"] = session_id
         response_body = await self.local_handler(completions_body)
         latency_ms = (time.perf_counter() - t0) * 1000
 

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -309,29 +309,40 @@ class ReverseProxy:
         token_ids: list[int],
         originally_requested_logprobs: bool = False,
     ) -> Response:
-        """Non-streaming cumulative turn: send non-streaming to vLLM, return JSON."""
+        """Non-streaming cumulative turn: send pre-tokenized prompt, return JSON.
+
+        Routes to the in-process ``local_handler`` (e.g. Tinker) when present,
+        otherwise POSTs ``/v1/completions`` to a vLLM worker. Both return a
+        completions-style body carrying ``prompt_token_ids`` + ``token_ids``.
+        """
         t0 = time.perf_counter()
 
-        worker = self.router.route(session_id)
-        url = self._build_url(worker.api_url, "/v1/completions", "")
-        headers = self._forward_headers(request)
-        raw_body = json.dumps(completions_body).encode()
-        try:
-            resp = await self._send_with_retry(
-                method="POST",
-                url=url,
-                content=raw_body,
-                headers=headers,
-            )
-            content = resp.content
-            status_code = resp.status_code
-        finally:
-            self.router.release(worker.url)
+        if self.local_handler is not None:
+            # In-process path (Tinker): sample directly from the pre-tokenized
+            # prompt; no HTTP worker, no re-tokenization.
+            response_body = await self.local_handler(completions_body)
+            status_code = 200
+        else:
+            worker = self.router.route(session_id)
+            url = self._build_url(worker.api_url, "/v1/completions", "")
+            headers = self._forward_headers(request)
+            raw_body = json.dumps(completions_body).encode()
+            try:
+                resp = await self._send_with_retry(
+                    method="POST",
+                    url=url,
+                    content=raw_body,
+                    headers=headers,
+                )
+                content = resp.content
+                status_code = resp.status_code
+            finally:
+                self.router.release(worker.url)
 
-        try:
-            response_body = json.loads(content)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            response_body = {}
+            try:
+                response_body = json.loads(content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                response_body = {}
 
         latency_ms = (time.perf_counter() - t0) * 1000
 
@@ -375,6 +386,11 @@ class ReverseProxy:
         token_ids: list[int],
     ) -> StreamingResponse:
         """Streaming cumulative turn: stream from vLLM, translate chunks to chat format."""
+        if self.local_handler is not None:
+            # In-process backends (Tinker) don't stream; synthesize an SSE
+            # stream from a single pre-tokenized completion call.
+            return await self._handle_cumulative_streaming_local(request, request_body, completions_body, session_id, acc, token_ids)
+
         completions_body["stream"] = True
 
         worker = self.router.route(session_id)
@@ -501,6 +517,97 @@ class ReverseProxy:
             media_type="text/event-stream",
             status_code=resp.status_code,
         )
+
+    async def _handle_cumulative_streaming_local(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        completions_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        token_ids: list[int],
+    ) -> StreamingResponse:
+        """Cumulative streaming via the in-process handler (fake-streaming).
+
+        The local handler returns a full completion in one shot; we ingest its
+        token IDs into the accumulator, translate to chat format, and emit it as
+        a synthesized SSE stream (role → content+tokens → finish → [DONE]).
+        """
+        assert self.local_handler is not None
+        t0 = time.perf_counter()
+        response_body = await self.local_handler(completions_body)
+        latency_ms = (time.perf_counter() - t0) * 1000
+
+        prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
+        completion_token_ids = extract_completion_token_ids(response_body)
+        acc.ingest_turn(prompt_token_ids, completion_token_ids)
+        acc.update_prefix(request_body.get("messages", []))
+
+        choices = response_body.get("choices") or []
+        content = choices[0].pop("text", "") if choices else ""
+        finish_reason = (choices[0].get("finish_reason") if choices else None) or "stop"
+        completion_logprobs = choices[0].get("logprobs") if choices else None
+
+        if session_id and response_body:
+            chat_body = dict(response_body)
+            chat_body["object"] = "chat.completion"
+            if chat_body.get("choices"):
+                chat_body["choices"][0]["message"] = {"role": "assistant", "content": content}
+            trace = build_trace_record(session_id, request_body, chat_body, latency_ms, weight_version=request.state.weight_version)
+            await self._persist(trace)
+
+        chat_id = response_body.get("id", "chatcmpl-local")
+        created = response_body.get("created", int(time.time()))
+        model = response_body.get("model", "")
+        usage = response_body.get("usage", {})
+
+        def _sanitize_chunk(chunk: dict[str, Any]) -> dict[str, Any]:
+            return strip_vllm_fields(chunk) if self.strip_vllm else chunk
+
+        async def event_generator():
+            def _sse(data: str) -> str:
+                return f"data: {data}\n\n"
+
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+                    }
+                )
+            )
+            yield _sse(
+                json.dumps(
+                    _sanitize_chunk(
+                        {
+                            "id": chat_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None, "token_ids": completion_token_ids, "logprobs": completion_logprobs}],
+                            "prompt_token_ids": prompt_token_ids,
+                        }
+                    )
+                )
+            )
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+                        "usage": usage,
+                    }
+                )
+            )
+            yield _sse("[DONE]")
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream", status_code=200)
 
     # ------------------------------------------------------------------
     # Streaming (SSE)

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -209,7 +209,7 @@ class ReverseProxy:
             # HTTP proxy path
             worker = self.router.route(session_id)
             url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
-            headers = self._forward_headers(request)
+            headers = self._forward_headers(request, session_id)
             try:
                 resp = await self._send_with_retry(
                     method=request.method,
@@ -331,7 +331,7 @@ class ReverseProxy:
         else:
             worker = self.router.route(session_id)
             url = self._build_url(worker.api_url, "/v1/completions", "")
-            headers = self._forward_headers(request)
+            headers = self._forward_headers(request, session_id)
             raw_body = json.dumps(completions_body).encode()
             try:
                 resp = await self._send_with_retry(
@@ -401,7 +401,7 @@ class ReverseProxy:
 
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, "/v1/completions", "")
-        headers = self._forward_headers(request)
+        headers = self._forward_headers(request, session_id)
         raw_body = json.dumps(completions_body).encode()
 
         assert self._http is not None
@@ -634,7 +634,7 @@ class ReverseProxy:
 
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
-        headers = self._forward_headers(request)
+        headers = self._forward_headers(request, session_id)
 
         assert self._http is not None
         upstream = self._http.stream(
@@ -915,5 +915,13 @@ class ReverseProxy:
         return url
 
     @staticmethod
-    def _forward_headers(request: Request) -> dict[str, str]:
-        return {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+    def _forward_headers(request: Request, session_id: str | None = None) -> dict[str, str]:
+        headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+        # Pin a trajectory's turns to one replica so Fireworks reuses its
+        # prompt-prefix KV (caching is per-replica). The training path sets these
+        # via the rollout engine; the HTTP path (eval) does it here. No-op for
+        # non-Fireworks upstreams; setdefault lets a client pin its own value.
+        if session_id:
+            headers.setdefault("x-session-affinity", str(session_id))
+            headers.setdefault("x-multi-turn-session-id", str(session_id))
+        return headers

--- a/rllm-model-gateway/src/rllm_model_gateway/session_router.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/session_router.py
@@ -181,7 +181,10 @@ class SessionRouter:
     async def start_health_checks(self) -> None:
         if self._health_task is not None:
             return
-        self._http = httpx.AsyncClient(timeout=httpx.Timeout(5.0))
+        # 20s (not 5s): under a concurrency spike the single proxy worker can be
+        # slow to answer /health while busy forwarding requests; a 5s timeout
+        # marked it dead → "No healthy workers available" → failed turns.
+        self._http = httpx.AsyncClient(timeout=httpx.Timeout(20.0))
         self._health_task = asyncio.create_task(self._health_loop())
 
     async def stop_health_checks(self) -> None:

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
@@ -1,0 +1,136 @@
+"""Cumulative token mode over the in-process ``local_handler`` (e.g. Tinker).
+
+The HTTP-worker path is covered by ``test_cumulative_token_mode.py``. These
+tests cover the local-handler branch added so backends without a vLLM
+``/v1/completions`` worker (Tinker runs in-process) get the same drift-free
+prefix-extension: turn 2+ samples directly from pre-tokenized prompt IDs built
+by the renderer, and the accumulator ingests the result.
+
+Tests drive the proxy methods directly (no HTTP server) via ``asyncio.run`` to
+avoid a pytest-asyncio dependency.
+"""
+
+import asyncio
+import json
+
+from rllm_model_gateway.proxy import ReverseProxy
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+
+class _State:
+    weight_version = 0
+
+
+class _Request:
+    """Minimal stand-in: the cumulative-local paths only read request.state."""
+
+    state = _State()
+
+
+def _make_proxy(local_handler):
+    """ReverseProxy wired for the local cumulative path (no router/worker)."""
+    return ReverseProxy(
+        router=None,
+        store=MemoryTraceStore(),
+        sync_traces=True,
+        local_handler=local_handler,
+        cumulative_token_mode=True,
+        renderer=None,  # accumulator state is set directly in these tests
+    )
+
+
+def _completion_handler(record):
+    """Fake Tinker token-path handler: echoes ``prompt`` as prompt_token_ids,
+    returns a fixed 2-token completion. Records the body it was called with."""
+
+    async def handler(body):
+        record.append(body)
+        return {
+            "id": "cmpl-x",
+            "object": "text_completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "next action",
+                    "token_ids": [91, 92],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2]},
+                }
+            ],
+            "prompt_token_ids": body["prompt"],
+            "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
+        }
+
+    return handler
+
+
+def test_cumulative_local_non_streaming_ingests_and_translates():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])  # turn 1: prompt + completion already captured
+    bridged = [1, 2, 3, 4, 5, 6, 7]  # what the renderer would produce for turn 2
+
+    completions_body = {"prompt": bridged, "add_special_tokens": False, "model": "q"}
+    resp = asyncio.run(
+        proxy._handle_cumulative_non_streaming(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            completions_body,
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    # The local handler was called with the pre-tokenized prompt, not messages.
+    assert record and record[0]["prompt"] == bridged
+    assert "messages" not in record[0]
+
+    # Response is translated back to chat format for the agent.
+    body = json.loads(resp.body)
+    assert resp.status_code == 200
+    assert body["object"] == "chat.completion"
+    assert body["choices"][0]["message"] == {"role": "assistant", "content": "next action"}
+
+    # Accumulator advanced: prefix-extension holds (bridged starts with prev prompt+completion).
+    assert acc.turn_count == 2
+    assert acc.prev_prompt_ids == bridged
+    assert acc.prev_completion_ids == [91, 92]
+    assert acc.cumulative_ids[: len([1, 2, 3, 4, 5])] == [1, 2, 3, 4, 5]
+
+
+def test_cumulative_local_streaming_emits_sse_and_ingests():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    bridged = [1, 2, 3, 4, 5, 6, 7]
+
+    resp = asyncio.run(
+        proxy._handle_cumulative_streaming_local(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            {"prompt": bridged},
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    chunks = []
+
+    async def drain():
+        async for c in resp.body_iterator:
+            chunks.append(c if isinstance(c, str) else c.decode())
+
+    asyncio.run(drain())
+
+    assert any('"role": "assistant"' in c for c in chunks)
+    assert any('"next action"' in c for c in chunks)
+    assert chunks[-1].strip().endswith("[DONE]")
+    # Same ingest as non-streaming.
+    assert acc.turn_count == 2 and acc.prev_completion_ids == [91, 92]

--- a/rllm/cli/_sampling.py
+++ b/rllm/cli/_sampling.py
@@ -147,14 +147,21 @@ def _flags(temperature: float | None, top_p: float | None, max_tokens: int | Non
     return SamplingConfig.from_obj(d)
 
 
+# Default sampling params applied to every ``rllm eval`` run unless the user
+# overrides them — surfaced in the eval header's Sampling row and
+# gateway-enforced. Mirrors the cookbook training rollout so eval samples the
+# model the same way it was trained.
+_EVAL_DEFAULT_SAMPLING = SamplingConfig(temperature=1.0, top_p=1.0)
+
+
 def resolve_eval_sampling(
     sampling_params: str | None,
     temperature: float | None = None,
     top_p: float | None = None,
     max_tokens: int | None = None,
 ) -> SamplingConfig:
-    """Resolve the SamplingConfig for ``rllm eval`` (string/@file, overridden by flags)."""
-    return _parse(sampling_params).merged(_flags(temperature, top_p, max_tokens))
+    """Resolve the SamplingConfig for ``rllm eval``: defaults < string/@file < flags."""
+    return _EVAL_DEFAULT_SAMPLING.merged(_parse(sampling_params)).merged(_flags(temperature, top_p, max_tokens))
 
 
 def resolve_train_sampling(

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -575,6 +575,17 @@ def _run_eval(
 @click.option("--temperature", default=None, type=float, help="Sampling temperature (shortcut for --sampling-params temperature=...).")
 @click.option("--top-p", "top_p", default=None, type=float, help="Nucleus sampling top_p (shortcut for --sampling-params top_p=...).")
 @click.option("--max-tokens", "max_tokens", default=None, type=int, help="Max generated tokens per call (shortcut for --sampling-params max_tokens=...).")
+@click.option(
+    "--agent-timeout",
+    "agent_timeout",
+    default=None,
+    type=int,
+    metavar="SECONDS",
+    help=(
+        "Per-rollout agent wall-clock timeout in seconds for sandboxed CLI harnesses (e.g. terminus2). "
+        "Default 3600. Sandbox lifetimes are sized to outlast this, so the environment isn't torn down mid-rollout."
+    ),
+)
 def eval_cmd(
     benchmark: str,
     agent_name: str | None,
@@ -598,6 +609,7 @@ def eval_cmd(
     temperature: float | None,
     top_p: float | None,
     max_tokens: int | None,
+    agent_timeout: int | None,
 ):
     """Evaluate a model on a benchmark dataset."""
     from rllm.cli._sampling import resolve_eval_sampling
@@ -671,6 +683,17 @@ def eval_cmd(
         agent_metadata["sandbox_backend"] = sandbox_backend
     if sandbox_concurrency is not None:
         agent_metadata["sandbox_concurrency"] = sandbox_concurrency
+    if agent_timeout is not None:
+        if agent_timeout < 1:
+            fail("--agent-timeout must be >= 1 second.")
+        # Consumed by BaseCliHarness.configure() → sets the harness run_timeout.
+        agent_metadata["agent_timeout"] = agent_timeout
+        # Also publish it as the canonical env knob so the Modal backend derives
+        # a sandbox lifetime with headroom over it (else a raised timeout would
+        # still be reaped at the default lifetime).
+        import os
+
+        os.environ["RLLM_HARNESS_RUN_TIMEOUT_S"] = str(agent_timeout)
 
     parsed_indices = parse_index_spec(task_indices) if task_indices is not None else None
 

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -46,11 +46,14 @@ def _apply_sandbox_overrides(agent, agent_metadata: dict | None) -> None:
 # Agent knobs surfaced in the eval header, in display order. Each entry is
 # (attribute, label, formatter); a flow that doesn't expose an attribute (or
 # leaves it ``None``) simply omits that pair, so this works across harnesses.
+# NB: temperature is intentionally omitted — sampling params (temperature,
+# top_p, …) are shown in the gateway-enforced "Sampling" row, which is
+# authoritative; listing the harness's requested temperature here too just
+# duplicated it with a (usually different, since the gateway wins) value.
 _AGENT_CONFIG_SPECS = (
     ("max_turns", "max turns", str),
     ("max_steps", "max steps", str),
     ("max_concurrent", "max concurrent", str),
-    ("temperature", "temperature", lambda v: f"{v:g}"),
     ("run_timeout", "run timeout", lambda v: f"{v}s"),
     ("install_timeout", "install timeout", lambda v: f"{v}s"),
 )

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -43,6 +43,40 @@ def _apply_sandbox_overrides(agent, agent_metadata: dict | None) -> None:
         logger.warning("--%s has no effect for agent %s", flag.replace("_", "-"), type(agent).__name__)
 
 
+# Agent knobs surfaced in the eval header, in display order. Each entry is
+# (attribute, label, formatter); a flow that doesn't expose an attribute (or
+# leaves it ``None``) simply omits that pair, so this works across harnesses.
+_AGENT_CONFIG_SPECS = (
+    ("max_turns", "max turns", str),
+    ("max_steps", "max steps", str),
+    ("max_concurrent", "max concurrent", str),
+    ("temperature", "temperature", lambda v: f"{v:g}"),
+    ("run_timeout", "run timeout", lambda v: f"{v}s"),
+    ("install_timeout", "install timeout", lambda v: f"{v}s"),
+)
+
+
+def _agent_config_rows(agent) -> list[tuple[str, str]]:
+    """Build the ``Config`` panel row from the loaded flow's effective knobs.
+
+    Reads the curated attributes off the agent instance (max turns, temperature,
+    timeouts, …) and renders each present one as a ``key value`` chip — dim key,
+    bold value — with chips separated by a dim ``·``. Spaces *within* a chip are
+    non-breaking (`` ``) so a pair never splits across a line wrap; wraps
+    fall on the separators instead. Returns an empty list when the flow exposes
+    none of the knobs.
+    """
+    chips = []
+    for attr, label, fmt in _AGENT_CONFIG_SPECS:
+        value = getattr(agent, attr, None)
+        if value is not None:
+            key = label.replace(" ", " ")
+            chips.append(f"[dim]{key}[/] [val]{fmt(value)}[/]")
+    if not chips:
+        return []
+    return [("Config", "  [dim]·[/]  ".join(chips))]
+
+
 def _dict_rows_to_tasks(rows: list[dict]) -> list[Task]:
     """Wrap dict-rows from a catalog dataset as Task objects.
 
@@ -363,6 +397,7 @@ def _run_eval(
         ("Benchmark", f"[val]{benchmark}[/]  [dim]({split}, {len(dataset)} examples)[/]"),
         ("Model", f"[val]{model}[/]"),
         ("Agent", agent_text),
+        *_agent_config_rows(agent),
         ("Evaluator", f"[dim]{evaluator_display}[/]"),
     ]
     if not use_snapshot:

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -578,6 +578,9 @@ def _run_eval(
 @click.option("--agent", "agent_name", default=None, help="Agent scaffold: registry name or module:object path.")
 @click.option("--evaluator", "evaluator_name", default=None, help="Evaluator: registry name or module:class path.")
 @click.option("--base-url", default=None, help="OpenAI-compatible API endpoint URL. If omitted, a proxy is auto-started using 'rllm setup' config.")
+@click.option(
+    "--proxy-port", "proxy_port", default=None, type=int, help="Pin the auto-started LiteLLM proxy to this port. Default: a free port is picked automatically (so concurrent eval jobs don't collide)."
+)
 @click.option("--model", default=None, help="Model name to evaluate. Defaults to configured model from 'rllm setup'.")
 @click.option("--split", default=None, help="Dataset split (default: from catalog eval_split).")
 @click.option("--concurrency", default=64, type=int, help="Number of parallel requests.")
@@ -629,6 +632,7 @@ def eval_cmd(
     agent_name: str | None,
     evaluator_name: str | None,
     base_url: str | None,
+    proxy_port: int | None,
     model: str | None,
     split: str | None,
     concurrency: int,
@@ -704,6 +708,7 @@ def eval_cmd(
                 provider=config.provider,
                 model_name=model,
                 api_key=config.api_key,
+                proxy_port=proxy_port,
             )
             with Status(f"[dim]Starting LiteLLM proxy for [bold]{config.provider}/{model}[/bold]...[/]", console=console):
                 try:

--- a/rllm/data/utils.py
+++ b/rllm/data/utils.py
@@ -16,12 +16,28 @@ def task_from_row(row: dict[str, Any], task_id: str) -> Task:
 
     Shared by the engine (per-task at rollout) and the sandbox warm-pool
     schedule so both derive the same ``env_key`` for a given row.
+
+    Harbor-sourced rows (r2egym, swebench-verified, swesmith, …) carry a
+    ``task_path`` pointing at the per-task directory. Root the Task there and
+    merge its ``task.toml`` + ``environment/Dockerfile`` metadata so per-task
+    verifier resolution and per-task image selection work on the sandbox path
+    — mirroring the eval CLI's ``_dict_rows_to_tasks``. Rows without
+    ``task_path`` keep ``dataset_dir=Path(".")`` and rely on a fixed evaluator.
     """
+    task_path = row.get("task_path")
+    metadata: dict[str, Any] = dict(row)
+    if task_path:
+        from rllm.tasks.loader import _merge_task_toml_metadata
+
+        dataset_dir = Path(task_path)
+        metadata = _merge_task_toml_metadata(dataset_dir, metadata)
+    else:
+        dataset_dir = Path(".")
     return Task(
         id=str(task_id),
         instruction=str(row.get("question", row.get("instruction", ""))),
-        metadata=row,
-        dataset_dir=Path("."),
+        metadata=metadata,
+        dataset_dir=dataset_dir,
     )
 
 

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -426,9 +426,18 @@ class AgentFlowEngine:
 
         results: list[Episode | None] = [None] * len(tasks)
         with tqdm(total=len(tasks), desc="Generating trajectories") as pbar:
+            n_done = 0
+            reward_sum = 0.0
             for future in asyncio.as_completed(futures):
                 task_id, rollout_idx, result_idx, episode = await future
                 results[result_idx] = episode
+                # Surface a running average reward on the progress bar so the
+                # current score is visible live (not just per-rollout lines).
+                if episode is not None:
+                    rewards = [t.reward for t in episode.trajectories if t.reward is not None]
+                    reward_sum += (sum(rewards) / len(rewards)) if rewards else (1.0 if episode.is_correct else 0.0)
+                    n_done += 1
+                    pbar.set_postfix(avg_reward=f"{reward_sum / n_done:.3f}")
                 pbar.update(1)
 
         ordered_results: list[Episode] = results  # type: ignore[assignment]

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -425,20 +425,25 @@ class AgentFlowEngine:
             futures.append(self.process_task_with_retry(task, task_id, rollout_idx, idx, is_validation=is_validation))
 
         results: list[Episode | None] = [None] * len(tasks)
+        # Running tallies for a live accuracy/reward readout on the progress bar.
+        n_correct = 0
+        reward_sum = 0.0
+        n_scored = 0
         with tqdm(total=len(tasks), desc="Generating trajectories") as pbar:
-            n_done = 0
-            reward_sum = 0.0
             for future in asyncio.as_completed(futures):
                 task_id, rollout_idx, result_idx, episode = await future
                 results[result_idx] = episode
-                # Surface a running average reward on the progress bar so the
-                # current score is visible live (not just per-rollout lines).
-                if episode is not None:
-                    rewards = [t.reward for t in episode.trajectories if t.reward is not None]
-                    reward_sum += (sum(rewards) / len(rewards)) if rewards else (1.0 if episode.is_correct else 0.0)
-                    n_done += 1
-                    pbar.set_postfix(avg_reward=f"{reward_sum / n_done:.3f}")
+                done = pbar.n + 1
+                if episode is not None and episode.is_correct:
+                    n_correct += 1
+                if episode is not None and episode.trajectories and episode.trajectories[0].reward is not None:
+                    reward_sum += float(episode.trajectories[0].reward)
+                    n_scored += 1
                 pbar.update(1)
+                postfix = f"acc {n_correct}/{done}={100.0 * n_correct / done:.1f}%"
+                if n_scored:
+                    postfix += f" reward={reward_sum / n_scored:.3f}"
+                pbar.set_postfix_str(postfix)
 
         ordered_results: list[Episode] = results  # type: ignore[assignment]
 

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -395,6 +395,7 @@ class AgentFlowEngine:
         tasks: list[dict | Task],
         task_ids: list[str] | None = None,
         is_validation: bool = False,
+        on_episode_complete=None,
         **kwargs,
     ) -> list[Episode]:
         """Run AgentFlows on a list of tasks; return enriched Episodes.
@@ -429,10 +430,33 @@ class AgentFlowEngine:
         n_correct = 0
         reward_sum = 0.0
         n_scored = 0
+        n_empty_rollouts = 0  # canary: rollouts whose LLM completions are all empty (upstream down)
         with tqdm(total=len(tasks), desc="Generating trajectories") as pbar:
             for future in asyncio.as_completed(futures):
                 task_id, rollout_idx, result_idx, episode = await future
                 results[result_idx] = episode
+                # Stream each enriched+scored episode as it finishes (eval:
+                # progressive UI upload + local write) instead of a burst at the
+                # end — keeps the UI live and avoids a giant end-of-run flush.
+                if on_episode_complete is not None and episode is not None:
+                    try:
+                        on_episode_complete(result_idx, episode)
+                    except Exception:
+                        logger.debug("on_episode_complete callback error", exc_info=True)
+                # Canary: a rollout whose LLM completions are ALL empty means the
+                # upstream returned nothing (dead litellm proxy, gateway "no healthy
+                # workers", or the model itself). Surface it loudly — otherwise the
+                # run silently produces garbage (every rollout scores 0).
+                if episode is not None:
+                    _steps = [s for t in (episode.trajectories or []) for s in (t.steps or [])]
+                    if _steps and all(not (s.model_response or "").strip() for s in _steps):
+                        n_empty_rollouts += 1
+                        colorful_print(
+                            f"[{task_id}:{rollout_idx}] ⚠️  EMPTY COMPLETIONS: all {len(_steps)} LLM calls "
+                            f"returned 0 tokens — upstream likely DOWN (dead litellm proxy :4000 / gateway "
+                            f"no-healthy-workers / model). [{n_empty_rollouts} empty rollouts so far]",
+                            fg="red",
+                        )
                 done = pbar.n + 1
                 if episode is not None and episode.is_correct:
                     n_correct += 1

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -18,6 +18,7 @@ is inherited from ``TinkerEngine``.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import dataclasses
 import logging
 from typing import Any
@@ -49,6 +50,39 @@ _TRANSIENT_ERROR_MARKERS = (
     "_SSETruncationError",
     "closed the SSE stream mid-generation",
 )
+
+
+# Per-request inference headers (e.g. Fireworks session-affinity) injected into
+# DeploymentSampler requests. ``DeploymentSampler.async_completions_stream`` only
+# forwards body params and a fixed set of client-level headers, so there is no
+# per-call header hook; we patch ``_inference_headers`` to merge whatever the
+# current async context stashed here. A ContextVar is async-safe — each rollout
+# task carries its own copy, so concurrent trajectories don't clobber each
+# other's session-affinity key.
+_per_request_headers: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar("rllm_fw_request_headers", default=None)
+
+
+def _install_inference_header_patch() -> None:
+    """Patch ``DeploymentSampler._inference_headers`` to merge per-request headers.
+
+    Idempotent: re-imports / repeated calls are no-ops.
+    """
+    orig = DeploymentSampler._inference_headers
+    if getattr(orig, "_rllm_session_affinity_patch", False):
+        return
+
+    def _inference_headers(self):  # noqa: ANN001 - matches SDK signature
+        headers = orig(self)
+        extra = _per_request_headers.get()
+        if extra:
+            headers = {**headers, **extra}
+        return headers
+
+    _inference_headers._rllm_session_affinity_patch = True  # type: ignore[attr-defined]
+    DeploymentSampler._inference_headers = _inference_headers
+
+
+_install_inference_header_patch()
 
 
 class _EmptyCompletionIdsError(RuntimeError):
@@ -85,6 +119,11 @@ class FireworksEngine(TinkerEngine):
     ``/inference/v1/completions`` endpoint, so ``TinkerTokenInput`` and
     ``TinkerTokenOutput`` are fully supported.
     """
+
+    # Signals the gateway handler to forward a per-trajectory ``rllm_session_id``
+    # so this engine can set Fireworks session-affinity headers (prefix-cache
+    # reuse across a rollout's turns). Other engines ignore the session id.
+    supports_session_affinity = True
 
     def __init__(
         self,
@@ -237,6 +276,10 @@ class FireworksEngine(TinkerEngine):
         requested_max_tokens = sampling_params.pop("max_tokens", requested_max_tokens)
         max_tokens = self._prepare_max_tokens(requested_max_tokens, input_length)
 
+        # Per-trajectory session id (gateway forwards it for affinity); it must
+        # NOT leak into the request body, so pop it before building sampling params.
+        session_id = kwargs.pop("rllm_session_id", None)
+
         for key in ("temperature", "top_p", "top_k", "user", "reasoning_effort"):
             if key in kwargs:
                 sampling_params[key] = kwargs.pop(key)
@@ -247,10 +290,21 @@ class FireworksEngine(TinkerEngine):
         if self.router_replay:
             sampling_params["include_routing_matrix"] = True
 
+        # Fireworks routes requests carrying the same session id to the same
+        # replica, so its per-replica prompt-prefix KV is reused across a
+        # trajectory's turns. Set once per turn from the trajectory id.
+        session_headers = None
+        if session_id:
+            session_headers = {
+                "x-multi-turn-session-id": str(session_id),
+                "x-session-affinity": str(session_id),
+            }
+
         raw, server_metrics = await self._completions_with_retry(
             prompt_ids,
             max_tokens,
             sampling_params,
+            session_headers=session_headers,
         )
 
         choice = raw["choices"][0]
@@ -296,21 +350,30 @@ class FireworksEngine(TinkerEngine):
         prompt_ids: list[int],
         max_tokens: int,
         sampling_kwargs: dict[str, Any],
+        session_headers: dict[str, str] | None = None,
     ) -> tuple[dict[str, Any], dict | None]:
         """Call ``DeploymentSampler.async_completions_stream`` with transient-error retries.
 
-        Returns (response_dict, server_metrics_dict)."""
+        ``session_headers``, when given, are merged into the request's HTTP
+        headers (via the ``_inference_headers`` patch) so Fireworks routes this
+        request to the trajectory's pinned replica. Returns
+        (response_dict, server_metrics_dict)."""
 
         for attempt in range(_MAX_SAMPLE_ATTEMPTS):
             try:
-                result, server_metrics = await self.sampling_client.async_completions_stream(
-                    prompt=prompt_ids,
-                    max_tokens=max_tokens,
-                    raw_output=True,
-                    logprobs=True,
-                    http_timeout=self.sample_timeout,
-                    **sampling_kwargs,
-                )
+                token = _per_request_headers.set(session_headers) if session_headers else None
+                try:
+                    result, server_metrics = await self.sampling_client.async_completions_stream(
+                        prompt=prompt_ids,
+                        max_tokens=max_tokens,
+                        raw_output=True,
+                        logprobs=True,
+                        http_timeout=self.sample_timeout,
+                        **sampling_kwargs,
+                    )
+                finally:
+                    if token is not None:
+                        _per_request_headers.reset(token)
                 metrics_dict = {k: v for k, v in dataclasses.asdict(server_metrics).items() if v is not None} if server_metrics else None
                 choice = (result.get("choices") or [{}])[0]
                 completion_ids = (choice.get("raw_output") or {}).get("completion_token_ids") or []

--- a/rllm/env.py
+++ b/rllm/env.py
@@ -19,6 +19,27 @@ parsing (and the ``RLLM_`` naming convention) lives in one place.
 from __future__ import annotations
 
 import os
+import re
+
+_RUN_ID: str | None = None
+
+
+def rllm_run_id() -> str:
+    """Stable per-process run identifier stamped onto cloud sandboxes.
+
+    Used as the Modal App name suffix and a sandbox tag so a single run's
+    sandboxes are greppable and terminable on a *shared* account (where you
+    can't just kill every ``rllm-*`` sandbox because others' runs use them).
+
+    Set ``RLLM_RUN_ID`` to a memorable value (e.g. ``alice-tb2-0621``);
+    otherwise a random 8-char id is generated once per process. Sanitized to
+    Modal's label charset (``[a-zA-Z0-9_.-]``).
+    """
+    global _RUN_ID
+    if _RUN_ID is None:
+        raw = re.sub(r"[^a-zA-Z0-9_.-]", "-", os.environ.get("RLLM_RUN_ID", "")).strip("-")
+        _RUN_ID = raw or os.urandom(4).hex()
+    return _RUN_ID
 
 
 def env_str(name: str, default: str) -> str:

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -196,15 +196,37 @@ def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, 
     return create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend), **backend_kwargs)
 
 
+def _should_replay_dockerfile(task: Task) -> bool:
+    """Whether to replay the Dockerfile's ``RUN`` steps on non-docker backends.
+
+    Two task conventions are supported via ``[environment].replay_dockerfile``:
+
+    * **SWE-bench style** (default, ``true``): the configured ``docker_image``
+      is a *base*; the Dockerfile's ``RUN`` steps (e.g. ``uv``, needed by the
+      grader) are not in that image and must be replayed on top.
+    * **Terminal-bench / Harbor style** (``false``): the configured
+      ``docker_image`` is the *fully built* task image, so replaying its ``RUN``
+      steps double-applies the build (``git clone ... already exists``, missing
+      ``COPY``'d files, etc.). These tasks set
+      ``[environment]\nreplay_dockerfile = false`` to boot the image as-is.
+    """
+    env = task.metadata.get("environment", {}) or {}
+    return bool(env.get("replay_dockerfile", True))
+
+
 def _replay_dockerfile(task: Task, sandbox: Sandbox, backend: str) -> None:
     """Replay the Dockerfile RUN steps on a live sandbox (stage C).
 
     Non-docker backends pull the Dockerfile's FROM base instead of building
     it, so the RUN steps (e.g. swebench's ``uv``, needed by the grader) must
     be replayed. Best-effort: a failed step shouldn't abort the task. Docker
-    builds the image, so its RUN steps already ran — skip.
+    builds the image, so its RUN steps already ran — skip. Tasks that boot a
+    fully-built image opt out via ``[environment].replay_dockerfile = false``
+    (see :func:`_should_replay_dockerfile`).
     """
     if backend == "docker":
+        return
+    if not _should_replay_dockerfile(task):
         return
     for cmd in _dockerfile_run_commands(task):
         _safe_exec(sandbox, cmd, timeout=900)
@@ -249,9 +271,13 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
 
 
 def _dockerfile_run_commands(task: Task) -> list[str]:
-    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps (joining
-    ``\\``-continuations). Non-``RUN`` directives — ``COPY``/``ADD`` etc. — are
-    skipped; only ``RUN`` is replayable on a live sandbox.
+    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps.
+
+    ``\\``-continuations are joined into a single logical command with a space
+    (matching shell line-continuation semantics) so multi-line ``RUN`` steps
+    stay valid when re-executed via ``bash -c``. Non-``RUN`` directives —
+    ``COPY``/``ADD`` etc. — are skipped; only ``RUN`` is replayable on a live
+    sandbox.
     """
     dockerfile = task.task_dir / "environment" / "Dockerfile"
     if not dockerfile.exists():
@@ -275,7 +301,7 @@ def _dockerfile_run_commands(task: Task) -> list[str]:
                 if i >= len(lines):
                     break
                 parts.append(lines[i])
-            cmd = "\n".join(parts).strip()
+            cmd = " ".join(part.strip() for part in parts).strip()
             if cmd:
                 commands.append(cmd)
         i += 1

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -248,6 +248,8 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
     OOM-kills compile-heavy graders (e.g. ``go test ./...``). Modal takes memory
     in MB; Daytona takes memory/disk in GB. Docker/local ignore the values.
     """
+    from rllm.env import env_int
+
     env = task.metadata.get("environment", {}) or {}
     cpus, mem_mb, disk_mb = env.get("cpus"), env.get("memory_mb"), env.get("storage_mb")
     kw: dict = {}
@@ -256,6 +258,15 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
             kw["cpu"] = float(cpus)
         if mem_mb:
             kw["memory"] = int(mem_mb)
+        # Size the sandbox lifetime to this task's own budget so the box always
+        # outlives the agent + verifier it hosts (both run here). A flat global
+        # default could be shorter than agent+verifier and reap the box mid-run
+        # ("Sandbox already shut down"). max() keeps an explicit override as a floor.
+        agent_t = float(task.metadata.get("agent_timeout") or env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600))
+        verifier_t = float(task.metadata.get("verifier_timeout") or 600.0)
+        install_t = float(env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600))
+        per_task_floor = int(agent_t + verifier_t + install_t + 600)  # +600s teardown/scheduling slack
+        kw["timeout"] = max(per_task_floor, env_int("RLLM_MODAL_SANDBOX_TIMEOUT_S", 0))
     elif backend == "daytona":
         if cpus:
             kw["cpu"] = int(cpus)

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -544,17 +544,30 @@ def save_config(config: RllmConfig) -> str:
     Creates parent directories as needed and sets file permissions to 0o600
     (owner read/write only) since the file contains API keys.
 
+    Merges into any existing file so unrelated keys (e.g. ``ui_api_key``
+    written by ``rllm login``) survive provider/model changes instead of
+    being clobbered.
+
     Returns the path that was written.
     """
     path = _config_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    data: dict[str, object] = {
-        "provider": config.provider,
-        "model": config.model,
-        "api_keys": dict(config.api_keys),
-    }
+    data: dict[str, object] = {}
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                data = loaded
+        except (json.JSONDecodeError, OSError):
+            data = {}
+    data["provider"] = config.provider
+    data["model"] = config.model
+    data["api_keys"] = dict(config.api_keys)
     if config.base_url:
         data["base_url"] = config.base_url
+    else:
+        data.pop("base_url", None)
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -402,13 +402,19 @@ def fetch_fireworks_models(api_key: str | None = None) -> list[str]:
 
 
 def fetch_fireworks_deployed_models(api_key: str | None = None) -> list[str]:
-    """Return the caller's actively deployed model IDs (best-effort).
+    """Return the caller's runnable dedicated-deployment IDs (best-effort).
 
-    Discovers the caller's account ID(s) via ``GET /v1/accounts``, then lists
-    each account's ``deployedModels`` that are in state ``DEPLOYED`` — i.e.
-    models currently serving inference on a dedicated deployment (not merely
-    uploaded). These can be sampled with no further setup. The shared public
-    ``fireworks`` namespace is excluded (see :func:`fetch_fireworks_models`).
+    Discovers the caller's account ID(s) via ``GET /v1/accounts``, then collects
+    two complementary sources (the shared public ``fireworks`` namespace is
+    excluded — see :func:`fetch_fireworks_models`):
+
+    * ``deployedModels`` in state ``DEPLOYED`` — a custom/fine-tuned model bound
+      to a deployment; addressed for inference by its ``model`` id.
+    * ``deployments`` in state ``READY`` — a dedicated deployment of a base
+      model has no ``deployedModel`` entry (``model`` is null) and is addressed
+      for inference by its own ``accounts/<acct>/deployments/<id>`` name. Without
+      this, base-model deployments are invisible to the picker even though
+      that's the exact id evals run against.
 
     Returns an empty list on any failure so callers can degrade gracefully.
     """
@@ -421,6 +427,9 @@ def fetch_fireworks_deployed_models(api_key: str | None = None) -> list[str]:
             for dm in _fireworks_paged(f"accounts/{account}/deployedModels", key, "deployedModels"):
                 if dm.get("state") == "DEPLOYED" and dm.get("model"):
                     names.append(dm["model"])
+            for dep in _fireworks_paged(f"accounts/{account}/deployments", key, "deployments"):
+                if dep.get("state") == "READY" and dep.get("name"):
+                    names.append(dep["name"])
         return sorted(set(names))
     except Exception:
         return []

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -4,9 +4,12 @@ The caller controls the proxy lifecycle::
 
     pm = EvalProxyManager(provider="openai", model_name="gpt-4o", api_key="sk-...")
     pm.start_proxy_subprocess(pm.build_proxy_config())
-    base_url = pm.get_proxy_url()  # http://127.0.0.1:4000/v1
+    base_url = pm.get_proxy_url()  # http://127.0.0.1:<auto-port>/v1
     # ... run eval ...
     pm.shutdown_proxy()
+
+By default the proxy binds a free port (so concurrent ``rllm eval`` jobs each
+get their own and don't collide); pass ``proxy_port=`` to pin a specific one.
 
 This proxy is the bridge to commercial providers during ``rllm eval``. For
 training and for vLLM-backed eval, requests go through ``rllm-model-gateway``
@@ -19,6 +22,7 @@ import atexit
 import logging
 import os
 import resource
+import socket
 import subprocess
 import sys
 import tempfile
@@ -34,6 +38,22 @@ logger = logging.getLogger(__name__)
 
 _NUM_RETRIES = env_int("RLLM_EVAL_PROXY_NUM_RETRIES", 3)  # set env var: export RLLM_EVAL_PROXY_NUM_RETRIES=xxx
 _STARTUP_TIMEOUT_S = env_float("RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S", 30.0)  # set env var: export RLLM_EVAL_PROXY_STARTUP_TIMEOUT_S=xxx
+# Retries for the rare TOCTOU race where an auto-picked free port is taken
+# between selection and the subprocess binding it (matters for concurrent
+# `rllm eval` launches, each auto-starting its own proxy).
+_PORT_BIND_RETRIES = env_int("RLLM_EVAL_PROXY_PORT_BIND_RETRIES", 5)
+
+
+def _find_free_port() -> int:
+    """Ask the OS for a free TCP port on the loopback interface.
+
+    Mirrors ``rllm.gateway.manager._find_free_port`` — used so every
+    auto-started eval proxy binds a distinct port instead of the fixed 4000,
+    letting multiple ``rllm eval`` jobs run concurrently without colliding.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
 
 class _ProxyManagerBase:
@@ -42,11 +62,15 @@ class _ProxyManagerBase:
     def __init__(
         self,
         proxy_host: str = "127.0.0.1",
-        proxy_port: int = 4000,
+        proxy_port: int | None = None,
         admin_token: str | None = None,
     ) -> None:
         self.proxy_host = proxy_host
-        self.proxy_port = proxy_port
+        # ``proxy_port=None`` (the default) auto-picks a free port so concurrent
+        # ``rllm eval`` jobs don't collide on the old hardcoded 4000. Pass an
+        # explicit port to pin it (e.g. for debugging a single run).
+        self._port_auto = proxy_port is None
+        self.proxy_port = proxy_port if proxy_port is not None else _find_free_port()
         self.admin_token = admin_token
         self._proxy_process: subprocess.Popen | None = None
 
@@ -95,6 +119,7 @@ class _ProxyManagerBase:
         if self._proxy_process is None:
             return
 
+        self._shutting_down = True  # tell the monitor this exit is expected
         logger.info("Shutting down proxy subprocess...")
         self._proxy_process.terminate()
         try:
@@ -117,7 +142,7 @@ class EvalProxyManager(_ProxyManagerBase):
         model_name: str,
         api_key: str,
         proxy_host: str = "127.0.0.1",
-        proxy_port: int = 4000,
+        proxy_port: int | None = None,
     ) -> None:
         super().__init__(proxy_host=proxy_host, proxy_port=proxy_port)
         self.provider = provider
@@ -167,16 +192,6 @@ class EvalProxyManager(_ProxyManagerBase):
         if not snapshot_path or not os.path.exists(snapshot_path):
             raise RuntimeError("Config snapshot not available. Cannot start proxy.")
 
-        cmd = [
-            sys.executable,
-            "-m",
-            "rllm.eval._litellm_server",
-            "--host",
-            self.proxy_host,
-            "--port",
-            str(self.proxy_port),
-        ]
-
         env = os.environ.copy()
         try:
             import certifi
@@ -195,32 +210,81 @@ class EvalProxyManager(_ProxyManagerBase):
             except (ValueError, OSError):
                 pass
 
-        # Capture stderr to a temp file so we can show errors on failure
-        stderr_file = tempfile.NamedTemporaryFile(mode="w", prefix="rllm_proxy_", suffix=".log", delete=False)
-        self._stderr_path = stderr_file.name
+        # An auto-picked free port can be grabbed by another process between
+        # selection and bind (concurrent eval launches), so retry on a fresh
+        # port. A pinned port gets a single attempt — the user asked for that
+        # exact port, so surface the failure instead of silently moving.
+        max_attempts = _PORT_BIND_RETRIES if self._port_auto else 1
+        for attempt in range(1, max_attempts + 1):
+            cmd = [
+                sys.executable,
+                "-m",
+                "rllm.eval._litellm_server",
+                "--host",
+                self.proxy_host,
+                "--port",
+                str(self.proxy_port),
+            ]
 
-        logger.info("Starting proxy subprocess: %s", " ".join(cmd))
-        self._proxy_process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=stderr_file,
-            env=env,
-            preexec_fn=set_limits,
-        )
+            # Fresh stderr capture per attempt so a death leaves a readable trail.
+            stderr_file = tempfile.NamedTemporaryFile(mode="w", prefix="rllm_proxy_", suffix=".log", delete=False)
+            self._stderr_path = stderr_file.name
 
-        try:
-            self._wait_for_proxy(timeout=_STARTUP_TIMEOUT_S)
-            logger.info("Proxy server started, sending configuration...")
-            self.reload_proxy_config(config=config)
-            logger.info("Proxy configuration loaded successfully")
-        except Exception:
-            self._report_proxy_failure()
-            self.shutdown_proxy()
-            raise
+            logger.info("Starting proxy subprocess (attempt %d/%d): %s", attempt, max_attempts, " ".join(cmd))
+            self._proxy_process = subprocess.Popen(
+                cmd,
+                stdout=stderr_file,  # capture stdout too (litellm logs + crash output) so a death leaves a trail
+                stderr=stderr_file,
+                env=env,
+                preexec_fn=set_limits,
+            )
+
+            try:
+                self._wait_for_proxy(timeout=_STARTUP_TIMEOUT_S)
+                logger.info("Proxy server started, sending configuration...")
+                self.reload_proxy_config(config=config)
+                logger.info("Proxy configuration loaded successfully")
+                break
+            except Exception:
+                self._report_proxy_failure()
+                self.shutdown_proxy()
+                if attempt >= max_attempts:
+                    raise
+                old_port = self.proxy_port
+                self.proxy_port = _find_free_port()
+                logger.warning("Proxy startup failed on port %s; retrying on %s", old_port, self.proxy_port)
 
         atexit.register(self.shutdown_proxy)
         logger.info("Proxy subprocess ready (PID: %s)", self._proxy_process.pid)
+        self._start_proxy_monitor()
         return snapshot_path
+
+    def _start_proxy_monitor(self) -> None:
+        """Watch the proxy subprocess; if it dies mid-run, scream loudly with its
+        captured output. Otherwise the gateway silently routes to a dead worker
+        and every subsequent rollout returns empty completions (scoring 0) with
+        no visible cause — exactly the failure that's been impossible to debug.
+        """
+        import threading
+
+        proc = self._proxy_process
+        if proc is None:
+            return
+
+        def _monitor() -> None:
+            rc = proc.wait()  # blocks until the proxy process exits
+            if getattr(self, "_shutting_down", False):
+                return  # expected teardown at end of run
+            tail = self._read_stderr_tail(max_lines=60)
+            logger.error(
+                "\n🚨🚨🚨 LITELLM PROXY DIED MID-RUN (exit code %s) 🚨🚨🚨\n"
+                "Every subsequent LLM call now returns EMPTY and all remaining rollouts "
+                "score 0. THIS is why the run is failing. Proxy stdout/stderr tail:\n%s\n",
+                rc,
+                tail or "(nothing captured — likely SIGKILL / OOM / external kill)",
+            )
+
+        threading.Thread(target=_monitor, daemon=True, name="rllm-proxy-monitor").start()
 
     def _wait_for_proxy(self, timeout: float = 30.0) -> None:
         if self._proxy_process is None:

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -108,7 +108,10 @@ async def run_dataset(
         gateway=gateway,
         model=model,
         n_parallel_tasks=effective_concurrency,
-        retry_limit=1,  # eval doesn't retry on flow errors
+        # One retry: rollout errors are usually transient infra (sandbox reaped,
+        # flaky create, install blip), not flow bugs. Without it they become
+        # permanent zeros that depress the score; only errored tasks re-run.
+        retry_limit=2,
         raise_on_error=False,  # capture per-task errors as error Episodes
         hooks=hooks,
         val_sampling_params=sampling_params or None,  # eval is always validation

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -135,7 +135,7 @@ async def run_dataset(
         # downstream consumer wants it) is stable; the engine's session uid
         # becomes f"{task.id}:0" which matches training's convention.
         task_ids = [getattr(t, "id", None) or str(idx) for idx, t in enumerate(tasks)]
-        episodes = await engine.execute_tasks(tasks, task_ids=task_ids, is_validation=True)
+        episodes = await engine.execute_tasks(tasks, task_ids=task_ids, is_validation=True, on_episode_complete=on_episode_complete)
     finally:
         if warm_queue is not None:
             warm_queue.shutdown()
@@ -169,11 +169,9 @@ async def run_dataset(
         if episode.trajectories and episode.trajectories[0].reward is not None:
             reward = float(episode.trajectories[0].reward)
 
-        if on_episode_complete is not None:
-            try:
-                on_episode_complete(idx, episode)
-            except Exception:
-                logger.debug("on_episode_complete callback error", exc_info=True)
+        # NOTE: on_episode_complete is now invoked *streaming* inside
+        # engine.execute_tasks (as each rollout finishes), not here — so UI
+        # uploads + local writes happen progressively instead of in a burst.
 
         items.append(
             EvalItem(

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -4,7 +4,7 @@ Two classes share most of the lifecycle (uvicorn-on-thread or subprocess,
 trace store, session API). They differ in how upstream workers are
 registered and what request-body injection the middleware applies.
 
-* :class:`GatewayManager` — training. Workers come from a verl/tinker
+* :class:`GatewayManager` — training. Workers come from a verl/tinker/fireworks
   rollout engine via :meth:`start(rollout_engine)`. Injects ``logprobs``
   and ``return_token_ids`` into request bodies (vLLM needs both for the
   loss math downstream).
@@ -159,8 +159,8 @@ class GatewayManager:
         from rllm.gateway.tunnel import parse_tunnel
 
         self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
-        # The gateway always pins ``body.model`` to whatever the trainer is serving
-        self.model: str | None = config.get("model", {}).get("name", None)
+        _model_cfg = config.get("model", {})
+        self.model: str | None = _model_cfg.get("tokenizer_model") or _model_cfg.get("name", None)
 
         # Cumulative token mode: drift-free multi-turn token forwarding. The
         # gateway loads the tokenizer from the served model path. renderers
@@ -207,11 +207,11 @@ class GatewayManager:
         """Start the gateway and register inference workers.
 
         For VerlEngine: registers the existing vLLM server addresses.
-        For TinkerEngine: creates an in-process handler (no sidecar needed).
+        For TinkerEngine / FireworksEngine: creates an in-process handler (no sidecar needed).
         """
         engine_cls = type(rollout_engine).__name__
 
-        if engine_cls == "TinkerEngine":
+        if engine_cls in ("TinkerEngine", "FireworksEngine"):
             # In-process handler — no HTTP backend, no worker registration
             from rllm.gateway.tinker_adapter import create_tinker_handler
 
@@ -227,6 +227,7 @@ class GatewayManager:
             for url in worker_urls:
                 worker_id = self.client.add_worker(url=url)
                 logger.info("Registered worker %s -> %s", worker_id, url)
+
         else:
             logger.warning("Unknown engine type %s — no workers registered", engine_cls)
 

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -17,6 +17,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from rllm.engine.rollout.tinker_engine import TinkerEngine
+from rllm.workflows import TerminationEvent, TerminationReason
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,32 @@ def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
             }
         )
     return result
+
+
+def _termination_http_error(reason: TerminationReason) -> Exception:
+    """Map a ``TerminationEvent`` to a non-retryable OpenAI-style 400.
+
+    For CLI harnesses the agent loop runs inside the sandbox, so the only way
+    to stop it is the HTTP response — a 500 makes the LLM client retry the
+    (still-too-long) call until the harness run-timeout SIGKILLs it, stalling
+    the whole group. ``context_length_exceeded`` maps to a NON-retryable
+    ContextWindowExceededError in litellm/openai SDKs, so the agent raises and
+    the rollout returns immediately with the turns so far.
+    """
+    from fastapi import HTTPException
+
+    is_prompt_limit = reason == TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED
+    return HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": f"Rollout terminated: {reason}. The conversation exceeded the model's prompt window.",
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded" if is_prompt_limit else "rollout_terminated",
+                "param": "messages",
+            }
+        },
+    )
 
 
 async def _token_prompt_completion(
@@ -122,7 +149,10 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         # path the HTTP backend uses for the same feature.
         prompt = request_body.get("prompt")
         if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
-            return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+            try:
+                return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+            except TerminationEvent as e:
+                raise _termination_http_error(e.reason) from e
 
         messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
@@ -130,7 +160,10 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         if tools:
             kwargs["tools"] = tools
 
-        model_output = await engine.get_model_response(messages, **kwargs)
+        try:
+            model_output = await engine.get_model_response(messages, **kwargs)
+        except TerminationEvent as e:
+            raise _termination_http_error(e.reason) from e
 
         response_text = model_output.content or model_output.text or ""
         prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else []

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -41,6 +41,56 @@ def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
     return result
 
 
+async def _token_prompt_completion(
+    engine: TinkerEngine,
+    request_body: dict[str, Any],
+    prompt_ids: list[int],
+    sampling_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Sample from a pre-tokenized prompt (cumulative-token mode).
+
+    Bypasses message rendering entirely: ``prompt_ids`` is fed straight to the
+    engine's token-input sampler. Returns a **completions-style** response dict
+    (``choices[0].text`` + ``token_ids``, root ``prompt_token_ids``,
+    ``logprobs.token_logprobs``) — the exact shape the gateway's cumulative-turn
+    handler extracts token IDs from and translates back to chat format.
+    """
+    token_output = await engine.get_token_output_from_token_input(prompt_ids, **sampling_kwargs)
+    model_output = engine.assemble_model_output(prompt_ids, token_output)
+
+    # Text the agent sees as the assistant turn (same precedence as the chat path).
+    text = model_output.content or model_output.text or ""
+    out_prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else list(prompt_ids)
+    completion_ids = list(model_output.completion_ids) if model_output.completion_ids else []
+    logprobs = model_output.logprobs or []
+    finish_reason = model_output.finish_reason or "stop"
+    prompt_len = model_output.prompt_length or len(out_prompt_ids)
+    completion_len = model_output.completion_length or len(completion_ids)
+
+    return {
+        "id": f"cmpl-{uuid.uuid4().hex[:12]}",
+        "object": "text_completion",
+        "created": int(time.time()),
+        "model": request_body.get("model", getattr(engine, "model_name", "default")),
+        "choices": [
+            {
+                "index": 0,
+                "text": text,
+                "token_ids": completion_ids,
+                "finish_reason": finish_reason,
+                "logprobs": {"token_logprobs": logprobs},
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_len,
+            "completion_tokens": completion_len,
+            "total_tokens": prompt_len + completion_len,
+        },
+        "prompt_token_ids": out_prompt_ids,
+        "weight_version": getattr(model_output, "weight_version", None),
+    }
+
+
 def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
     """Return an async handler that calls TinkerEngine in-process.
 
@@ -50,22 +100,35 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
     """
 
     async def handler(request_body: dict[str, Any]) -> dict[str, Any]:
+        # Sampling params shared by the chat and pre-tokenized paths.
+        sampling_kwargs: dict[str, Any] = {}
+        if request_body.get("temperature") is not None:
+            sampling_kwargs["temperature"] = request_body["temperature"]
+        if request_body.get("top_p") is not None:
+            sampling_kwargs["top_p"] = request_body["top_p"]
+        if request_body.get("top_k") is not None:
+            sampling_kwargs["top_k"] = request_body["top_k"]
+        if request_body.get("max_tokens") is not None:
+            sampling_kwargs["max_tokens"] = request_body["max_tokens"]
+        if request_body.get("max_completion_tokens") is not None:
+            sampling_kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
+
+        # Cumulative-token-mode path: the gateway rewrites turn 2+ to a
+        # completions-style request whose ``prompt`` is raw token IDs built by
+        # ``renderers.bridge_to_next_turn`` (= prior turns' prompt+completion
+        # tokens + the new messages). Sample straight from those tokens — no
+        # re-render, no re-tokenization — so the sequence the optimizer trains on
+        # is byte-for-byte what was generated. Mirrors the vLLM /v1/completions
+        # path the HTTP backend uses for the same feature.
+        prompt = request_body.get("prompt")
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+
         messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
-
-        kwargs: dict[str, Any] = {}
+        kwargs = dict(sampling_kwargs)
         if tools:
             kwargs["tools"] = tools
-        if request_body.get("temperature") is not None:
-            kwargs["temperature"] = request_body["temperature"]
-        if request_body.get("top_p") is not None:
-            kwargs["top_p"] = request_body["top_p"]
-        if request_body.get("top_k") is not None:
-            kwargs["top_k"] = request_body["top_k"]
-        if request_body.get("max_tokens") is not None:
-            kwargs["max_tokens"] = request_body["max_tokens"]
-        if request_body.get("max_completion_tokens") is not None:
-            kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
 
         model_output = await engine.get_model_response(messages, **kwargs)
 

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -140,6 +140,13 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         if request_body.get("max_completion_tokens") is not None:
             sampling_kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
 
+        # Per-trajectory session id (injected by the gateway) — forwarded only to
+        # engines that use it for inference session affinity (Fireworks prefix-cache
+        # reuse across a rollout's turns). Popped so it never reaches a chat body.
+        session_id = request_body.pop("rllm_session_id", None)
+        if session_id and getattr(engine, "supports_session_affinity", False):
+            sampling_kwargs["rllm_session_id"] = session_id
+
         # Cumulative-token-mode path: the gateway rewrites turn 2+ to a
         # completions-style request whose ``prompt`` is raw token IDs built by
         # ``renderers.bridge_to_next_turn`` (= prior turns' prompt+completion

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -34,7 +34,7 @@ import uuid
 from abc import abstractmethod
 
 from rllm.env import env_int
-from rllm.sandbox.protocol import Sandbox
+from rllm.sandbox.protocol import Sandbox, SandboxCommandTimeout
 from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
 from rllm.types import AgentConfig, Task
 
@@ -307,6 +307,10 @@ class BaseCliHarness(SandboxedAgentFlow):
 
         try:
             self._exec_agent(sandbox, cmd, timeout=timeout, env=env_vars)
+        except SandboxCommandTimeout as e:
+            # Expected, not a failure: the agent spent its whole time budget; the
+            # captured steps are still scored by the verifier. INFO, not WARNING.
+            logger.info("%s reached its time budget: %s", type(self).__name__, e)
         except Exception as e:
             # Surface as a warning for operator visibility; the engine
             # still gets None and the gateway traces (if any LLM calls

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -64,7 +64,22 @@ class BaseCliHarness(SandboxedAgentFlow):
     stdout_log_path: str = "/tmp/agent-stdout.log"
     # Per-call timeouts (seconds). Tasks may override via metadata.
     install_timeout: int = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)  # set env var: export RLLM_HARNESS_INSTALL_TIMEOUT_S=xxx
-    run_timeout: int = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 1800)  # set env var: export RLLM_HARNESS_RUN_TIMEOUT_S=xxx
+    run_timeout: int = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600)  # set env var: export RLLM_HARNESS_RUN_TIMEOUT_S=xxx
+
+    def configure(self, overrides: dict) -> dict:
+        """Consume CLI overrides this harness understands, then defer to the base.
+
+        ``agent_timeout`` (seconds) caps a single rollout's wall-clock — it's the
+        timeout handed to the in-sandbox ``exec``. ``rllm eval --agent-timeout``
+        routes here. Backends with a hard sandbox lifetime (e.g. Modal, see
+        ``modal_backend._default_sandbox_timeout``) size it to exceed this so the
+        environment can't be reaped before the agent's own timeout fires.
+        """
+        leftovers = super().configure(overrides)
+        timeout = leftovers.pop("agent_timeout", None)
+        if timeout is not None:
+            self.run_timeout = int(timeout)
+        return leftovers
 
     # ---------------------------------------------------------------------
     # Sandbox helpers

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -29,6 +29,7 @@ propagates ``config.base_url`` through the appropriate env var
 from __future__ import annotations
 
 import logging
+import os
 import shlex
 import uuid
 from abc import abstractmethod
@@ -65,6 +66,12 @@ class BaseCliHarness(SandboxedAgentFlow):
     # Per-call timeouts (seconds). Tasks may override via metadata.
     install_timeout: int = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)  # set env var: export RLLM_HARNESS_INSTALL_TIMEOUT_S=xxx
     run_timeout: int = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600)  # set env var: export RLLM_HARNESS_RUN_TIMEOUT_S=xxx
+    # When an operator sets RLLM_HARNESS_RUN_TIMEOUT_S (or --agent-timeout),
+    # run_timeout is a hard CEILING on the per-task ``agent_timeout``, not just a
+    # fallback — effective timeout = min(agent_timeout, run_timeout). When it is
+    # unset, the task's own agent_timeout governs (so eval honors each
+    # benchmark's per-task budget). Captured at import; configure() flips it on.
+    run_timeout_is_cap: bool = "RLLM_HARNESS_RUN_TIMEOUT_S" in os.environ
 
     def configure(self, overrides: dict) -> dict:
         """Consume CLI overrides this harness understands, then defer to the base.
@@ -79,6 +86,7 @@ class BaseCliHarness(SandboxedAgentFlow):
         timeout = leftovers.pop("agent_timeout", None)
         if timeout is not None:
             self.run_timeout = int(timeout)
+            self.run_timeout_is_cap = True  # an explicit --agent-timeout is a hard ceiling
         return leftovers
 
     # ---------------------------------------------------------------------
@@ -302,7 +310,17 @@ class BaseCliHarness(SandboxedAgentFlow):
         self.write_configs(sandbox, task, config, env_vars)
 
         instruction = str(task.instruction).strip()
-        timeout = float(task.metadata.get("agent_timeout", self.run_timeout))
+        # The task's own agent_timeout (from task.toml) applies, but an
+        # operator-set RLLM_HARNESS_RUN_TIMEOUT_S / --agent-timeout is a hard
+        # ceiling over it — otherwise a task declaring e.g. 3600s would ignore a
+        # 1800s cap meant to bound training-rollout wall-clock.
+        per_task = task.metadata.get("agent_timeout")
+        if per_task is None:
+            timeout = float(self.run_timeout)
+        elif self.run_timeout_is_cap:
+            timeout = min(float(per_task), float(self.run_timeout))
+        else:
+            timeout = float(per_task)
         cmd = self.build_invocation(instruction, task, config)
 
         try:

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -58,7 +58,25 @@ if ! command -v mini-swe-agent >/dev/null 2>&1; then
         fi
     fi
     if ! command -v uv >/dev/null 2>&1; then
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+        # Sandbox->GitHub egress (astral.sh redirects to
+        # release-assets.githubusercontent.com) intermittently resets the
+        # connection on cloud backends (Modal/Daytona). Without a retry a
+        # single ``curl: (35/56) Connection reset by peer`` aborts the whole
+        # install under ``set -e`` and the rollout scores 0. Retry a few times
+        # with backoff before giving up.
+        uv_installed=0
+        for attempt in 1 2 3 4 5; do
+            if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+                uv_installed=1
+                break
+            fi
+            echo "uv install attempt ${attempt} failed; retrying in $((attempt * 3))s" >&2
+            sleep $((attempt * 3))
+        done
+        if [ "$uv_installed" -ne 1 ]; then
+            echo "uv install failed after 5 attempts" >&2
+            exit 1
+        fi
     fi
     export PATH="$HOME/.local/bin:$PATH"
     # Pin a modern interpreter for the tool's ISOLATED venv. mini-swe-agent

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -89,7 +89,11 @@ class Terminus2Harness(BaseCliHarness):
     terminus_python: str = "3.12"
     parser_name: str = "json"  # "json" or "xml"
     temperature: float = 0.7
-    max_turns: int = 50
+    # Per-rollout turn cap. ``None`` = don't impose one — let Harbor's own
+    # (effectively unbounded) default apply, so the agent isn't artificially
+    # cut short; the per-rollout run timeout (RLLM_HARNESS_RUN_TIMEOUT_S) still
+    # bounds wall-clock. Set a value (e.g. via the train_*.sh scripts) to cap.
+    max_turns: int | None = None
     # Asciinema recording needs an extra dep and a writable trial dir; off by
     # default since rLLM scores from the verifier, not the cast.
     record_terminal_session: bool = False
@@ -118,12 +122,14 @@ class Terminus2Harness(BaseCliHarness):
             "RLLM_TERMINUS_API_BASE": gateway_url,
             "RLLM_TERMINUS_WORKDIR": str(task.metadata.get("workdir") or ""),
             "RLLM_TERMINUS_PARSER": self.parser_name,
-            "RLLM_TERMINUS_MAX_TURNS": str(self.max_turns),
             "RLLM_TERMINUS_TEMPERATURE": str(self.temperature),
             "RLLM_TERMINUS_RECORD": "1" if self.record_terminal_session else "0",
             "RLLM_TERMINUS_INSTRUCTION_FILE": _INSTRUCTION_PATH,
             "RLLM_TERMINUS_LOGS_DIR": _LOGS_DIR,
         }
+        # Only pass a turn cap when one is set; absent var = no artificial limit.
+        if self.max_turns is not None:
+            env["RLLM_TERMINUS_MAX_TURNS"] = str(self.max_turns)
         return env
 
     def write_configs(
@@ -260,7 +266,10 @@ async def _main():
     api_base = os.environ.get("RLLM_TERMINUS_API_BASE") or None
     workdir = os.environ.get("RLLM_TERMINUS_WORKDIR") or None
     parser = os.environ.get("RLLM_TERMINUS_PARSER", "json")
-    max_turns = int(os.environ.get("RLLM_TERMINUS_MAX_TURNS", "50"))
+    # Unset/empty = no artificial cap; Harbor's Terminus2 treats max_turns=None
+    # as its own (effectively unbounded) default.
+    _max_turns = os.environ.get("RLLM_TERMINUS_MAX_TURNS")
+    max_turns = int(_max_turns) if _max_turns else None
     temperature = float(os.environ.get("RLLM_TERMINUS_TEMPERATURE", "0.7"))
     record = os.environ.get("RLLM_TERMINUS_RECORD", "0") == "1"
     logs_dir = Path(os.environ.get("RLLM_TERMINUS_LOGS_DIR", "/tmp/terminus2/logs"))

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -88,7 +88,10 @@ class Terminus2Harness(BaseCliHarness):
     harbor_version: str = "0.3.0"
     terminus_python: str = "3.12"
     parser_name: str = "json"  # "json" or "xml"
-    temperature: float = 0.7
+    # Temperature the agent requests; in `rllm eval`/training the gateway
+    # enforces its own sampling params on top (default 1.0), so this is the
+    # value used only when sampling isn't gateway-enforced. Kept at 1.0 to match.
+    temperature: float = 1.0
     # Per-rollout turn cap. ``None`` = don't impose one — let Harbor's own
     # (effectively unbounded) default apply, so the agent isn't artificially
     # cut short; the per-rollout run timeout (RLLM_HARNESS_RUN_TIMEOUT_S) still
@@ -270,7 +273,7 @@ async def _main():
     # as its own (effectively unbounded) default.
     _max_turns = os.environ.get("RLLM_TERMINUS_MAX_TURNS")
     max_turns = int(_max_turns) if _max_turns else None
-    temperature = float(os.environ.get("RLLM_TERMINUS_TEMPERATURE", "0.7"))
+    temperature = float(os.environ.get("RLLM_TERMINUS_TEMPERATURE", "1.0"))
     record = os.environ.get("RLLM_TERMINUS_RECORD", "0") == "1"
     logs_dir = Path(os.environ.get("RLLM_TERMINUS_LOGS_DIR", "/tmp/terminus2/logs"))
     logs_dir.mkdir(parents=True, exist_ok=True)

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -327,7 +327,13 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
     """
     from daytona import CreateSnapshotParams, Daytona, DaytonaNotFoundError, Image, Resources
 
-    from rllm.eval._resolution import _as_single_run_line, _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
+    from rllm.eval._resolution import (
+        _as_single_run_line,
+        _dockerfile_run_commands,
+        _resolve_image,
+        _sandbox_resource_kwargs,
+        _should_replay_dockerfile,
+    )
 
     client = Daytona()
     try:
@@ -341,7 +347,9 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
         pass
 
     img = Image.base(_resolve_image(task, "daytona"))
-    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)]
+    # Honor [environment].replay_dockerfile: fully-built task images opt out so
+    # their RUN steps aren't double-applied on top of the prebuilt image.
+    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
     if install_script:
         run_commands.append(_as_single_run_line(install_script))
     if run_commands:

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -26,9 +26,28 @@ from rllm.sandbox.protocol import SnapshotNotFound
 
 logger = logging.getLogger(__name__)
 
-# Default sandbox lifetime: 30 minutes (Modal default is 5 min). Raise via the
-# env var for workloads whose single rollout can exceed it (e.g. long builds).
-_DEFAULT_TIMEOUT = env_int("RLLM_MODAL_SANDBOX_TIMEOUT_S", 30 * 60)
+# Headroom the sandbox lifetime keeps *beyond* the agent run timeout + install,
+# to cover the post-run verifier, teardown, and scheduling slack.
+_SANDBOX_LIFETIME_HEADROOM_S = 10 * 60
+
+
+def _default_sandbox_timeout() -> int:
+    """Default Modal sandbox lifetime (seconds) — must outlast a full rollout.
+
+    The lifetime clock starts at ``Sandbox.create()``, *before* the cold-path
+    install, the agent run, and the verifier. If it doesn't exceed their sum the
+    container is reaped mid-rollout (exit 137 + "Sandbox already shut down").
+    So derive it from the agent run-timeout knob with headroom for install +
+    verify + teardown. ``RLLM_MODAL_SANDBOX_TIMEOUT_S`` overrides outright.
+    (Modal's own default is only 5 min.)
+    """
+    explicit = env_int("RLLM_MODAL_SANDBOX_TIMEOUT_S", 0)
+    if explicit > 0:
+        return explicit
+    run_timeout = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600)
+    install_timeout = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)
+    return run_timeout + install_timeout + _SANDBOX_LIFETIME_HEADROOM_S
+
 
 # Modal caps an exec's total argv at 64 KiB (ARG_MAX); payloads above this go
 # through a chunked temp-file path instead of being inlined in the command.
@@ -84,7 +103,7 @@ class ModalSandbox:
 
         self.name = name
         self._image_spec = image
-        self._timeout = kwargs.pop("timeout", _DEFAULT_TIMEOUT)
+        self._timeout = kwargs.pop("timeout", None) or _default_sandbox_timeout()
         self._app_name = kwargs.pop("app_name", "rllm-sandbox")
 
         # A stored snapshot ref is a bare Modal image id ("im-…", no registry/tag);
@@ -335,11 +354,12 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
 
     # Size the build sandbox's lifetime to the worst-case replay: each RUN is
     # bounded at 900s (a step that hangs against a prebuilt image burns its
-    # full bound), plus the install bound and pull/capture slack. With the
-    # 30-min default, two hung steps killed the sandbox mid-build.
+    # full bound), plus the install bound and pull/capture slack — floored at
+    # the rollout default. Without this floor, two hung steps killed the
+    # sandbox mid-build.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
     n_replay = len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0
-    build_timeout = max(_DEFAULT_TIMEOUT, 900 * n_replay + install_budget + 600)
+    build_timeout = max(_default_sandbox_timeout(), 900 * n_replay + install_budget + 600)
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
     try:
         _replay_dockerfile(task, sb, "modal")

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -22,7 +22,7 @@ import threading
 import time
 import weakref
 
-from rllm.env import env_float, env_int
+from rllm.env import env_float, env_int, rllm_run_id
 from rllm.sandbox.protocol import SandboxCommandTimeout, SnapshotNotFound
 
 logger = logging.getLogger(__name__)
@@ -163,7 +163,11 @@ class ModalSandbox:
         self.name = name
         self._image_spec = image
         self._timeout = kwargs.pop("timeout", None) or _default_sandbox_timeout()
-        self._app_name = kwargs.pop("app_name", "rllm-sandbox")
+        # Per-run App name so a run's sandboxes are isolated on a shared Modal
+        # account: `modal app stop rllm-sandbox-<run_id>` kills only this run's
+        # sandboxes (set RLLM_RUN_ID; else a random per-process id). Pass an
+        # explicit app_name to override.
+        self._app_name = kwargs.pop("app_name", None) or f"rllm-sandbox-{rllm_run_id()}"
 
         # A stored snapshot ref is a bare Modal image id ("im-…", no registry/tag);
         # the ":" / "/" guard keeps real docker images off the from_id path.
@@ -183,6 +187,11 @@ class ModalSandbox:
                 modal_image = image  # already a modal.Image
 
             create_kwargs: dict = {"app": self._app, "image": modal_image, "timeout": self._timeout}
+            # name = per-task label (visible in `modal sandbox list`); tags carry
+            # the run id so you can filter/terminate a run's sandboxes:
+            #   modal.Sandbox.list(tags={"rllm_run_id": "<id>"})  -> .terminate()
+            create_kwargs["name"] = self.name[:64]
+            create_kwargs["tags"] = {"rllm_run_id": rllm_run_id()}
             for key in ("secrets", "volumes", "workdir", "gpu", "cpu", "memory"):
                 if key in kwargs:
                     create_kwargs[key] = kwargs.pop(key)

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -19,10 +19,11 @@ import logging
 import os
 import tarfile
 import threading
+import time
 import weakref
 
-from rllm.env import env_int
-from rllm.sandbox.protocol import SnapshotNotFound
+from rllm.env import env_float, env_int
+from rllm.sandbox.protocol import SandboxCommandTimeout, SnapshotNotFound
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,64 @@ _B64_ARGV_LIMIT = 50_000
 # atexit-tracked sandboxes; terminated on process exit to avoid leaks.
 _LIVE_SANDBOXES: weakref.WeakSet = weakref.WeakSet()
 _LIVE_LOCK = threading.Lock()
+
+
+class _CreateRateLimiter:
+    """Process-global token bucket pacing ``Sandbox.create()``.
+
+    Modal's create cap is a **token bucket**, not a flat cap: it absorbs an
+    initial burst, then refills at the rate its ``RESOURCE_EXHAUSTED`` error
+    advertises (~5/s). That shape is why a batch of ~192 concurrent creates can
+    sail through while ~256 trips it — the burst fits the bucket, then the extra
+    creates outrun the refill and Modal's client spends the batch in
+    retry/backoff (the repeated rate-limit warnings).
+
+    This mirrors that bucket on our side, gating every create through the one
+    chokepoint (:meth:`ModalSandbox.__init__`): up to ``burst`` go through
+    immediately, after which creates are paced at ``rate``/s. Tuned under
+    Modal's envelope, the startup burst is absorbed and only the long tail is
+    throttled — so creates queue locally instead of failing-and-retrying, with
+    little added latency for batches within the burst.
+
+    Thread-safe; token accounting is serialized under the lock while the wait
+    sleeps outside it, so concurrent callers self-correct on the next loop and
+    never collectively exceed ``rate``. Scope is per-process, which matches the
+    AgentFlowEngine path (all creates happen in the driver process).
+    """
+
+    def __init__(self, rate: float, burst: float) -> None:
+        self._rate = rate
+        self._capacity = max(1.0, burst)
+        self._tokens = self._capacity
+        self._last = time.monotonic()
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        if self._rate <= 0:  # disabled — e.g. account limit was raised
+            return
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                self._tokens = min(self._capacity, self._tokens + (now - self._last) * self._rate)
+                self._last = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                wait = (1.0 - self._tokens) / self._rate
+            time.sleep(wait)
+
+
+# Defaults sit inside the envelope observed live: a burst of ~192 concurrent
+# creates is fine, ~256 trips the limit, and the error advertises a ~5/s
+# refill. So allow a 150 burst (comfortably under the 192 that worked) and
+# refill at 4/s (under the stated 5/s) as a backstop for the long tail.
+# Steady-state create rate is usually far below the refill anyway (rollouts
+# free slots only as tasks finish), so in practice this just smooths startup.
+# Tune RLLM_MODAL_SANDBOX_CREATE_BURST / _RPS for your account; set _RPS=0 to
+# disable entirely (e.g. once Modal raises your limit).
+_CREATE_RATE_RPS = env_float("RLLM_MODAL_SANDBOX_CREATE_RPS", 4.0)
+_CREATE_BURST = env_float("RLLM_MODAL_SANDBOX_CREATE_BURST", 150.0)
+_CREATE_LIMITER = _CreateRateLimiter(_CREATE_RATE_RPS, _CREATE_BURST)
 
 
 def _terminate_all_live() -> None:
@@ -128,6 +187,8 @@ class ModalSandbox:
                 if key in kwargs:
                     create_kwargs[key] = kwargs.pop(key)
 
+            # Pace creates under Modal's account-wide rate cap (see _CreateRateLimiter).
+            _CREATE_LIMITER.acquire()
             self._sandbox = modal.Sandbox.create(**create_kwargs)
         except modal.exception.NotFoundError as e:
             if from_snapshot:
@@ -158,6 +219,7 @@ class ModalSandbox:
         if timeout is not None:
             exec_kwargs["timeout"] = int(timeout)
 
+        start = time.monotonic()
         process = self._sandbox.exec("bash", "-c", command, **exec_kwargs)
 
         stdout = process.stdout.read()
@@ -166,8 +228,21 @@ class ModalSandbox:
         # Wait for the process to complete and get exit code
         process.wait()
         exit_code = process.returncode
+        elapsed = time.monotonic() - start
 
         if exit_code != 0:
+            # A timeout SIGKILL surfaces as a negative returncode; flag it so an
+            # agent that simply spent its time budget isn't reported as a failure.
+            timed_out = timeout is not None and exit_code < 0 and elapsed >= timeout * 0.95
+            if timed_out:
+                logger.warning(
+                    "Command hit its %ds timeout in sandbox %s (killed after %.0fs): %s",
+                    int(timeout),
+                    self.name,
+                    elapsed,
+                    command[:200],
+                )
+                raise SandboxCommandTimeout(f"Command hit its {int(timeout)}s timeout in sandbox {self.name} (killed after {elapsed:.0f}s)")
             logger.warning(
                 "Command failed in sandbox %s: %s\nstderr: %s",
                 self.name,

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -322,7 +322,12 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     (stored as a diff from the base). A failed install fails the build — a
     snapshot keyed on the install must actually contain it.
     """
-    from rllm.eval._resolution import _create_base_sandbox, _dockerfile_run_commands, _replay_dockerfile
+    from rllm.eval._resolution import (
+        _create_base_sandbox,
+        _dockerfile_run_commands,
+        _replay_dockerfile,
+        _should_replay_dockerfile,
+    )
 
     if prior_ref and not force and _modal_ref_alive(prior_ref):
         logger.info("modal snapshot %s already live (%s) — reusing", key, prior_ref)
@@ -333,7 +338,8 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     # full bound), plus the install bound and pull/capture slack. With the
     # 30-min default, two hung steps killed the sandbox mid-build.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
-    build_timeout = max(_DEFAULT_TIMEOUT, 900 * len(_dockerfile_run_commands(task)) + install_budget + 600)
+    n_replay = len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0
+    build_timeout = max(_DEFAULT_TIMEOUT, 900 * n_replay + install_budget + 600)
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
     try:
         _replay_dockerfile(task, sb, "modal")

--- a/rllm/sandbox/protocol.py
+++ b/rllm/sandbox/protocol.py
@@ -13,6 +13,14 @@ class SnapshotNotFound(Exception):
     """
 
 
+class SandboxCommandTimeout(RuntimeError):
+    """Raised by a backend's ``exec`` when a command is killed for exceeding its
+    own ``timeout``. Distinct from a genuine non-zero exit so callers can treat
+    "the agent spent its whole time budget" as expected, not a failure.
+    Subclasses ``RuntimeError`` so existing handlers keep catching it.
+    """
+
+
 @runtime_checkable
 class Sandbox(Protocol):
     """Protocol for sandbox backends (Docker, Local, Modal, etc.)."""

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -70,9 +70,10 @@ def env_key(backend: str, base_image: str, run_commands: list[str], install_scri
 
 def env_key_for(task: Task, backend: str, install_script: str = "") -> str:
     """Fingerprint a task's environment via the shared image/RUN resolution."""
-    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image
+    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _should_replay_dockerfile
 
-    return env_key(backend, _resolve_image(task, backend), _dockerfile_run_commands(task), install_script)
+    run_commands = _dockerfile_run_commands(task) if _should_replay_dockerfile(task) else []
+    return env_key(backend, _resolve_image(task, backend), run_commands, install_script)
 
 
 def install_script_for(agent_flow: object) -> str:

--- a/rllm/trainer/algorithms/__init__.py
+++ b/rllm/trainer/algorithms/__init__.py
@@ -5,6 +5,16 @@ This module provides shared functionality across different trainer backends (ver
 """
 
 from rllm.trainer.algorithms.advantage import collect_reward_and_advantage_from_trajectory_groups
+from rllm.trainer.algorithms.aux_loss import (
+    AUX_LOSS_REGISTRY,
+    MASK_ACTION,
+    MASK_OBSERVATION,
+    AuxiliaryLoss,
+    EnvPredictionLoss,
+    build_aux_losses,
+    get_aux_loss,
+    register_aux_loss,
+)
 from rllm.trainer.algorithms.config import (
     AlgorithmConfig,
     AsyncTrainingConfig,
@@ -43,6 +53,15 @@ __all__ = [
     # Advantage computation
     "rLLMAdvantageEstimator",
     "collect_reward_and_advantage_from_trajectory_groups",
+    # Auxiliary losses
+    "AuxiliaryLoss",
+    "EnvPredictionLoss",
+    "build_aux_losses",
+    "register_aux_loss",
+    "get_aux_loss",
+    "AUX_LOSS_REGISTRY",
+    "MASK_ACTION",
+    "MASK_OBSERVATION",
     # Metrics
     "reduce_metrics_by_trajectory_name",
     "reduce_metrics_lists",

--- a/rllm/trainer/algorithms/advantage.py
+++ b/rllm/trainer/algorithms/advantage.py
@@ -136,6 +136,18 @@ def calculate_rloo_advantages(rewards: list[np.ndarray], algorithm_config: Algor
     return advantages_by_group, returns_by_group
 
 
+@register_rllm_adv_estimator(rLLMAdvantageEstimator.ECHO)
+def calculate_echo_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """ECHO (arXiv:2605.24517): advantages are identical to GRPO.
+
+    ECHO's only departure from GRPO is an auxiliary cross-entropy loss on
+    environment-observation tokens, added in each backend's loss path and gated
+    by ``algorithm_config.env_loss_coef``. The advantage estimation here is just
+    GRPO so the policy-gradient term is unchanged.
+    """
+    return calculate_grpo_advantages(rewards, algorithm_config, **kwargs)
+
+
 def _collect_precomputed_advantages(group: TrajectoryGroup, group_role: str) -> list[float]:
     """Collect pre-computed per-token advantages from all steps.
 

--- a/rllm/trainer/algorithms/aux_loss.py
+++ b/rllm/trainer/algorithms/aux_loss.py
@@ -1,0 +1,135 @@
+"""Auxiliary token-level losses added on top of the policy-gradient loss.
+
+See ``design/auxiliary-losses.md``. A growing family of agent-RL algorithms keep
+GRPO as the optimization backbone and add a token-level auxiliary loss of the
+form ``coef * Agg_mask(weight_t * [-log p_theta(token_t)])`` — e.g. ECHO (predict
+environment-observation tokens) and SDAR (gated on-policy self-distillation).
+
+An :class:`AuxiliaryLoss` declares *what* to add (a named token subset, a
+coefficient, and an optional dynamic per-token weight). Backend executors decide
+*how* to compute it:
+
+* verl folds the term into the single existing forward/backward pass
+  (``rllm.trainer.verl.verl_backend.CustomPPOLoss``).
+* tinker / fireworks submit an extra gradient-accumulated ``cross_entropy`` pass
+  (``rllm.trainer.tinker.aux_loss``).
+
+This module is backend-agnostic (no torch / tinker imports): it only defines the
+spec, the registry, and the config plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Named token subsets. Resolved to concrete masks by each backend executor
+# (verl: tensor masks from response_mask/responses; tinker/fireworks: the datum
+# ``mask`` field). Defining the names here keeps the vocabulary in one place.
+# ---------------------------------------------------------------------------
+MASK_ACTION = "action"  # assistant/action tokens (what GRPO trains)
+MASK_OBSERVATION = "observation"  # environment-observation tokens (tool/terminal output)
+_KNOWN_MASKS = {MASK_ACTION, MASK_OBSERVATION}
+
+
+AUX_LOSS_REGISTRY: dict[str, type[AuxiliaryLoss]] = {}
+
+
+def register_aux_loss(name: str):
+    """Register an :class:`AuxiliaryLoss` subclass under ``name`` (the config ``type``)."""
+
+    def deco(cls: type[AuxiliaryLoss]) -> type[AuxiliaryLoss]:
+        cls.name = name
+        AUX_LOSS_REGISTRY[name] = cls
+        return cls
+
+    return deco
+
+
+def get_aux_loss(name: str) -> type[AuxiliaryLoss]:
+    if name not in AUX_LOSS_REGISTRY:
+        raise ValueError(f"Unknown auxiliary loss '{name}'. Registered: {sorted(AUX_LOSS_REGISTRY)}. Register one with @register_aux_loss.")
+    return AUX_LOSS_REGISTRY[name]
+
+
+class AuxiliaryLoss:
+    """Declarative spec for a token-level auxiliary loss.
+
+    Subclasses set class attributes and (optionally) override :meth:`weight`.
+    The contributed loss is ``coef * Agg_mask(weight_t * [-log p_theta(token_t)])``
+    over the tokens selected by ``mask``; ``token_t`` is the rollout's own token
+    at each masked position (already scored by the forward pass).
+
+    Attributes:
+        name: registry key (set by :func:`register_aux_loss`).
+        mask: which token subset the loss applies to (``MASK_*``).
+        requires: declared auxiliary forward passes (e.g. SDAR's teacher branch).
+            Not yet implemented — a non-empty value raises (design step 4).
+    """
+
+    name: str = ""
+    mask: str = MASK_OBSERVATION
+    requires: tuple = ()
+
+    def __init__(self, coef: float, **cfg):
+        self.coef = float(coef)
+        self.cfg = cfg
+        if self.mask not in _KNOWN_MASKS:
+            raise ValueError(f"Auxiliary loss '{self.name or type(self).__name__}' has unknown mask '{self.mask}' (known: {sorted(_KNOWN_MASKS)})")
+        if self.requires:
+            # AuxForward (dynamic-weight losses needing an extra teacher/privileged
+            # forward pass, e.g. SDAR) is the next milestone; see the design doc.
+            raise NotImplementedError(f"Auxiliary loss '{self.name}' declares requires={self.requires!r}, but AuxForward is not implemented yet (design step 4).")
+
+    def weight(self, ctx) -> None:
+        """Per-token weight tensor, or ``None`` for uniform (coef-only) weighting.
+
+        ``ctx`` is the backend-specific context (forward-pass log-probs, entropy,
+        masks). Returning ``None`` — the default — means every masked token is
+        weighted equally, i.e. plain coef-scaled cross-entropy (ECHO). Dynamic
+        weights (e.g. SDAR's detached sigmoid gate) override this.
+        """
+        return None
+
+
+@register_aux_loss("env_prediction")
+class EnvPredictionLoss(AuxiliaryLoss):
+    """ECHO (arXiv:2605.24517): length-normalized cross-entropy on environment
+    observation tokens. Reuses the existing forward pass; uniform weight."""
+
+    mask = MASK_OBSERVATION
+
+
+def build_aux_losses(algorithm_config) -> list[AuxiliaryLoss]:
+    """Instantiate the auxiliary losses configured on an ``AlgorithmConfig``.
+
+    Reads ``algorithm_config.aux_losses`` (a list of ``{"type", "coef", ...}``
+    specs). For backward compatibility, a positive ``algorithm_config.env_loss_coef``
+    is treated as shorthand for an ``env_prediction`` aux loss (this is how
+    ``adv_estimator=echo`` enables ECHO), unless ``env_prediction`` is already
+    listed explicitly.
+    """
+    specs = list(getattr(algorithm_config, "aux_losses", None) or [])
+    losses: list[AuxiliaryLoss] = []
+    seen_types: set[str] = set()
+    for spec in specs:
+        spec = dict(spec)
+        loss_type = spec.pop("type", None)
+        if loss_type is None:
+            raise ValueError(f"aux_losses entry is missing 'type': {spec}")
+        coef = spec.pop("coef", None)
+        if coef is None:
+            raise ValueError(f"aux_losses entry '{loss_type}' is missing 'coef'")
+        losses.append(get_aux_loss(loss_type)(coef=coef, **spec))
+        seen_types.add(loss_type)
+
+    # Back-compat sugar: env_loss_coef == an env_prediction aux loss.
+    env_coef = float(getattr(algorithm_config, "env_loss_coef", 0.0) or 0.0)
+    if env_coef > 0.0 and "env_prediction" not in seen_types:
+        losses.append(EnvPredictionLoss(coef=env_coef))
+
+    if losses:
+        logger.info("Auxiliary losses enabled: %s", [(loss.name, loss.coef) for loss in losses])
+    return losses

--- a/rllm/trainer/algorithms/config.py
+++ b/rllm/trainer/algorithms/config.py
@@ -35,6 +35,19 @@ def _plain(value: Any) -> Any:
     return OmegaConf.to_container(value, resolve=False) if OmegaConf.is_config(value) else value
 
 
+def _to_plain_list(value: Any) -> list:
+    """Convert an OmegaConf list (e.g. ``algorithm.aux_losses``) to a plain list.
+
+    Returns ``[]`` for ``None``. Used so downstream code (``build_aux_losses``)
+    sees ordinary dicts rather than OmegaConf nodes.
+    """
+    if value is None:
+        return []
+    if OmegaConf.is_config(value):
+        return OmegaConf.to_container(value, resolve=True)  # type: ignore[return-value]
+    return list(value)
+
+
 def sync_shared_keys(
     config: DictConfig,
     shared_keys: list[tuple[str, str]],
@@ -250,6 +263,10 @@ class rLLMAdvantageEstimator(str, Enum):
     REINFORCE_PLUS_PLUS_BASELINE = "reinforce_plus_plus_baseline"
     PRPO = "prpo"
     RLOO = "rloo"
+    # ECHO (arXiv:2605.24517): GRPO advantages + an auxiliary cross-entropy loss
+    # on environment-observation tokens. The advantage math is identical to GRPO;
+    # selecting `echo` flips on the env-loss term (see `env_loss_coef`).
+    ECHO = "echo"
     OTHER = "other"
 
     @classmethod
@@ -285,6 +302,19 @@ class AlgorithmConfig:
     use_precomputed_advantage: bool = False
     # Global loss function (backend-specific values; null = backend default)
     loss_fn: str | None = None
+    # ECHO (arXiv:2605.24517) auxiliary environment-prediction loss weight (lambda).
+    # The total loss is L_GRPO + env_loss_coef * L_env, where L_env is the
+    # length-normalized cross-entropy on environment-observation tokens (tool
+    # output) that the policy conditions on but GRPO never trains. None = auto:
+    # resolved in __post_init__ to 0.05 when adv_estimator=echo, else 0.0
+    # (disabled). Backends read the resolved float; 0.0 reproduces plain GRPO.
+    # Shorthand for `aux_losses: [{type: env_prediction, coef: <env_loss_coef>}]`.
+    env_loss_coef: float | None = None
+    # General auxiliary token-level losses added on top of the policy loss
+    # (see rllm.trainer.algorithms.aux_loss and design/auxiliary-losses.md). Each
+    # entry is a {"type": <registered name>, "coef": <float>, ...} spec. Backends
+    # build these via build_aux_losses(); empty = none (plain GRPO).
+    aux_losses: list = field(default_factory=list)
     lr_schedule: Literal["linear", "cosine", "constant"] = "constant"
     warmup_steps: int = -1
     warmup_steps_ratio: float = 0.0
@@ -328,6 +358,8 @@ class AlgorithmConfig:
             norm_adv_by_std_in_grpo=algorithm_config.get("norm_adv_by_std_in_grpo", True),
             use_precomputed_advantage=algorithm_config.get("use_precomputed_advantage", False),
             loss_fn=algorithm_config.get("loss_fn", None),
+            env_loss_coef=algorithm_config.get("env_loss_coef", None),
+            aux_losses=_to_plain_list(algorithm_config.get("aux_losses", None)),
             lr_schedule=algorithm_config.get("lr_schedule", "constant"),
             warmup_steps=algorithm_config.get("warmup_steps", -1),
             warmup_steps_ratio=algorithm_config.get("warmup_steps_ratio", 0.0),
@@ -348,6 +380,12 @@ class AlgorithmConfig:
                 DeprecationWarning,
                 stacklevel=2,
             )
+
+        # ECHO: resolve the auxiliary env-loss coefficient. `adv_estimator=echo`
+        # implies the paper's default lambda (0.05) unless the user set
+        # `env_loss_coef` explicitly; any other estimator defaults to 0.0 (off).
+        if self.env_loss_coef is None:
+            self.env_loss_coef = 0.05 if self.estimator == rLLMAdvantageEstimator.ECHO else 0.0
 
         # Normalize estimator_map: split (estimator, loss_fn) tuples.
         normalized_map: dict[str, rLLMAdvantageEstimator | str] = {}

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -73,11 +73,16 @@ trainer:
 
 # Algorithm Configuration
 algorithm:
-  adv_estimator: grpo # [grpo, reinforce, reinforce_plus_plus_baseline, rloo]
+  adv_estimator: grpo # [grpo, reinforce, reinforce_plus_plus_baseline, rloo, echo]
   norm_adv_by_std_in_grpo: true
   use_rllm: null  # deprecated, unified trainer only support rllm advantage estimators
   use_precomputed_advantage: false # use pre-computed step.advantage from the workflow (e.g. distillation)
   loss_fn: null           # backend-specific values; null = backend default
+  # ECHO (arXiv:2605.24517): auxiliary cross-entropy on environment-observation
+  # tokens, added as `env_loss_coef * L_env` to the GRPO loss. null = auto
+  # (0.05 when adv_estimator=echo, else 0.0 = disabled / plain GRPO). Works on
+  # verl, tinker, and fireworks via the unified trainer.
+  env_loss_coef: null
   loss_agg_mode: null     # [null, token-mean, seq-mean-token-sum, seq-mean-token-mean]
   lr_schedule: constant   # [constant, linear, cosine]
   warmup_steps: -1        # Absolute optimizer-step warmup; <=0 uses warmup_steps_ratio

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -73,6 +73,41 @@ def builtin_loss_args(algorithm_config: AlgorithmConfig):
     )
 
 
+def _fold_aux_into_loss(inner_loss_fn, aux_weight_vecs):
+    """Wrap a cookbook client policy ``loss_fn(data, logprobs_list)`` so it also
+    adds each token-level auxiliary term (ECHO, ...) computed from the *same*
+    forward's per-token logprobs.
+
+    Each auxiliary term is ``sum_t weights_t * (-logprob_t)`` over the rollout's
+    tokens -- exactly the loss the managed backends' separate ``cross_entropy``
+    pass computed (``cross_entropy`` is ``sum_t -logprobs_t * weights_t``). So
+    folding it into the policy closure makes the accumulated gradient equal
+    policy-grad + aux-grad from the old two-pass path, for one fewer backward.
+
+    ``aux_weight_vecs`` is ``list[(name, [per-datum weight list | None])]``;
+    ``None`` skips a datum with no selected (e.g. observation) token.
+    """
+    import torch
+
+    def loss_fn(data, logprobs_list):
+        loss, metrics = inner_loss_fn(data, logprobs_list)
+        for name, wvecs in aux_weight_vecs:
+            term = None
+            for i, lp in enumerate(logprobs_list):
+                wv = wvecs[i] if i < len(wvecs) else None
+                if wv is None:
+                    continue
+                w = torch.tensor(wv, dtype=lp.dtype, device=lp.device)
+                contrib = -(lp * w).sum()
+                term = contrib if term is None else term + contrib
+            if term is not None:
+                loss = loss + term
+                metrics[f"aux_{name}_loss"] = float(term.item())
+        return loss, metrics
+
+    return loss_fn
+
+
 class FireworksPolicyTrainer:
     """Handles policy updates via gradient descent using Fireworks Firetitan.
 
@@ -274,31 +309,6 @@ class FireworksPolicyTrainer:
 
         return clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens
 
-    @staticmethod
-    def _build_aux_datums(raw_datums: list[tinker.Datum], aux, n_seq: int) -> list[tinker.Datum]:
-        """Build ``cross_entropy`` datums for one auxiliary loss (ECHO, ...).
-
-        For each rollout we emit a datum over the same tokens, weighting every
-        selected token (``aux.mask``) by ``coef / (n_seq * |selected_i|)`` and the
-        rest by 0. Under ``GradAccNormalization.NONE`` the summed gradient equals
-        ``coef * d/dtheta [ mean_i (1/|selected_i|) sum_t -log p(target_t) ]``,
-        i.e. ``coef`` times the length-normalized, sequence-mean auxiliary loss
-        (for ECHO, the paper's L_env). Datums with no selected token are skipped.
-        """
-        from rllm.trainer.tinker.aux_loss import aux_positions, build_aux_ce_datum
-
-        out: list[tinker.Datum] = []
-        for datum in raw_datums:
-            positions = aux_positions(aux, datum.loss_fn_inputs["mask"].data)
-            count = sum(1 for p in positions if p)
-            if count == 0:
-                continue
-            scale = aux.coef / (n_seq * count)
-            built = build_aux_ce_datum(datum.model_input, datum.loss_fn_inputs["target_tokens"], positions, scale)
-            if built is not None:
-                out.append(built)
-        return out
-
     async def _compute_proximal_logprobs(
         self,
         datums: list[tinker.Datum],
@@ -447,7 +457,12 @@ class FireworksPolicyTrainer:
         trajectory_groups: list[TrajectoryGroup],
         algorithm_config: AlgorithmConfig | None = None,
     ) -> tuple[list[tinker.Datum] | dict[str, list[tinker.Datum]], list[torch.Tensor], dict]:
-        """Run forward-backward pass using the builtin server-side loss kernel.
+        """Run the forward-backward pass for one optimizer step.
+
+        Without auxiliary losses this uses the fast server-side builtin loss
+        kernel. With an auxiliary loss (ECHO, ...) it switches to the client
+        loss path and folds the aux term into a single ``forward_backward_custom``
+        (see ``_forward_backward_client_with_aux``).
 
         Args:
             trajectory_groups: List of TrajectoryGroup objects (already filtered/transformed).
@@ -481,34 +496,10 @@ class FireworksPolicyTrainer:
             for i in range(len(advantages)):
                 advantages[i] /= max(1, num_loss_tokens[i])
 
-        # Auxiliary losses (ECHO, ...): build a second, gradient-accumulated
-        # cross_entropy pass per loss. Fireworks' optim_step normalizes the
-        # *summed* gradient by token/sequence counts across ALL passes, which
-        # would rescale the policy gradient. To keep the policy-gradient term
-        # identical to a non-aux run, we fold the normalization optim would have
-        # applied into the advantages here and force GradAccNormalization.NONE at
-        # optim_step (see optim_step()). The aux datums carry their own
-        # per-sequence length normalization so each term equals exactly
-        # ``coef * grad(aux_loss)``.
         aux_losses = build_aux_losses(algorithm_config)
-        aux_passes: list[tuple] = []  # (aux, datums)
-        if aux_losses:
-            n_seq = max(1, len(raw_datums))
-            agg = algorithm_config.loss_agg_mode
-            if agg in ("seq-mean-token-sum", "seq-mean-token-mean"):
-                for i in range(len(advantages)):
-                    advantages[i] /= n_seq  # optim would divide by NUM_SEQUENCES
-            elif agg == "token-mean":
-                total_action_tokens = max(1, sum(num_loss_tokens))
-                for i in range(len(advantages)):
-                    advantages[i] /= total_action_tokens  # optim would divide by NUM_LOSS_TOKENS
-            # agg None/other => optim NONE => no fold needed.
-            for aux in aux_losses:
-                datums = self._build_aux_datums(raw_datums, aux, n_seq)
-                if datums:
-                    aux_passes.append((aux, datums))
 
-        # Proximal logprobs
+        # Proximal logprobs (pi_old): rollout logprobs in bypass mode, else a
+        # separate forward (3-policy / decoupled PPO).
         t0 = time.perf_counter()
         if rc.bypass_mode:
             prox_logprobs = inf_logprobs
@@ -523,8 +514,29 @@ class FireworksPolicyTrainer:
         )
         adv_metrics["time/proximal_forward"] = time.perf_counter() - t0
 
-        # Build datums for the builtin kernel.
         tis_config = TISConfig(level=rc.tis_mode or "token", cap=rc.tis_cap) if rc.tis_mode else None
+
+        # Auxiliary losses (ECHO, ...): the managed builtin kernel can only
+        # express the policy loss, so rather than a second cross_entropy pass we
+        # take the client loss path and fold every aux term into ONE
+        # forward_backward_custom (see _forward_backward_client_with_aux). One
+        # fewer backward; same accumulated gradient as the old two-pass path.
+        if aux_losses:
+            await self._forward_backward_client_with_aux(
+                raw_datums=raw_datums,
+                advantages=advantages,
+                inf_logprobs=inf_logprobs,
+                prox_logprobs=prox_logprobs,
+                prompt_lens=prompt_lens,
+                num_loss_tokens=num_loss_tokens,
+                aux_losses=aux_losses,
+                algorithm_config=algorithm_config,
+                tis_config=tis_config,
+                adv_metrics=adv_metrics,
+            )
+            return raw_datums, [], adv_metrics
+
+        # No auxiliary loss: server-side builtin kernel (fast path).
         builtin_datums = build_builtin_loss_datums(
             clean_datums,
             advantages,
@@ -549,22 +561,111 @@ class FireworksPolicyTrainer:
                 if k not in self._METRIC_SKIP_KEYS:
                     adv_metrics[f"train/{k}"] = v
 
-        # Auxiliary-loss passes: each accumulates gradients on top of the policy
-        # gradient before the (externally invoked) optim_step.
-        for aux, datums in aux_passes:
-            aux_fwd_bwd = await asyncio.to_thread(
-                self.training_client.forward_backward,
-                datums,
-                "cross_entropy",
-            )
-            if hasattr(aux_fwd_bwd, "metrics") and aux_fwd_bwd.metrics:
-                for k, v in aux_fwd_bwd.metrics.items():
-                    if k not in self._METRIC_SKIP_KEYS:
-                        adv_metrics[f"train/aux_{aux.name}_{k}"] = v
-            adv_metrics[f"train/aux_{aux.name}_coef"] = aux.coef
-            adv_metrics[f"train/aux_{aux.name}_sequences"] = len(datums)
-
         return raw_datums, [], adv_metrics
+
+    @require_training_client
+    async def _forward_backward_client_with_aux(
+        self,
+        *,
+        raw_datums: list[tinker.Datum],
+        advantages: list[float],
+        inf_logprobs: list[list[float]],
+        prox_logprobs: list[list[float]],
+        prompt_lens: list[int],
+        num_loss_tokens: list[int],
+        aux_losses: list,
+        algorithm_config: AlgorithmConfig,
+        tis_config,
+        adv_metrics: dict,
+    ) -> None:
+        """Fold token-level auxiliary losses (ECHO) into the policy-gradient pass.
+
+        The managed builtin kernel only expresses the policy loss, so ECHO is
+        normally a *second* ``cross_entropy`` pass. Here we take the client loss
+        path: ONE ``forward_backward_custom`` whose closure computes the policy
+        loss (cookbook ``build_loss_fn``) plus each aux term from the single
+        forward's per-token logprobs. The accumulated gradient is identical to
+        the two-pass builtin path -- the advantages carry the policy
+        normalization optim would apply, and each aux token carries
+        ``coef/(n_seq*|O_i|)`` (the same weights the separate cross_entropy pass
+        used) -- for one fewer backward. ``optim_step`` forces
+        ``GradAccNormalization.NONE`` while aux losses are active, so neither
+        term is rescaled.
+
+        Mutates ``advantages`` in place (folds normalization) and writes metrics
+        into ``adv_metrics``.
+        """
+        from training.utils.rl.losses import build_loss_fn
+
+        from rllm.trainer.tinker.aux_loss import aux_positions, build_aux_ce_datum
+
+        n_seq = max(1, len(raw_datums))
+
+        # Fold the normalization optim_step would otherwise apply into the
+        # advantages (matches the builtin path; optim_step then uses NONE).
+        # agg None/other => optim NONE already => no fold needed.
+        agg = algorithm_config.loss_agg_mode
+        if agg in ("seq-mean-token-sum", "seq-mean-token-mean"):
+            for i in range(len(advantages)):
+                advantages[i] /= n_seq  # optim would divide by NUM_SEQUENCES
+        elif agg == "token-mean":
+            total_action_tokens = max(1, sum(num_loss_tokens))
+            for i in range(len(advantages)):
+                advantages[i] /= total_action_tokens  # optim would divide by NUM_LOSS_TOKENS
+
+        # Per-aux, per-datum token weight vectors -- the SAME weights the
+        # separate cross_entropy pass built (build_aux_ce_datum with
+        # scale=coef/(n_seq*|O_i|)), so summing -logp*weight reproduces L_env.
+        # None marks a datum with no selected (observation) token.
+        aux_weight_vecs: list[tuple[str, list]] = []
+        for aux in aux_losses:
+            wvecs: list = []
+            n_with_obs = 0
+            for d in raw_datums:
+                positions = aux_positions(aux, d.loss_fn_inputs["mask"].data)
+                count = sum(1 for p in positions if p)
+                if count == 0:
+                    wvecs.append(None)
+                    continue
+                n_with_obs += 1
+                built = build_aux_ce_datum(
+                    d.model_input,
+                    d.loss_fn_inputs["target_tokens"],
+                    positions,
+                    aux.coef / (n_seq * count),
+                )
+                wvecs.append(list(built.loss_fn_inputs["weights"].data) if built is not None else None)
+            aux_weight_vecs.append((aux.name, wvecs))
+            adv_metrics[f"train/aux_{aux.name}_coef"] = aux.coef
+            adv_metrics[f"train/aux_{aux.name}_sequences"] = n_with_obs
+
+        # Policy-loss closure (cookbook). kl_beta is 0 on the managed path
+        # (validated at setup), so ref_logprobs is unused.
+        args = builtin_loss_args(algorithm_config)
+        if tis_config is not None:
+            args.tis = tis_config
+        inner_loss_fn = build_loss_fn(args)(advantages, [], prompt_lens, inf_logprobs, prox_logprobs)
+        loss_fn = _fold_aux_into_loss(inner_loss_fn, aux_weight_vecs)
+
+        # forward_backward_custom accepts only {target_tokens, weights}; the
+        # action mask rides under "weights" so run_loss_loop reads it as the
+        # per-token loss mask (1 on action tokens).
+        custom_datums = [
+            tinker.Datum(
+                model_input=d.model_input,
+                loss_fn_inputs={
+                    "target_tokens": d.loss_fn_inputs["target_tokens"],
+                    "weights": d.loss_fn_inputs["mask"],
+                },
+            )
+            for d in raw_datums
+        ]
+
+        result = await asyncio.to_thread(self.training_client.forward_backward_custom, custom_datums, loss_fn)
+        if hasattr(result, "metrics") and result.metrics:
+            for k, v in result.metrics.items():
+                if k not in self._METRIC_SKIP_KEYS:
+                    adv_metrics[f"train/{k}"] = v
 
     # ------------------------------------------------------------------
     # Optimizer step
@@ -606,11 +707,11 @@ class FireworksPolicyTrainer:
             "seq-mean-token-mean": GradAccNormalization.NUM_SEQUENCES,
         }
         grad_norm = _LOSS_AGG_MAP.get(self.algorithm_config.loss_agg_mode)
-        # Auxiliary losses accumulate extra gradient passes before this step and
-        # fold the intended normalization into the per-datum weights/advantages
-        # (see forward_backward_from_trajectory_groups). Re-normalizing here by
-        # token/sequence counts that span all passes would rescale the policy
-        # gradient, so we disable server-side grad-accumulation normalization.
+        # With auxiliary losses the step uses the client loss path, which folds
+        # the intended policy normalization into the advantages and carries the
+        # aux term's own length normalization in its weights (see
+        # _forward_backward_client_with_aux). Re-normalizing here would rescale
+        # the policy gradient, so disable server-side grad-accumulation norm.
         if build_aux_losses(self.algorithm_config):
             grad_norm = GradAccNormalization.NONE
         optim_result = await asyncio.to_thread(

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -28,6 +28,7 @@ from rllm.trainer.algorithms import (
     AlgorithmConfig,
     CompactFilteringConfig,
     TransformConfig,
+    build_aux_losses,
 )
 from rllm.trainer.tinker.tinker_policy_trainer import (
     compute_schedule_lr_multiplier,
@@ -273,6 +274,31 @@ class FireworksPolicyTrainer:
 
         return clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens
 
+    @staticmethod
+    def _build_aux_datums(raw_datums: list[tinker.Datum], aux, n_seq: int) -> list[tinker.Datum]:
+        """Build ``cross_entropy`` datums for one auxiliary loss (ECHO, ...).
+
+        For each rollout we emit a datum over the same tokens, weighting every
+        selected token (``aux.mask``) by ``coef / (n_seq * |selected_i|)`` and the
+        rest by 0. Under ``GradAccNormalization.NONE`` the summed gradient equals
+        ``coef * d/dtheta [ mean_i (1/|selected_i|) sum_t -log p(target_t) ]``,
+        i.e. ``coef`` times the length-normalized, sequence-mean auxiliary loss
+        (for ECHO, the paper's L_env). Datums with no selected token are skipped.
+        """
+        from rllm.trainer.tinker.aux_loss import aux_positions, build_aux_ce_datum
+
+        out: list[tinker.Datum] = []
+        for datum in raw_datums:
+            positions = aux_positions(aux, datum.loss_fn_inputs["mask"].data)
+            count = sum(1 for p in positions if p)
+            if count == 0:
+                continue
+            scale = aux.coef / (n_seq * count)
+            built = build_aux_ce_datum(datum.model_input, datum.loss_fn_inputs["target_tokens"], positions, scale)
+            if built is not None:
+                out.append(built)
+        return out
+
     async def _compute_proximal_logprobs(
         self,
         datums: list[tinker.Datum],
@@ -455,6 +481,33 @@ class FireworksPolicyTrainer:
             for i in range(len(advantages)):
                 advantages[i] /= max(1, num_loss_tokens[i])
 
+        # Auxiliary losses (ECHO, ...): build a second, gradient-accumulated
+        # cross_entropy pass per loss. Fireworks' optim_step normalizes the
+        # *summed* gradient by token/sequence counts across ALL passes, which
+        # would rescale the policy gradient. To keep the policy-gradient term
+        # identical to a non-aux run, we fold the normalization optim would have
+        # applied into the advantages here and force GradAccNormalization.NONE at
+        # optim_step (see optim_step()). The aux datums carry their own
+        # per-sequence length normalization so each term equals exactly
+        # ``coef * grad(aux_loss)``.
+        aux_losses = build_aux_losses(algorithm_config)
+        aux_passes: list[tuple] = []  # (aux, datums)
+        if aux_losses:
+            n_seq = max(1, len(raw_datums))
+            agg = algorithm_config.loss_agg_mode
+            if agg in ("seq-mean-token-sum", "seq-mean-token-mean"):
+                for i in range(len(advantages)):
+                    advantages[i] /= n_seq  # optim would divide by NUM_SEQUENCES
+            elif agg == "token-mean":
+                total_action_tokens = max(1, sum(num_loss_tokens))
+                for i in range(len(advantages)):
+                    advantages[i] /= total_action_tokens  # optim would divide by NUM_LOSS_TOKENS
+            # agg None/other => optim NONE => no fold needed.
+            for aux in aux_losses:
+                datums = self._build_aux_datums(raw_datums, aux, n_seq)
+                if datums:
+                    aux_passes.append((aux, datums))
+
         # Proximal logprobs
         t0 = time.perf_counter()
         if rc.bypass_mode:
@@ -495,6 +548,21 @@ class FireworksPolicyTrainer:
             for k, v in fwd_bwd_result.metrics.items():
                 if k not in self._METRIC_SKIP_KEYS:
                     adv_metrics[f"train/{k}"] = v
+
+        # Auxiliary-loss passes: each accumulates gradients on top of the policy
+        # gradient before the (externally invoked) optim_step.
+        for aux, datums in aux_passes:
+            aux_fwd_bwd = await asyncio.to_thread(
+                self.training_client.forward_backward,
+                datums,
+                "cross_entropy",
+            )
+            if hasattr(aux_fwd_bwd, "metrics") and aux_fwd_bwd.metrics:
+                for k, v in aux_fwd_bwd.metrics.items():
+                    if k not in self._METRIC_SKIP_KEYS:
+                        adv_metrics[f"train/aux_{aux.name}_{k}"] = v
+            adv_metrics[f"train/aux_{aux.name}_coef"] = aux.coef
+            adv_metrics[f"train/aux_{aux.name}_sequences"] = len(datums)
 
         return raw_datums, [], adv_metrics
 
@@ -538,6 +606,13 @@ class FireworksPolicyTrainer:
             "seq-mean-token-mean": GradAccNormalization.NUM_SEQUENCES,
         }
         grad_norm = _LOSS_AGG_MAP.get(self.algorithm_config.loss_agg_mode)
+        # Auxiliary losses accumulate extra gradient passes before this step and
+        # fold the intended normalization into the per-datum weights/advantages
+        # (see forward_backward_from_trajectory_groups). Re-normalizing here by
+        # token/sequence counts that span all passes would rescale the policy
+        # gradient, so we disable server-side grad-accumulation normalization.
+        if build_aux_losses(self.algorithm_config):
+            grad_norm = GradAccNormalization.NONE
         optim_result = await asyncio.to_thread(
             self.training_client.optim_step,
             adam_params,

--- a/rllm/trainer/tinker/aux_loss.py
+++ b/rllm/trainer/tinker/aux_loss.py
@@ -1,0 +1,61 @@
+"""Managed-backend executor for token-level auxiliary losses (tinker / fireworks).
+
+Both managed backends compute their primary loss in a fixed server-side kernel,
+so an auxiliary loss (see ``rllm.trainer.algorithms.aux_loss`` and
+``design/auxiliary-losses.md``) is expressed as an extra gradient-accumulated
+``cross_entropy`` pass over the same rollout datums, weighting the selected token
+subset. Tinker's ``cross_entropy`` loss is ``-sum_t weights_t * logprob(target_t)``,
+so weighting position ``t`` by ``w_t`` contributes ``w_t * (-logprob(target_t))``
+to the (accumulated) gradient.
+
+This module holds the parts shared by tinker and fireworks: the token-subset
+selector and the datum builder. The per-token weight *scale* differs by backend
+normalization (tinker accumulates raw; fireworks folds normalization into the
+weights and disables grad-accumulation normalization) and is supplied by the
+caller.
+"""
+
+from __future__ import annotations
+
+import tinker
+from tinker.types.tensor_data import TensorData
+
+from rllm.trainer.algorithms import MASK_ACTION, MASK_OBSERVATION
+from rllm.trainer.algorithms.aux_loss import AuxiliaryLoss
+
+
+def aux_positions(aux: AuxiliaryLoss, mask_values) -> list[bool]:
+    """Boolean per-token selector for ``aux`` from a datum's action mask.
+
+    The datum ``mask`` is ``1.0`` on action tokens and ``0.0`` on environment
+    observation tokens (built by ``rllm.trainer.tinker.transform``).
+    """
+    is_obs = [float(m) == 0.0 for m in mask_values]
+    if aux.mask == MASK_OBSERVATION:
+        return is_obs
+    if aux.mask == MASK_ACTION:
+        return [not o for o in is_obs]
+    raise ValueError(f"Auxiliary mask '{aux.mask}' is not supported on managed (tinker/fireworks) backends")
+
+
+def build_aux_ce_datum(model_input, target_tokens, positions: list[bool], scale) -> tinker.Datum | None:
+    """Build a ``cross_entropy`` datum weighting ``positions`` by ``scale``.
+
+    ``scale`` is either a float (the same weight on every selected position) or a
+    per-token sequence aligned with ``positions``. Returns ``None`` when no
+    position is selected (e.g. a single-turn rollout has no observation tokens),
+    so the caller can skip empty datums.
+    """
+    if not any(positions):
+        return None
+    if isinstance(scale, int | float):
+        weights = [float(scale) if p else 0.0 for p in positions]
+    else:
+        weights = [float(scale[i]) if p else 0.0 for i, p in enumerate(positions)]
+    return tinker.Datum(
+        model_input=model_input,
+        loss_fn_inputs={
+            "target_tokens": target_tokens,
+            "weights": TensorData(data=weights, dtype="float32"),
+        },
+    )

--- a/rllm/trainer/tinker/tinker_policy_trainer.py
+++ b/rllm/trainer/tinker/tinker_policy_trainer.py
@@ -35,11 +35,15 @@ logger = logging.getLogger(__name__)
 
 
 # Mapping from rLLMAdvantageEstimator to their default Tinker loss function (overriding is allowed through config)
+# ECHO uses the same GRPO/`ppo` policy-gradient loss on action tokens; its extra
+# environment-prediction term is applied as a separate gradient-accumulated
+# ``cross_entropy`` pass (see ``_get_aux_loss_futures``).
 ADV_TO_LOSS_FN_AUTO_MAP = {
     rLLMAdvantageEstimator.REINFORCE: "importance_sampling",
     rLLMAdvantageEstimator.REINFORCE_PLUS_PLUS_BASELINE: "importance_sampling",
     rLLMAdvantageEstimator.GRPO: "ppo",
     rLLMAdvantageEstimator.RLOO: "importance_sampling",
+    rLLMAdvantageEstimator.ECHO: "ppo",
     rLLMAdvantageEstimator.OTHER: "importance_sampling",
 }
 
@@ -166,12 +170,71 @@ class TinkerPolicyTrainer:
         )
 
     @require_training_client
+    async def _get_aux_loss_futures(
+        self,
+        training_datums: list[tinker.Datum] | dict[str, list[tinker.Datum]],
+        algorithm_config: AlgorithmConfig,
+    ) -> list[tinker.APIFuture]:
+        """Submit one ``cross_entropy`` pass per configured auxiliary loss (ECHO, ...).
+
+        Tinker accumulates gradients across ``forward_backward`` calls until the
+        next ``optim_step``, and its ``optim_step`` applies no extra normalization,
+        so each pass adds ``coef * grad(aux_loss)`` on top of the policy-gradient
+        pass without rescaling it. No extra rollout is needed — only one more
+        backward over the rollouts already collected. See
+        ``rllm.trainer.algorithms.aux_loss`` / ``design/auxiliary-losses.md``.
+        """
+        from rllm.trainer.algorithms import build_aux_losses
+        from rllm.trainer.tinker.aux_loss import aux_positions, build_aux_ce_datum
+
+        aux_losses = build_aux_losses(algorithm_config)
+        if not aux_losses:
+            return []
+        flat = [d for datums in training_datums.values() for d in datums] if isinstance(training_datums, dict) else training_datums
+
+        futures = []
+        for aux in aux_losses:
+            datums = []
+            for d in flat:
+                positions = aux_positions(aux, d.loss_fn_inputs["mask"].data)
+                # Tinker accumulates raw gradients, so the per-token weight is just
+                # the coefficient (matching how GRPO broadcasts a constant per-token
+                # advantage). Dynamic weights (design step 4) would replace this.
+                datum = build_aux_ce_datum(d.model_input, d.loss_fn_inputs["target_tokens"], positions, aux.coef)
+                if datum is not None:
+                    datums.append(datum)
+            if datums:
+                futures.append(await self.training_client.forward_backward_async(datums, loss_fn="cross_entropy"))  # type: ignore[attr-defined]
+        return futures
+
+    @staticmethod
+    async def _record_aux_loss_metrics(aux_futures: list[tinker.APIFuture], adv_metrics: dict) -> None:
+        """Await the auxiliary-loss futures (so their gradients are applied) and
+        surface any server-side metrics under ``train/aux_*``."""
+        if not aux_futures:
+            return
+        aux_results = await asyncio.gather(*aux_futures)
+        for aux_result in aux_results:
+            if aux_result.metrics:
+                for k, v in aux_result.metrics.items():
+                    if k.startswith("clock_cycle"):
+                        continue
+                    adv_metrics[f"train/aux_{k.replace(':', '/')}"] = v
+
+    @require_training_client
     async def _get_forward_backward_futures(
         self,
         training_datums: list[tinker.Datum] | dict[str, list[tinker.Datum]],
         estimator_map: dict[str, rLLMAdvantageEstimator | str],
         algorithm_config: AlgorithmConfig,
-    ) -> list[tinker.APIFuture]:
+    ) -> tuple[list[tinker.APIFuture], list[tinker.APIFuture]]:
+        """Submit the policy-gradient pass(es) plus any auxiliary-loss passes.
+
+        Returns ``(policy_futures, aux_futures)``. The aux futures are submitted
+        *before* any subsequent ``optim_step`` so their gradients accumulate, but
+        are returned separately so callers extract training logprobs only from
+        the policy-gradient futures (keeping per-datum alignment).
+        """
         fwd_bwd_futures = []
         if isinstance(training_datums, dict):
             for group_role, datums in training_datums.items():
@@ -193,7 +256,8 @@ class TinkerPolicyTrainer:
             )
             fwd_bwd_futures.append(fwd_bwd_future)
 
-        return fwd_bwd_futures
+        aux_futures = await self._get_aux_loss_futures(training_datums, algorithm_config)
+        return fwd_bwd_futures, aux_futures
 
     @require_training_client
     async def forward_backward_from_trajectory_groups(
@@ -226,8 +290,8 @@ class TinkerPolicyTrainer:
             algorithm_config=algorithm_config,
         )
 
-        # Forward-backward pass
-        fwd_bwd_futures = await self._get_forward_backward_futures(
+        # Forward-backward pass (plus the optional ECHO env-prediction pass)
+        fwd_bwd_futures, aux_futures = await self._get_forward_backward_futures(
             training_datums=training_datums,
             estimator_map=algorithm_config.estimator_map,
             algorithm_config=algorithm_config,
@@ -248,6 +312,8 @@ class TinkerPolicyTrainer:
                     if k.startswith("clock_cycle"):
                         continue
                     adv_metrics[f"train/{k.replace(':', '/')}"] = v
+
+        await self._record_aux_loss_metrics(aux_futures, adv_metrics)
 
         return training_datums, training_logprobs, adv_metrics
 
@@ -299,8 +365,11 @@ class TinkerPolicyTrainer:
             algorithm_config=self.algorithm_config,
         )
 
-        # Forward-backward and optimizer future together
-        fwd_bwd_futures = await self._get_forward_backward_futures(
+        # Forward-backward and optimizer future together. The ECHO env-prediction
+        # pass (if enabled) is submitted inside _get_forward_backward_futures —
+        # i.e. before the optim_step below — so its gradient accumulates into the
+        # same step.
+        fwd_bwd_futures, aux_futures = await self._get_forward_backward_futures(
             training_datums=training_datums,
             estimator_map=self.algorithm_config.estimator_map,
             algorithm_config=self.algorithm_config,
@@ -328,6 +397,8 @@ class TinkerPolicyTrainer:
                     if k.startswith("clock_cycle"):
                         continue
                     adv_metrics[f"train/{k.replace(':', '/')}"] = v
+
+        await self._record_aux_loss_metrics(aux_futures, adv_metrics)
 
         return training_datums, training_logprobs, adv_metrics, scheduled_learning_rate
 

--- a/rllm/trainer/verl/verl_backend.py
+++ b/rllm/trainer/verl/verl_backend.py
@@ -61,19 +61,30 @@ _VERL_KNOWN_LOSSES: set[str] | None = None
 
 
 class CustomPPOLoss:
-    """Wraps Verl's ``ppo_loss`` to support per-call loss mode override.
+    """Wraps Verl's ``ppo_loss`` to support per-call loss mode override and
+    rLLM's token-level auxiliary losses (the in-process aux-loss executor).
 
     When the data TensorDict contains ``policy_loss_mode_override``,
     the loss mode is temporarily overridden for that call.  Instances
     are serialised via cloudpickle and sent to remote workers through
     Verl's ``set_loss_fn`` RPC.
+
+    Auxiliary losses (see ``rllm.trainer.algorithms.aux_loss`` and
+    ``design/auxiliary-losses.md``) are added as
+    ``coef * Agg_mask(weight_t * [-log p_theta(token_t)])``. Because verl owns
+    the actor loss, each term folds into the *same* forward/backward pass —
+    the per-token log-probs are already computed by ``ppo_loss``; we only gather
+    them at a different set of token positions. ECHO (env-observation prediction)
+    is the first such loss, and costs no extra rollout or forward pass.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, aux_losses=None, pad_token_id: int | None = None):
         # Convert OmegaConf DictConfig → ActorConfig dataclass
         from verl.utils.config import omega_conf_to_dataclass
 
         self.config = omega_conf_to_dataclass(config)
+        self.aux_losses = list(aux_losses or [])
+        self.pad_token_id = pad_token_id
 
     def __call__(self, model_output, data, dp_group=None):
         from verl.utils import tensordict_utils as _tu
@@ -84,10 +95,60 @@ class CustomPPOLoss:
             original = self.config.policy_loss.get("loss_mode", "vanilla")
             self.config.policy_loss["loss_mode"] = override
             try:
-                return ppo_loss(self.config, model_output, data, dp_group)
+                policy_loss, metrics = ppo_loss(self.config, model_output, data, dp_group)
             finally:
                 self.config.policy_loss["loss_mode"] = original
-        return ppo_loss(self.config, model_output, data, dp_group)
+        else:
+            policy_loss, metrics = ppo_loss(self.config, model_output, data, dp_group)
+
+        if self.aux_losses:
+            policy_loss, metrics = self._apply_aux_losses(policy_loss, metrics, model_output, data)
+        return policy_loss, metrics
+
+    def _apply_aux_losses(self, policy_loss, metrics, model_output, data):
+        """In-process aux-loss executor: add each configured auxiliary loss.
+
+        Each loss contributes ``coef * Agg_mask(weight_t * [-log p_theta(token_t)])``,
+        aggregated with the same ``loss_agg_mode``/global-batch normalization as the
+        policy gradient so the coefficients are on a comparable scale. The masks are
+        resolved from the merged multi-turn row produced by
+        ``transform._process_trajectory``: action tokens are ``response_mask == 1``;
+        observation tokens are the remaining non-pad response tokens.
+        """
+        import torch
+        from verl.trainer.ppo.core_algos import agg_loss
+        from verl.utils.metric import AggregationType, Metric
+        from verl.workers.utils.padding import no_padding_2_padding
+
+        from rllm.trainer.algorithms import MASK_ACTION, MASK_OBSERVATION
+
+        # Per-token current-policy log-probs over the whole response, repadded to
+        # (bs, response_length) — already computed; ppo_loss used the same call.
+        log_prob = no_padding_2_padding(model_output["log_probs"], data)
+        response_mask = data["response_mask"].to(torch.bool)
+
+        # Padding is detected the same way rLLM built the response attention mask
+        # (responses != pad_token_id); fall back to the response attention slice.
+        if self.pad_token_id is not None:
+            non_pad = data["responses"] != self.pad_token_id
+        else:
+            resp_len = response_mask.shape[-1]
+            non_pad = data["attention_mask"][:, -resp_len:].to(torch.bool)
+        masks = {MASK_ACTION: response_mask, MASK_OBSERVATION: non_pad & (~response_mask)}
+
+        gbi = self.config.global_batch_info
+        distributed = gbi.get("dp_size", 1) > 1 or gbi.get("batch_num_tokens") is not None or gbi.get("global_batch_size") is not None or self.config.loss_scale_factor is not None
+        agg = AggregationType.SUM if distributed else AggregationType.MEAN
+
+        for aux in self.aux_losses:
+            mask = masks[aux.mask]
+            weight = aux.weight(self)  # None => uniform (ECHO); dynamic weights land in design step 4
+            loss_mat = -log_prob if weight is None else -weight * log_prob
+            term = agg_loss(loss_mat=loss_mat, loss_mask=mask.to(log_prob.dtype), loss_agg_mode=self.config.loss_agg_mode, **gbi)
+            policy_loss = policy_loss + aux.coef * term
+            metrics[f"actor/aux_{aux.name}_loss"] = Metric(value=term, aggregation=agg)
+            metrics[f"actor/aux_{aux.name}_token_frac"] = Metric(value=mask.float().mean(), aggregation=AggregationType.MEAN)
+        return policy_loss, metrics
 
 
 def _get_verl_known_losses() -> set[str]:
@@ -310,11 +371,6 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
 
         assert self.async_rollout_manager is not None
 
-        if hasattr(self.actor_rollout_wg, "set_loss_fn"):
-            self.actor_rollout_wg.set_loss_fn(CustomPPOLoss(self.config.actor_rollout_ref.actor))
-        else:
-            logger.warning("RayWorkerGroup.set_loss_fn not available — skipping custom loss injection")
-
         servers = zip(self.async_rollout_manager.server_addresses, self.async_rollout_manager.server_handles, strict=True)
         if self.is_separated:
             from rllm.trainer.verl.async_agent_loop import FullyAsyncLLMServerManager
@@ -333,6 +389,26 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         )
 
         self.algorithm_config = kwargs.get("algorithm_config")
+
+        # Install the custom actor loss. Carries any token-level auxiliary losses
+        # (e.g. ECHO; empty = plain GRPO) and the pad token id so the worker can
+        # identify environment-observation tokens. Installed after algorithm_config
+        # is resolved so the `echo` / env_loss_coef defaults are reflected.
+        if hasattr(self.actor_rollout_wg, "set_loss_fn"):
+            from rllm.trainer.algorithms import build_aux_losses
+
+            aux_losses = build_aux_losses(self.algorithm_config) if self.algorithm_config is not None else []
+            self.actor_rollout_wg.set_loss_fn(
+                CustomPPOLoss(
+                    self.config.actor_rollout_ref.actor,
+                    aux_losses=aux_losses,
+                    pad_token_id=getattr(self.tokenizer, "pad_token_id", None),
+                )
+            )
+            if aux_losses:
+                logger.info("Auxiliary losses enabled on verl actor: %s", [(loss.name, loss.coef) for loss in aux_losses])
+        else:
+            logger.warning("RayWorkerGroup.set_loss_fn not available — skipping custom loss injection")
 
         return self.rollout_engine
 

--- a/rllm/utils/tracking.py
+++ b/rllm/utils/tracking.py
@@ -32,6 +32,11 @@ from typing import Any
 from rllm.env import env_float
 
 _UI_HTTP_TIMEOUT_S = env_float("RLLM_UI_HTTP_TIMEOUT_S", 5.0)  # set env var: export RLLM_UI_HTTP_TIMEOUT_S=xxx
+# Max seconds to drain the episode-upload queue on finish(). Episodes are
+# enqueued in a burst at the end of an eval, so a short cap silently drops
+# uploads (the UI ends up empty while local files are fine). Raise for runs
+# with many/large episodes (e.g. terminus2). set: export RLLM_UI_DRAIN_TIMEOUT_S=xxx
+_UI_DRAIN_TIMEOUT_S = env_float("RLLM_UI_DRAIN_TIMEOUT_S", 600.0)
 
 
 def concat_dict_to_str(dict: dict, step):
@@ -638,9 +643,9 @@ class UILogger:
         # processes queued episodes.
         if hasattr(self, "_worker_thread"):
             self._queue.put(None)  # sentinel: worker exits after draining
-            self._worker_thread.join(timeout=30)
+            self._worker_thread.join(timeout=_UI_DRAIN_TIMEOUT_S)
             if self._worker_thread.is_alive():
-                self.logger.warning("UILogger worker thread did not finish within 30s")
+                self.logger.warning("UILogger worker thread did not finish within %.0fs", _UI_DRAIN_TIMEOUT_S)
                 self._worker_stop.set()  # force-stop only if join timed out
 
         # Stop heartbeat thread

--- a/tests/cli/test_sampling_resolution.py
+++ b/tests/cli/test_sampling_resolution.py
@@ -12,12 +12,15 @@ BASE = {"temperature": 1.0, "top_p": 1.0, "top_k": -1, "max_tokens": 2048}
 # -- eval: single config, empty base, always validation ---------------------
 
 
-def test_eval_empty_by_default():
-    assert resolve_eval_sampling(None).is_empty
+def test_eval_default_sampling():
+    # Eval seeds temperature=1.0, top_p=1.0 (mirrors the cookbook training rollout).
+    assert resolve_eval_sampling(None).as_dict() == {"temperature": 1.0, "top_p": 1.0}
 
 
 def test_eval_string_only():
-    assert resolve_eval_sampling("temperature=0.3,top_k=20").as_dict() == {"temperature": 0.3, "top_k": 20}
+    # User params override the defaults (temperature) and add new keys (top_k);
+    # the unspecified default (top_p) stays.
+    assert resolve_eval_sampling("temperature=0.3,top_k=20").as_dict() == {"temperature": 0.3, "top_p": 1.0, "top_k": 20}
 
 
 def test_eval_flags_beat_string():
@@ -31,7 +34,7 @@ def test_eval_standalone_flags_only():
 def test_eval_flat_file(tmp_path):
     p = tmp_path / "sp.yaml"
     p.write_text("temperature: 0.42\npresence_penalty: 0.3\n")
-    assert resolve_eval_sampling(f"@{p}").as_dict() == {"temperature": 0.42, "presence_penalty": 0.3}
+    assert resolve_eval_sampling(f"@{p}").as_dict() == {"temperature": 0.42, "top_p": 1.0, "presence_penalty": 0.3}
 
 
 def test_eval_nonmapping_file_raises(tmp_path):

--- a/tests/eval/test_dockerfile_replay.py
+++ b/tests/eval/test_dockerfile_replay.py
@@ -1,0 +1,84 @@
+"""Tests for Dockerfile RUN-replay handling in :mod:`rllm.eval._resolution`.
+
+Covers two fixes:
+
+* ``_dockerfile_run_commands`` joins ``\\``-continuations into a single valid
+  shell command (so multi-line ``RUN`` steps don't become invalid ``bash``).
+* ``_should_replay_dockerfile`` honors ``[environment].replay_dockerfile``:
+  default ``True`` (SWE-bench: replay RUN steps on a base image), ``False`` for
+  fully-built terminal-bench/Harbor images (boot as-is, no double-apply).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rllm.eval._resolution import _dockerfile_run_commands, _should_replay_dockerfile
+from rllm.tasks.loader import _load_task_from_dir
+from rllm.types import Task
+
+
+def _task_with_dockerfile(tmp_path: Path, dockerfile: str, metadata: dict | None = None) -> Task:
+    env = tmp_path / "environment"
+    env.mkdir(parents=True, exist_ok=True)
+    (env / "Dockerfile").write_text(dockerfile)
+    return Task(id="t", instruction="", metadata=metadata or {}, dataset_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _dockerfile_run_commands: continuation join + COPY skipping
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_run_joins_with_space_not_newline(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\nRUN apt-get update && apt-get install -y \\\n    python3-pip \\\n    && rm -rf /var/lib/apt/lists/*\n",
+    )
+    cmds = _dockerfile_run_commands(task)
+    assert cmds == ["apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*"]
+    # The old bug joined with "\n", which bash rejects ("syntax error near '&&'").
+    assert "\n" not in cmds[0]
+
+
+def test_copy_directives_are_skipped(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\nCOPY input_files/data.json /app/data.json\nRUN echo hi\nADD x.tar /app/\n",
+    )
+    assert _dockerfile_run_commands(task) == ["echo hi"]
+
+
+def test_single_line_run_unchanged(tmp_path):
+    task = _task_with_dockerfile(tmp_path, "FROM ubuntu:24.04\nRUN pip3 install ansible-core==2.16.3\n")
+    assert _dockerfile_run_commands(task) == ["pip3 install ansible-core==2.16.3"]
+
+
+# ---------------------------------------------------------------------------
+# _should_replay_dockerfile: the [environment].replay_dockerfile toggle
+# ---------------------------------------------------------------------------
+
+
+def test_replay_defaults_true_when_unset():
+    assert _should_replay_dockerfile(Task(id="t", instruction="", metadata={}, dataset_dir=Path("."))) is True
+    task = Task(id="t", instruction="", metadata={"environment": {"docker_image": "base"}}, dataset_dir=Path("."))
+    assert _should_replay_dockerfile(task) is True
+
+
+def test_replay_disabled_when_flag_false():
+    task = Task(
+        id="t",
+        instruction="",
+        metadata={"environment": {"docker_image": "prebuilt", "replay_dockerfile": False}},
+        dataset_dir=Path("."),
+    )
+    assert _should_replay_dockerfile(task) is False
+
+
+def test_replay_flag_read_from_task_toml(tmp_path):
+    """End-to-end: [environment].replay_dockerfile in task.toml reaches metadata."""
+    (tmp_path / "environment").mkdir()
+    (tmp_path / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\nRUN echo hi\n")
+    (tmp_path / "task.toml").write_text('[environment]\ndocker_image = "org/img:t"\nreplay_dockerfile = false\n')
+    task = _load_task_from_dir(tmp_path, dataset_dir=tmp_path)
+    assert _should_replay_dockerfile(task) is False

--- a/tests/eval/test_eval_config.py
+++ b/tests/eval/test_eval_config.py
@@ -148,6 +148,20 @@ class TestLoadSaveConfig:
             data = json.load(f)
         assert "base_url" not in data
 
+    def test_save_preserves_unrelated_keys(self, tmp_rllm_home):
+        """save_config must not clobber keys it doesn't own (e.g. ui_api_key from `rllm login`)."""
+        config_path = os.path.join(tmp_rllm_home, "config.json")
+        os.makedirs(tmp_rllm_home, exist_ok=True)
+        with open(config_path, "w") as f:
+            json.dump({"provider": "openai", "api_keys": {"openai": "k1"}, "model": "m1", "ui_api_key": "rllm_abc"}, f)
+        # A provider/model swap should leave the UI token intact.
+        save_config(RllmConfig(provider="tinker", api_keys={"tinker": "tml-xyz"}, model="m2"))
+        with open(config_path) as f:
+            data = json.load(f)
+        assert data["ui_api_key"] == "rllm_abc"
+        assert data["provider"] == "tinker"
+        assert data["model"] == "m2"
+
 
 class TestConstants:
     def test_openai_in_supported_providers(self):

--- a/tests/test_tinker_adapter_cumulative.py
+++ b/tests/test_tinker_adapter_cumulative.py
@@ -1,0 +1,91 @@
+"""Tinker adapter: pre-tokenized prompt path for cumulative token mode.
+
+When the gateway runs in ``cumulative_token_mode``, turn 2+ arrives at the
+in-process handler as a completions-style request whose ``prompt`` is raw token
+IDs (built by ``renderers.bridge_to_next_turn``). The handler must sample
+straight from those tokens — bypassing message rendering — and return a
+completions-style body the gateway can extract token IDs from.
+
+Uses a fake engine so no Tinker service / model is required.
+"""
+
+import asyncio
+
+from rllm.gateway.tinker_adapter import create_tinker_handler
+
+
+class _ModelOutput:
+    text = "ls -la"
+    content = "ls -la"
+    reasoning = ""
+    tool_calls = []
+    prompt_ids = [1, 2, 3, 4]
+    completion_ids = [10, 11]
+    logprobs = [-0.1, -0.2]
+    prompt_length = 4
+    completion_length = 2
+    finish_reason = "stop"
+
+
+class _FakeEngine:
+    model_name = "qwen"
+
+    def __init__(self):
+        self.token_input = None
+        self.messages = None
+
+    async def get_token_output_from_token_input(self, token_input, **kwargs):
+        self.token_input = token_input
+        self.sampling_kwargs = kwargs
+        return "sampled"
+
+    def assemble_model_output(self, token_input, token_output):
+        return _ModelOutput()
+
+    async def get_model_response(self, messages, **kwargs):
+        self.messages = messages
+        return _ModelOutput()
+
+
+def test_token_prompt_path_samples_from_tokens():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"prompt": [1, 2, 3, 4], "temperature": 0.7, "model": "qwen"}))
+
+    # Sampled directly from the token IDs — message rendering bypassed.
+    assert engine.token_input == [1, 2, 3, 4]
+    assert engine.messages is None
+    assert engine.sampling_kwargs.get("temperature") == 0.7
+
+    # Completions-style body the gateway's cumulative handler understands.
+    assert resp["object"] == "text_completion"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+    assert resp["choices"][0]["text"] == "ls -la"
+    assert resp["choices"][0]["token_ids"] == [10, 11]
+    assert resp["choices"][0]["logprobs"]["token_logprobs"] == [-0.1, -0.2]
+
+
+def test_chat_path_unchanged_by_token_branch():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"messages": [{"role": "user", "content": "hi"}], "model": "qwen"}))
+
+    assert engine.messages == [{"role": "user", "content": "hi"}]
+    assert engine.token_input is None  # token path not taken
+    assert resp["object"] == "chat.completion"
+    assert resp["choices"][0]["message"]["content"] == "ls -la"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+
+
+def test_non_int_prompt_falls_through_to_chat():
+    """A string ``prompt`` (or none) must not trigger the token path."""
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    # No messages and a string prompt: should still go down the chat path
+    # (messages defaulting to []), not the token path.
+    asyncio.run(handler({"prompt": "hello", "messages": [{"role": "user", "content": "hi"}]}))
+    assert engine.token_input is None
+    assert engine.messages == [{"role": "user", "content": "hi"}]

--- a/tests/unified_trainer/test_algorithm_config.py
+++ b/tests/unified_trainer/test_algorithm_config.py
@@ -16,6 +16,7 @@ _spec = importlib.util.spec_from_file_location("rllm_common_config", _CONFIG_PAT
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 AlgorithmConfig = _mod.AlgorithmConfig
+rLLMAdvantageEstimator = _mod.rLLMAdvantageEstimator
 
 
 def _make_config(norm_adv_by_std_in_grpo: bool = True, warmup_steps: int = -1):
@@ -63,3 +64,47 @@ def test_warmup_steps_from_algorithm():
     config = _make_config(warmup_steps=25)
     algo_config = AlgorithmConfig.from_config(config.rllm.algorithm, stepwise_advantage_mode=config.rllm.stepwise_advantage.mode)
     assert algo_config.warmup_steps == 25
+
+
+# --- ECHO (arXiv:2605.24517) -------------------------------------------------
+
+
+def _echo_config(adv_estimator: str = "echo", env_loss_coef=None):
+    section = {
+        "adv_estimator": adv_estimator,
+        "norm_adv_by_std_in_grpo": True,
+    }
+    if env_loss_coef is not None:
+        section["env_loss_coef"] = env_loss_coef
+    return OmegaConf.create({"rllm": {"algorithm": section, "stepwise_advantage": {"mode": "broadcast"}}})
+
+
+def test_echo_estimator_resolves():
+    """adv_estimator=echo resolves to the ECHO enum (not OTHER)."""
+    config = _echo_config()
+    algo_config = AlgorithmConfig.from_config(config.rllm.algorithm)
+    assert algo_config.estimator == rLLMAdvantageEstimator.ECHO
+
+
+def test_echo_defaults_lambda_to_paper_value():
+    """echo with no explicit coef defaults env_loss_coef to the paper's 0.05."""
+    algo_config = AlgorithmConfig.from_config(_echo_config().rllm.algorithm)
+    assert algo_config.env_loss_coef == 0.05
+
+
+def test_grpo_disables_env_loss_by_default():
+    """Non-echo estimators leave env_loss_coef at 0.0 (plain GRPO, no env loss)."""
+    algo_config = AlgorithmConfig.from_config(_echo_config(adv_estimator="grpo").rllm.algorithm)
+    assert algo_config.env_loss_coef == 0.0
+
+
+def test_echo_explicit_coef_overrides_default():
+    """An explicit env_loss_coef wins over the echo default."""
+    algo_config = AlgorithmConfig.from_config(_echo_config(env_loss_coef=0.02).rllm.algorithm)
+    assert algo_config.env_loss_coef == 0.02
+
+
+def test_env_loss_coef_can_enable_on_grpo():
+    """env_loss_coef is the real switch: it can enable the env loss with adv_estimator=grpo."""
+    algo_config = AlgorithmConfig.from_config(_echo_config(adv_estimator="grpo", env_loss_coef=0.05).rllm.algorithm)
+    assert algo_config.env_loss_coef == 0.05

--- a/tests/unified_trainer/test_aux_loss.py
+++ b/tests/unified_trainer/test_aux_loss.py
@@ -1,0 +1,184 @@
+"""Tests for the auxiliary-loss framework (rllm.trainer.algorithms.aux_loss).
+
+Covers the spec/registry, config resolution (incl. ECHO back-compat sugar), the
+managed-backend datum builder, and the in-process (verl) executor math via a
+faithful reimplementation of ``seq-mean-token-mean`` aggregation (verl's
+``agg_loss`` is not importable without the verl extra).
+
+See design/auxiliary-losses.md.
+"""
+
+import math
+
+import pytest
+from omegaconf import OmegaConf
+
+from rllm.trainer.algorithms import AlgorithmConfig
+from rllm.trainer.algorithms.aux_loss import (
+    AUX_LOSS_REGISTRY,
+    MASK_ACTION,
+    MASK_OBSERVATION,
+    AuxiliaryLoss,
+    EnvPredictionLoss,
+    build_aux_losses,
+    get_aux_loss,
+    register_aux_loss,
+)
+
+
+def _algo(**kw):
+    base = {"adv_estimator": "grpo", "norm_adv_by_std_in_grpo": True}
+    base.update(kw)
+    return AlgorithmConfig.from_config(OmegaConf.create(base))
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_env_prediction_registered():
+    assert "env_prediction" in AUX_LOSS_REGISTRY
+    assert get_aux_loss("env_prediction") is EnvPredictionLoss
+    assert EnvPredictionLoss.mask == MASK_OBSERVATION
+
+
+def test_get_aux_loss_unknown_raises():
+    with pytest.raises(ValueError):
+        get_aux_loss("does_not_exist")
+
+
+# --- spec validation --------------------------------------------------------
+
+
+def test_unknown_mask_raises():
+    @register_aux_loss("_bad_mask_test")
+    class _Bad(AuxiliaryLoss):
+        mask = "not_a_mask"
+
+    with pytest.raises(ValueError):
+        _Bad(coef=0.1)
+    del AUX_LOSS_REGISTRY["_bad_mask_test"]
+
+
+def test_requires_not_implemented_raises():
+    @register_aux_loss("_needs_forward_test")
+    class _NeedsForward(AuxiliaryLoss):
+        mask = MASK_ACTION
+        requires = ("teacher",)
+
+    with pytest.raises(NotImplementedError):
+        _NeedsForward(coef=0.1)
+    del AUX_LOSS_REGISTRY["_needs_forward_test"]
+
+
+def test_default_weight_is_uniform():
+    assert EnvPredictionLoss(coef=0.05).weight(ctx=None) is None
+
+
+# --- build_aux_losses / config ---------------------------------------------
+
+
+def test_echo_sugar_yields_env_prediction():
+    """adv_estimator=echo (env_loss_coef auto 0.05) builds one env_prediction loss."""
+    losses = build_aux_losses(_algo(adv_estimator="echo"))
+    assert [(loss.name, loss.coef, loss.mask) for loss in losses] == [("env_prediction", 0.05, MASK_OBSERVATION)]
+
+
+def test_grpo_builds_no_aux_losses():
+    assert build_aux_losses(_algo()) == []
+
+
+def test_explicit_aux_losses_list():
+    losses = build_aux_losses(_algo(aux_losses=[{"type": "env_prediction", "coef": 0.02}]))
+    assert len(losses) == 1 and losses[0].coef == 0.02
+
+
+def test_explicit_list_takes_precedence_over_sugar():
+    """An explicit env_prediction entry is not double-added by the env_loss_coef sugar."""
+    losses = build_aux_losses(_algo(adv_estimator="echo", aux_losses=[{"type": "env_prediction", "coef": 0.03}]))
+    assert len(losses) == 1 and losses[0].coef == 0.03
+
+
+def test_env_loss_coef_on_grpo_enables_env_prediction():
+    losses = build_aux_losses(_algo(env_loss_coef=0.05))
+    assert len(losses) == 1 and losses[0].name == "env_prediction" and losses[0].coef == 0.05
+
+
+def test_unknown_type_raises():
+    with pytest.raises(ValueError):
+        build_aux_losses(_algo(aux_losses=[{"type": "nope", "coef": 0.1}]))
+
+
+def test_missing_coef_raises():
+    with pytest.raises(ValueError):
+        build_aux_losses(_algo(aux_losses=[{"type": "env_prediction"}]))
+
+
+# --- managed-backend datum builder (tinker / fireworks) ---------------------
+
+
+def test_managed_aux_positions_and_weights():
+    tinker = pytest.importorskip("tinker")
+    from tinker.types.tensor_data import TensorData
+
+    from rllm.trainer.tinker.aux_loss import aux_positions, build_aux_ce_datum
+
+    mask = [1.0, 1.0, 0.0, 0.0, 0.0, 1.0]  # actions: 0,1,5 ; observations: 2,3,4
+    echo = EnvPredictionLoss(coef=0.05)
+    obs_pos = aux_positions(echo, mask)
+    assert obs_pos == [False, False, True, True, True, False]
+
+    targets = TensorData(data=[10, 11, 12, 13, 14, 15], dtype="int64")
+    datum = build_aux_ce_datum(tinker.ModelInput.from_ints([10, 11, 12, 13, 14, 15]), targets, obs_pos, echo.coef)
+    weights = list(datum.loss_fn_inputs["weights"].data)
+    assert all(math.isclose(w, e, abs_tol=1e-6) for w, e in zip([0, 0, 0.05, 0.05, 0.05, 0], weights, strict=True))
+
+    # an action-masked loss (e.g. a future SDAR client) selects the complement
+    class _ActionLoss(AuxiliaryLoss):
+        mask = MASK_ACTION
+
+    assert aux_positions(_ActionLoss(coef=0.1), mask) == [True, True, False, False, False, True]
+
+
+def test_managed_builder_skips_empty():
+    tinker = pytest.importorskip("tinker")
+    from tinker.types.tensor_data import TensorData
+
+    from rllm.trainer.tinker.aux_loss import aux_positions, build_aux_ce_datum
+
+    mask = [1.0, 1.0, 1.0]  # all action tokens -> no observation tokens to train
+    pos = aux_positions(EnvPredictionLoss(coef=0.05), mask)
+    datum = build_aux_ce_datum(tinker.ModelInput.from_ints([1, 2, 3]), TensorData(data=[1, 2, 3], dtype="int64"), pos, 0.05)
+    assert datum is None
+
+
+# --- executor math (faithful reimplementation of agg_loss seq-mean-token-mean) ---
+
+
+def _seq_mean_token_mean(neglogp_rows, mask_rows):
+    """Mirror verl's agg_loss(loss_agg_mode='seq-mean-token-mean'): per-sequence
+    token-mean over the mask, then mean over sequences with >0 masked tokens."""
+    seq_losses, seq_valid = [], []
+    for nlp, m in zip(neglogp_rows, mask_rows, strict=True):
+        cnt = sum(m)
+        seq_losses.append(sum(x * mm for x, mm in zip(nlp, m, strict=True)) / (cnt + 1e-8))
+        seq_valid.append(1.0 if cnt > 0 else 0.0)
+    denom = sum(seq_valid)
+    return sum(loss * v for loss, v in zip(seq_losses, seq_valid, strict=True)) / denom if denom else 0.0
+
+
+def test_inprocess_env_loss_equals_paper_l_env():
+    """The verl in-process executor adds coef * mean_seq((1/|O|) sum_obs -log p);
+    this guards that formula (the executor calls agg_loss with the obs mask)."""
+    # seq 0: obs at idx 2,3,4 ; seq 1: obs at idx 1 (rest padding/action)
+    neglogp = [[1.0, 2.0, 0.5, 0.5, 1.0, 3.0], [1.0, 0.8, 2.0, 0.0, 0.0, 0.0]]
+    obs_mask = [[0, 0, 1, 1, 1, 0], [0, 1, 0, 0, 0, 0]]
+    env_ce = _seq_mean_token_mean(neglogp, obs_mask)
+    paper = ((0.5 + 0.5 + 1.0) / 3 + 0.8 / 1) / 2
+    # abs_tol accommodates the 1e-8 denominator epsilon agg_loss uses.
+    assert math.isclose(env_ce, paper, abs_tol=1e-6)
+
+
+def test_inprocess_empty_obs_is_safe():
+    """A rollout with no observation tokens contributes 0 (no NaN)."""
+    val = _seq_mean_token_mean([[1.0, 2.0, 3.0]], [[0, 0, 0]])
+    assert val == 0.0 and math.isfinite(val)

--- a/tests/unified_trainer/test_aux_loss.py
+++ b/tests/unified_trainer/test_aux_loss.py
@@ -182,3 +182,94 @@ def test_inprocess_empty_obs_is_safe():
     """A rollout with no observation tokens contributes 0 (no NaN)."""
     val = _seq_mean_token_mean([[1.0, 2.0, 3.0]], [[0, 0, 0]])
     assert val == 0.0 and math.isfinite(val)
+
+
+# --- fireworks client fold (single forward_backward_custom) ------------------
+
+
+def test_fireworks_client_fold_equals_paper_l_env():
+    """Folding ECHO into the client loss closure -- summing ``weights_t * -logp_t``
+    over all datums using the SAME per-token weights the separate cross_entropy
+    pass built (scale=coef/(n_seq*|O_i|)) -- reproduces the paper's
+    ``coef * mean_seq((1/|O|) sum_obs -log p)``. This guards the fold math
+    against the two-pass implementation it replaces.
+    """
+    tinker = pytest.importorskip("tinker")
+    from tinker.types.tensor_data import TensorData
+
+    from rllm.trainer.tinker.aux_loss import aux_positions, build_aux_ce_datum
+
+    coef = 0.05
+    # action masks (1=action, 0=observation); seq0 obs at 2,3,4 ; seq1 obs at 1
+    masks = [[1.0, 1.0, 0.0, 0.0, 0.0, 1.0], [1.0, 0.0, 1.0, 1.0, 1.0, 1.0]]
+    # per-token -log p(target) the single forward would yield
+    neglogp = [[1.0, 2.0, 0.5, 0.5, 1.0, 3.0], [1.0, 0.8, 2.0, 0.1, 0.2, 0.3]]
+    n_seq = len(masks)
+    echo = EnvPredictionLoss(coef=coef)
+
+    folded = 0.0
+    for mask, nlp in zip(masks, neglogp, strict=True):
+        positions = aux_positions(echo, mask)
+        count = sum(1 for p in positions if p)
+        if count == 0:
+            continue
+        datum = build_aux_ce_datum(
+            tinker.ModelInput.from_ints(list(range(len(mask)))),
+            TensorData(data=list(range(len(mask))), dtype="int64"),
+            positions,
+            coef / (n_seq * count),
+        )
+        weights = list(datum.loss_fn_inputs["weights"].data)
+        # closure adds sum_t weights_t * (-logp_t); here -logp_t == neglogp.
+        folded += sum(w * nl for w, nl in zip(weights, nlp, strict=True))
+
+    paper = coef * (((0.5 + 0.5 + 1.0) / 3) + (0.8 / 1)) / n_seq
+    assert math.isclose(folded, paper, abs_tol=1e-6)
+
+
+def test_fold_aux_into_loss_adds_term_and_gradient():
+    """``_fold_aux_into_loss`` adds ``sum_t weights_t * -logp_t`` to the policy
+    loss and yields the right gradient on the logprobs (``d/dlogp = -weights``)."""
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("tinker")
+
+    from rllm.trainer.fireworks.fireworks_policy_trainer import _fold_aux_into_loss
+
+    def inner(data, logprobs_list):
+        # Isolate the aux term: zero policy loss.
+        return torch.zeros((), requires_grad=True), {"mean_loss": 0.0}
+
+    lp = torch.tensor([-1.0, -2.0, -3.0], requires_grad=True)
+    wv = [0.0, 0.5, 0.0]  # weight 0.5 on token 1 only
+    loss_fn = _fold_aux_into_loss(inner, [("env_prediction", [wv])])
+
+    loss, metrics = loss_fn([None], [lp])
+    # term = -(lp * w).sum() = -((-2.0) * 0.5) = 1.0  (a positive cross-entropy)
+    assert math.isclose(loss.item(), 1.0, abs_tol=1e-6)
+    assert math.isclose(metrics["aux_env_prediction_loss"], 1.0, abs_tol=1e-6)
+
+    loss.backward()
+    assert torch.allclose(lp.grad, torch.tensor([0.0, -0.5, 0.0]), atol=1e-6)
+
+
+def test_fold_aux_into_loss_skips_none_and_accumulates_on_policy():
+    """A ``None`` per-datum weight (no observation tokens) is skipped; the aux
+    term accumulates on top of a non-zero policy loss."""
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("tinker")
+
+    from rllm.trainer.fireworks.fireworks_policy_trainer import _fold_aux_into_loss
+
+    def inner(data, logprobs_list):
+        return torch.tensor(5.0, requires_grad=True), {}
+
+    lp0 = torch.tensor([-1.0, -2.0], requires_grad=True)  # has obs weights
+    lp1 = torch.tensor([-1.0, -1.0], requires_grad=True)  # skipped (None)
+    loss_fn = _fold_aux_into_loss(inner, [("env_prediction", [[1.0, 0.0], None])])
+
+    loss, metrics = loss_fn([None, None], [lp0, lp1])
+    # policy 5.0 + term -(lp0*[1,0]).sum() = 5.0 - (-1.0) = 6.0
+    assert math.isclose(loss.item(), 6.0, abs_tol=1e-6)
+    assert "aux_env_prediction_loss" in metrics
+    loss.backward()
+    assert lp1.grad is None  # untouched datum gets no gradient from the aux term


### PR DESCRIPTION
## What

ECHO's environment-prediction loss is currently applied on the Fireworks backend as a **second, gradient-accumulated `cross_entropy` forward_backward** on top of the builtin GRPO kernel pass. The managed builtin kernel can only express the policy loss, so the aux term needed its own pass (extra forward + backward over the same rollout tokens).

This PR folds ECHO into a **single pass** via the cookbook's **client loss path**. When an auxiliary loss is active, `forward_backward_from_trajectory_groups` now runs one `forward_backward_custom` whose closure computes the policy loss (`training.utils.rl.losses.build_loss_fn`) **plus** each aux term, from the single forward's per-token logprobs. Non-ECHO runs keep the fast server-side builtin kernel path. **Tinker is unchanged** (its cookbook has no client-side policy closure; ECHO isn't wired on Tinker in the cookbooks).

## Why it's equivalent

- **Env term:** reuses the *exact same* per-token weights the separate pass built (`build_aux_ce_datum` with `scale = coef/(n_seq·|O_i|)`). Adding `Σ_t weights_t·(−logp_t)` inside the closure vs. a separate accumulated `cross_entropy` backward yields the same gradient.
- **Policy term:** now computed by the cookbook's client closure (`make_grpo_loss_fn` → `run_loss_loop`) instead of the server builtin kernel. The cookbook asserts these are in-lockstep (the client path is its documented always-correct fallback), so any difference is at most fp-level. Advantages are folded and `optim_step` keeps `GradAccNormalization.NONE` while aux losses are active, exactly as before — neither term is rescaled.

## Cost

ECHO drops from ~**2 fwd + 2 bwd** to ~**2 fwd + 1 bwd** per step (`forward_backward_custom` = one logprobs forward + one linear backward). One fewer backward, no extra rollouts.

## Changes

- `rllm/trainer/fireworks/fireworks_policy_trainer.py`
  - new `_forward_backward_client_with_aux` (client-path fused pass)
  - new module-level `_fold_aux_into_loss` (wraps the policy closure to add aux terms)
  - branch in `forward_backward_from_trajectory_groups`: aux active → client path, else builtin kernel (unchanged)
  - removed now-dead `_build_aux_datums`; updated `optim_step` comment
- `tests/unified_trainer/test_aux_loss.py`: fold reproduces the paper's `L_env`; `_fold_aux_into_loss` adds the term with the correct gradient (`d/dlogp = −weights`) and skips obs-free datums

## Notes

- Faithful port: the managed env mask is `mask==0`, which includes initial-prompt tokens (pre-existing behavior; verl's ECHO excludes them via the response mask). Preserved here to keep equivalence — flagging in case we want to align them separately.
- Verification: `py_compile` ✓, `ruff` ✓, trainer + backend import ✓, **19/19** `test_aux_loss.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)