### PR TITLE
fix(fireworks): retry sampling timeouts + consolidate timeout config

### DIFF
--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -23,6 +23,7 @@ import dataclasses
 import logging
 from typing import Any
 
+import httpx
 from fireworks.training.sdk import DeploymentSampler
 from typing_extensions import override
 
@@ -420,13 +421,17 @@ class FireworksEngine(TinkerEngine):
             except Exception as exc:
                 err = str(exc)
                 exc_name = exc.__class__.__name__
-                transient = isinstance(exc, _EmptyCompletionIdsError) or any(marker in err or marker in exc_name for marker in _TRANSIENT_ERROR_MARKERS)
+                # Timeouts/transport errors have an empty str(exc), so the string
+                # markers below miss them; classify by type instead.
+                is_network_error = isinstance(exc, httpx.TimeoutException | httpx.TransportError)
+                transient = isinstance(exc, _EmptyCompletionIdsError) or is_network_error or any(marker in err or marker in exc_name for marker in _TRANSIENT_ERROR_MARKERS)
                 if transient and attempt < _MAX_SAMPLE_ATTEMPTS - 1:
                     wait = 10 * (attempt + 1)
                     logger.debug(
-                        "Attempt %d/%d failed (%s), retrying in %ds...",
+                        "Attempt %d/%d failed (%s: %s), retrying in %ds...",
                         attempt + 1,
                         _MAX_SAMPLE_ATTEMPTS,
+                        exc_name,
                         exc,
                         wait,
                     )
@@ -434,8 +439,9 @@ class FireworksEngine(TinkerEngine):
                     continue
                 resp_text = getattr(getattr(exc, "response", None), "text", None)
                 logger.error(
-                    "Sampling failed permanently after %d attempts: %s\n%s",
+                    "Sampling failed permanently after %d attempts (%s): %s\n%s",
                     attempt + 1,
+                    exc_name,
                     exc,
                     resp_text or "",
                 )

--- a/rllm/trainer/config/rllm/backend/fireworks.yaml
+++ b/rllm/trainer/config/rllm/backend/fireworks.yaml
@@ -30,7 +30,6 @@ training:
   weight_decay: 0.01
   grad_clip_norm: 1.0
   max_length: null  # Auto-derived from training shape if null
-  client_timeout: 3600  # Timeout for forward / forward_backward / optim_step calls (seconds)
   resume_from_fireworks_job_id: null  # Source trainer job id for loading a DCP checkpoint
   resume_from_dcp_checkpoint: null  # Explicit DCP name to load; null uses latest on the source/current job
 
@@ -53,6 +52,12 @@ rollout_engine:
   disable_thinking: false
   bypass_render_with_parser: false
   renderer_name: null
+  # Canonical sampling HTTP timeout (s). On a streaming SSE call this is httpx's
+  # per-read timeout — a cap on silence between tokens (TTFT + inter-token gaps),
+  # NOT total generation, so it can safely stay high. Raise it only if TTFT can
+  # legitimately exceed it (huge prefills, high-effort reasoning that buffers).
+  # fireworks_infra.deployments.rollout.sample_timeout follows this value.
+  sample_timeout: 600
 
 # Data Configuration
 data:
@@ -98,20 +103,22 @@ fireworks_infra:
     lora_rank: ${model.lora_rank}            # 0 = full-parameter training
     learning_rate: 1e-5      # placeholder for fireworks managed flow. Should be overridden in the training codes.
     max_seq_len: null        # null = use the training shape's default context length
-    step_timeout: 3600       # SDK default (3600s)
-    # Transient-fault tolerance for training-client RPCs (fwd/bwd, optim, weight
-    # hot-load). A blip on the shared training client around the per-step
-    # hot-load otherwise crashes the whole run, since the SDK does not retry.
-    step_max_retries: 2      # retries on transient errors (timeout/connection); 0 disables
-    step_retry_backoff_s: 10 # base linear backoff between retries (seconds)
-    weight_sync_timeout: 600
+    # Training-step RPCs (fwd/bwd, optim, weight hot-load): one timeout + one
+    # retry policy. Kept generous — a stalled step is expensive to abandon, and
+    # the SDK does not retry these itself, so a blip around the per-step hot-load
+    # would otherwise crash the whole run. For genuine slowness, raise the
+    # timeout rather than leaning on retries.
+    step_timeout: 3600         # per-step RPC ceiling (guards a hung call)
+    step_max_retries: 2        # retries on transient errors (timeout/connection); 0 disables
+    step_retry_backoff_s: 10   # base linear backoff between retries (seconds)
+    weight_sync_timeout: 600   # weight hot-load ceiling
 
   deployments:
     rollout:
       deployment_id: null # null = create a new deployment; set to reattach to an existing deployment
       deployment_shape: null # Leave deployment_shape null so the SDK uses the shape linked to the training shape.
       replica_count: ${fireworks_config.rollout_deployment_replica_count}
-      sample_timeout: 600
+      sample_timeout: ${rollout_engine.sample_timeout}  # follow the canonical sampling timeout
       disable_speculative_decoding: false
       extra_values: null
 
@@ -124,7 +131,7 @@ fireworks_infra:
       # Optional fields for admin users.
       custom_image_tag: null
       region: null           # optional explicit trainer region; prefer leaving unset
-      timeout_s: 3600       # trainer startup/readiness timeout, not per-step timeout
+      timeout_s: 3600       # trainer startup/readiness timeout (shared source; reference follows), not per-step
       extra_args: null
       skip_validations: false
 
@@ -137,7 +144,7 @@ fireworks_infra:
       # Optional fields for admin users.
       custom_image_tag: null
       region: null           # optional explicit trainer region; prefer leaving unset
-      timeout_s: 3600       # trainer startup/readiness timeout, not per-step timeout
+      timeout_s: ${fireworks_infra.trainers.policy.timeout_s}  # follow policy readiness timeout
       extra_args: null
       skip_validations: false
 


### PR DESCRIPTION
## Problem

Sampling out of `FireworksEngine` intermittently died on `httpx.ReadTimeout` / `httpcore.ReadError`, logged as **`Sampling failed permanently after 1 attempts`** with an empty message.

`_completions_with_retry` classified transient errors by string-matching `str(exc)` / the class name. But `str(httpx.ReadTimeout())` is `""` and the class names (`ReadTimeout`, `ReadError`) match none of `_TRANSIENT_ERROR_MARKERS`, so a timeout / connection reset was treated as non-transient and gave up after the first attempt. The Fireworks SDK's own retry can't cover it either — its budget (`MAX_WAIT_TIME = 300s`) is smaller than the per-attempt `http_timeout`, so a single timeout exhausts it.

The exception propagates as a 500 to the rollout's gateway call → dropped trajectory, shrunken GRPO groups, wasted sandbox compute, idle bubbles in async training.

## Changes

**Retry fix**
- Classify `httpx.TimeoutException` / `TransportError` as transient **by type** (not string), so read timeouts and connection resets (`ReadError`) are retried instead of failing the whole sampling call.
- Log the exception class name in retry / permanent-failure messages (timeouts have an empty `str(exc)`, so the old logs were blank).

**Timeout config consolidation** (no change to effective defaults)
- `sample_timeout` **stays 600** (the prior default; an earlier draft of this PR lowered it to 240 — reverted). On a streaming SSE call this is httpx's *per-read* timeout — a cap on inter-token silence (TTFT + gaps), **not** total generation — so it doesn't clip long-but-active generations. Made `rollout_engine.sample_timeout` the single source of truth; `fireworks_infra.deployments.rollout.sample_timeout` now follows it via interpolation.
- Removed dead `training.client_timeout` (no consumer in the repo or the training SDK).
- Grouped the training-step RPC knobs (`step_timeout` / `step_max_retries` / `step_retry_backoff_s` / `weight_sync_timeout`) as one timeout + retry policy.
- Shared trainer readiness timeout: `reference` follows `policy.timeout_s`.

Net model: one timeout + retry policy per operation class — **sample** (600s, retry 5×), **step** (3600s, retry 2×), **ready** (3600s, no retry).

## Verification
- `fireworks_engine.py` parses; classification confirmed: `httpx.ReadError` / `ReadTimeout` / `ConnectTimeout` / `PoolTimeout` / `RemoteProtocolError` → transient (retried); `ValueError` → still fails fast.
- Config resolves as the provisioner loads it (`OmegaConf.to_container(cfg.fireworks_infra, resolve=True)`): `deployments.rollout.sample_timeout → 600`, `trainers.{policy,reference}.timeout_s → 3600`; `client_timeout` absent.
- Rebased onto latest `terminal-rl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
