### PR TITLE
feat(cookbooks): tmax terminal-agent RL cookbook + tmax-15k dataset

### DIFF
--- a/cookbooks/tmax/README.md
+++ b/cookbooks/tmax/README.md
@@ -1,0 +1,278 @@
+# Tmax
+
+Reproduce **[Tmax](https://arxiv.org/abs/2606.23321)** — Ai2's "simple recipe
+for terminal agents" (Ivison et al., 2026) — inside rLLM. This cookbook ports
+Ai2's published **~14.6K-task `tmax-15k` corpus** as a first-class rLLM dataset
+and launches RL on **`Qwen/Qwen3.5-9B`** with hyperparameters tracking their
+official **DPPO** run, evaluating on [Terminal-Bench](https://www.tbench.ai).
+
+It's the sibling of [`cookbooks/terminal-rl`](../terminal-rl/README.md): same
+machinery (a terminal harness running *inside* each task's sandbox, scored by
+the task's own in-sandbox verifier), but the **data is Ai2's** and the **recipe
+targets their 9B result**.
+
+Tmax-9B reaches **~27.2% on Terminal-Bench 2.0** (daytona), about **+6 points**
+over the `Qwen3.5-9B` base under the same harness, with the best checkpoint at
+**step ~200**.
+
+## What "porting their data" means here
+
+Ai2 publishes the corpus on Hugging Face in two complementary forms. We **join
+them by `task_id`** to build the native rLLM dataset:
+
+| Form | What it provides | Used here? |
+|---|---|---|
+| [`allenai/TMax-15K`](https://huggingface.co/datasets/allenai/TMax-15K) | Raw corpus: `description` (task prompt) + **`test_final_state`** (the programmatic pytest verifier — pass/fail is the reward) + `container_def` + `truth`. | **verifier + prompt** |
+| [`allenai/tmax-15k-open-instruct`](https://huggingface.co/datasets/allenai/tmax-15k-open-instruct) | Training-ready: per-task **prebuilt image** `env_config.image` = `hamishi740/swerl-tmax-v3:<digest>` (so we pull a ready env instead of building `container_def`). | **prebuilt image** |
+| [`tmax/TMax-15K-Harbor`](https://www.harborframework.com/docs/datasets) | Ai2's README says the corpus is *also* on the Harbor registry — but it is **not present in the public Harbor package registry** (`harbor` `list_datasets()` returns 80 datasets, none tmax; harbor 0.13–0.15 all query the same registry). | ✗ not reachable |
+
+The native dataset **`tmax-15k`** is a catalog entry in
+[`rllm/registry/datasets.json`](../../rllm/registry/datasets.json) backed by a
+builder, [`rllm/data/tmax_builder.py`](../../rllm/data/tmax_builder.py)
+(the same pattern as `r2egym` / `swesmith`). `rllm dataset pull tmax-15k`
+downloads both HF datasets, joins them, and materializes one Harbor task dir per
+task: `FROM` the prebuilt image, `instruction.md` from `description`, and a
+`tests/test.sh` that runs `test_final_state.py` under pytest inside the image —
+**reward = 1.0 iff it passes**, written to `/tmp/rllm/reward.json` (rLLM's
+`script_evaluator` reads that). This reproduces Tmax's outcome-only
+`verification_reward` without depending on the missing Harbor registry entry.
+
+> **Docker Hub note:** the per-task images live under `hamishi740/swerl-tmax-v3`.
+> Pulling all ~14.6K at training scale wants a Docker Hub business account (their
+> README says the same); small subsets pull fine. `--train-limit N` caps what
+> *training* uses, but the builder still downloads both full HF datasets (≈200 MB)
+> to perform the join.
+
+> **Status:** the builder's join + materialization are validated offline; the
+> reward path (`test_final_state.py` pass/fail) follows Ai2's documented
+> verifier semantics and rLLM's proven `r2egym` verifier structure, but running
+> it end-to-end needs Docker Hub access to the images — confirm on a small subset
+> first (Tier 3 below).
+
+## Architecture
+
+```
+AgentTrainer.train()
+  │
+  ├── for each tmax-15k task: launch a sandbox (Modal / Daytona / Docker)
+  │       │
+  │       └── terminal harness runs IN the sandbox
+  │             │   (multi-turn bash/tmux loop; each LLM call → gateway)
+  │             │
+  │             └── rLLM gateway routes to the trainer-hosted policy,
+  │                  capturing the full trajectory.
+  │
+  └── verifier: tests/test.sh runs test_final_state.py (pytest) in the sandbox
+        │   writes {"reward": 1.0/0.0} to /tmp/rllm/reward.json
+        │
+        └──  →  RL reward signal (Tmax's outcome-only verification_reward)
+```
+
+Like terminal-rl, this ships **no custom AgentFlow and no custom evaluator** —
+the harness owns the action loop, the gateway owns the trajectory, the
+in-sandbox verifier owns the reward.
+
+## Installation
+
+```bash
+# full fine-tune (faithful reproduction):
+uv pip install -e ".[verl,harbor]"
+bash scripts/install_megatron.sh <cu128|cu129|...>
+
+# or an accessible LoRA backend:
+uv pip install -e ".[fireworks,harbor]"     # managed
+uv pip install -e ".[tinker,harbor]"        # single-machine
+
+# then install this cookbook (registers prepare_data / train):
+uv pip install --no-deps -e cookbooks/tmax
+```
+
+The `harbor` extra lets the CLI resolve `harbor:` dataset names and ships the
+terminal agent code (Terminus-2 / mini-swe-agent install into each task sandbox
+on first run — no host-side agent install needed).
+
+## Datasets
+
+```bash
+python cookbooks/tmax/prepare_data.py
+# or a fast smoke run on a 50-task subset:
+python cookbooks/tmax/prepare_data.py --train-limit 50
+```
+
+| Dataset | Role | Source | Verifier |
+|---|---|---|---|
+| `tmax-15k` | train (~14.6K) | HF builder (`allenai/TMax-15K` + `tmax-15k-open-instruct`) | `tests/test.sh` runs `test_final_state.py` (pytest) → `/tmp/rllm/reward.json` |
+| `terminal-bench@2.0` | eval (89) | `harbor:terminal-bench@2.0` | in-sandbox `tests/test.sh` → `/logs/verifier/reward.txt` |
+
+`tmax-15k` is a real catalog entry, so you can also pull it standalone (or
+materialize a subset directly via the builder for a quick check):
+
+```bash
+rllm dataset pull tmax-15k
+# or a small offline materialization (no training):
+python -m rllm.data.tmax_builder --out-dir /tmp/tmax-smoke --limit 5
+```
+
+`TB_EVAL_VERSION` selects the Terminal-Bench eval version (default `2.0`, the
+number Tmax reports). The registry publishes `2.0` today; flip to `2.1` once it
+lands — `prepare_data.py` and `train.py` both read it so the names stay in sync.
+
+## Training
+
+### verl (full fine-tuning — the faithful reproduction)
+
+```bash
+bash cookbooks/tmax/train_verl.sh
+```
+
+Full-parameter RL on `Qwen/Qwen3.5-9B` with the Tmax hyperparameters (below).
+This is the only backend that matches their **full-parameter DPPO** run at
+9B / 65K context / group 32. It is heavy — see **Hardware**.
+
+### Fireworks (managed LoRA) / Tinker (single-machine LoRA)
+
+```bash
+export FIREWORKS_API_KEY=...
+bash cookbooks/tmax/train_fireworks.sh     # managed trainer + deployment
+bash cookbooks/tmax/train_tinker.sh        # single machine
+```
+
+`train_fireworks.sh` is aligned **field-for-field** with Tmax's DPPO config —
+67584 context (= `pack_length`: 51200 cumulative prompt + 16384 per-turn
+response); in fully-async mode prompts/step = `async_training.mini_batch_size=8`
+(= `num_unique_prompts_rollout`; `data.train_batch_size` is ignored — async
+forces the dataloader batch to 1) × group 32 = 256 rollouts/step; `async_steps=4`
+→ `staleness_threshold=3.0`; ~500 steps (`total_batches`, = `total_episodes
+128000 / 256`), seed 42, save_freq 20, constant LR, no KL, centered advantages,
+64-turn cap, temp 1.0. The **only intended differences are what LoRA + the
+backend force**:
+
+- **LoRA-32**, not full-parameter DPPO → higher LR `2e-5` (the paper's `1e-6`
+  barely moves a rank-32 adapter).
+- **GRPO + PPO clip** instead of DPPO's TV trust region (rLLM has no DPPO); the
+  centered-advantage / no-KL / outcome-only parts are matched.
+- `async_steps=4` maps only approximately to `async_training.staleness_threshold`;
+  `lm_head_fp32` / Liger are backend-internal.
+
+Scale **down** for cost: `ROLLOUT_REPLICAS=2 GROUP_SIZE=8 bash
+train_fireworks.sh rllm.async_training.mini_batch_size=2`. `train_tinker.sh` is
+the single-machine LoRA sibling.
+
+### Reproduction recipe — Tmax's DPPO config → rLLM
+
+Pulled verbatim from Ai2's
+`training/open-instruct/scripts/tmax/RL/qwen35_9b.sh`
+(`open_instruct/grpo_fast.py`):
+
+| Tmax (open-instruct) | Value | rLLM equivalent (`train_verl.sh`) |
+|---|---|---|
+| `model_name_or_path` | `Qwen3.5-9B` | `Qwen/Qwen3.5-9B`, full FT (no LoRA) |
+| `num_unique_prompts_rollout` | 8 | `data.train_batch_size=8` |
+| `num_samples_per_prompt_rollout` (group) | 32 | `actor_rollout_ref.rollout.n=32` |
+| `response_length` (episode) | 65536 | per-turn windows summing to ~64K |
+| `per_turn_max_tokens` | 16384 | `data.max_response_length=16384` |
+| `max_steps` (tool calls/episode) | 64 | `TERMINUS_MAX_TURNS=64` |
+| `learning_rate` | 1e-6 | `actor.optim.lr=1e-6` |
+| `lr_scheduler_type` | constant | verl default (`warmup_steps_ratio=0.0`) |
+| `beta` (KL) | 0.0 | `rllm.algorithm.kl_beta=0.0` (→ `use_kl_loss=False`) |
+| `temperature` | 1.0 | `rollout.temperature=1.0` |
+| `advantage_normalization_type` | centered | `rllm.algorithm.norm_adv_by_std_in_grpo=false` |
+| `loss_fn` | dppo (tv, thr 0.1) | `rllm.algorithm.adv_estimator=grpo` + PPO clip ⚠️ |
+| `verification_reward` | 1.0 | per-task `tests/test.sh` → 1.0/0.0 |
+| `seed` | 42 | `rllm.data.seed=42` |
+| `num_epochs` | 1 | `trainer.total_epochs=1` |
+| `deepspeed_stage` | 3 (full param) | FSDP + param/optimizer offload |
+
+## Fidelity vs. the paper
+
+Honest about the gaps. Reproduce the recipe; expect to be close, not identical.
+
+- **DPPO ⚠️.** rLLM does not implement Tmax's exact DPPO loss (a total-variation
+  trust region with divergence threshold 0.1). We map it to **GRPO with
+  PPO-style ratio clipping** — the practical analog (outcome-only advantages, no
+  learned reward model, on-policy clip as the trust region). The **`centered`
+  advantage normalization is reproduced** (`norm_adv_by_std_in_grpo=false`:
+  mean-subtract without std division). `lm_head_fp32` and `use_liger_grpo_loss`
+  from their script are backend-internal and not exposed.
+- **Harness.** Tmax trained with their **Vanillux2** agent (a mini-SWE-agent-
+  derived bash-tool harness: submit marker, format-error recovery, output
+  truncation). This cookbook defaults to **`terminus2`** (rLLM's proven training
+  harness, and the agent the `TMax-15K-Harbor` dataset is documented to run with).
+  For the closest match to Vanillux2, set `TMAX_HARNESS=mini-swe-agent`. Different
+  scaffolds → different prompts/rollouts, so absolute numbers will shift.
+- **Full FT vs LoRA.** Only `train_verl.sh` does full-parameter training.
+  `train_fireworks.sh` / `train_tinker.sh` train LoRA adapters (see deviations
+  above).
+- **Hardware / topology.** Tmax used **8× H100 nodes** (2 for training with
+  `sequence_parallel_size 4`, 6 for vLLM inference). rLLM's verl path colocates
+  rollout + training (`hybrid_engine`) — a different topology. Full FT of a 9B at
+  65K context + group 32 wants ≥2 nodes and/or Ulysses sequence parallelism
+  (append `actor_rollout_ref.actor.ulysses_sequence_parallel_size=4`). Set
+  `NNODES` / `GPUS_PER_NODE` for `train_verl.sh`.
+
+### Expected results (from the [Tmax-9B model card](https://huggingface.co/allenai/tmax-9b))
+
+| Model | TB Lite | TB 2.1 | TB 2.0 (daytona) |
+|---|---|---|---|
+| Qwen 3.5 9B (base) | 41.9 | 16.1 | 21.1 |
+| **Tmax 9B** | **57.2** | **28.8** | **27.2** |
+
+Best checkpoint at **step ~200**. The optional ECHO variant
+(`rllm.algorithm.adv_estimator=echo`) adds free dense supervision from the
+terminal output and is a natural fit for a hard, failure-heavy benchmark — see
+[terminal-rl](../terminal-rl/README.md#echo-train-on-environment-feedback).
+
+## Evaluation (no training)
+
+```bash
+# matches Tmax's reported "TB 2.0 (daytona)" column
+rllm eval harbor:terminal-bench@2.0 \
+    --agent terminus2 --sandbox-backend daytona \
+    --max-tokens 16384 --temperature 1.0 \
+    --max-examples 20
+```
+
+Per-task results land in `~/.rllm/eval_results/`; `rllm view` opens the
+trajectory UI. See the
+[Terminal-Bench eval cookbook](../../docs/cookbooks/terminal_bench.mdx) for full
+benchmark runs (pass@k, sandbox lifetimes).
+
+## Sandbox backend
+
+Training uses rLLM's own `SandboxedAgentFlow` path (`AgentFlowEngine`). Pick a
+backend via `TERMINAL_SANDBOX_BACKEND`:
+
+| Backend | Setup | Notes |
+|---|---|---|
+| `modal` | `pip install modal` + `modal token new` | Default — per-task billing, scales to many parallel sandboxes. |
+| `daytona` | `pip install daytona` + `DAYTONA_API_KEY` | Cloud sandboxes; the backend Tmax's reported 27.2% used for eval. |
+| `docker` | local | Fastest iteration; needs the Docker daemon + free disk. |
+
+The scripts keep two timeouts ordered — **`RLLM_MODAL_SANDBOX_TIMEOUT_S`
+(sandbox lifetime, 2400s) > `RLLM_HARNESS_RUN_TIMEOUT_S` (agent run cap,
+1800s)** — so a long rollout still gets verified before its sandbox is reaped.
+See terminal-rl's README for why making them equal causes
+`NotFoundError: Sandbox has already shut down` storms.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `prepare_data.py` | Pull `tmax-15k` (train) + `terminal-bench@<ver>` (eval) |
+| `train.py` | Load both datasets, select the harness, hand to `AgentTrainer` |
+| `train_verl.sh` | **verl — full FT 9B, the faithful DPPO→GRPO reproduction** |
+| `train_fireworks.sh` | Fireworks — managed LoRA-32 variant |
+| `train_tinker.sh` | Tinker — single-machine LoRA-32 variant |
+| `test.py` | Import/catalog/wiring smoke tests |
+| `pyproject.toml` | Cookbook metadata |
+
+## Citation
+
+```bibtex
+@misc{ivison2026tmaxsimplerecipeterminal,
+      title={Tmax: A simple recipe for terminal agents},
+      author={Hamish Ivison and Junjie Oscar Yin and Rulin Shao and Teng Xiao and Nathan Lambert and Hannaneh Hajishirzi},
+      year={2026}, eprint={2606.23321}, archivePrefix={arXiv}, primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2606.23321}
+}
+```

--- a/cookbooks/tmax/prepare_data.py
+++ b/cookbooks/tmax/prepare_data.py
@@ -1,0 +1,140 @@
+"""Pull the train + eval datasets for the tmax cookbook.
+
+Both sides are sandbox-format benchmarks (self-contained per-task environment +
+``tests/test.sh`` verifier) in Harbor's directory-per-task layout. They differ
+only in *where* the tasks come from:
+
+* **Train** — ``tmax-15k``, a first-class rLLM dataset registered in
+  ``rllm/registry/datasets.json`` and materialized by
+  ``rllm.data.tmax_builder`` from Ai2's Hugging Face corpus: ``allenai/TMax-15K``
+  (the ``test_final_state`` pytest verifier + task description) joined by
+  ``task_id`` with ``allenai/tmax-15k-open-instruct`` (the per-task prebuilt
+  image ``hamishi740/swerl-tmax-v3:<digest>``). This is the full ~14.6K
+  compositional terminal-agent RL corpus behind the Tmax models
+  (arXiv:2606.23321). ``rllm dataset pull tmax-15k`` builds the Harbor task
+  dirs and registers them under ``tmax-15k/train``. Each task's verifier runs
+  ``test_final_state.py`` in the prebuilt image and writes ``/tmp/rllm/reward.json``
+  — the signal rLLM's per-task verifier reads back as the RL reward.
+
+  (Ai2's README points at a Harbor-registry copy, ``tmax/TMax-15K-Harbor``, but
+  that dataset is not present in the public Harbor registry, so we build from
+  Hugging Face instead. Pulling the per-task images at full 15K scale may need
+  a Docker Hub business account; ``--train-limit`` keeps smoke runs small but
+  note the builder still downloads both full HF datasets to do the join.)
+* **Eval** — ``harbor:terminal-bench@<version>`` pulled straight from the
+  Harbor registry (the same path the Terminal-Bench eval cookbook uses).
+  ``TB_EVAL_VERSION`` selects the version (default ``2.0``, which is the
+  ``TB 2.0`` number Tmax reports in its model card). The registry only
+  publishes ``2.0`` today, so set ``TB_EVAL_VERSION=2.1`` once it lands.
+
+Re-runs are cheap: the Harbor pulls are no-ops once the tasks are cached
+locally.
+
+Usage::
+
+    python cookbooks/tmax/prepare_data.py
+    # smoke run with a small training cap (re-registers a truncated split):
+    python cookbooks/tmax/prepare_data.py --train-limit 50
+    # evaluate against a different Terminal-Bench version:
+    TB_EVAL_VERSION=2.1 python cookbooks/tmax/prepare_data.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+# First-class rLLM dataset name (catalog entry in rllm/registry/datasets.json,
+# source: harbor:tmax/TMax-15K-Harbor@latest). Registered under the "train" split.
+TRAIN_DATASET = "tmax-15k"
+TRAIN_SPLIT = "train"
+
+# Terminal-Bench eval version (Harbor registry). 2.0 is what the registry
+# publishes today and the number Tmax reports; flip via TB_EVAL_VERSION.
+EVAL_VERSION = os.environ.get("TB_EVAL_VERSION", "2.0")
+EVAL_DATASET = f"terminal-bench@{EVAL_VERSION}"
+
+
+def _pull(name: str) -> None:
+    """``rllm dataset pull <name>`` as a subprocess (uses the catalog/Harbor path)."""
+    cmd = [sys.executable, "-m", "rllm.cli.main", "dataset", "pull", name]
+    print(f"[tmax] $ {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def _pull_train() -> None:
+    """Build + register the tmax-15k corpus from Hugging Face (via the catalog builder)."""
+    try:
+        _pull(TRAIN_DATASET)
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            f"[tmax] Failed to build '{TRAIN_DATASET}'. It is materialized by "
+            f"rllm.data.tmax_builder from allenai/TMax-15K + allenai/tmax-15k-open-instruct; "
+            f"set HF_TOKEN if rate-limited and ensure network access to the HF Hub."
+        ) from e
+
+
+def _truncate_train(limit: int) -> int:
+    """Re-register only the first ``limit`` tasks of the train split (smoke runs)."""
+    from rllm.data import DatasetRegistry
+
+    ds = DatasetRegistry.load_dataset(TRAIN_DATASET, TRAIN_SPLIT)
+    if ds is None:
+        raise RuntimeError(f"'{TRAIN_DATASET}/{TRAIN_SPLIT}' not found after pull")
+    rows = list(ds.get_data() if hasattr(ds, "get_data") else ds.data)
+    rows = rows[:limit]
+    DatasetRegistry.register_dataset(
+        name=TRAIN_DATASET,
+        data=rows,
+        split=TRAIN_SPLIT,
+        source="allenai/TMax-15K",
+        description=f"TMax-15K (truncated to {len(rows)} tasks for a smoke run)",
+        category="agentic",
+    )
+    return len(rows)
+
+
+def _pull_eval() -> None:
+    """Pull the Terminal-Bench eval split from the Harbor registry."""
+    name = f"harbor:{EVAL_DATASET}"
+    try:
+        _pull(name)
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            f"[tmax] Failed to pull '{name}'. The Harbor registry currently "
+            f"publishes terminal-bench@2.0; if you requested a version it does not "
+            f"have, set TB_EVAL_VERSION to an available one (e.g. 2.0)."
+        ) from e
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--train-limit",
+        type=int,
+        default=None,
+        help="Cap training tasks (default: all ~14.6K). Useful for smoke runs.",
+    )
+    args = ap.parse_args()
+
+    _pull_train()
+    n_train = None
+    if args.train_limit is not None:
+        n_train = _truncate_train(args.train_limit)
+        print(f"[tmax] Truncated {TRAIN_DATASET}/{TRAIN_SPLIT} to {n_train} tasks", flush=True)
+
+    _pull_eval()
+
+    suffix = f" ({n_train})" if n_train is not None else ""
+    print(
+        f"\n[tmax] Done. Train: {TRAIN_DATASET}{suffix}   Eval: {EVAL_DATASET}\n"
+        f"        Run `bash cookbooks/tmax/train_verl.sh` to reproduce the 9B run,\n"
+        f"        or `bash cookbooks/tmax/train_fireworks.sh` for the managed LoRA variant.",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/tmax/pyproject.toml
+++ b/cookbooks/tmax/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tmax"
+version = "0.1.0"
+description = "Reproduce Ai2's Tmax terminal-agent RL recipe in rLLM: train Qwen3.5-9B on the tmax-15k corpus, eval on Terminal-Bench"
+requires-python = ">=3.10"
+dependencies = ["rllm"]
+
+[tool.setuptools]
+py-modules = ["prepare_data", "train"]

--- a/cookbooks/tmax/test.py
+++ b/cookbooks/tmax/test.py
@@ -1,0 +1,93 @@
+"""Smoke tests for the tmax cookbook.
+
+These tests don't boot sandboxes, run agents, or train. They only verify the
+wiring: the terminal harnesses are importable, the Harbor loader is reachable,
+the ``tmax-15k`` dataset is registered in the in-repo catalog with a Harbor
+source, and ``train.py`` / ``prepare_data.py`` import without side effects and
+expose the expected dataset names.
+
+Run::
+
+    pytest cookbooks/tmax/test.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+_COOKBOOK_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _COOKBOOK_DIR.parent.parent
+_CATALOG = _REPO_ROOT / "rllm" / "registry" / "datasets.json"
+
+
+def _import_cookbook_module(name: str):
+    if str(_COOKBOOK_DIR) not in sys.path:
+        sys.path.insert(0, str(_COOKBOOK_DIR))
+    return importlib.import_module(name)
+
+
+# -- Harness wiring -----------------------------------------------------------
+
+
+def test_terminus2_harness_importable():
+    """``terminus2`` is the default harness this cookbook drives; it must import."""
+    mod = importlib.import_module("rllm.harnesses.terminus2")
+    assert hasattr(mod, "Terminus2Harness")
+    assert mod.Terminus2Harness.name == "terminus2"
+
+
+def test_mini_swe_agent_harness_importable():
+    """``mini-swe-agent`` is the high-fidelity (Vanillux2-like) harness option."""
+    mod = importlib.import_module("rllm.harnesses.mini_swe_agent")
+    assert hasattr(mod, "MiniSweAgentHarness")
+    assert mod.MiniSweAgentHarness.name == "mini-swe-agent"
+
+
+def test_harbor_loader_importable():
+    """tmax-15k is pulled + flattened via the Harbor dataset loader."""
+    mod = importlib.import_module("rllm.integrations.harbor.dataset_loader")
+    assert hasattr(mod, "harbor_task_to_row")
+
+
+# -- Dataset catalog ----------------------------------------------------------
+
+
+def test_tmax15k_in_catalog():
+    """``tmax-15k`` must be a first-class catalog entry built from the HF corpus."""
+    catalog = json.loads(_CATALOG.read_text(encoding="utf-8"))
+    entry = catalog["datasets"].get("tmax-15k")
+    assert entry is not None, "tmax-15k missing from rllm/registry/datasets.json"
+    assert entry["source"] == "allenai/TMax-15K", entry["source"]
+    assert entry["builder"] == "rllm.data.tmax_builder:build_benchmark", entry.get("builder")
+    assert "train" in entry["splits"]
+
+
+def test_tmax_builder_importable():
+    """The native builder that materializes TMax-15K must import and expose build_benchmark."""
+    mod = importlib.import_module("rllm.data.tmax_builder")
+    assert callable(mod.build_benchmark)
+    assert mod.DEFAULT_HF_REPO_ID == "allenai/TMax-15K"
+    assert mod.IMAGE_HF_REPO_ID == "allenai/tmax-15k-open-instruct"
+
+
+# -- Cookbook scripts ---------------------------------------------------------
+
+
+def test_train_module_imports():
+    """``train.py`` must import without triggering Hydra or starting training."""
+    mod = _import_cookbook_module("train")
+    assert mod.TRAIN_DATASET == "tmax-15k"
+    assert mod.VAL_DATASET.startswith("terminal-bench@")
+    assert mod.TMAX_HARNESS in ("terminus2", "mini-swe-agent")
+    assert callable(mod.main)
+
+
+def test_prepare_data_module_imports():
+    """``prepare_data.py`` must import and expose its dataset names."""
+    mod = _import_cookbook_module("prepare_data")
+    assert mod.TRAIN_DATASET == "tmax-15k"
+    assert mod.EVAL_DATASET.startswith("terminal-bench@")
+    assert callable(mod.main)

--- a/cookbooks/tmax/train.py
+++ b/cookbooks/tmax/train.py
@@ -1,0 +1,122 @@
+"""Reproduce Ai2's Tmax terminal-agent RL run on the tmax-15k corpus, eval on
+Terminal-Bench.
+
+This cookbook is the sibling of ``cookbooks/terminal-rl`` — same machinery, but
+the training data is Ai2's published ~14.6K-task ``tmax-15k`` corpus and the
+hyperparameters track their DPPO recipe (arXiv:2606.23321). Like terminal-rl it
+ships no custom AgentFlow or evaluator:
+
+* The **agent** is an in-tree terminal harness run as a
+  :class:`~rllm.sandbox.sandboxed_flow.SandboxedAgentFlow` inside each task's
+  sandbox. ``TMAX_HARNESS`` selects it:
+
+  - ``terminus2`` (default) — Harbor's Terminus-2 tmux agent. The proven
+    training path in this repo and the agent the ``tmax/TMax-15K-Harbor``
+    dataset is documented to run with (``harbor run --agent terminus-2``).
+  - ``mini-swe-agent`` — the architectural match to Tmax's *official* harness
+    (their "Vanillux2" is a mini-SWE-agent-derived bash-tool agent). Use this
+    for the highest-fidelity reproduction of their rollout shape.
+
+  The rLLM gateway intercepts every LLM call, so the trainer sees full
+  trajectories without the harness knowing it's being trained.
+* The **evaluator** is each task's own verifier (sandbox-shell), resolved
+  per-task by :class:`rllm.hooks.SandboxTaskHooks`. Both the tmax-15k training
+  tasks and the Terminal-Bench eval tasks ship a ``tests/test.sh`` that writes
+  ``1.0``/``0.0`` to ``/logs/verifier/reward.txt``; rLLM reads that back as the
+  RL reward (Tmax's outcome-only ``verification_reward``).
+
+Because we pass an ``agent_flow`` (and no explicit ``evaluator``/``hooks``),
+:class:`AgentTrainer` runs the rLLM-native SandboxedAgentFlow path
+(``AgentFlowEngine``) — sandboxes are created locally by ``SandboxTaskHooks``
+via a pluggable ``sandbox_backend`` (``docker`` | ``local`` | ``modal`` |
+``daytona``). This is NOT the remote-runtime / Harbor-runtime path.
+
+The sandbox backend is selected by ``TERMINAL_SANDBOX_BACKEND`` (default
+``modal``). Everything else is Hydra overrides on the command line — see
+``train_verl.sh`` (full fine-tuning, the faithful reproduction) and
+``train_fireworks.sh`` / ``train_tinker.sh`` (managed/single-machine LoRA).
+
+Usage (from the rllm repo root)::
+
+    TERMINAL_SANDBOX_BACKEND=modal python cookbooks/tmax/train.py rllm/backend=verl
+"""
+
+from __future__ import annotations
+
+import os
+
+import hydra
+from omegaconf import DictConfig
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.trainer import AgentTrainer
+
+TRAIN_DATASET = "tmax-15k"
+TRAIN_SPLIT = "train"
+
+# Terminal-Bench eval version (Harbor registry). Must match prepare_data.py;
+# both read TB_EVAL_VERSION so the pulled and loaded dataset names agree.
+EVAL_VERSION = os.environ.get("TB_EVAL_VERSION", "2.0")
+VAL_DATASET = f"terminal-bench@{EVAL_VERSION}"
+
+# Sandbox backend for the SandboxedAgentFlow path: docker | local | modal | daytona.
+SANDBOX_BACKEND = os.environ.get("TERMINAL_SANDBOX_BACKEND", "modal")
+
+# Agent harness: "terminus2" (default; proven training path, runs the
+# TMax-15K-Harbor tasks) or "mini-swe-agent" (closest match to Tmax's official
+# Vanillux2 harness for fidelity).
+TMAX_HARNESS = os.environ.get("TMAX_HARNESS", "terminus2")
+
+# Optional cap on the validation set size. Terminal-Bench 2.0 is 89 tasks;
+# validation runs ALL of them every time it fires, which is slow. Set
+# TB_VAL_MAX=N to validate on the first N tasks instead (0/unset = all).
+TB_VAL_MAX = int(os.environ.get("TB_VAL_MAX", "0"))
+
+# Per-rollout tool-call cap. Tmax uses max_steps=64 (max tool calls per
+# episode). The train_*.sh scripts default TERMINUS_MAX_TURNS=64; set it to
+# empty/0 to uncap. Only terminus2 honours this knob.
+_max_turns = os.environ.get("TERMINUS_MAX_TURNS")
+TERMINUS_MAX_TURNS = int(_max_turns) if _max_turns and int(_max_turns) > 0 else None
+
+
+def _build_agent_flow():
+    """Construct the selected harness as a SandboxedAgentFlow."""
+    if TMAX_HARNESS == "mini-swe-agent":
+        from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
+
+        return MiniSweAgentHarness(sandbox_backend=SANDBOX_BACKEND)
+    if TMAX_HARNESS == "terminus2":
+        from rllm.harnesses.terminus2 import Terminus2Harness
+
+        return Terminus2Harness(sandbox_backend=SANDBOX_BACKEND, max_turns=TERMINUS_MAX_TURNS)
+    raise ValueError(f"Unknown TMAX_HARNESS={TMAX_HARNESS!r} (expected 'terminus2' or 'mini-swe-agent')")
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config: DictConfig) -> None:
+    train_dataset = DatasetRegistry.load_dataset(TRAIN_DATASET, TRAIN_SPLIT)
+    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "default")
+
+    if train_dataset is None:
+        raise RuntimeError(f"Dataset '{TRAIN_DATASET}' not found. Run: python cookbooks/tmax/prepare_data.py")
+    if val_dataset is None:
+        raise RuntimeError(f"Dataset '{VAL_DATASET}' not found. Run: rllm dataset pull harbor:{VAL_DATASET} (or: python cookbooks/tmax/prepare_data.py)")
+
+    if TB_VAL_MAX > 0 and TB_VAL_MAX < len(val_dataset):
+        val_dataset = val_dataset.select(range(TB_VAL_MAX))
+
+    agent_flow = _build_agent_flow()
+
+    trainer = AgentTrainer(
+        backend=config.rllm.get("backend", "verl"),
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        agent_flow=agent_flow,
+        sandbox_backend=SANDBOX_BACKEND,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/tmax/train_fireworks.sh
+++ b/cookbooks/tmax/train_fireworks.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Train a Tmax-style terminal agent on tmax-15k, eval on Terminal-Bench —
+# Fireworks backend (managed, LoRA). This is the ACCESSIBLE variant: it trains a
+# LoRA adapter on Qwen3.5-9B instead of the full-parameter DPPO run Tmax used.
+# For the faithful full fine-tune, use train_verl.sh.
+#
+# Prerequisites:
+#   1. Install rllm with fireworks + harbor extras:  uv pip install -e ".[fireworks,harbor]"
+#   2. Install this cookbook:                        uv pip install --no-deps -e cookbooks/tmax
+#   3. Pull the datasets:                            python cookbooks/tmax/prepare_data.py
+#   4. Set your API key:                             export FIREWORKS_API_KEY=...
+#
+# The trainer job and inference deployment are provisioned on Fireworks at
+# startup and torn down on shutdown.
+#
+# This is aligned field-for-field with Tmax's official DPPO run
+# (scripts/tmax/RL/qwen35_9b.sh); the ONLY intended differences are those LoRA
+# and the rLLM backend force (listed at the bottom). Matched values:
+#   - Context: max_length=67584 = Tmax pack_length (51200 cumulative prompt
+#     window + 16384 per-turn response = Tmax's response_length 65536 + initial
+#     prompt 2048). Cumulative token mode forwards exact trajectory tokens.
+#   - per-turn response 16384 = per_turn_max_tokens; 64 tool calls = max_steps.
+#   - In FULLY-ASYNC mode, prompts/step = async_training.mini_batch_size (the
+#     dataloader batch is forced to 1; data.train_batch_size is IGNORED). So
+#     mini_batch_size=8 = num_unique_prompts_rollout, x group 32 (GROUP_SIZE) =
+#     256 rollouts/step = num_unique_prompts_rollout x num_samples_per_prompt_rollout.
+#   - async_steps=4 -> staleness_threshold=3.0: max in-flight groups =
+#     (1+staleness)*trigger*mini_batch, so (1+3)*1 = 4 steps ahead = async_steps.
+#   - ~500 optimizer steps (total_batches; 500*256 = Tmax's total_episodes
+#     128000), 1 epoch, save_freq 20, seed 42, temperature 1.0, constant LR.
+#   - Centered advantages (norm_adv_by_std_in_grpo=false) = Tmax
+#     advantage_normalization_type=centered. No KL (beta=0.0). Compact filtering
+#     drops overlong rollouts (Tmax's overlong handling).
+#
+# Intended differences (LoRA + backend, NOT recipe choices):
+#   - LoRA-32 adapter, not full-parameter DPPO. LoRA needs a higher LR than the
+#     paper's full-FT 1e-6, so this uses 2e-5 (1e-6 barely moves an adapter).
+#   - loss_fn: GRPO + PPO clip, since rLLM has no DPPO (tv trust region). The
+#     centered-advantage / no-KL / outcome-only parts ARE matched.
+#   - lm_head_fp32 / Liger GRPO are backend-internal (not exposed on Fireworks).
+#
+# Model: Qwen3.5-9B + LoRA-32 on the qwen3p5-9b-256k-lora training shape.
+# Sandbox backend via TERMINAL_SANDBOX_BACKEND; harness via TMAX_HARNESS.
+#
+# Flip GRPO -> ECHO (free dense supervision from terminal output; great for a
+# hard, failure-heavy benchmark) by appending: rllm.algorithm.adv_estimator=echo
+#
+# Defaults are Tmax-aligned (GROUP_SIZE=32, mini_batch_size=8 prompts/step,
+# 67584 ctx). Scale down via env vars to cut cost: TRAINER_REPLICAS (trainer
+# copies, default 1), ROLLOUT_REPLICAS (inference copies for rollout throughput,
+# default 6), GROUP_SIZE (samples/prompt, default 32). Override anything else
+# with Hydra args. Examples:
+#   bash train_fireworks.sh                                          # Tmax-aligned
+#   ROLLOUT_REPLICAS=2 GROUP_SIZE=8 bash train_fireworks.sh \
+#       rllm.async_training.mini_batch_size=2                        # cheap smoke
+
+set -euo pipefail
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export TMAX_HARNESS="${TMAX_HARNESS:-terminus2}"
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-64}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+# --- Fireworks scale knobs (the two distinct "replicas") -------------------
+#  TRAINER_REPLICAS  -> fireworks_config.policy_trainer_replica_count
+#      Copies of the LoRA *trainer* job (fwd/bwd + optim on the training shape).
+#      The gradient side; rarely the RL bottleneck. 1 is standard for LoRA-9B.
+#  ROLLOUT_REPLICAS  -> fireworks_config.rollout_deployment_replica_count
+#      Copies of the *inference* deployment that generates rollouts. This is the
+#      throughput knob (analog of Tmax's 6 inference nodes / 48 vLLM engines) and
+#      seeds the adaptive sampling window (8 * replica_count). Raise for speed/$$.
+#  GROUP_SIZE        -> samples per prompt. Default 32 = Tmax's
+#      num_samples_per_prompt_rollout. Drop to 16/8 to cut cost (lower fidelity).
+#  Reference-trainer replicas stay 0: Tmax has beta=0 (no KL), so no ref model.
+TRAINER_REPLICAS="${TRAINER_REPLICAS:-1}"
+ROLLOUT_REPLICAS="${ROLLOUT_REPLICAS:-6}"
+GROUP_SIZE="${GROUP_SIZE:-32}"
+
+python -u train.py \
+    rllm/backend=fireworks \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora \
+    fireworks_config.policy_trainer_replica_count=$TRAINER_REPLICAS \
+    fireworks_config.rollout_deployment_replica_count=$ROLLOUT_REPLICAS \
+    fireworks_config.reference_trainer_replica_count=0 \
+    training.group_size=$GROUP_SIZE \
+    training.learning_rate=2e-5 \
+    training.max_length=67584 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=51200 \
+    data.max_response_length=16384 \
+    data.val_batch_size=-1 \
+    rllm.data.max_prompt_length=51200 \
+    rllm.data.max_response_length=16384 \
+    rllm.data.val_batch_size=-1 \
+    rllm.data.seed=42 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=false \
+    rllm.algorithm.lr_schedule=constant \
+    rllm.algorithm.kl_beta=0.0 \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=8 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=3.0 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=256 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9091 \
+    rllm.gateway.tunnel=https://rllm.ngrok.dev \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.total_batches=500 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='tmax' \
+    rllm.trainer.experiment_name='tmax-qwen3p5-9b-fireworks-lora' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=20 \
+    rllm.trainer.save_freq=20 \
+    "$@"

--- a/cookbooks/tmax/train_tinker.sh
+++ b/cookbooks/tmax/train_tinker.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Train a Tmax-style terminal agent on tmax-15k, eval on Terminal-Bench —
+# Tinker backend (single-machine, LoRA). Accessible variant: a LoRA adapter on
+# Qwen3.5-9B rather than the full-parameter DPPO run. For the faithful full
+# fine-tune, use train_verl.sh.
+#
+# Prerequisites:
+#   1. Install rllm with tinker + harbor extras:  uv pip install -e ".[tinker,harbor]"
+#   2. Install this cookbook:                     uv pip install --no-deps -e cookbooks/tmax
+#   3. Pull the datasets:                         python cookbooks/tmax/prepare_data.py
+#
+# What this configures:
+#   - Async GRPO with compact filtering.
+#   - Centered advantages (norm_adv_by_std_in_grpo=false) = Tmax's
+#     advantage_normalization_type=centered. No KL (beta=0.0). Temperature 1.0.
+#   - 64 tool-call cap per episode (Tmax max_steps=64).
+#   - 64K single-turn window (49K prompt history + 16K response), matching
+#     Tmax's per_turn_max_tokens=16384. Tmax found ~65K output length important
+#     for 9B stability — keep max_length high.
+#
+# LoRA deviations from the paper: LoRA-32 not full-FT (so LR 2e-5, not 1e-6);
+# group_size 8 not 32 (raise it if you have the GPUs/time).
+#
+# Sandbox backend via TERMINAL_SANDBOX_BACKEND; harness via TMAX_HARNESS.
+# Flip to ECHO with: rllm.algorithm.adv_estimator=echo
+#
+# Override anything by appending Hydra args:
+#   bash train_tinker.sh training.group_size=16
+
+set -euo pipefail
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export TMAX_HARNESS="${TMAX_HARNESS:-terminus2}"
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-64}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+python -u train.py \
+    rllm/backend=tinker \
+    model.name=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    training.group_size=8 \
+    training.learning_rate=2e-5 \
+    training.max_length=65536 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.rollout.val.temperature=1.0 \
+    rllm.rollout.val.top_p=1.0 \
+    data.max_prompt_length=49152 \
+    data.max_response_length=16384 \
+    data.train_batch_size=1 \
+    data.val_batch_size=-1 \
+    rllm.compact_filtering.enable=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=false \
+    rllm.algorithm.lr_schedule=constant \
+    rllm.algorithm.kl_beta=0.0 \
+    rllm.async_training.enable=true \
+    rllm.async_training.mini_batch_size=16 \
+    rllm.async_training.fwd_bwd_group_size=1 \
+    rllm.async_training.staleness_threshold=0.5 \
+    rllm.async_training.trigger_parameter_sync_step=1 \
+    rllm.async_training.partial_rollout=true \
+    rllm.workflow.n_parallel_tasks=128 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9091 \
+    rllm.gateway.cumulative_token_mode=true \
+    rllm.gateway.renderer_family=qwen3.5 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.logger='[wandb]' \
+    rllm.trainer.project_name='tmax' \
+    rllm.trainer.experiment_name='tmax-qwen3p5-9b-tinker-lora' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=10 \
+    "$@"

--- a/cookbooks/tmax/train_verl.sh
+++ b/cookbooks/tmax/train_verl.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Reproduce Ai2's Tmax-9B terminal-agent RL run with the verl (distributed)
+# backend — FULL fine-tuning of Qwen3.5-9B, the faithful path.
+#
+# Prerequisites:
+#   1. Install rllm with verl + harbor extras:  uv pip install -e ".[verl,harbor]"
+#   2. Install megatron:                         bash scripts/install_megatron.sh <cu128|cu129|...>
+#   3. Install this cookbook:                    uv pip install --no-deps -e cookbooks/tmax
+#   4. Pull the datasets:                        python cookbooks/tmax/prepare_data.py
+#
+# ---------------------------------------------------------------------------
+# Mapping Tmax's official DPPO recipe (training/open-instruct/scripts/tmax/RL/
+# qwen35_9b.sh, open_instruct/grpo_fast.py) onto rLLM's unified trainer:
+#
+#   Tmax (open-instruct)              | here (rLLM / verl)
+#   ----------------------------------|------------------------------------------
+#   model hamishivi/Qwen3.5-9B        | Qwen/Qwen3.5-9B, FULL fine-tune (no LoRA)
+#   num_unique_prompts_rollout 8      | data.train_batch_size=8
+#   num_samples_per_prompt_rollout 32 | actor_rollout_ref.rollout.n=32  (group size)
+#   response_length 65536 (episode)   | per-turn windows summing to ~64K (below)
+#   per_turn_max_tokens 16384         | data.max_response_length=16384
+#   max_steps 64 (tool calls/episode) | TERMINUS_MAX_TURNS=64
+#   learning_rate 1e-6                | actor.optim.lr=1e-6
+#   lr_scheduler_type constant        | algorithm.lr_schedule=constant
+#   beta 0.0 (no KL)                  | use_kl_loss=False / kl_beta=0.0
+#   temperature 1.0                   | rollout.temperature=1.0
+#   advantage_normalization centered  | norm_adv_by_std_in_grpo=false (mean-center)
+#   loss_fn dppo (tv, thr 0.1)        | adv_estimator=grpo + PPO clip  (see NOTE)
+#   verification_reward 1.0           | per-task tests/test.sh -> reward 1.0/0.0
+#   seed 42                           | data.seed=42
+#   deepspeed_stage 3 (full param)    | FSDP, param+optimizer offload
+#
+# NOTE — DPPO: rLLM does not implement Tmax's exact DPPO loss (a total-variation
+# trust region, divergence threshold 0.1). We map it to GRPO with PPO-style ratio
+# clipping, which is the practical analog (no learned reward model, outcome-only
+# advantages, on-policy clip as the trust region). The `centered` advantage
+# normalization IS reproduced (norm_adv_by_std_in_grpo=false). FP32 LM head and
+# Liger GRPO loss (lm_head_fp32 / use_liger_grpo_loss in their script) are
+# backend-internal and not exposed here. See README "Fidelity vs. the paper".
+#
+# HARDWARE — Tmax used 8x H100 nodes (2 for training w/ sequence_parallel_size 4,
+# 6 for vLLM inference). rLLM's verl path colocates rollout + training
+# (hybrid_engine), a different topology. Full FT of a 9B at 65K context + group
+# 32 is heavy: a single 8x H100 node is the practical floor and you will likely
+# want >=2 nodes and/or Ulysses sequence parallelism (append
+# actor_rollout_ref.actor.ulysses_sequence_parallel_size=4). Set NNODES /
+# GPUS_PER_NODE below. For an accessible (LoRA) run, use train_fireworks.sh or
+# train_tinker.sh instead.
+#
+# Sandbox backend is chosen by TERMINAL_SANDBOX_BACKEND (docker | local | modal |
+# daytona; default modal). Harness via TMAX_HARNESS (terminus2 | mini-swe-agent).
+#
+# Override anything by appending Hydra args:
+#   bash train_verl.sh actor_rollout_ref.rollout.n=16 trainer.nnodes=2
+
+set -euo pipefail
+
+unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export TMAX_HARNESS="${TMAX_HARNESS:-terminus2}"
+# Per-rollout tool-call cap (Tmax max_steps=64). Read by train.py.
+export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-64}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
+# Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
+# above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as
+# "Sandbox has already shut down" (NotFoundError) and exit-137 kills.
+export RLLM_MODAL_SANDBOX_TIMEOUT_S="${RLLM_MODAL_SANDBOX_TIMEOUT_S:-2400}"
+
+NNODES="${NNODES:-1}"
+GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+MODEL_PATH="${MODEL_PATH:-Qwen/Qwen3.5-9B}"
+
+# NOTE: use the rllm.algorithm.* namespace (preferred) — verl-native algorithm.*
+# overrides warn as deprecated. rllm.algorithm.kl_beta maps to verl's
+# kl_loss_coef and derives actor.use_kl_loss. Tmax's constant LR is verl's
+# default (no warmup/decay configured). rllm.data.seed sets the data seed
+# (verl's top-level data config has no seed key).
+python -u train.py \
+    rllm/backend=verl \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=false \
+    rllm.algorithm.use_rllm=true \
+    rllm.algorithm.kl_beta=0.0 \
+    rllm.algorithm.warmup_steps_ratio=0.0 \
+    data.train_batch_size=8 \
+    data.val_batch_size=-1 \
+    data.max_prompt_length=49152 \
+    data.max_response_length=16384 \
+    rllm.data.seed=42 \
+    +model.name=$MODEL_PATH \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=65536 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    +actor_rollout_ref.rollout.max_model_len=65536 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.n=32 \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=1.0 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.workflow.raise_on_error=false \
+    rllm.gateway.port=9091 \
+    trainer.logger="['console','wandb']" \
+    trainer.project_name=tmax \
+    trainer.experiment_name=tmax-qwen3p5-9b-dppo-verl \
+    trainer.val_before_train=true \
+    trainer.n_gpus_per_node=$GPUS_PER_NODE \
+    trainer.nnodes=$NNODES \
+    trainer.save_freq=20 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=1 \
+    trainer.default_hdfs_dir=null \
+    trainer.resume_mode=disable \
+    "$@"

--- a/rllm/data/tmax_builder.py
+++ b/rllm/data/tmax_builder.py
@@ -1,0 +1,375 @@
+"""Builder for Ai2's TMax-15K terminal-agent RL corpus.
+
+TMax-15K (arXiv:2606.23321) is ~14.6K compositional terminal-agent tasks. Ai2
+publishes it on the Hugging Face Hub in two complementary forms, which this
+builder joins by ``task_id``:
+
+* ``allenai/TMax-15K`` (raw) carries the **programmatic verifier**
+  ``test_final_state`` (a pytest module whose pass/fail IS the RL reward — see
+  the project's ``rl_data/README.md``: "test_final_state.py = programmatic
+  verifier (pass/fail signal)") plus the task ``description`` and the
+  ``container_def`` the environment was built from.
+* ``allenai/tmax-15k-open-instruct`` (training-ready) carries the **per-task
+  prebuilt Docker image** (``env_config.image`` = ``hamishi740/swerl-tmax-v3:<digest>``),
+  so we pull a ready environment instead of building from ``container_def``.
+
+The Ai2 README claims the corpus is also on the Harbor registry as
+``tmax/TMax-15K-Harbor``, but that dataset is not present in the public Harbor
+package registry (``list_datasets()`` returns 80 datasets, none tmax), so this
+builder sources from Hugging Face instead.
+
+Each row becomes a Harbor-format task directory whose verifier runs the task's
+``test_final_state.py`` with pytest inside the prebuilt image; reward = 1.0 iff
+it passes. This mirrors ``r2egym_builder`` / ``swesmith_builder``.
+
+On-disk output (``<out_dir>/``)::
+
+    tmax-15k/
+    ├── dataset.toml                       # type="sandbox"
+    ├── <task_id>/
+    │   ├── task.toml                      # docker_image=<prebuilt image>
+    │   ├── instruction.md                 # task description
+    │   ├── environment/Dockerfile         # FROM <image> + ENTRYPOINT []
+    │   └── tests/
+    │       ├── test.sh                    # run test_final_state.py, write reward
+    │       └── test_final_state.py        # the programmatic verifier (from raw)
+    └── ...
+
+Invoked from ``rllm dataset pull tmax-15k`` via the ``builder`` field in
+``rllm/registry/datasets.json`` → :func:`rllm.cli._pull.pull_dataset`.
+
+NOTE: pulling the per-task images at the full 15K scale needs a Docker Hub
+business account (rate limits); small subsets (``--limit``) pull fine.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Raw corpus: carries test_final_state (verifier) + description.
+DEFAULT_HF_REPO_ID = "allenai/TMax-15K"
+# Training-ready corpus: carries the per-task prebuilt docker image.
+IMAGE_HF_REPO_ID = "allenai/tmax-15k-open-instruct"
+
+# Per-instance resource defaults. The swerl images bundle a full task
+# environment (compilers, services, oracle binaries for graded verifiers).
+_DEFAULT_RESOURCES = {
+    "cpus": 4,
+    "memory_mb": 8192,
+    "storage_mb": 20480,
+    "build_timeout_sec": 1800.0,
+}
+_DEFAULT_TIMEOUTS = {
+    "agent_timeout_sec": 1800.0,
+    "verifier_timeout_sec": 300.0,
+}
+
+
+def _load_rows(hf_repo_id: str, hf_split: str, *, retries: int = 4, backoff_sec: float = 10.0) -> list[dict]:
+    """Load HF rows with retries on transient Hub errors (mirrors r2egym_builder)."""
+    from datasets import load_dataset
+
+    last_exc: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            ds = load_dataset(hf_repo_id, split=hf_split)
+            return [dict(r) for r in ds]
+        except Exception as e:  # noqa: BLE001
+            last_exc = e
+            if attempt == retries:
+                break
+            wait = backoff_sec * attempt
+            logger.warning("[tmax] load_dataset(%s) failed (attempt %d/%d): %s — retry in %.0fs", hf_repo_id, attempt, retries, e, wait)
+            time.sleep(wait)
+    raise RuntimeError(f"load_dataset({hf_repo_id!r}, split={hf_split!r}) failed after {retries} attempts") from last_exc
+
+
+def _load_image_map(image_repo_id: str, hf_split: str) -> dict[str, str]:
+    """Map ``task_id`` → prebuilt docker image from the open-instruct dataset."""
+    rows = _load_rows(image_repo_id, hf_split)
+    image_map: dict[str, str] = {}
+    for r in rows:
+        env = r.get("env_config") or {}
+        tid = env.get("task_id")
+        img = env.get("image")
+        if tid and img:
+            image_map[tid] = img
+    logger.info("[tmax] loaded %d task→image mappings from %s", len(image_map), image_repo_id)
+    return image_map
+
+
+def _build_dockerfile(docker_image: str) -> str:
+    """``FROM <image>`` + clear ENTRYPOINT so the sandbox can exec into it."""
+    return f"FROM {docker_image}\nENTRYPOINT []\n"
+
+
+def _build_task_toml(*, task_id: str, domain: str, docker_image: str) -> str:
+    """Synthesize a Harbor-format ``task.toml``."""
+    safe_domain = (domain or "").replace('"', "'")
+    lines = [
+        'schema_version = "1.1"',
+        "",
+        "[task]",
+        f'name = "tmax-15k/{task_id}"',
+        f'description = "TMax-15K task ({safe_domain})"',
+        'keywords = ["tmax", "terminal-agent"]',
+        "",
+        "[metadata]",
+        f'task_id = "{task_id}"',
+        f'domain = "{safe_domain}"',
+        "",
+        "[environment]",
+        f'docker_image = "{docker_image}"',
+        f"cpus = {_DEFAULT_RESOURCES['cpus']}",
+        f"memory_mb = {_DEFAULT_RESOURCES['memory_mb']}",
+        f"storage_mb = {_DEFAULT_RESOURCES['storage_mb']}",
+        f"build_timeout_sec = {_DEFAULT_RESOURCES['build_timeout_sec']}",
+        "allow_internet = true",
+        "",
+        "[agent]",
+        f"timeout_sec = {_DEFAULT_TIMEOUTS['agent_timeout_sec']}",
+        "",
+        "[verifier]",
+        f"timeout_sec = {_DEFAULT_TIMEOUTS['verifier_timeout_sec']}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# Reward = 1.0 iff the task's programmatic verifier (test_final_state.py) passes
+# under pytest, run inside the prebuilt image. pytest exit 0 = all collected
+# tests passed; exit 5 (no tests collected) or any failure ⇒ 0.0. The reward
+# file path matches rllm.eval.script_evaluator's search order (/tmp/rllm/reward.json
+# wins). The verifier file ships in the task's tests/ dir, available at
+# /tests/test_final_state.py inside the sandbox.
+_VERIFIER_TEMPLATE = r"""#!/bin/bash
+set -uo pipefail
+mkdir -p /tmp/rllm /logs/verifier
+log() { echo "[verifier] $*"; }
+
+PY=python3; command -v "$PY" >/dev/null 2>&1 || PY=python
+# test_final_state.py is a pytest module; ensure pytest is importable.
+if ! "$PY" -m pytest --version >/dev/null 2>&1; then
+    "$PY" -m pip install -q pytest >/dev/null 2>&1 || true
+fi
+
+TEST=/tests/test_final_state.py
+reward=0.0
+if [ -f "$TEST" ]; then
+    "$PY" -m pytest -q -rA "$TEST" > /tmp/test_output.txt 2>&1
+    rc=$?
+    log "pytest exit=$rc"
+    tail -n 40 /tmp/test_output.txt 2>/dev/null || true
+    [ "$rc" -eq 0 ] && reward=1.0
+else
+    log "missing $TEST"
+fi
+
+"$PY" - "$reward" <<'PY'
+import json, os, sys
+r = float(sys.argv[1])
+tail = ""
+if os.path.exists("/tmp/test_output.txt"):
+    tail = open("/tmp/test_output.txt").read()[-1500:]
+json.dump({"reward": r, "is_correct": r >= 1.0, "metadata": {"log_tail": tail}},
+          open("/tmp/rllm/reward.json", "w"))
+PY
+exit 0
+"""
+
+
+def _write_dataset_toml(out: Path, *, name: str, split: str, description: str, default_agent: str) -> None:
+    content = "\n".join(
+        [
+            "[dataset]",
+            f'name = "{name}"',
+            'type = "sandbox"',
+            f'description = "{description}"',
+            'default_sandbox = "docker"',
+            f'default_agent = "{default_agent}"',
+            f'split = "{split}"',
+            "",
+            "[verifier]",
+            'script = "tests/test.sh"',
+            "",
+        ]
+    )
+    (out / "dataset.toml").write_text(content, encoding="utf-8")
+
+
+def _materialize_task(task_dir: Path, row: dict, docker_image: str) -> None:
+    """Expand a single raw TMax-15K row + image into a Harbor-format task tree."""
+    task_dir.mkdir(parents=True, exist_ok=True)
+    task_id = row["task_id"]
+
+    (task_dir / "task.toml").write_text(
+        _build_task_toml(task_id=task_id, domain=row.get("domain", ""), docker_image=docker_image),
+        encoding="utf-8",
+    )
+    (task_dir / "instruction.md").write_text((row.get("description") or "").strip() + "\n", encoding="utf-8")
+
+    env_dir = task_dir / "environment"
+    env_dir.mkdir(parents=True, exist_ok=True)
+    (env_dir / "Dockerfile").write_text(_build_dockerfile(docker_image), encoding="utf-8")
+
+    tests_dst = task_dir / "tests"
+    tests_dst.mkdir(parents=True, exist_ok=True)
+    (tests_dst / "test.sh").write_text(_VERIFIER_TEMPLATE, encoding="utf-8")
+    (tests_dst / "test.sh").chmod(0o755)
+    (tests_dst / "test_final_state.py").write_text(row.get("test_final_state") or "", encoding="utf-8")
+    (tests_dst / "instance.json").write_text(
+        json.dumps({"task_id": task_id, "domain": row.get("domain", "")}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def build_benchmark(
+    *,
+    name: str = "tmax-15k",
+    split: str = "train",
+    out_dir: str | Path,
+    catalog_entry: dict | None = None,
+    task_ids: list[str] | None = None,
+    limit: int | None = None,
+    default_agent: str = "terminus-2",
+    hf_repo_id: str | None = None,
+    hf_split: str = "train",
+    image_repo_id: str = IMAGE_HF_REPO_ID,
+    clean: bool = False,
+    register: bool = True,
+) -> Path:
+    """Materialize TMax-15K into a sandbox benchmark directory.
+
+    Joins ``allenai/TMax-15K`` (verifier + description) with
+    ``allenai/tmax-15k-open-instruct`` (prebuilt image) by ``task_id``. Tasks
+    without a prebuilt image are skipped (the raw ``container_def`` is Apptainer
+    format and not built here).
+    """
+    if catalog_entry:
+        default_agent = catalog_entry.get("default_agent") or default_agent
+        hf_repo_id = hf_repo_id or catalog_entry.get("source")
+    hf_repo_id = hf_repo_id or DEFAULT_HF_REPO_ID
+
+    out = Path(out_dir).expanduser()
+    if clean and out.exists():
+        logger.info("[tmax] removing existing %s", out)
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    image_map = _load_image_map(image_repo_id, hf_split)
+    logger.info("[tmax] loading raw corpus %s split=%s ...", hf_repo_id, hf_split)
+    rows = _load_rows(hf_repo_id, hf_split)
+
+    if task_ids is not None:
+        keep = set(task_ids)
+        rows = [r for r in rows if r.get("task_id") in keep]
+    if limit is not None:
+        rows = rows[:limit]
+    logger.info("[tmax] selected %d rows (task_ids=%s, limit=%s)", len(rows), task_ids and len(task_ids), limit)
+
+    written = 0
+    skipped_no_image = 0
+    skipped_no_verifier = 0
+    reg_rows: list[dict] = []
+    for row in rows:
+        task_id = row.get("task_id")
+        if not task_id:
+            continue
+        docker_image = image_map.get(task_id)
+        if not docker_image:
+            skipped_no_image += 1
+            continue
+        if not (row.get("test_final_state") or "").strip():
+            skipped_no_verifier += 1
+            continue
+        task_dst = out / task_id
+        if task_dst.exists():
+            shutil.rmtree(task_dst)
+        _materialize_task(task_dst, row, docker_image)
+        written += 1
+        reg_rows.append(
+            {
+                "id": task_id,
+                "task_id": task_id,
+                "instruction": (row.get("description") or "").strip() + "\n",
+                "task_path": str(task_dst),
+                "docker_image": docker_image,
+                "domain": row.get("domain", ""),
+            }
+        )
+
+    description = (catalog_entry or {}).get("description") or ("TMax-15K (Ai2): compositional terminal-agent RL tasks with per-instance prebuilt Docker images and pytest test_final_state verifiers.")
+    _write_dataset_toml(out, name=name, split=split, description=description, default_agent=default_agent)
+    logger.info(
+        "[tmax] wrote %d task dirs to %s (skipped: no image=%d, no verifier=%d)",
+        written,
+        out,
+        skipped_no_image,
+        skipped_no_verifier,
+    )
+
+    if not reg_rows:
+        raise RuntimeError(
+            f"[tmax] no tasks materialized from {hf_repo_id} (joined with {image_repo_id}). Skipped {skipped_no_image} without a prebuilt image, {skipped_no_verifier} without a verifier."
+        )
+
+    if register:
+        try:
+            from rllm.data import DatasetRegistry
+
+            DatasetRegistry.register_dataset(
+                name=name,
+                data=reg_rows,
+                split=split,
+                source=hf_repo_id,
+                description=description,
+                category=(catalog_entry or {}).get("category", "agentic"),
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("[tmax] could not register rows in DatasetRegistry (non-fatal)", exc_info=True)
+
+    return out
+
+
+def main() -> None:
+    """CLI: ``python -m rllm.data.tmax_builder --out-dir <dir> [--limit N]``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Materialize TMax-15K into an rLLM sandbox benchmark directory.")
+    parser.add_argument("--out-dir", required=True, help="Output benchmark directory.")
+    parser.add_argument("--name", default="tmax-15k")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--hf-repo-id", default=None, help="Override raw HF source (default: allenai/TMax-15K).")
+    parser.add_argument("--image-repo-id", default=IMAGE_HF_REPO_ID)
+    parser.add_argument("--hf-split", default="train")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--task-ids", nargs="*", default=None)
+    parser.add_argument("--default-agent", default="terminus-2")
+    parser.add_argument("--clean", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=os.environ.get("RLLM_LOG_LEVEL", "INFO"))
+    build_benchmark(
+        name=args.name,
+        split=args.split,
+        out_dir=args.out_dir,
+        task_ids=args.task_ids,
+        limit=args.limit,
+        default_agent=args.default_agent,
+        hf_repo_id=args.hf_repo_id,
+        image_repo_id=args.image_repo_id,
+        hf_split=args.hf_split,
+        clean=args.clean,
+        register=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -50,6 +50,18 @@
       "eval_split": "train",
       "default_agent": "claude-code"
     },
+    "tmax-15k": {
+      "description": "TMax-15K (Ai2): ~14.6K compositional terminal-agent RL tasks (domain/skill/persona/complexity axes) with per-instance prebuilt Docker images (hamishi740/swerl-tmax-v3) and pytest test_final_state verifiers. Built from allenai/TMax-15K (verifier) joined with allenai/tmax-15k-open-instruct (images). Training corpus behind Ai2's Tmax terminal agents (arXiv:2606.23321).",
+      "source": "allenai/TMax-15K",
+      "builder": "rllm.data.tmax_builder:build_benchmark",
+      "category": "agentic",
+      "splits": [
+        "train"
+      ],
+      "eval_split": "train",
+      "train_split": "train",
+      "default_agent": "terminus-2"
+    },
     "gsm8k": {
       "description": "Grade school math word problems (8.5K train, 1.3K test)",
       "source": "openai/gsm8k",


### PR DESCRIPTION
Reproduce Ai2's **Tmax** recipe ([arXiv:2606.23321](https://arxiv.org/abs/2606.23321)) in rLLM — train a terminal agent on the TMax-15K corpus over Qwen3.5-9B, eval on Terminal-Bench. Sibling of `cookbooks/terminal-rl`.

## What's added
- **`rllm/data/tmax_builder.py`** — native builder for the TMax-15K corpus. Ai2's README cites a Harbor-registry copy (`tmax/TMax-15K-Harbor`), but that dataset is **not in the public Harbor registry** (`list_datasets()` returns 80, none tmax). So we build from HuggingFace instead: join `allenai/TMax-15K` (the `test_final_state` pytest verifier + task description) with `allenai/tmax-15k-open-instruct` (per-task prebuilt images `hamishi740/swerl-tmax-v3:<digest>`) by `task_id`, and materialize Harbor task dirs. Reward = `test_final_state.py` pytest pass/fail → `/tmp/rllm/reward.json`. Same pattern as `r2egym`/`swesmith`.
- **`tmax-15k`** catalog entry in `rllm/registry/datasets.json` (builder-backed).
- **`cookbooks/tmax/`** — `prepare_data.py`, `train.py`, `train_verl.sh` (faithful full-FT DPPO→GRPO + centered advantages), `train_fireworks.sh` / `train_tinker.sh` (LoRA variants), `test.py`, `README.md`.

## Fidelity
`train_verl.sh` and `train_fireworks.sh` are aligned field-for-field with Tmax's DPPO config (group 32, 8 prompts/step, 67584 ctx = pack_length, lr-schedule constant, no KL, centered advantages, 64-turn cap, seed 42, ~500 steps = 128000 episodes). Intended differences are LoRA-/backend-forced: LoRA (→ lr 2e-5), GRPO+PPO-clip instead of DPPO's TV trust region (rLLM has no DPPO).

## Validation
Builder join + materialization validated on real HF data; `cookbooks/tmax/test.py` passes 7/7 (imports, catalog, wiring). In-container reward execution needs Docker Hub access to the swerl images (full 15K scale wants a business account, per Ai2's README) — confirm on a small subset first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)