### PR TITLE
feat(gateway,engine): unify cumulative-mode rendering on one renderer (PR A)

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -264,6 +264,24 @@ class ReverseProxy:
                             f"{[type(m.get('content')).__name__ for m in new_messages]})"
                         )
                     acc.reset(reason)
+            else:
+                # First turn (turn 0): render the initial messages from scratch via
+                # the renderer and route through the *same* token-in path as later
+                # turns, so the ENTIRE trajectory is tokenized by one renderer — no
+                # chat-template-vs-renderer seam at the turn-0/turn-1 boundary. Falls
+                # back to the chat path if the renderer can't render turn 0 (the chat
+                # path then seeds the accumulator via its own turn-0 ingest below).
+                messages = request_body.get("messages", [])
+                token_ids = acc.build_first_prompt(messages, tools=request_body.get("tools")) if messages else None
+                if token_ids is not None:
+                    return await self._handle_cumulative_turn(
+                        request,
+                        request_body,
+                        session_id,
+                        acc,
+                        token_ids,
+                        originally_requested_logprobs,
+                    )
 
         if is_stream:
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -194,6 +194,31 @@ class TokenAccumulator:
         self._prefix_fingerprint = _messages_fingerprint(messages)
         self._prefix_msg_fingerprints = [_messages_fingerprint([m]) for m in messages]
 
+    def build_first_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int] | None:
+        """Construct the prompt token IDs for the FIRST turn (turn 0).
+
+        Renders the initial message list from scratch via the renderer's
+        ``render_ids`` (with a trailing generation prompt). Routing turn 0 through
+        the *same* renderer that bridges every later turn is what makes cumulative
+        mode drift-free: otherwise turn 0 would be tokenized by the engine's chat
+        template and turns 2+ by the renderer's bridge — two tokenizers stitched
+        mid-trajectory, which only coincidentally agree per model.
+
+        Returns ``None`` if the renderer cannot render the messages, so the caller
+        can fall back to the chat path (which then seeds the accumulator as before).
+        """
+        try:
+            token_ids = self.renderer.render_ids(messages, tools=tools, add_generation_prompt=True)
+        except Exception as err:  # noqa: BLE001 - fall back to the chat path on any render failure
+            logger.warning("render_ids failed for first turn (%s); falling back to chat path", err)
+            return None
+        return list(token_ids) if token_ids else None
+
     def build_next_prompt(
         self,
         new_messages: list[dict[str, Any]],

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
@@ -583,3 +583,91 @@ class TestStructuredCumulativeResponse:
         import json as _json
 
         assert _json.loads(msg.tool_calls[0].function.arguments) == {"cmd": "ls"}
+
+
+class _MockRendererFull(_MockRendererWithParse):
+    """A complete renderer: bridge + parse_response + render_ids.
+
+    ``render_ids`` is what turn 0 uses, so the WHOLE trajectory is tokenized by
+    one renderer (no chat-template-vs-renderer seam). Deterministic encoding:
+    ``[200, 10, 201] + ord(last user content[:3]) + [202]``.
+    """
+
+    def render_ids(self, messages, *, tools=None, add_generation_prompt=False):
+        content = ""
+        for m in messages:
+            if m.get("role") == "user":
+                content = m.get("content", "")
+        return [200, 10, 201] + [ord(c) for c in content[:3]] + [202]
+
+
+@pytest.fixture
+def cumulative_gateway_full(mock_vllm: MockVLLMServer):
+    """Cumulative gateway whose renderer implements render_ids (turn 0 included)."""
+    config = GatewayConfig(
+        store_worker="memory",
+        workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
+        health_check_interval=999,
+        sync_traces=True,
+        cumulative_token_mode=False,
+    )
+    app = create_app(config)
+    app.state.proxy.renderer = _MockRendererFull()
+    app.state.proxy.cumulative_token_mode = True
+    server = GatewayServer(app, port=0)
+    server.start()
+    yield server, mock_vllm
+    server.stop()
+
+
+class TestCumulativeTurn0ViaRenderer:
+    """Turn 0 is rendered by the renderer (render_ids) and sent token-in, exactly
+    like turns 2+, so one renderer owns the entire trajectory."""
+
+    def test_turn0_uses_completions_with_token_ids(self, cumulative_gateway_full):
+        server, mock_vllm = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-completions/v1", api_key="dummy")
+        oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])
+
+        assert len(mock_vllm.request_log) == 1
+        req = mock_vllm.request_log[0]
+        # Turn 0 went to /v1/completions (token-in), NOT /chat/completions.
+        assert "messages" not in req
+        assert isinstance(req["prompt"], list) and all(isinstance(t, int) for t in req["prompt"])
+
+    def test_turn0_prompt_equals_render_ids(self, cumulative_gateway_full):
+        server, mock_vllm = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-render/v1", api_key="dummy")
+        oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])
+
+        expected = _MockRendererFull().render_ids([{"role": "user", "content": "Hello"}])
+        assert mock_vllm.request_log[0]["prompt"] == expected
+
+    def test_turn0_returns_parsed_message(self, cumulative_gateway_full):
+        """Turn 0's completion is parsed via the renderer too (not raw worker text)."""
+        server, _ = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-parse/v1", api_key="dummy")
+        resp = oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])
+        assert resp.choices[0].message.content == "parsed answer"  # parsed, not "Hello from mock!"
+
+    def test_single_renderer_trajectory_no_seam(self, cumulative_gateway_full):
+        """The seam fix: turn 1's prompt extends turn 0's render_ids output +
+        completion byte-for-byte — both produced by the same renderer, so there is
+        no chat-template/renderer boundary mismatch."""
+        server, mock_vllm = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-seam/v1", api_key="dummy")
+
+        oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])  # turn 0
+        oai.chat.completions.create(  # turn 1
+            model="m",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "More"},
+            ],
+        )
+
+        turn0_prompt = _MockRendererFull().render_ids([{"role": "user", "content": "Hello"}])
+        # mock_vllm echoes the prompt as prompt_token_ids and returns completion [10,11,12].
+        turn1_prompt = mock_vllm.request_log[1]["prompt"]
+        assert turn1_prompt[: len(turn0_prompt) + 3] == turn0_prompt + [10, 11, 12]

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -141,6 +141,7 @@ class FireworksEngine(TinkerEngine):
         sample_timeout: int = 600,
         processor=None,
         router_replay: bool = False,
+        cumulative_token_mode: bool = False,
         **kwargs,
     ):
         """
@@ -178,12 +179,31 @@ class FireworksEngine(TinkerEngine):
         self.train_sampling_params = dict((sampling_params or {}).get("train", {}))
         self.val_sampling_params = dict((sampling_params or {}).get("val", {}))
 
-        # Rendering setup. Default: ChatTemplateParser bypass mode (Jinja
+        # Rendering setup.
+        #
+        # Cumulative token mode: the gateway renders EVERY turn (turn-0 via the
+        # renderer's render_ids, turns 2+ via bridge_to_next_turn) and parses the
+        # completion via the renderer too, so the engine is a pure token-in /
+        # token-out sampler — it never renders messages or parses completions.
+        # We therefore build no ChatTemplateParser (which would crash here for
+        # models whose Jinja template the parser's equivalence self-check can't
+        # render, e.g. GLM) and no tinker renderer. assemble_model_output uses the
+        # raw-decode branch; get_model_response (the chat path) is never called.
+        self.cumulative_token_mode = cumulative_token_mode
+        self.raw_token_mode = cumulative_token_mode
+        self.renderer = None
+        if cumulative_token_mode:
+            self.chat_parser = None
+            self.bypass_render_with_parser = False
+            self.sample_timeout = sample_timeout
+            self.router_replay = router_replay
+            self.sampling_client = sampler
+            return
+        # Non-cumulative. Default: ChatTemplateParser bypass mode (Jinja
         # chat-template models). Some models (e.g. DeepSeek-V4) ship no Jinja
         # chat_template — they use a hand-rolled encoder exposed via the
         # tinker/Fireworks renderer. Fall back to that renderer, using the
         # non-bypass path the inherited assemble_model_output already supports.
-        self.renderer = None
         try:
             self.chat_parser = ChatTemplateParser.get_parser(
                 tokenizer,
@@ -225,6 +245,14 @@ class FireworksEngine(TinkerEngine):
 
     @override
     async def get_model_response(self, messages: list[dict], **kwargs) -> ModelOutput:
+        if self.raw_token_mode:
+            raise RuntimeError(
+                "FireworksEngine is in cumulative_token_mode (token-in/token-out only): the "
+                "gateway renders every turn, so get_model_response (message rendering) must not "
+                "be called. This means turn-0 fell back to the chat path because the gateway "
+                "renderer could not render the initial messages — fix the renderer/renderer_family "
+                "(it must not resolve to DefaultRenderer) rather than the engine."
+            )
         application_id = kwargs.pop("application_id", None)
 
         tools = kwargs.pop("tools", [])

--- a/rllm/engine/rollout/tinker_engine.py
+++ b/rllm/engine/rollout/tinker_engine.py
@@ -339,7 +339,16 @@ class TinkerEngine(RolloutEngine):
         sampled_sequence = cast(TinkerTokenOutput, token_output)
         response_tokens, logprobs = sampled_sequence.tokens, sampled_sequence.logprobs
 
-        if self.bypass_render_with_parser:
+        if getattr(self, "raw_token_mode", False):
+            # Cumulative token mode: the gateway re-parses the completion token IDs
+            # with the renderer (renderer.parse_response) to build the structured
+            # assistant message, so the engine does no parsing — just expose the
+            # raw decoded text (used only as the gateway's fallback) plus the raw
+            # token IDs. No chat_parser / renderer is built in this mode.
+            content = self.tokenizer.decode(response_tokens, skip_special_tokens=True)  # type: ignore
+            reasoning = ""
+            tool_calls = []
+        elif self.bypass_render_with_parser:
             assert self.chat_parser is not None, "chat_parser must be set when bypass_render_with_parser=True"
             parsed_output = self.chat_parser.parse_completion(response_tokens)
             content = parsed_output.get("content", "")

--- a/rllm/trainer/fireworks/fireworks_backend.py
+++ b/rllm/trainer/fireworks/fireworks_backend.py
@@ -227,6 +227,9 @@ class FireworksBackend(TinkerBackend):
                 accumulate_reasoning=rollout_extra.pop("accumulate_reasoning", False),
                 reasoning_effort=rollout_extra.pop("reasoning_effort", "medium"),
                 router_replay=cfg.rllm.algorithm.get("router_replay", "disabled") == "R3",
+                # Cumulative token mode → the gateway renders/parses every turn;
+                # the engine is a pure token-in/token-out sampler (no chat_parser).
+                cumulative_token_mode=cfg.rllm.get("gateway", {}).get("cumulative_token_mode", False),
                 **rollout_extra,
             )
             return self.rollout_engine

--- a/tests/test_fireworks_engine_cumulative.py
+++ b/tests/test_fireworks_engine_cumulative.py
@@ -1,0 +1,79 @@
+"""FireworksEngine cumulative-token-mode (pure token-in/token-out) behavior.
+
+In cumulative mode the gateway renders every turn and parses every completion
+via the renderer, so the engine must be a pure sampler: it builds NO
+ChatTemplateParser (which would crash in __init__ for models whose Jinja
+template the parser's equivalence self-check can't render, e.g. GLM) and
+assemble_model_output returns raw-decoded text instead of parsing.
+"""
+
+import pytest
+
+pytest.importorskip("fireworks", reason="Fireworks SDK not installed")
+
+from rllm.engine.rollout.fireworks_engine import FireworksEngine
+from rllm.engine.rollout.tinker_engine import TinkerEngine
+
+
+class _BoomTokenizer:
+    """Any attribute access raises — proves the engine never consults the
+    tokenizer for parser/renderer setup in cumulative mode (the GLM crash path)."""
+
+    name_or_path = "zai-org/GLM-5.1"
+
+    def __getattr__(self, key):
+        raise RuntimeError(f"tokenizer.{key} must not be touched in cumulative mode")
+
+
+class _DecodeTokenizer:
+    def decode(self, ids, skip_special_tokens=True):
+        return "DECODED:" + ",".join(map(str, ids))
+
+
+class _DummySampler:
+    pass
+
+
+class _Seq:
+    tokens = [10, 11, 12]
+    logprobs = [0.0, 0.0, 0.0]
+    stop_reason = "stop"
+
+
+def _make_engine():
+    return FireworksEngine(
+        tokenizer=_BoomTokenizer(),
+        sampler=_DummySampler(),
+        max_prompt_length=100,
+        max_response_length=50,
+        max_model_length=200,
+        cumulative_token_mode=True,
+    )
+
+
+def test_cumulative_construct_skips_chat_template_parser():
+    eng = _make_engine()
+    assert eng.chat_parser is None
+    assert eng.renderer is None
+    assert eng.raw_token_mode is True
+    assert eng.bypass_render_with_parser is False
+
+
+def test_raw_assemble_decodes_without_parsing():
+    eng = _make_engine()
+    eng.tokenizer = _DecodeTokenizer()
+    out = TinkerEngine.assemble_model_output(eng, [1, 2, 3], _Seq())
+    assert out.content == "DECODED:10,11,12"
+    assert out.reasoning == ""
+    assert out.tool_calls == []
+    assert out.completion_ids == [10, 11, 12]
+    assert out.prompt_ids == [1, 2, 3]
+
+
+def test_get_model_response_rejected_in_cumulative_mode():
+    """The chat (message-rendering) path must not be reachable in cumulative mode."""
+    import asyncio
+
+    eng = _make_engine()
+    with pytest.raises(RuntimeError, match="cumulative_token_mode"):
+        asyncio.run(eng.get_model_response([{"role": "user", "content": "hi"}]))


### PR DESCRIPTION
## What & why

In cumulative token mode the trajectory was rendered by **two different tokenizers**: turn 0 by the engine's `ChatTemplateParser` (HF `apply_chat_template`) and turns 2+ by the gateway renderer's `bridge_to_next_turn`. The seam between them only *coincidentally* agreed per model (Qwen worked) and crashed engine construction for models whose Jinja template the parser's equivalence self-check can't render (**GLM**: `'str object' has no attribute 'items'`).

This is **PR A** of the renderer-unification plan (PR 0 = `feat/native-renderers`, the base of this PR; PRs B–C = repoint the non-cumulative engine path at `resolve()` and retire `ChatTemplateParser`). It makes **one renderer own the entire trajectory** and reduces the engine to a pure token-in/token-out sampler in cumulative mode.

## Changes

**Gateway (backend-agnostic — fixes Fireworks, Tinker, and vLLM at once):**
- `token_accumulator.py`: `build_first_prompt()` renders turn 0 via `renderer.render_ids(msgs, tools, add_generation_prompt=True)` — the turn-0 analog of `build_next_prompt`.
- `proxy.py`: `handle()` intercepts the **first** turn and sends it token-in through the existing cumulative path (falls back to the chat path if the renderer can't render it — which then seeds the accumulator as before). Completion parsing already flows through `renderer.parse_response` (PR 0).

**Engine (FireworksEngine; `TinkerEngine` untouched):**
- Builds **no** `ChatTemplateParser` in cumulative mode → kills the GLM `get_parser` crash at the source.
- `assemble_model_output` gains a raw-decode branch (gated on `raw_token_mode`, default off → all non-cumulative paths unchanged).
- `get_model_response` raises an actionable error if reached in cumulative mode (the gateway owns rendering).
- Flag plumbed from `cfg.rllm.gateway.cumulative_token_mode`.

## Why the facade makes this correct
The prefix that `bridge_to_next_turn` extends is now the renderer's **own** turn-0 output, so the trajectory is self-consistent by construction for **every** model the registry resolves — not just Qwen.

## Tests (53 passing)
- New: `test_turn0_uses_completions_with_token_ids`, `test_turn0_prompt_equals_render_ids`, `test_turn0_returns_parsed_message`, and **`test_single_renderer_trajectory_no_seam`** (turn-1 extends turn-0's `render_ids` output byte-for-byte).
- New `tests/test_fireworks_engine_cumulative.py`: cumulative construct skips `ChatTemplateParser` (verified with a tokenizer that raises on any access), raw-assemble decodes without parsing, chat path rejected.
- All 40 pre-existing cumulative/accumulator tests + renderer/tinker-adapter/injection suites pass unchanged (the existing `_MockRenderer` has no `render_ids`, so they now exercise the documented fallback).

## Scope / follow-ups
- **Backend-agnostic** via the gateway. Only `FireworksEngine` needed the pure-sampler change; `TinkerEngine` symmetry is a clean follow-up.
- Streaming turn-0 emits raw-text deltas (same as streaming turn-2+ today; the non-streaming training path parses). Pre-existing, noted not fixed.
- **Before merge:** (1) Qwen byte-parity gate — confirm `render_ids`-turn-0 yields the same training rows as the old chat-path turn-0 (the one behavior change for already-working models); (2) GLM end-to-end smoke via `train_fireworks_glm5p2.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)