### PR TITLE
feat(trainer): per-task datum/step breakdown + group reward distribution on the queued log line

### DIFF
--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -270,14 +270,25 @@ class TrajectoryGroupBuffer:
         # Per-task fine-grained accounting: a task is consumed as one GRPO group,
         # which collapses into training rows/datums under prefix-merge. Surface
         # trajectories / steps (turns) / datums (rows after merge) so the merge
-        # ratio is visible per task, not just as a batch aggregate.
+        # ratio is visible per task, not just as a batch aggregate. Also surface
+        # the group's reward distribution (mean/min/max): GRPO advantages come
+        # from within-group reward spread, so a min==max group carries no signal.
         n_traj = sum(len(g.trajectories) for g in traj_groups)
         n_steps = sum(len(t.steps) for g in traj_groups for t in g.trajectories)
         n_datums = sum(self._segment_count(t) for g in traj_groups for t in g.trajectories)
+        rewards = [r for g in traj_groups for t in g.trajectories if (r := self._traj_reward(t)) is not None]
+        mean_reward = (sum(rewards) / len(rewards)) if rewards else 0.0
         logger.info(
-            "Task %s queued: %d group(s), %d trajectories, %d steps -> %d datums (rows) [%.2f steps/datum]",
-            task_id, len(traj_groups), n_traj, n_steps, n_datums,
+            "Task %s queued: %d group(s), %d trajectories, %d steps -> %d datums (rows) [%.2f steps/datum] | reward avg=%.4f min=%.4f max=%.4f",
+            task_id,
+            len(traj_groups),
+            n_traj,
+            n_steps,
+            n_datums,
             (n_steps / n_datums) if n_datums else 0.0,
+            mean_reward,
+            min(rewards) if rewards else 0.0,
+            max(rewards) if rewards else 0.0,
         )
 
         self._log_prompt_group_finished(
@@ -399,6 +410,20 @@ class TrajectoryGroupBuffer:
                 segments += 1
             full = ids + list(step.response_ids)
         return max(segments, 1)
+
+    @staticmethod
+    def _traj_reward(traj) -> float | None:
+        """Scalar reward for a trajectory, or ``None`` if unscored.
+
+        Prefer the trajectory-level reward; fall back to the last step's reward.
+        Mirrors the extraction in ``_log_prompt_group_finished`` so the per-task
+        average matches the per-episode rewards logged there.
+        """
+        if traj.reward is not None:
+            return traj.reward
+        if traj.steps:
+            return traj.steps[-1].reward
+        return None
 
     def _log_prompt_group_finished(
         self,

--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -267,6 +267,19 @@ class TrajectoryGroupBuffer:
         self._queue_update_event.set()
         self._record_classified_prompt_group()
 
+        # Per-task fine-grained accounting: a task is consumed as one GRPO group,
+        # which collapses into training rows/datums under prefix-merge. Surface
+        # trajectories / steps (turns) / datums (rows after merge) so the merge
+        # ratio is visible per task, not just as a batch aggregate.
+        n_traj = sum(len(g.trajectories) for g in traj_groups)
+        n_steps = sum(len(t.steps) for g in traj_groups for t in g.trajectories)
+        n_datums = sum(self._segment_count(t) for g in traj_groups for t in g.trajectories)
+        logger.info(
+            "Task %s queued: %d group(s), %d trajectories, %d steps -> %d datums (rows) [%.2f steps/datum]",
+            task_id, len(traj_groups), n_traj, n_steps, n_datums,
+            (n_steps / n_datums) if n_datums else 0.0,
+        )
+
         self._log_prompt_group_finished(
             task_id=task_id,
             episodes=episodes,
@@ -368,6 +381,24 @@ class TrajectoryGroupBuffer:
     @staticmethod
     def _termination_value(reason: TerminationReason | str) -> str:
         return str(getattr(reason, "value", reason))
+
+    @staticmethod
+    def _segment_count(traj) -> int:
+        """Number of training rows/datums a trajectory becomes under prefix-merge.
+
+        Each step whose ``prompt_ids`` is NOT a byte-prefix-extension of the
+        running cumulative sequence starts a new row — mirroring the backend
+        transform's datum split. =1 for a healthy cumulative trajectory (all
+        turns merge into one row); >1 when the prefix chain breaks.
+        """
+        full: list[int] | None = None
+        segments = 0
+        for step in traj.steps:
+            ids = list(step.prompt_ids)
+            if full is None or ids[: len(full)] != full:
+                segments += 1
+            full = ids + list(step.response_ids)
+        return max(segments, 1)
 
     def _log_prompt_group_finished(
         self,


### PR DESCRIPTION
## What

Adds a per-task accounting line emitted when a task's GRPO group is finalized and queued for training:

```
Task <id> queued: N group(s), N trajectories, N steps -> N datums (rows) [X.XX steps/datum] | reward avg=… min=… max=…
```

Two commits:

1. **`per-task datum/step/segment breakdown`** — cherry-picked from `feat/native-renderers` (`9d1466e4`). A task is consumed as one GRPO group that prefix-merges into training rows/datums; previously only batch-level merge metrics were visible. This logs per-task trajectories / steps (turns) / datums (rows after prefix-merge) and the steps/datum ratio. `_segment_count()` applies the same prefix-extension check the backend transform uses, so the per-task datum count matches what's trained (`steps/datum == 1` is a clean cumulative trajectory; `>1` a prefix break).

2. **`+ group reward distribution`** (new) — extends that same line with the group's reward distribution: `avg / min / max` over its trajectories. GRPO advantages are driven by *within-group* reward spread, so a `min == max` group carries no learning signal — surfacing this per task makes a degenerate group visible at a glance.

## Notes

- `_traj_reward()` mirrors the reward extraction already used in `_log_prompt_group_finished` (trajectory-level reward, falling back to the last step's reward), so the per-task average is consistent with the per-episode rewards logged there.
- Unscored trajectories are excluded from the average; an all-unscored group reports `0.0` without error.
- Logging-only change; no effect on training behavior.

## Test plan

- `python -m py_compile rllm/trainer/buffer.py` ✅
- Verified the reward aggregation logic (trajectory-level reward, last-step fallback, unscored exclusion, empty-group safety) against mock trajectory groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)