### PR TITLE
feat(gateway): classify and explain TokenAccumulator resets in the log

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -26,8 +26,8 @@ from rllm_model_gateway.models import TraceRecord
 from rllm_model_gateway.session_router import SessionRouter
 from rllm_model_gateway.store.base import TraceStore
 from rllm_model_gateway.token_accumulator import (
+    ResetReason,
     TokenAccumulator,
-    extract_new_messages,
 )
 
 logger = logging.getLogger(__name__)
@@ -104,7 +104,7 @@ class ReverseProxy:
     def _get_accumulator(self, session_id: str) -> TokenAccumulator:
         """Return the TokenAccumulator for *session_id*, creating if needed."""
         if session_id not in self._accumulators:
-            self._accumulators[session_id] = TokenAccumulator(self.renderer)
+            self._accumulators[session_id] = TokenAccumulator(self.renderer, session_id=session_id)
         return self._accumulators[session_id]
 
     async def start(self) -> None:
@@ -153,16 +153,21 @@ class ReverseProxy:
             acc = self._get_accumulator(session_id)
             if acc.should_rewrite():
                 messages = request_body.get("messages", [])
-                if not acc.is_cumulative(messages):
-                    # Message history diverged — reset and fall through to
-                    # normal chat path (treated as fresh turn-0).
-                    acc.reset()
-                else:
-                    new_messages = extract_new_messages(messages, acc.message_count)
-                    token_ids = None
-                    if new_messages:
-                        token_ids = acc.build_next_prompt(new_messages, tools=request_body.get("tools"))
+                # Classify the incoming request against the accumulated snapshot.
+                # plan.action is "extend" (build a /v1/completions bridge) or
+                # "reset" (fall through to the chat path as a fresh turn-0). Every
+                # reset is logged with its classified ResetReason + diagnostics so
+                # the *why* is recoverable from the gateway log.
+                plan = acc.plan_turn(messages)
+                if plan.action == "extend":
+                    token_ids = acc.build_next_prompt(plan.new_messages, tools=request_body.get("tools"))
                     if token_ids is not None:
+                        logger.debug(
+                            "TokenAccumulator extend session=%s turn=%d +%d new msgs",
+                            session_id,
+                            acc.turn_count,
+                            len(plan.new_messages),
+                        )
                         return await self._handle_cumulative_turn(
                             request,
                             request_body,
@@ -171,13 +176,21 @@ class ReverseProxy:
                             token_ids,
                             originally_requested_logprobs,
                         )
-                    # No new messages, or the renderer couldn't prove the
-                    # prefix-extension contract (e.g. DefaultRenderer, or an
-                    # assistant message in the new slice). Reset so this turn is
-                    # re-ingested as a fresh turn-0 on the chat path; otherwise
-                    # the stale prefix would drop this turn's completion tokens
-                    # from the next cumulative prompt and break prefix-extension.
-                    acc.reset()
+                    # Structurally a valid extension, but the renderer couldn't
+                    # prove the prefix-extension contract (e.g. DefaultRenderer).
+                    # Reset so this turn is re-ingested as a fresh turn-0;
+                    # otherwise the stale prefix would drop this turn's completion
+                    # tokens from the next cumulative prompt and break extension.
+                    acc.reset(
+                        ResetReason.RENDERER_NO_BRIDGE,
+                        diagnostics={
+                            **plan.diagnostics,
+                            "renderer": type(acc.renderer).__name__,
+                            "new_roles": [m.get("role") for m in plan.new_messages],
+                        },
+                    )
+                else:
+                    acc.reset(plan.reason, diagnostics=plan.diagnostics)
 
         if is_stream:
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -233,7 +233,23 @@ class TokenAccumulator:
 
         # _REL_PREFIX_CHANGED
         diag.update(self._divergence_diag(messages))
+        # Token count of the (typically compacted) incoming request, so a
+        # prefix_changed line shows how far the history shrank — compare
+        # snapshot_tokens (pre-reset history) against the model's context limit
+        # to confirm a token-limit-triggered compaction.
+        diag["incoming_tokens"] = self._count_tokens(messages)
         return TurnPlan(action="reset", reason=ResetReason.PREFIX_CHANGED, diagnostics=diag)
+
+    def _count_tokens(self, messages: list[dict[str, Any]]) -> int | None:
+        """Best-effort token count of *messages* via the renderer.
+
+        Returns ``None`` if the renderer can't tokenize the list (e.g. a mock,
+        or content it rejects) — diagnostics must never break the reset path.
+        """
+        try:
+            return len(self.renderer.render_ids(messages))
+        except Exception:
+            return None
 
     def _divergence_diag(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
         """Locate where *messages* first diverges from the snapshot prefix."""
@@ -277,14 +293,21 @@ class TokenAccumulator:
         """
         self.reset_count += 1
         diag = diagnostics or {}
+        # snapshot_tokens = size of the accumulated history right before this
+        # reset (prompt + completion of the last ingested turn). Compare against
+        # the model's context limit to spot token-limit-triggered compaction.
+        snapshot_tokens = len(self.prev_prompt_ids) + len(self.prev_completion_ids)
         logger.info(
-            "TokenAccumulator reset (session=%s) reason=%s: %s [turn=%d msgs=%d incoming=%s reset_count=%d]",
+            "TokenAccumulator reset (session=%s) reason=%s: %s "
+            "[turn=%d msgs=%d snapshot_tokens=%d incoming=%s incoming_tokens=%s reset_count=%d]",
             self.session_id,
             reason.value if isinstance(reason, ResetReason) else reason,
             self._explain(reason, diag),
             self.turn_count,
             self.message_count,
+            snapshot_tokens,
             diag.get("incoming_len", "?"),
+            diag.get("incoming_tokens", "?"),
             self.reset_count,
         )
         self.prev_prompt_ids = []

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -10,6 +10,12 @@ start-of-next-generation) is delegated to the ``renderers`` package
 ``bridge_to_next_turn`` guarantees the returned sequence starts byte-for-byte
 with ``previous_prompt + previous_completion`` — exactly the prefix-extension
 invariant the training-side merger relies on.
+
+When an incoming request can't be served as a cumulative extension, the
+accumulator resets to a fresh turn-0. ``ResetReason`` classifies *why* by the
+observable structural relationship between the incoming message list and the
+snapshot we last processed — see that enum for the taxonomy and the likely
+upstream cause behind each reason.
 """
 
 from __future__ import annotations
@@ -17,18 +23,96 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-def _messages_fingerprint(messages: list[dict[str, Any]]) -> str:
-    """Compute a stable fingerprint for a message list prefix.
+class ResetReason(str, Enum):
+    """Why a :class:`TokenAccumulator` dropped its state and restarted.
 
-    Uses JSON serialization + SHA-256 to detect any content/role changes.
+    Each value names the *observable structural relationship* between the
+    incoming chat request and the accumulated snapshot — never a guessed root
+    cause. The likely cause is documented per value but deliberately kept out of
+    the name (a short incoming list, for instance, is not necessarily a retry).
+    The reasons are mutually exclusive and total: the only non-reset outcome is
+    the healthy ``extend`` path.
     """
-    raw = json.dumps(messages, sort_keys=True, ensure_ascii=False)
+
+    #: Incoming list is byte-identical to the snapshot we already processed —
+    #: the conversation did **not advance**. Almost always an upstream retry /
+    #: duplicate request; the log's ``age_s`` (seconds since the snapshot) tells
+    #: you whether it was a fast resend.
+    DUPLICATE = "duplicate"
+
+    #: The messages *covering the snapshot prefix* changed: the list is shorter
+    #: than what we processed, or its shared prefix no longer matches what we
+    #: recorded. The history under the boundary was rewritten / compacted, or a
+    #: ``session_id`` was reused. The log's ``first_divergent_index`` and
+    #: ``incoming_at_divergence`` show what changed.
+    PREFIX_CHANGED = "prefix_changed"
+
+    #: Incoming list cleanly extends the snapshot (prefix matches, list grew),
+    #: but the only new messages are assistant-role — nothing renderable to
+    #: bridge (assistant tokens are already captured as completion ids).
+    #: Distinct from DUPLICATE: here the conversation *did* move forward and
+    #: aligns; it just moved forward by an assistant message. Typically
+    #: append-assistant-and-recall.
+    EMPTY_DELTA = "empty_delta"
+
+    #: Clean extension with renderable (non-assistant) new messages, but
+    #: ``renderer.bridge_to_next_turn`` returned ``None`` — the renderer cannot
+    #: prove the prefix-extension contract for this model. A renderer gap, not
+    #: an upstream-traffic problem.
+    RENDERER_NO_BRIDGE = "renderer_no_bridge"
+
+    #: Explicit/manual reset (tests, shutdown) with no structural cause.
+    MANUAL = "manual"
+
+
+# Structural relationship of an incoming message list to the snapshot prefix.
+# Internal classifier output; mapped to a ResetReason (or the extend path) by
+# ``plan_turn``.
+_REL_FIRST_TURN = "first_turn"
+_REL_EXTENDS = "extends"
+_REL_DUPLICATE = "duplicate"
+_REL_PREFIX_CHANGED = "prefix_changed"
+
+
+@dataclass
+class TurnPlan:
+    """How an incoming request should be handled against the current snapshot.
+
+    ``action`` is ``"extend"`` (build a cumulative bridge from ``new_messages``)
+    or ``"reset"`` (drop state and re-ingest as turn-0, logging ``reason``).
+    ``diagnostics`` carries the structural facts for the reset log.
+    """
+
+    action: str
+    reason: ResetReason | None = None
+    new_messages: list[dict[str, Any]] | None = None
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+
+def _message_fingerprint(message: dict[str, Any]) -> str:
+    """Stable SHA-256 of a single message (detects any role/content change)."""
+    raw = json.dumps(message, sort_keys=True, ensure_ascii=False)
     return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _per_message_fingerprints(messages: list[dict[str, Any]]) -> list[str]:
+    """Per-message fingerprints, so divergence can be located by index."""
+    return [_message_fingerprint(m) for m in messages]
+
+
+def _content_preview(message: dict[str, Any], limit: int = 60) -> str:
+    """Short, log-safe preview of a message's content."""
+    content = message.get("content")
+    text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+    return (text or "")[:limit]
 
 
 def extract_new_messages(messages: list[dict[str, Any]], prev_message_count: int) -> list[dict[str, Any]]:
@@ -61,13 +145,23 @@ class TokenAccumulator:
     automatically resets, so the training-side merger sees a segment break.
     """
 
-    def __init__(self, renderer: Any) -> None:
+    def __init__(self, renderer: Any, session_id: str | None = None) -> None:
         self.renderer = renderer
+        self.session_id = session_id or "unknown"
         self.prev_prompt_ids: list[int] = []
         self.prev_completion_ids: list[int] = []
         self.turn_count: int = 0
         self.message_count: int = 0
-        self._prefix_fingerprint: str = ""
+        # Per-message fingerprints of the snapshot (the message_count messages
+        # we last verified). Per-message (not whole-list) so a divergence can be
+        # localized to an index for the reset log.
+        self._prefix_fps: list[str] = []
+        # Monotonic time the snapshot was taken — reported as ``age_s`` on a
+        # DUPLICATE reset to show how soon the resend arrived.
+        self._snapshot_mono: float | None = None
+        # Survives reset(): how many times this session has reset. A climbing
+        # count on one session is the signal for a reset storm.
+        self.reset_count: int = 0
 
     @property
     def cumulative_ids(self) -> list[int]:
@@ -82,34 +176,123 @@ class TokenAccumulator:
         """Return True if this session should use /v1/completions rewriting."""
         return self.turn_count > 0
 
-    def is_cumulative(self, messages: list[dict[str, Any]]) -> bool:
-        """Check if *messages* is a cumulative extension of the tracked prefix.
+    def _classify_prefix(self, messages: list[dict[str, Any]]) -> str:
+        """Structural relationship of *messages* to the snapshot prefix.
 
-        Returns True if the first `message_count` messages in the new list
-        match the fingerprint of the messages we already processed.
-        Returns False (and the caller should reset) if:
-          - The new list has fewer messages than what we've processed.
-          - The prefix (first `message_count` msgs) differs from what we saw.
+        Returns one of ``_REL_FIRST_TURN``, ``_REL_EXTENDS``,
+        ``_REL_DUPLICATE``, ``_REL_PREFIX_CHANGED``.
         """
         if self.turn_count == 0:
-            return True
-        if len(messages) <= self.message_count:
-            return False
-        prefix = messages[: self.message_count]
-        return _messages_fingerprint(prefix) == self._prefix_fingerprint
+            return _REL_FIRST_TURN
+        incoming = len(messages)
+        if incoming < self.message_count:
+            # Can't cover our snapshot prefix at all → history shrank/rewritten.
+            return _REL_PREFIX_CHANGED
+        if _per_message_fingerprints(messages[: self.message_count]) != self._prefix_fps:
+            # Same-or-greater length, but the snapshot-covered messages differ.
+            return _REL_PREFIX_CHANGED
+        if incoming == self.message_count:
+            # Prefix matches and nothing was appended → identical resend.
+            return _REL_DUPLICATE
+        return _REL_EXTENDS
 
-    def reset(self) -> None:
-        """Clear all accumulated state, restarting this session's history."""
+    def is_cumulative(self, messages: list[dict[str, Any]]) -> bool:
+        """Whether *messages* is a (possibly empty) cumulative extension.
+
+        True on the first turn and when the incoming list strictly extends the
+        verified snapshot prefix. False when the list does not advance
+        (duplicate) or the snapshot-covered prefix changed.
+        """
+        return self._classify_prefix(messages) in (_REL_FIRST_TURN, _REL_EXTENDS)
+
+    def plan_turn(self, messages: list[dict[str, Any]]) -> TurnPlan:
+        """Decide how to handle an incoming chat request for an active session.
+
+        Returns a :class:`TurnPlan`: either ``extend`` (with the new messages to
+        bridge) or ``reset`` (with the classified :class:`ResetReason` and
+        diagnostics for the log). Does not call the renderer — a structurally
+        valid extension that the renderer later declines is surfaced separately
+        by the caller as :attr:`ResetReason.RENDERER_NO_BRIDGE`.
+        """
+        relation = self._classify_prefix(messages)
+        diag: dict[str, Any] = {"incoming_len": len(messages), "relation": relation}
+
+        if relation in (_REL_FIRST_TURN, _REL_EXTENDS):
+            new_messages = extract_new_messages(messages, self.message_count)
+            if new_messages:
+                return TurnPlan(action="extend", new_messages=new_messages, diagnostics=diag)
+            # Clean extension, but the appended slice is assistant-only.
+            new_slice = messages[self.message_count :]
+            diag["new_roles"] = [m.get("role") for m in new_slice]
+            return TurnPlan(action="reset", reason=ResetReason.EMPTY_DELTA, diagnostics=diag)
+
+        if relation == _REL_DUPLICATE:
+            if self._snapshot_mono is not None:
+                diag["age_s"] = round(time.monotonic() - self._snapshot_mono, 2)
+            return TurnPlan(action="reset", reason=ResetReason.DUPLICATE, diagnostics=diag)
+
+        # _REL_PREFIX_CHANGED
+        diag.update(self._divergence_diag(messages))
+        return TurnPlan(action="reset", reason=ResetReason.PREFIX_CHANGED, diagnostics=diag)
+
+    def _divergence_diag(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
+        """Locate where *messages* first diverges from the snapshot prefix."""
+        incoming_fps = _per_message_fingerprints(messages)
+        overlap = min(len(incoming_fps), len(self._prefix_fps))
+        idx = next((i for i in range(overlap) if incoming_fps[i] != self._prefix_fps[i]), overlap)
+        diag: dict[str, Any] = {"first_divergent_index": idx}
+        if idx < len(messages):
+            diag["incoming_at_divergence"] = {
+                "role": messages[idx].get("role"),
+                "preview": _content_preview(messages[idx]),
+            }
+        return diag
+
+    @staticmethod
+    def _explain(reason: ResetReason, diag: dict[str, Any]) -> str:
+        """A short plain-language note on *why* a reset happened, for the log."""
+        if reason is ResetReason.DUPLICATE:
+            age = diag.get("age_s")
+            when = f", resent {age}s later" if age is not None else ""
+            return f"identical to the last processed turn{when} — likely an upstream retry/duplicate"
+        if reason is ResetReason.PREFIX_CHANGED:
+            idx = diag.get("first_divergent_index")
+            at = diag.get("incoming_at_divergence") or {}
+            where = f" at msg #{idx}" if idx is not None else ""
+            detail = f" (role={at.get('role')!r}: {at.get('preview')!r})" if at else ""
+            return f"processed history changed{where}{detail} — compacted/edited or session id reused"
+        if reason is ResetReason.EMPTY_DELTA:
+            return f"only adds assistant msg(s) {diag.get('new_roles')} — nothing new to render"
+        if reason is ResetReason.RENDERER_NO_BRIDGE:
+            rdr = diag.get("renderer", "the renderer")
+            return f"{rdr} couldn't bridge new msg(s) {diag.get('new_roles')} for this model"
+        return "manual reset"
+
+    def reset(self, reason: ResetReason = ResetReason.MANUAL, *, diagnostics: dict[str, Any] | None = None) -> None:
+        """Clear all accumulated state, restarting this session's history.
+
+        Logs *why* at INFO: the machine-readable ``reason`` plus a plain-language
+        explanation and the structural context. The reason distinguishes benign
+        compaction from upstream retries and renderer gaps.
+        """
+        self.reset_count += 1
+        diag = diagnostics or {}
         logger.info(
-            "Resetting TokenAccumulator (was at turn %d, %d messages)",
+            "TokenAccumulator reset (session=%s) reason=%s: %s [turn=%d msgs=%d incoming=%s reset_count=%d]",
+            self.session_id,
+            reason.value if isinstance(reason, ResetReason) else reason,
+            self._explain(reason, diag),
             self.turn_count,
             self.message_count,
+            diag.get("incoming_len", "?"),
+            self.reset_count,
         )
         self.prev_prompt_ids = []
         self.prev_completion_ids = []
         self.turn_count = 0
         self.message_count = 0
-        self._prefix_fingerprint = ""
+        self._prefix_fps = []
+        self._snapshot_mono = None
 
     def ingest_turn(self, prompt_token_ids: list[int], completion_token_ids: list[int]) -> None:
         """Record the token IDs from a completed turn.
@@ -126,7 +309,8 @@ class TokenAccumulator:
     def update_prefix(self, messages: list[dict[str, Any]]) -> None:
         """Snapshot the current message list as the verified prefix."""
         self.message_count = len(messages)
-        self._prefix_fingerprint = _messages_fingerprint(messages)
+        self._prefix_fps = _per_message_fingerprints(messages)
+        self._snapshot_mono = time.monotonic()
 
     def build_next_prompt(
         self,

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -298,8 +298,7 @@ class TokenAccumulator:
         # the model's context limit to spot token-limit-triggered compaction.
         snapshot_tokens = len(self.prev_prompt_ids) + len(self.prev_completion_ids)
         logger.info(
-            "TokenAccumulator reset (session=%s) reason=%s: %s "
-            "[turn=%d msgs=%d snapshot_tokens=%d incoming=%s incoming_tokens=%s reset_count=%d]",
+            "TokenAccumulator reset (session=%s) reason=%s: %s [turn=%d msgs=%d snapshot_tokens=%d incoming=%s incoming_tokens=%s reset_count=%d]",
             self.session_id,
             reason.value if isinstance(reason, ResetReason) else reason,
             self._explain(reason, diag),

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
@@ -341,7 +341,7 @@ class TestCumulativeTokenMode:
             model="mock-model",
             messages=[{"role": "user", "content": "Fresh start"}],
         )
-        # is_cumulative returns False when len(messages) <= message_count, triggering reset
+        # Snapshot-covered prefix changed (PREFIX_CHANGED) -> reset -> chat path.
         assert "messages" in mock_vllm.request_log[1]  # went through chat path
 
         # Turn 3 — cumulative extension of the new history

--- a/rllm-model-gateway/tests/unit/test_token_accumulator.py
+++ b/rllm-model-gateway/tests/unit/test_token_accumulator.py
@@ -243,3 +243,114 @@ class TestExtractNewMessages:
             {"role": "tool", "content": "result"},
             {"role": "user", "content": "thanks"},
         ]
+
+
+class TestPlanTurnClassification:
+    """plan_turn maps the incoming request to extend or a classified reset.
+
+    Mirrors the four mutually-exclusive ResetReasons (+ the healthy extend) the
+    gateway logs, so a reset's *why* is recoverable from one line.
+    """
+
+    def _seed(self, messages, *, prompt=(1, 2, 3), completion=(10, 11)):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(renderer=_MockRenderer(), session_id="s1")
+        acc.ingest_turn(list(prompt), list(completion))
+        acc.update_prefix(messages)
+        return acc
+
+    def test_extend_on_cumulative_growth(self):
+        acc = self._seed([{"role": "user", "content": "Hello"}])
+        plan = acc.plan_turn(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+                {"role": "user", "content": "More"},
+            ]
+        )
+        assert plan.action == "extend"
+        # The assistant turn is dropped; only the new user message is bridged.
+        assert plan.new_messages == [{"role": "user", "content": "More"}]
+
+    def test_duplicate_identical_resend(self):
+        from rllm_model_gateway.token_accumulator import ResetReason
+
+        msgs = [{"role": "user", "content": "Hello"}]
+        acc = self._seed(msgs)
+        plan = acc.plan_turn([{"role": "user", "content": "Hello"}])  # byte-identical
+        assert plan.action == "reset"
+        assert plan.reason is ResetReason.DUPLICATE
+        # age_s is populated from the snapshot time (>= 0).
+        assert plan.diagnostics.get("age_s") is not None
+
+    def test_prefix_changed_same_length_different_content(self):
+        from rllm_model_gateway.token_accumulator import ResetReason
+
+        acc = self._seed([{"role": "user", "content": "Hello"}])
+        plan = acc.plan_turn([{"role": "user", "content": "Fresh start"}])
+        assert plan.action == "reset"
+        assert plan.reason is ResetReason.PREFIX_CHANGED
+        assert plan.diagnostics["first_divergent_index"] == 0
+        assert plan.diagnostics["incoming_at_divergence"]["preview"] == "Fresh start"
+
+    def test_prefix_changed_when_history_shrinks(self):
+        from rllm_model_gateway.token_accumulator import ResetReason
+
+        acc = self._seed(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ]
+        )
+        plan = acc.plan_turn([{"role": "user", "content": "Hello"}])  # shorter
+        assert plan.action == "reset"
+        assert plan.reason is ResetReason.PREFIX_CHANGED
+
+    def test_empty_delta_assistant_only_extension(self):
+        from rllm_model_gateway.token_accumulator import ResetReason
+
+        acc = self._seed([{"role": "user", "content": "Hello"}])
+        # The list grows and the prefix matches, but the only new message is an
+        # assistant turn -> nothing renderable -> EMPTY_DELTA (not DUPLICATE).
+        plan = acc.plan_turn(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "sampled"},
+            ]
+        )
+        assert plan.action == "reset"
+        assert plan.reason is ResetReason.EMPTY_DELTA
+        assert plan.diagnostics["new_roles"] == ["assistant"]
+
+
+class TestResetLogging:
+    def test_reset_logs_reason_and_session(self, caplog):
+        import logging
+
+        from rllm_model_gateway.token_accumulator import ResetReason, TokenAccumulator
+
+        acc = TokenAccumulator(renderer=_MockRenderer(), session_id="sess-xyz")
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        acc.update_prefix([{"role": "user", "content": "Hello"}])
+
+        with caplog.at_level(logging.INFO):
+            acc.reset(ResetReason.DUPLICATE, diagnostics={"incoming_len": 1, "age_s": 0.5})
+
+        rec = caplog.records[-1]
+        assert rec.levelno == logging.INFO
+        msg = caplog.text
+        assert "reason=duplicate" in msg
+        assert "session=sess-xyz" in msg
+        assert "reset_count=1" in msg
+        # Plain-language explanation with the resend timing woven in.
+        assert "identical to the last processed turn" in msg
+        assert "0.5s" in msg
+
+    def test_reset_count_survives_reset(self):
+        from rllm_model_gateway.token_accumulator import ResetReason, TokenAccumulator
+
+        acc = TokenAccumulator(renderer=_MockRenderer(), session_id="s")
+        acc.reset(ResetReason.MANUAL)
+        acc.reset(ResetReason.MANUAL)
+        assert acc.reset_count == 2

--- a/rllm-model-gateway/tests/unit/test_token_accumulator.py
+++ b/rllm-model-gateway/tests/unit/test_token_accumulator.py
@@ -294,6 +294,26 @@ class TestPlanTurnClassification:
         assert plan.diagnostics["first_divergent_index"] == 0
         assert plan.diagnostics["incoming_at_divergence"]["preview"] == "Fresh start"
 
+    def test_prefix_changed_counts_incoming_tokens(self):
+        """A compaction (prefix_changed) line carries the incoming token count."""
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        class _CountingRenderer(_MockRenderer):
+            def render_ids(self, messages, *, tools=None, add_generation_prompt=False):
+                return [0] * (7 * len(messages))  # 7 fake tokens per message
+
+        acc = TokenAccumulator(renderer=_CountingRenderer(), session_id="s1")
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        acc.update_prefix([{"role": "user", "content": "Hello"}])
+        plan = acc.plan_turn([{"role": "user", "content": "compacted handoff"}])
+        assert plan.diagnostics["incoming_tokens"] == 7  # 1 message * 7
+
+    def test_incoming_tokens_none_when_renderer_cannot_tokenize(self):
+        """_count_tokens never raises — falls back to None (logged as '?')."""
+        acc = self._seed([{"role": "user", "content": "Hello"}])  # _MockRenderer has no render_ids
+        plan = acc.plan_turn([{"role": "user", "content": "different"}])
+        assert plan.diagnostics["incoming_tokens"] is None
+
     def test_prefix_changed_when_history_shrinks(self):
         from rllm_model_gateway.token_accumulator import ResetReason
 
@@ -343,6 +363,8 @@ class TestResetLogging:
         assert "reason=duplicate" in msg
         assert "session=sess-xyz" in msg
         assert "reset_count=1" in msg
+        # Snapshot token count (prompt+completion of the ingested turn) is logged.
+        assert "snapshot_tokens=5" in msg
         # Plain-language explanation with the resend timing woven in.
         assert "identical to the last processed turn" in msg
         assert "0.5s" in msg


### PR DESCRIPTION
## Problem

During training the gateway emits a flood of identical, uninformative lines:

```
INFO - Resetting TokenAccumulator (was at turn 1, 1 messages)
```

This single line collapses **four structurally different causes** and omits the
`session_id`, so it's impossible to tell why a reset is happening. A reset at
turn 1 is almost always wrong (the only legitimate reset is a context compaction
at the turn limit), and left undiagnosed it corrupts the cumulative
prefix-extension invariant and can degrade/collapse training. We could not tell
whether these were upstream retries, rewritten histories, or a renderer that
can't bridge.

## Change

Classify each reset by the **observable structural relationship** between the
incoming request and the accumulated snapshot — names describe what happened,
not a guessed cause:

| `reason=` | Condition | Likely cause |
|---|---|---|
| `duplicate` | incoming list identical to the last processed turn (no progress) | upstream retry / duplicate request |
| `prefix_changed` | snapshot-covered messages shrank or diverged | history compacted/edited, or `session_id` reused |
| `empty_delta` | clean extension, but only assistant message(s) added | append-assistant-and-recall |
| `renderer_no_bridge` | valid extension the renderer declined | renderer can't prove the prefix-extension contract |

- New `plan_turn()` classifier on `TokenAccumulator` is now the single source of
  truth, replacing the split `is_cumulative` / `extract_new_messages` logic at
  the proxy call site.
- `reset()` logs at **INFO** with the session id, machine-readable `reason=`, a
  short plain-language explanation, reason-specific diagnostics (`age_s`,
  `first_divergent_index`, ...), and a `reset_count` that surfaces reset storms.
- Snapshot now uses per-message fingerprints so `prefix_changed` can report the
  first divergent message + a short preview.

## Log: before → after

```
# before
INFO - Resetting TokenAccumulator (was at turn 1, 1 messages)

# after
INFO - TokenAccumulator reset (session=9fa3f89f:9) reason=duplicate: identical to the
  last processed turn, resent 0.0s later — likely an upstream retry/duplicate
  [turn=1 msgs=1 incoming=1 reset_count=1]
```

## How to read it during a run

- Watch `reason=` to localize the cause (`duplicate` → upstream retries;
  `renderer_no_bridge` → renderer gap, e.g. on a custom renderer).
- A climbing `reset_count` on a single session is an early warning of a reset
  storm before it degrades training.

## Testing

- Added per-reason classification tests and reset-logging tests.
- Existing cumulative-mode unit + integration tests pass (37/37 in the affected
  files). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
