### PR TITLE
feat(renderers): native renderer layer + unified cumulative-mode rendering

### DIFF
--- a/RENDERER_MERGE_PLAN.md
+++ b/RENDERER_MERGE_PLAN.md
@@ -1,0 +1,328 @@
+# Renderer Merge Plan — unify prime-rl + Fireworks renderers for rLLM training
+
+**Goal:** support more models for rLLM **RL-rollout** training by combining the
+model coverage of two renderer ecosystems behind a single rLLM-side interface,
+preferring the backend that gives the strongest multi-turn token-identity
+guarantee.
+
+**Status:** native renderer package **implemented** (`rllm/renderers/`, tests in
+`tests/test_renderers.py`, 13 passing). Engine/gateway repointing (§6 PR 4–5) is
+**not yet done** — the new layer is additive and not yet wired into the rollout
+engines or the gateway.
+
+### Implemented (this change)
+- `rllm/renderers/` — native token-level `Renderer` protocol + `RenderedTokens` /
+  `ParsedResponse` / `ToolSpec` (reuses `rllm.tools.tool_base.ToolCall`).
+- `resolve()` / `select_backend()` registry with RL-first precedence
+  (prime-rl exact-match → tinker/Fireworks adapter → DefaultRenderer), plus
+  `renderer_family` (prime) and `renderer_name` (tinker) overrides.
+- prime-rl backend wrapper (`_prime.py`) and tinker/Fireworks adapter
+  (`_tinker.py`); Fireworks registration shim (`_fw_register.py`) — lazy, so
+  `import rllm.renderers` stays ~0.5s and pulls no transformers/torch until first
+  use.
+- Verified byte-for-byte parity vs `apply_chat_template` for prime (Qwen3-8B,
+  Qwen3.5-4B) and the tinker adapter; prime bridge extends the prefix
+  byte-for-byte; DeepSeek-V4-Flash (a prime-rl gap) renders via the adapter.
+
+### DeepSeek-V4 (and other Fireworks models): rollout + cumulative mode (done)
+
+**Constraint:** `rllm` depends on `rllm-model-gateway` (pyproject line 21), so the
+gateway must **not** import `rllm` (circular) — and it must stay free of
+tinker/Fireworks deps ("lightweight" package). All tinker/Fireworks knowledge
+therefore lives in `rllm.renderers`; the gateway receives a built renderer by
+**injection**.
+
+- **Generic cross-turn bridge** in `rllm/renderers/_tinker.py`
+  (`TinkerAdapter.bridge_to_next_turn`) — built from the same primitives
+  `build_generation_prompt` uses (`render_message` + `_get_generation_suffix`),
+  anchored to the turn-close (inline `trim_to_turn_close`). **Byte-for-byte vs
+  prime-rl's hand-coded bridge for Qwen3 / Qwen3.5**; preserves verbatim sampled
+  history (incl. thinking) where a full re-render would strip it. Returns `None`
+  on assistant-in-new-slice / truncation-without-close / multimodal. `has_bridge`
+  is `True`. No gateway dependency.
+- **Rollout fix** in `rllm/engine/rollout/fireworks_engine.py`: DeepSeek-V4's
+  tokenizer ships **no Jinja `chat_template`**, so `ChatTemplateParser` crashed in
+  `__init__`. FireworksEngine now falls back to the tinker/Fireworks renderer
+  (TinkerEngine's existing non-bypass render + parse path) when there's no chat
+  template. Chat-template models are unchanged.
+- **Gateway stays dependency-free**: `create_app(..., renderer=...)` accepts an
+  injected renderer; with none, it builds a **prime-rl** renderer from config as
+  before (its only renderer dep). Startup guard is `_renderer_has_bridge()`.
+- **Injection** (`rllm/gateway/manager.py`): in-process (thread) mode —
+  used by the Fireworks backend (`gateway_mode = "process" if verl else "thread"`)
+  — builds the renderer via `rllm.renderers.resolve()` and passes it to
+  `create_app`. prime-rl models → prime bridge; DeepSeek-V4 etc. → tinker adapter
+  bridge. Subprocess (verl) mode keeps the prime-rl-only config build.
+- Tests: bridge parity + DeepSeek-V4 in `tests/test_renderers.py`; gateway
+  injection contract in `rllm-model-gateway/tests/unit/test_renderer_injection.py`.
+  Existing gateway cumulative-mode + tinker-engine tests still pass.
+
+### Tool-call bridge (validated)
+The bridge renders the new turn's delta via `build_generation_prompt(sentinel +
+new_messages)` and splits on the sentinel's N-th close token, so the renderer
+does its own turn-level tool preprocessing (merging consecutive tool results into
+one user turn, pairing them with the assistant's calls, role handling). Per-
+message rendering was wrong here — DeepSeek-V4's `render_message` rejects raw
+`tool` role outright. Validated: DeepSeek-V4 merges consecutive tool results into
+a single user turn (history kept verbatim); Qwen3.5 tool-result bridge equals
+prime-rl's hand-coded bridge byte-for-byte. Note: tinker's *Qwen* renderer
+doesn't group multi-tool, but Qwen routes to prime-rl (which does) — so only the
+tinker-served models (DeepSeek-V4, …) rely on this path, and DeepSeek's
+`build_generation_prompt` merges correctly.
+
+### Remaining
+- Repoint `tinker_engine` at `rllm.renderers.resolve()` for consistency (§6 PR 4).
+- Migrate/retire `ChatTemplateParser` once parity is proven in the engines.
+- Parity-check the bridge on the other tinker-served FW models (Gemma-4,
+  Ministral-3, Kimi-K2.7-code) before relying on cumulative mode for them; the
+  bridge returns `None` on anything it can't render (safe full-re-render fallback).
+
+---
+
+## 1. Background — four renderer systems, two abstractions
+
+| System | Import | Abstraction | Key API | Built for |
+|---|---|---|---|---|
+| **prime-rl `renderers`** | `import renderers` (`PrimeIntellect-ai/renderers`) | **token-level** | `create_renderer`, `render_ids`, `parse_response`, `get_stop_token_ids`, **`bridge_to_next_turn`** | RL rollouts: multi-turn **token identity** |
+| **Fireworks cookbook** | `import training.renderer` (`fw-ai/cookbook#training`) | **message-level** | subclasses `tinker_cookbook.renderers.Renderer`; `register_renderer` | SFT: `build_supervised_examples` + disaggregate |
+| `tinker_cookbook.renderers` | `import tinker_cookbook.renderers` | message-level | `get_renderer`, `build_generation_prompt`, `parse_response` | SFT + Tinker RL via "extension property" |
+| `rllm.parser.ChatTemplateParser` | in-repo | text/token | `parse`, `tokenize_and_mask`, `parse_completion` | de-facto rollout path (`bypass_render_with_parser=True`) |
+
+The two packages named in the request **share no base class**. prime-rl is
+token-in/token-out with a `bridge_to_next_turn` contract; Fireworks renderers
+are message-level `tinker_cookbook.Renderer` subclasses. So "merge" =
+**a facade in rLLM that exposes one interface and routes each model to whichever
+backend supports it** — not a code-level union of the two upstreams.
+
+### Current consumption in rLLM (verified)
+- **Rollout engines:** `rllm/engine/rollout/fireworks_engine.py` and
+  `tinker_engine.py` both default to `bypass_render_with_parser=True` → rollout
+  tokens come from `rllm.parser.ChatTemplateParser`, **not** from either renderer
+  package. `tinker_engine` also calls `renderers.get_renderer(name, tokenizer, …)`
+  (tinker_cookbook) for stop sequences / the non-bypass path.
+- **Gateway (prime-rl IS used here):** `rllm-model-gateway` uses prime-rl
+  `renderers` for **cumulative token mode** (drift-free multi-turn token
+  forwarding), gated behind `cumulative_token_mode` (default `False`):
+  - `rllm/gateway/manager.py:361` launches the gateway with
+    `--cumulative-token-mode` (+ `--renderer-family`) when enabled.
+  - `rllm-model-gateway/.../server.py:161,176` → `from renderers import
+    create_renderer`; `create_renderer(tokenizer, renderer=config.renderer_family)`.
+    **Hard-fails if it resolves to `DefaultRenderer`** (no bridge).
+  - `rllm-model-gateway/.../token_accumulator.py:145` →
+    `renderer.bridge_to_next_turn(...)` extends prior `prompt+completion`.
+- **`training.renderer` (Fireworks) is imported nowhere** in rLLM.
+
+### Two findings that shape the plan
+1. **Fireworks renderers are installed but dead.** `fireworks-training-cookbook`
+   is a dependency (pyproject line 96) and `training.renderer` is importable, but
+   nothing imports it, so `register_renderer` never fires —
+   `get_renderer("deepseek_v4", …)` currently misses. **One import wires up
+   DeepSeek-V4 / Gemma4 / Kimi-K2.7-code + the SFT disaggregate fix.**
+2. **prime-rl `renderers` is already integrated via the gateway** (not just
+   pip-installed). The gateway's `create_renderer(...)` call **hard-errors when a
+   model isn't in prime-rl's `MODEL_RENDERER_MAP`** — that error site is the
+   natural insertion point for the Fireworks/tinker adapter (§3.4), so unsupported
+   models fall back instead of failing. The facade should treat the gateway as the
+   *existing* prime-rl integration, not a greenfield one.
+
+---
+
+## 2. Model coverage — who brings what
+
+**Only Fireworks brings (the "more models" target):** DeepSeek-V4-Flash,
+Gemma4, Kimi-K2.7-code; plus tinker-style minimax_m2 / glm5 / nemotron and the
+multi-turn-SFT disaggregate correctness fix.
+
+**Only prime-rl brings:** GLM-5.1, GLM-4.5, Laguna-XS.2, Nemotron-3-Ultra,
+token-level MiniMax-M2.5 — plus `bridge_to_next_turn` for **every** model.
+
+**Neither:** MiniMax-M3 (template diverges hard from M2 — see §7).
+
+---
+
+## 3. Target architecture — `rllm/renderers/` facade
+
+```
+rllm/renderers/
+  __init__.py     # public: resolve(), Renderer protocol, RendererSpec
+  protocol.py     # the token-level Protocol rLLM rollouts speak
+  registry.py     # unified model -> backend map + precedence + resolve()
+  _prime.py       # passthrough wrapper over prime-rl create_renderer
+  _tinker.py      # adapter: tinker_cookbook/Fireworks Renderer -> Protocol
+  _default.py     # last-resort apply_chat_template wrapper (bridge -> None)
+```
+
+### 3.1 `protocol.py` — the one interface (prime-rl's shape; RL-first)
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class Renderer(Protocol):
+    def render_ids(self, messages, *, tools=None,
+                   add_generation_prompt=False) -> list[int]: ...
+    def parse_response(self, token_ids) -> "ParsedResponse": ...
+    def get_stop_token_ids(self) -> list[int]: ...
+    # RL-critical: return prev_prompt_ids + prev_completion_ids + new turn,
+    # byte-for-byte, or None to signal "caller must full-re-render".
+    def bridge_to_next_turn(self, previous_prompt_ids, previous_completion_ids,
+                            new_messages, *, tools=None) -> list[int] | None: ...
+
+# ParsedResponse = (content, reasoning_content, tool_calls) — mirror prime-rl.
+```
+
+This is intentionally prime-rl's contract: RL rollout correctness lives in
+`bridge_to_next_turn`, which the message-level abstractions don't natively have.
+
+### 3.2 `_prime.py` — passthrough (no real work)
+
+prime-rl renderers already implement this Protocol exactly. Wrapper just holds
+the instance and forwards. Coverage test = membership in
+`renderers.base.MODEL_RENDERER_MAP` (exact match on `tokenizer.name_or_path`);
+do **not** rely on `create_renderer` "succeeding" — it always returns a
+`DefaultRenderer` fallback.
+
+### 3.3 `_tinker.py` — adapter (the real work)
+
+Wrap a `tinker_cookbook.renderers.Renderer` (incl. Fireworks subclasses) to the
+Protocol:
+
+| Protocol method | Maps to tinker_cookbook | Notes |
+|---|---|---|
+| `render_ids(msgs, tools, add_gen)` | `build_generation_prompt(msgs, …)` | extract int token ids from the returned ModelInput; **verify exact return type against the pinned tinker_cookbook version at impl time** |
+| `parse_response(ids)` | `renderer.parse_response(ids)` | map tinker `Message` → `ParsedResponse(content, reasoning_content, tool_calls)` |
+| `get_stop_token_ids()` | `renderer.get_stop_sequences()` | convert any string stops → ids via tokenizer |
+| `bridge_to_next_turn(...)` | — | **return `None`** unless `getattr(renderer, "has_extension_property", False)`; if true, do prefix-extension (render new messages only and append). Conservative `None` is always *correct* (caller full-re-renders) — never emit a wrong bridge. |
+
+The `None`-bridge path means RL multi-turn on tinker-backed models falls back to
+full re-render per turn (same behavior as today's `ChatTemplateParser`), so this
+is **no regression** — and any model that *also* exists in prime-rl gets the real
+bridge via precedence (§3.4).
+
+### 3.4 `registry.py` — precedence (RL-first)
+
+```python
+def resolve(model_name, tokenizer, *, renderer_name=None,
+            image_processor=None) -> Renderer:
+    # 0. explicit override always wins
+    if renderer_name:
+        return _explicit(renderer_name, tokenizer, image_processor)
+    # 1. prime-rl exact match -> token bridge available  (PREFERRED for RL)
+    if model_name in renderers.base.MODEL_RENDERER_MAP:
+        return PrimeRenderer(create_renderer(tokenizer))
+    # 2. Fireworks/tinker covers a model prime-rl lacks (DeepSeek-V4, Gemma4, ...)
+    name = _tinker_renderer_name(model_name)   # see §4 — incl. FW models
+    if name is not None:
+        return TinkerAdapter(get_renderer(name, tokenizer, image_processor))
+    # 3. last resort
+    return DefaultRenderer(tokenizer)          # apply_chat_template, bridge->None
+```
+
+Precedence order is what encodes "RL rollout primary": a model in **both**
+ecosystems routes to prime-rl so it gets `bridge_to_next_turn`.
+
+---
+
+## 4. Model → renderer-name resolution (`_tinker_renderer_name`)
+
+`tinker_engine` already uses `model_info.get_recommended_renderer_name(model)`,
+but tinker_cookbook's `model_info` lags new models and **does not know the
+Fireworks-only renderers**. Add a small rLLM-side override map:
+
+```python
+_FW_MODEL_RENDERER = {
+    "deepseek-ai/DeepSeek-V4-Flash": "deepseek_v4",
+    "google/Gemma4-...":             "gemma4",
+    "moonshotai/Kimi-K2.7-...":      "kimi_k27_code",
+    # glm5 / minimax_m2 / nemotron also available via FW registrations
+}
+def _tinker_renderer_name(model_name):
+    if model_name in _FW_MODEL_RENDERER:
+        return _FW_MODEL_RENDERER[model_name]
+    try:
+        return model_info.get_recommended_renderer_name(model_name)
+    except KeyError:
+        return None
+```
+
+(Exact HF repo ids for Gemma4 / Kimi-K2.7 to be filled from the FW renderer
+docstrings / `MODEL_RENDERER_MAP` analogues at impl time.)
+
+---
+
+## 5. File-by-file changes
+
+| File | Change |
+|---|---|
+| `rllm/renderers/__init__.py` (new) | export `resolve`, `Renderer`, `ParsedResponse` |
+| `rllm/renderers/protocol.py` (new) | Protocol + `ParsedResponse` |
+| `rllm/renderers/registry.py` (new) | `resolve()`, precedence, `_tinker_renderer_name`, `_FW_MODEL_RENDERER` |
+| `rllm/renderers/_prime.py` (new) | prime-rl passthrough wrapper |
+| `rllm/renderers/_tinker.py` (new) | tinker_cookbook/Fireworks adapter |
+| `rllm/renderers/_default.py` (new) | apply_chat_template fallback (bridge→None) |
+| `rllm/renderers/_fw_register.py` (new) | `import training.renderer` (the dead-code fix), guarded in try/except for envs without the cookbook |
+| `rllm/engine/rollout/fireworks_engine.py` | swap `ChatTemplateParser.get_parser(...)` for `rllm.renderers.resolve(...)`; use `render_ids` / `bridge_to_next_turn` for multi-turn rollouts; keep `ChatTemplateParser` as a 4th backend behind a flag during migration |
+| `rllm/engine/rollout/tinker_engine.py` | route through `resolve()` instead of bare `renderers.get_renderer`; preserve the existing `renderer_name` override path |
+| `rllm-model-gateway/.../server.py` | replace the bare `create_renderer(...)` (which hard-errors off `MODEL_RENDERER_MAP`) with `resolve()` so cumulative token mode falls back to the tinker/FW adapter for models prime-rl lacks, instead of failing. **Highest-leverage integration point** — prime-rl already lives here. |
+| `pyproject.toml` | pin `renderers` (prime-rl) as an explicit dep instead of relying on the transitive install |
+
+---
+
+## 6. Rollout (suggested PR sequencing)
+
+1. **PR 1 — quick win (low risk):** add `rllm/renderers/_fw_register.py` and import
+   it where renderers are resolved. Unlocks DeepSeek-V4 / Gemma4 / Kimi-K2.7-code
+   + the SFT disaggregate fix through the *existing* `get_renderer` path. No
+   facade yet.
+2. **PR 2 — facade skeleton:** `protocol.py` + `_prime.py` + `_default.py` +
+   `registry.resolve()` with prime-rl-only precedence; unit + parity tests.
+3. **PR 3 — tinker adapter:** `_tinker.py` + `_tinker_renderer_name`; precedence
+   step 2 live. DeepSeek-V4 etc. now reachable through the facade.
+4. **PR 4 — repoint engines:** fireworks/tinker engines call `resolve()`; gate
+   `ChatTemplateParser` behind a deprecation flag.
+5. **PR 5 — migrate/retire `ChatTemplateParser`** once parity is proven.
+
+---
+
+## 7. MiniMax-M3 (explicitly out, but noted)
+
+Neither package supports MiniMax-M3, and its `chat_template.jinja` is a ground-up
+redesign vs M2/M2.5 (new `]<]minimax[>[` namespace token, `<mm:think>` tags,
+recursive `to_xml` tool-call args, `root`/`developer` role split, `thinking_mode`).
+The M2 renderer in **either** ecosystem produces token-for-token wrong output for
+M3. Supporting M3 = a new hand-coded renderer; under this plan, write it as a
+**prime-rl-shaped** renderer (so it gets `bridge_to_next_turn`) and register it in
+the unified registry. Tracked separately.
+
+---
+
+## 8. Testing
+
+- **Parity:** for each model, assert `resolve(...).render_ids(msgs)` ==
+  `tokenizer.apply_chat_template(msgs, tokenize=True)` for single-turn (catches
+  adapter token-extraction bugs). prime-rl ships such tests; mirror for the
+  adapter.
+- **Bridge correctness (RL-critical):** assert
+  `bridge_to_next_turn(p, c, new)` starts with `p + c` byte-for-byte, or is
+  `None`. Never a third outcome.
+- **Precedence:** a model in both ecosystems resolves to `PrimeRenderer`
+  (i.e. exposes a non-`None` bridge).
+- **Env guard:** facade imports succeed when the Fireworks cookbook is absent
+  (try/except around `_fw_register`).
+
+---
+
+## 9. Risks / open questions
+
+- **Adapter token extraction:** `build_generation_prompt` return type varies by
+  tinker_cookbook version — verify against the pinned version; the int-id
+  extraction is the riskiest line in the adapter.
+- **Stop-token conversion:** tinker `get_stop_sequences()` may return strings;
+  need a tokenizer-based string→id conversion that matches what the engine
+  expects.
+- **Double tokenizer load:** prime-rl `create_renderer` and the engine both load
+  tokenizers; reuse one instance to avoid the startup cost (prime-rl supports
+  passing a tokenizer in).
+- **`model_info` lag:** Fireworks model ids must be in `_FW_MODEL_RENDERER`
+  because tinker `model_info` won't know them — keep that map close to the FW
+  cookbook version it targets.

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -123,6 +123,10 @@ class GatewayConfig(BaseModel):
     sync_traces: bool = False
     model: str | None = None  # When set, overrides ``body.model``
     cumulative_token_mode: bool = False
-    # renderers family for the cumulative-mode bridge. Check supported model families
-    # in MODEL_RENDERER_MAP of https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
+    # prime-rl renderer family for the gateway-built cumulative-mode renderer.
+    # "auto" matches the tokenizer's HF id against MODEL_RENDERER_MAP; set
+    # explicitly (e.g. "qwen3.5", "glm-5", "deepseek-v3") for local checkpoint
+    # paths. Models without a prime-rl renderer (e.g. DeepSeek-V4) are supported
+    # by injecting a renderer from the rllm side (in-process gateway). Families:
+    # https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
     renderer_family: str = "auto"

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -65,6 +65,44 @@ def _strip_logprobs(response: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _tool_call_to_openai(tc: Any, index: int) -> dict[str, Any]:
+    """Convert a renderer ToolCall to OpenAI ``tool_calls`` entry format.
+
+    Handles the shapes ``parse_response`` may return: an object with
+    ``name``/``arguments``, an object with ``function.name``/
+    ``function.arguments``, or a dict. ``arguments`` is JSON-encoded (OpenAI
+    sends it as a string).
+    """
+    fn = getattr(tc, "function", None)
+    if fn is not None:
+        name, arguments = getattr(fn, "name", ""), getattr(fn, "arguments", {})
+    elif isinstance(tc, dict):
+        name, arguments = tc.get("name", ""), tc.get("arguments", {})
+    else:
+        name, arguments = getattr(tc, "name", ""), getattr(tc, "arguments", {})
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments)
+    return {"id": f"call_{index}", "type": "function", "function": {"name": name, "arguments": arguments}}
+
+
+def _parsed_response_to_message(parsed: Any) -> dict[str, Any]:
+    """Build an OpenAI assistant message from a renderer ``ParsedResponse``.
+
+    Matches the shape the chat-completions endpoint returns — clean ``content``,
+    plus ``reasoning_content`` and structured ``tool_calls`` when present — so
+    cumulative-mode (token-in) turns are consumed identically to the first
+    (chat-path) turn instead of dumping the raw completion text into ``content``.
+    """
+    message: dict[str, Any] = {"role": "assistant", "content": getattr(parsed, "content", "") or ""}
+    reasoning = getattr(parsed, "reasoning_content", "") or ""
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    tool_calls = getattr(parsed, "tool_calls", None) or []
+    if tool_calls:
+        message["tool_calls"] = [_tool_call_to_openai(tc, i) for i, tc in enumerate(tool_calls)]
+    return message
+
+
 class ReverseProxy:
     """Forward requests to inference workers, capture traces.
 
@@ -154,9 +192,49 @@ class ReverseProxy:
             if acc.should_rewrite():
                 messages = request_body.get("messages", [])
                 if not acc.is_cumulative(messages):
-                    # Message history diverged — reset and fall through to
-                    # normal chat path (treated as fresh turn-0).
-                    acc.reset()
+                    kind, idx = acc.divergence(messages)
+                    # Duplicate / retried request (byte-identical to the already-
+                    # folded turn): the agent re-sent the same turn (its prior
+                    # attempt was rejected/failed). Re-sample that turn *in place*
+                    # from its existing prompt and overwrite its trace, instead of
+                    # resetting — so the cumulative chain isn't torn down and the
+                    # trajectory isn't split into two steps. Non-streaming only;
+                    # streaming retries fall through to reset below.
+                    if kind == "duplicate" and not is_stream and acc.prev_prompt_ids:
+                        # Report the prior attempt's outcome so the *cause* of the
+                        # re-send is visible: finish_reason=length → still length;
+                        # completion=0 → empty/failed response (deployment/infra);
+                        # finish_reason=stop with completion>0 → a valid response
+                        # the agent rejected (look agent-side, e.g. parse).
+                        logger.info(
+                            "Re-sampling duplicate request in place (session=%s, turn=%d, %d msgs); prior attempt: finish_reason=%s, completion=%d tok — chain preserved",
+                            session_id,
+                            acc.turn_count,
+                            acc.message_count,
+                            acc.last_finish_reason,
+                            acc.last_completion_len,
+                        )
+                        return await self._handle_cumulative_turn(
+                            request,
+                            request_body,
+                            session_id,
+                            acc,
+                            list(acc.prev_prompt_ids),
+                            originally_requested_logprobs,
+                            is_retry=True,
+                        )
+                    # Otherwise reset and fall through to the normal chat path
+                    # (fresh turn-0). Log *why* so resets can be root-caused.
+                    if kind == "changed":
+                        role = messages[idx].get("role", "?") if idx < len(messages) else "?"
+                        reason = f"prefix not append-only: msg {idx} (role={role}) changed vs verified prefix"
+                    elif kind == "shrunk":
+                        reason = f"history shrank to {idx} msgs (verified prefix was {acc.message_count}); summarization/unwind"
+                    elif kind == "duplicate":
+                        reason = f"duplicate request ({idx} msgs); resetting (streaming retry or no prior prompt to re-sample)"
+                    else:
+                        reason = f"non-cumulative message list (len={len(messages)} <= prefix {acc.message_count})"
+                    acc.reset(reason)
                 else:
                     new_messages = extract_new_messages(messages, acc.message_count)
                     token_ids = None
@@ -171,13 +249,37 @@ class ReverseProxy:
                             token_ids,
                             originally_requested_logprobs,
                         )
-                    # No new messages, or the renderer couldn't prove the
-                    # prefix-extension contract (e.g. DefaultRenderer, or an
-                    # assistant message in the new slice). Reset so this turn is
-                    # re-ingested as a fresh turn-0 on the chat path; otherwise
-                    # the stale prefix would drop this turn's completion tokens
-                    # from the next cumulative prompt and break prefix-extension.
-                    acc.reset()
+                    # No bridgeable new messages, or the renderer couldn't prove
+                    # the prefix-extension contract (DefaultRenderer, assistant in
+                    # the new slice, multimodal, a renderer error). Reset so this
+                    # turn is re-ingested as a fresh turn-0 on the chat path;
+                    # otherwise the stale prefix would drop this turn's completion
+                    # tokens from the next cumulative prompt and break extension.
+                    # Log which case it was + the new-slice shape to root-cause.
+                    if not new_messages:
+                        raw_roles = [m.get("role") for m in messages[acc.message_count :]]
+                        reason = f"no bridgeable new messages (raw new-slice roles={raw_roles})"
+                    else:
+                        reason = f"bridge returned None (new-slice roles={[m.get('role') for m in new_messages]}, content_types={[type(m.get('content')).__name__ for m in new_messages]})"
+                    acc.reset(reason)
+            else:
+                # First turn (turn 0): render the initial messages from scratch via
+                # the renderer and route through the *same* token-in path as later
+                # turns, so the ENTIRE trajectory is tokenized by one renderer — no
+                # chat-template-vs-renderer seam at the turn-0/turn-1 boundary. Falls
+                # back to the chat path if the renderer can't render turn 0 (the chat
+                # path then seeds the accumulator via its own turn-0 ingest below).
+                messages = request_body.get("messages", [])
+                token_ids = acc.build_first_prompt(messages, tools=request_body.get("tools")) if messages else None
+                if token_ids is not None:
+                    return await self._handle_cumulative_turn(
+                        request,
+                        request_body,
+                        session_id,
+                        acc,
+                        token_ids,
+                        originally_requested_logprobs,
+                    )
 
         if is_stream:
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)
@@ -198,14 +300,18 @@ class ReverseProxy:
         t0 = time.perf_counter()
 
         if self.local_handler is not None:
-            # In-process path: call handler directly, no HTTP
+            # In-process path: call handler directly, no HTTP.
+            # Forward the rollout session id so affinity-aware engines (Fireworks)
+            # can pin a trajectory's turns to one replica for prefix-cache reuse.
+            if session_id:
+                request_body["rllm_session_id"] = session_id
             response_body = await self.local_handler(request_body)
             status_code = 200
         else:
             # HTTP proxy path
             worker = self.router.route(session_id)
             url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
-            headers = self._forward_headers(request)
+            headers = self._forward_headers(request, session_id)
             try:
                 resp = await self._send_with_retry(
                     method=request.method,
@@ -240,6 +346,10 @@ class ReverseProxy:
                     if prompt_ids or completion_ids:
                         acc.ingest_turn(prompt_ids, completion_ids)
                         acc.update_prefix(request_body.get("messages", []))
+                        # Remember this turn's trace so a duplicate/retried turn-0
+                        # request can overwrite it instead of appending a new row.
+                        acc.last_trace_id = trace.trace_id
+                        acc.record_outcome((response_body.get("choices") or [{}])[0].get("finish_reason"), len(completion_ids))
 
         # Sanitise response
         needs_strip_vllm = self.strip_vllm
@@ -270,17 +380,23 @@ class ReverseProxy:
         acc: TokenAccumulator,
         token_ids: list[int],
         originally_requested_logprobs: bool = False,
+        is_retry: bool = False,
     ) -> Response:
         """Rewrite chat/completions to /v1/completions with pre-tokenized prompt.
 
         ``token_ids`` is the full bridge-extended prompt for this turn, built
         by ``acc.build_next_prompt`` in ``handle()``.
 
+        ``is_retry``: this is a re-sample of an already-folded turn (a duplicate
+        request). The completion is swapped in place (``resample_completion``)
+        and its trace is overwritten, rather than folding a new turn — keeping
+        the cumulative chain intact. Retries are routed non-streaming.
+
         Respects the original stream setting: if the client requested streaming,
         we stream from vLLM and translate completions chunks to chat format in
         real-time.
         """
-        is_stream = request_body.get("stream", False)
+        is_stream = request_body.get("stream", False) and not is_retry
 
         # Construct completions request: forward everything except chat-specific fields
         completions_body = {k: v for k, v in request_body.items() if k not in ("messages", "stream", "stream_options", "tools", "tool_choice")}
@@ -297,6 +413,7 @@ class ReverseProxy:
             acc,
             token_ids,
             originally_requested_logprobs,
+            is_retry=is_retry,
         )
 
     async def _handle_cumulative_non_streaming(
@@ -308,48 +425,89 @@ class ReverseProxy:
         acc: TokenAccumulator,
         token_ids: list[int],
         originally_requested_logprobs: bool = False,
+        is_retry: bool = False,
     ) -> Response:
-        """Non-streaming cumulative turn: send non-streaming to vLLM, return JSON."""
+        """Non-streaming cumulative turn: send pre-tokenized prompt, return JSON.
+
+        Routes to the in-process ``local_handler`` (e.g. Tinker) when present,
+        otherwise POSTs ``/v1/completions`` to a vLLM worker. Both return a
+        completions-style body carrying ``prompt_token_ids`` + ``token_ids``.
+        """
         t0 = time.perf_counter()
 
-        worker = self.router.route(session_id)
-        url = self._build_url(worker.api_url, "/v1/completions", "")
-        headers = self._forward_headers(request)
-        raw_body = json.dumps(completions_body).encode()
-        try:
-            resp = await self._send_with_retry(
-                method="POST",
-                url=url,
-                content=raw_body,
-                headers=headers,
-            )
-            content = resp.content
-            status_code = resp.status_code
-        finally:
-            self.router.release(worker.url)
+        if self.local_handler is not None:
+            # In-process path (Tinker): sample directly from the pre-tokenized
+            # prompt; no HTTP worker, no re-tokenization.
+            if session_id:
+                completions_body["rllm_session_id"] = session_id
+            response_body = await self.local_handler(completions_body)
+            status_code = 200
+        else:
+            worker = self.router.route(session_id)
+            url = self._build_url(worker.api_url, "/v1/completions", "")
+            headers = self._forward_headers(request, session_id)
+            raw_body = json.dumps(completions_body).encode()
+            try:
+                resp = await self._send_with_retry(
+                    method="POST",
+                    url=url,
+                    content=raw_body,
+                    headers=headers,
+                )
+                content = resp.content
+                status_code = resp.status_code
+            finally:
+                self.router.release(worker.url)
 
-        try:
-            response_body = json.loads(content)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            response_body = {}
+            try:
+                response_body = json.loads(content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                response_body = {}
 
         latency_ms = (time.perf_counter() - t0) * 1000
 
         prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
         completion_token_ids = extract_completion_token_ids(response_body)
 
-        acc.ingest_turn(prompt_token_ids, completion_token_ids)
-        acc.update_prefix(request_body.get("messages", []))
+        if is_retry:
+            # Duplicate/retried turn: swap the completion in place (don't advance
+            # turn_count/message_count) so the cumulative chain stays intact.
+            acc.resample_completion(completion_token_ids)
+        else:
+            acc.ingest_turn(prompt_token_ids, completion_token_ids)
+            acc.update_prefix(request_body.get("messages", []))
+        # Record this turn's outcome so a later duplicate re-send can report why.
+        acc.record_outcome((response_body.get("choices") or [{}])[0].get("finish_reason"), len(completion_token_ids))
 
-        # Translate to chat format
+        # Translate completions response → chat format. Parse the completion into
+        # the structured shape the chat endpoint returns (clean content +
+        # reasoning_content + tool_calls) via the renderer, so cumulative turns
+        # are consumed identically to the chat-path first turn. /v1/completions
+        # returns the model's raw text (e.g. "reasoning</think>answer" or raw
+        # tool-call markup for thinking/tool models); dumping that verbatim into
+        # `content` breaks the agent's action/tool parsing on every cumulative
+        # turn. Fall back to the raw text if the renderer can't parse it.
         choices = response_body.get("choices") or []
         if choices:
             first_choice = choices[0]
-            first_choice["message"] = {"role": "assistant", "content": first_choice.pop("text", "")}
+            raw_text = first_choice.pop("text", "")
+            message: dict[str, Any] | None = None
+            if self.renderer is not None and completion_token_ids:
+                try:
+                    parsed = self.renderer.parse_response(list(completion_token_ids))
+                    message = _parsed_response_to_message(parsed)
+                except Exception as err:  # noqa: BLE001 - never break the response on a parse error
+                    logger.warning("cumulative parse_response failed (%s); falling back to raw text", err)
+            first_choice["message"] = message if message is not None else {"role": "assistant", "content": raw_text}
         response_body["object"] = "chat.completion"
 
         if session_id and response_body:
             trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version)
+            if is_retry and acc.last_trace_id:
+                # Overwrite the rejected attempt's trace (stores upsert by
+                # trace_id), so the trajectory keeps one row for this turn.
+                trace.trace_id = acc.last_trace_id
+            acc.last_trace_id = trace.trace_id
             await self._persist(trace)
 
         sanitized = response_body
@@ -375,11 +533,16 @@ class ReverseProxy:
         token_ids: list[int],
     ) -> StreamingResponse:
         """Streaming cumulative turn: stream from vLLM, translate chunks to chat format."""
+        if self.local_handler is not None:
+            # In-process backends (Tinker) don't stream; synthesize an SSE
+            # stream from a single pre-tokenized completion call.
+            return await self._handle_cumulative_streaming_local(request, request_body, completions_body, session_id, acc, token_ids)
+
         completions_body["stream"] = True
 
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, "/v1/completions", "")
-        headers = self._forward_headers(request)
+        headers = self._forward_headers(request, session_id)
         raw_body = json.dumps(completions_body).encode()
 
         assert self._http is not None
@@ -502,6 +665,99 @@ class ReverseProxy:
             status_code=resp.status_code,
         )
 
+    async def _handle_cumulative_streaming_local(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        completions_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        token_ids: list[int],
+    ) -> StreamingResponse:
+        """Cumulative streaming via the in-process handler (fake-streaming).
+
+        The local handler returns a full completion in one shot; we ingest its
+        token IDs into the accumulator, translate to chat format, and emit it as
+        a synthesized SSE stream (role → content+tokens → finish → [DONE]).
+        """
+        assert self.local_handler is not None
+        t0 = time.perf_counter()
+        if session_id:
+            completions_body["rllm_session_id"] = session_id
+        response_body = await self.local_handler(completions_body)
+        latency_ms = (time.perf_counter() - t0) * 1000
+
+        prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
+        completion_token_ids = extract_completion_token_ids(response_body)
+        acc.ingest_turn(prompt_token_ids, completion_token_ids)
+        acc.update_prefix(request_body.get("messages", []))
+
+        choices = response_body.get("choices") or []
+        content = choices[0].pop("text", "") if choices else ""
+        finish_reason = (choices[0].get("finish_reason") if choices else None) or "stop"
+        completion_logprobs = choices[0].get("logprobs") if choices else None
+
+        if session_id and response_body:
+            chat_body = dict(response_body)
+            chat_body["object"] = "chat.completion"
+            if chat_body.get("choices"):
+                chat_body["choices"][0]["message"] = {"role": "assistant", "content": content}
+            trace = build_trace_record(session_id, request_body, chat_body, latency_ms, weight_version=request.state.weight_version)
+            await self._persist(trace)
+
+        chat_id = response_body.get("id", "chatcmpl-local")
+        created = response_body.get("created", int(time.time()))
+        model = response_body.get("model", "")
+        usage = response_body.get("usage", {})
+
+        def _sanitize_chunk(chunk: dict[str, Any]) -> dict[str, Any]:
+            return strip_vllm_fields(chunk) if self.strip_vllm else chunk
+
+        async def event_generator():
+            def _sse(data: str) -> str:
+                return f"data: {data}\n\n"
+
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+                    }
+                )
+            )
+            yield _sse(
+                json.dumps(
+                    _sanitize_chunk(
+                        {
+                            "id": chat_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None, "token_ids": completion_token_ids, "logprobs": completion_logprobs}],
+                            "prompt_token_ids": prompt_token_ids,
+                        }
+                    )
+                )
+            )
+            yield _sse(
+                json.dumps(
+                    {
+                        "id": chat_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+                        "usage": usage,
+                    }
+                )
+            )
+            yield _sse("[DONE]")
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream", status_code=200)
+
     # ------------------------------------------------------------------
     # Streaming (SSE)
     # ------------------------------------------------------------------
@@ -519,7 +775,7 @@ class ReverseProxy:
 
         worker = self.router.route(session_id)
         url = self._build_url(worker.api_url, request.url.path, str(request.url.query))
-        headers = self._forward_headers(request)
+        headers = self._forward_headers(request, session_id)
 
         assert self._http is not None
         upstream = self._http.stream(
@@ -800,5 +1056,13 @@ class ReverseProxy:
         return url
 
     @staticmethod
-    def _forward_headers(request: Request) -> dict[str, str]:
-        return {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+    def _forward_headers(request: Request, session_id: str | None = None) -> dict[str, str]:
+        headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+        # Pin a trajectory's turns to one replica so Fireworks reuses its
+        # prompt-prefix KV (caching is per-replica). The training path sets these
+        # via the rollout engine; the HTTP path (eval) does it here. No-op for
+        # non-Fireworks upstreams; setdefault lets a client pin its own value.
+        if session_id:
+            headers.setdefault("x-session-affinity", str(session_id))
+            headers.setdefault("x-multi-turn-session-id", str(session_id))
+        return headers

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -108,6 +108,24 @@ def _load_policy(dotted_path: str):
 
 
 # ------------------------------------------------------------------
+# Cumulative-mode renderer
+# ------------------------------------------------------------------
+
+
+def _renderer_has_bridge(renderer: object) -> bool:
+    """Whether ``renderer`` provides a real cross-turn bridge.
+
+    Renderers may carry an explicit ``has_bridge`` flag (e.g. an injected
+    rllm renderer); prime-rl renderers don't, so we treat anything but
+    ``DefaultRenderer`` (whose bridge always returns ``None``) as bridge-capable.
+    """
+    flag = getattr(renderer, "has_bridge", None)
+    if flag is not None:
+        return bool(flag)
+    return type(renderer).__name__ != "DefaultRenderer"
+
+
+# ------------------------------------------------------------------
 # App factory
 # ------------------------------------------------------------------
 
@@ -116,8 +134,17 @@ def create_app(
     config: GatewayConfig | None = None,
     store: TraceStore | None = None,
     local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+    renderer: object | None = None,
 ) -> FastAPI:
-    """Create and return a fully configured FastAPI application."""
+    """Create and return a fully configured FastAPI application.
+
+    ``renderer``: an optional pre-built cumulative-mode renderer. The in-process
+    (thread-mode) ``GatewayManager`` injects one here — built on the rllm side via
+    ``rllm.renderers.resolve`` so it can support models prime-rl lacks (e.g.
+    DeepSeek-V4) without the gateway depending on tinker/Fireworks. When ``None``
+    and cumulative mode is on, the gateway builds a prime-rl renderer from
+    ``config`` (its only renderer dependency).
+    """
     if config is None:
         config = GatewayConfig()
 
@@ -148,50 +175,48 @@ def create_app(
             )
         )
 
-    # Build the renderer for cumulative token mode. The renderer owns
-    # message↔token conversion and the cross-turn bridge (see
-    # token_accumulator.TokenAccumulator). The tokenizer is loaded from the
-    # served model path (``config.model``), which we assume is a complete,
-    # unmodified HuggingFace checkpoint.
-    renderer = None
+    # Renderer for cumulative token mode. The renderer owns message↔token
+    # conversion and the cross-turn bridge (see token_accumulator.TokenAccumulator).
+    # If one was injected (in-process mode), use it as-is. Otherwise build a
+    # prime-rl renderer from config — the gateway's only renderer dependency.
+    # The tokenizer is loaded from the served model path (``config.model``),
+    # which we assume is a complete, unmodified HuggingFace checkpoint.
     if config.cumulative_token_mode:
-        if not config.model:
-            raise ValueError("cumulative_token_mode=True requires 'model' to be set in GatewayConfig (path to the served HuggingFace checkpoint).")
-        try:
-            from renderers import create_renderer
-            from transformers import AutoTokenizer
-        except ImportError as err:
-            raise ImportError("cumulative_token_mode requires the 'renderers' and 'transformers' packages. Install them with: pip install renderers transformers") from err
+        if renderer is None:
+            if not config.model:
+                raise ValueError("cumulative_token_mode=True requires 'model' to be set in GatewayConfig (path to the served HuggingFace checkpoint).")
+            try:
+                from renderers import create_renderer
+                from transformers import AutoTokenizer
+            except ImportError as err:
+                raise ImportError("cumulative_token_mode requires the 'renderers' and 'transformers' packages. Install them with: pip install renderers transformers") from err
 
-        tokenizer = AutoTokenizer.from_pretrained(config.model)
+            tokenizer = AutoTokenizer.from_pretrained(config.model)
+            # renderer_family="auto" resolves by matching the tokenizer's
+            # name_or_path against renderers' MODEL_RENDERER_MAP; a local/custom
+            # checkpoint path misses and falls back to DefaultRenderer (no bridge).
+            renderer = create_renderer(tokenizer, renderer=config.renderer_family)
+            logger.info(
+                "Built %s (family=%r) from %s for cumulative token mode",
+                type(renderer).__name__,
+                config.renderer_family,
+                config.model,
+            )
+        else:
+            logger.info("Using injected %s for cumulative token mode", type(renderer).__name__)
 
-        # renderer_family="auto" lets renderers resolve the family by matching the
-        # tokenizer's name_or_path against its MODEL_RENDERER_MAP. This succeeds
-        # when ``model`` is a canonical HF id (e.g. "Qwen/Qwen3-8B") but misses for
-        # a local/custom checkpoint path, which falls back to DefaultRenderer (whose
-        # bridge_to_next_turn always returns None, disabling drift protection). When
-        # serving from a path, set renderer_family explicitly. Supported families /
-        # MODEL_RENDERER_MAP:
-        #   https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
-        renderer = create_renderer(tokenizer, renderer=config.renderer_family)
-        logger.info(
-            "Built %s (family=%r) from %s for cumulative token mode",
-            type(renderer).__name__,
-            config.renderer_family,
-            config.model,
-        )
-        if type(renderer).__name__ == "DefaultRenderer":
+        if not _renderer_has_bridge(renderer):
             raise ValueError(
-                f"Cumulative token mode resolved to DefaultRenderer for renderer_family="
-                f"{config.renderer_family!r} (model={config.model!r}). DefaultRenderer "
+                f"Cumulative token mode resolved to {type(renderer).__name__} for "
+                f"renderer_family={config.renderer_family!r} (model={config.model!r}), which "
                 "provides no cross-turn bridge, so drift-free token forwarding is disabled. "
                 "renderer_family='auto' only resolves when 'model' is a canonical HuggingFace "
                 "id present in renderers' MODEL_RENDERER_MAP; a local/custom checkpoint path "
                 "will not match. Either pass a recognized HF id as 'model', or set "
                 "renderer_family explicitly to match your model (e.g. 'qwen3', 'qwen3.5', "
-                "'qwen3.6', 'glm-5', 'deepseek-v3', 'gpt-oss'). Check supported families in "
-                "MODEL_RENDERER_MAP of: https://github.com/PrimeIntellect-ai/renderers/blob/"
-                "main/renderers/base.py"
+                "'glm-5', 'deepseek-v3', 'gpt-oss'). For models without a prime-rl renderer "
+                "(e.g. DeepSeek-V4), run the gateway in-process so rllm can inject a "
+                "tinker/Fireworks-backed renderer."
             )
 
     proxy = ReverseProxy(

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -68,6 +68,17 @@ class TokenAccumulator:
         self.turn_count: int = 0
         self.message_count: int = 0
         self._prefix_fingerprint: str = ""
+        # Per-message fingerprints of the last verified prefix, for diagnosing
+        # exactly where a non-cumulative request diverged (see divergence).
+        self._prefix_msg_fingerprints: list[str] = []
+        # trace_id of the most recently folded turn, so a duplicate/retried
+        # request can overwrite that turn's trace instead of appending a new one.
+        self.last_trace_id: str | None = None
+        # Outcome of the most recently folded/resampled turn, for diagnosing *why*
+        # a duplicate re-send happened (empty completion / length / normal-but-
+        # rejected). Set on every fold + resample.
+        self.last_finish_reason: str | None = None
+        self.last_completion_len: int = 0
 
     @property
     def cumulative_ids(self) -> list[int]:
@@ -98,18 +109,62 @@ class TokenAccumulator:
         prefix = messages[: self.message_count]
         return _messages_fingerprint(prefix) == self._prefix_fingerprint
 
-    def reset(self) -> None:
-        """Clear all accumulated state, restarting this session's history."""
+    def reset(self, reason: str = "") -> None:
+        """Clear all accumulated state, restarting this session's history.
+
+        ``reason`` (optional) is logged so the cause of a cumulative-mode break
+        is visible — see the call sites in ``ReverseProxy.handle``.
+        """
         logger.info(
-            "Resetting TokenAccumulator (was at turn %d, %d messages)",
+            "Resetting TokenAccumulator (was at turn %d, %d messages)%s",
             self.turn_count,
             self.message_count,
+            f" — {reason}" if reason else "",
         )
         self.prev_prompt_ids = []
         self.prev_completion_ids = []
         self.turn_count = 0
         self.message_count = 0
         self._prefix_fingerprint = ""
+        self._prefix_msg_fingerprints = []
+        self.last_trace_id = None
+        self.last_finish_reason = None
+        self.last_completion_len = 0
+
+    def record_outcome(self, finish_reason: str | None, completion_len: int) -> None:
+        """Remember the last folded/resampled turn's sampling outcome so a
+        subsequent duplicate re-send can report *why* the agent likely retried."""
+        self.last_finish_reason = finish_reason
+        self.last_completion_len = completion_len
+
+    def divergence(self, messages: list[dict[str, Any]]) -> tuple[str, int]:
+        """Diagnose why ``messages`` is not a cumulative extension of the stored
+        prefix. Returns ``(kind, index)``:
+
+          - ``("changed", i)``: ``messages[i]`` differs from the stored prefix's
+            message ``i`` — the prefix was *mutated*, not just appended to
+            (e.g. an edited/reformatted earlier message).
+          - ``("shrunk", n)``: the overlap matches but ``messages`` has only ``n``
+            messages (fewer than the verified prefix) — the conversation got
+            *shorter*, i.e. summarization / history unwind.
+          - ``("duplicate", n)``: ``messages`` is byte-identical to the verified
+            prefix (same length, every message matches) — the agent re-sent an
+            already-processed request, i.e. a retried / replayed sampling call.
+          - ``("clean", -1)``: no divergence found.
+
+        Only called on a reset (after ``is_cumulative`` already returned False),
+        so the per-message rehash here is off the hot path.
+        """
+        prior = self._prefix_msg_fingerprints
+        overlap = min(len(messages), len(prior))
+        for i in range(overlap):
+            if _messages_fingerprint([messages[i]]) != prior[i]:
+                return ("changed", i)
+        if len(messages) < len(prior):
+            return ("shrunk", len(messages))
+        if len(messages) == len(prior):
+            return ("duplicate", len(messages))
+        return ("clean", -1)
 
     def ingest_turn(self, prompt_token_ids: list[int], completion_token_ids: list[int]) -> None:
         """Record the token IDs from a completed turn.
@@ -123,10 +178,46 @@ class TokenAccumulator:
         self.prev_completion_ids = list(completion_token_ids)
         self.turn_count += 1
 
+    def resample_completion(self, completion_token_ids: list[int]) -> None:
+        """Replace the most recent turn's completion *in place* — used when the
+        agent re-sends an already-folded turn (a retry). The prompt
+        (``prev_prompt_ids``), ``turn_count``, ``message_count`` and prefix
+        fingerprints are unchanged, so the cumulative chain is preserved and the
+        next real turn still extends it. Only the sampled completion is swapped
+        for the retry's fresh sample.
+        """
+        self.prev_completion_ids = list(completion_token_ids)
+
     def update_prefix(self, messages: list[dict[str, Any]]) -> None:
         """Snapshot the current message list as the verified prefix."""
         self.message_count = len(messages)
         self._prefix_fingerprint = _messages_fingerprint(messages)
+        self._prefix_msg_fingerprints = [_messages_fingerprint([m]) for m in messages]
+
+    def build_first_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int] | None:
+        """Construct the prompt token IDs for the FIRST turn (turn 0).
+
+        Renders the initial message list from scratch via the renderer's
+        ``render_ids`` (with a trailing generation prompt). Routing turn 0 through
+        the *same* renderer that bridges every later turn is what makes cumulative
+        mode drift-free: otherwise turn 0 would be tokenized by the engine's chat
+        template and turns 2+ by the renderer's bridge — two tokenizers stitched
+        mid-trajectory, which only coincidentally agree per model.
+
+        Returns ``None`` if the renderer cannot render the messages, so the caller
+        can fall back to the chat path (which then seeds the accumulator as before).
+        """
+        try:
+            token_ids = self.renderer.render_ids(messages, tools=tools, add_generation_prompt=True)
+        except Exception as err:  # noqa: BLE001 - fall back to the chat path on any render failure
+            logger.warning("render_ids failed for first turn (%s); falling back to chat path", err)
+            return None
+        return list(token_ids) if token_ids else None
 
     def build_next_prompt(
         self,

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode.py
@@ -152,6 +152,38 @@ class TestCumulativeTokenMode:
         # So turn 2 prompt should start with [1,2,3,4,5,10,11,12] + bridge
         assert prompt[:8] == [1, 2, 3, 4, 5, 10, 11, 12]
 
+    def test_duplicate_request_resampled_in_place_not_reset(self, cumulative_gateway):
+        """A duplicate/retried request (identical to an already-folded turn) is
+        re-sampled in place: the cumulative chain is preserved (no reset) and the
+        turn's trace is overwritten rather than appended (no trajectory split)."""
+        server, mock_vllm = cumulative_gateway
+        gw_url = server.url
+        client = GatewayClient(gw_url)
+        oai = openai.OpenAI(base_url=f"{gw_url}/sessions/dup-test/v1", api_key="dummy")
+
+        # Turn 1 (chat path)
+        oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])
+        turn2 = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hello from mock!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        # Turn 2 (cumulative)
+        oai.chat.completions.create(model="m", messages=turn2)
+        acc = server.app.state.proxy._accumulators["dup-test"]
+        assert acc.turn_count == 2
+
+        # Re-send the EXACT same turn-2 request (a retry).
+        resp = oai.chat.completions.create(model="m", messages=turn2)
+        assert resp.choices[0].message.content  # graceful 200, not an error
+
+        # Chain preserved: not reset, turn not advanced (re-sampled in place).
+        assert acc.turn_count == 2
+        # Trace overwritten, not appended: still 2 traces (turn1 + turn2), not 3.
+        traces = client.get_session_traces("dup-test")
+        assert len(traces) == 2
+        client.close()
+
     def test_traces_have_correct_token_ids(self, cumulative_gateway):
         """Both turns produce traces with prompt_token_ids and completion_token_ids."""
         server, mock_vllm = cumulative_gateway
@@ -449,3 +481,191 @@ class TestCumulativeStreaming:
         usage = usage_chunks[-1]["usage"]
         assert "prompt_tokens" in usage
         assert "completion_tokens" in usage
+
+
+# ---------------------------------------------------------------------------
+# Structured cumulative response (option 3): parse the completion via the
+# renderer so cumulative turns match the chat-path shape (clean content +
+# reasoning_content + structured tool_calls) instead of dumping raw text.
+# ---------------------------------------------------------------------------
+
+
+class _ParsedResp:
+    def __init__(self, content="", reasoning_content="", tool_calls=None):
+        self.content = content
+        self.reasoning_content = reasoning_content
+        self.tool_calls = tool_calls or []
+
+
+class _ToolCall:
+    def __init__(self, name, arguments):
+        self.name = name
+        self.arguments = arguments
+
+
+class _MockRendererWithParse(_MockRenderer):
+    """Adds parse_response — returns a fixed structured response distinct from
+    the mock worker's raw text, so a test can prove parse_response is used."""
+
+    def parse_response(self, token_ids):
+        return _ParsedResp(
+            content="parsed answer",
+            reasoning_content="my thinking",
+            tool_calls=[_ToolCall("run_cmd", {"cmd": "ls"})],
+        )
+
+
+class TestStructuredCumulativeResponse:
+    def test_pure_message_builder(self):
+        from rllm_model_gateway.proxy import _parsed_response_to_message
+
+        msg = _parsed_response_to_message(_ParsedResp("hello", "thinking", [_ToolCall("f", {"a": 1})]))
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "hello"
+        assert msg["reasoning_content"] == "thinking"
+        assert msg["tool_calls"][0]["type"] == "function"
+        assert msg["tool_calls"][0]["function"]["name"] == "f"
+        import json as _json
+
+        assert _json.loads(msg["tool_calls"][0]["function"]["arguments"]) == {"a": 1}
+
+    def test_pure_message_builder_omits_empty_fields(self):
+        from rllm_model_gateway.proxy import _parsed_response_to_message
+
+        msg = _parsed_response_to_message(_ParsedResp("just text"))
+        assert msg == {"role": "assistant", "content": "just text"}  # no reasoning/tool_calls keys
+
+    def test_tool_call_function_shape(self):
+        from rllm_model_gateway.proxy import _tool_call_to_openai
+
+        class _FnTc:
+            class function:  # noqa: N801
+                name = "g"
+                arguments = '{"x": 2}'  # already a string
+
+        out = _tool_call_to_openai(_FnTc(), 3)
+        assert out["id"] == "call_3"
+        assert out["function"] == {"name": "g", "arguments": '{"x": 2}'}
+
+    def test_cumulative_turn_returns_parsed_message(self, mock_vllm):
+        """End-to-end: a cumulative (token-in) turn returns the renderer-parsed
+        message shape, not the worker's raw completion text."""
+        config = GatewayConfig(
+            store_worker="memory",
+            workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
+            health_check_interval=999,
+            sync_traces=True,
+            cumulative_token_mode=False,
+        )
+        app = create_app(config)
+        app.state.proxy.renderer = _MockRendererWithParse()
+        app.state.proxy.cumulative_token_mode = True
+        server = GatewayServer(app, port=0)
+        server.start()
+        try:
+            oai = openai.OpenAI(base_url=f"{server.url}/sessions/parse-test/v1", api_key="dummy")
+            oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hi"}])  # turn 1
+            resp = oai.chat.completions.create(  # turn 2 — cumulative
+                model="m",
+                messages=[
+                    {"role": "user", "content": "Hi"},
+                    {"role": "assistant", "content": "Hello from mock!"},
+                    {"role": "user", "content": "go"},
+                ],
+            )
+        finally:
+            server.stop()
+        msg = resp.choices[0].message
+        assert msg.content == "parsed answer"  # parsed, not the raw "Hello from mock!"
+        assert msg.tool_calls[0].function.name == "run_cmd"
+        import json as _json
+
+        assert _json.loads(msg.tool_calls[0].function.arguments) == {"cmd": "ls"}
+
+
+class _MockRendererFull(_MockRendererWithParse):
+    """A complete renderer: bridge + parse_response + render_ids.
+
+    ``render_ids`` is what turn 0 uses, so the WHOLE trajectory is tokenized by
+    one renderer (no chat-template-vs-renderer seam). Deterministic encoding:
+    ``[200, 10, 201] + ord(last user content[:3]) + [202]``.
+    """
+
+    def render_ids(self, messages, *, tools=None, add_generation_prompt=False):
+        content = ""
+        for m in messages:
+            if m.get("role") == "user":
+                content = m.get("content", "")
+        return [200, 10, 201] + [ord(c) for c in content[:3]] + [202]
+
+
+@pytest.fixture
+def cumulative_gateway_full(mock_vllm: MockVLLMServer):
+    """Cumulative gateway whose renderer implements render_ids (turn 0 included)."""
+    config = GatewayConfig(
+        store_worker="memory",
+        workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
+        health_check_interval=999,
+        sync_traces=True,
+        cumulative_token_mode=False,
+    )
+    app = create_app(config)
+    app.state.proxy.renderer = _MockRendererFull()
+    app.state.proxy.cumulative_token_mode = True
+    server = GatewayServer(app, port=0)
+    server.start()
+    yield server, mock_vllm
+    server.stop()
+
+
+class TestCumulativeTurn0ViaRenderer:
+    """Turn 0 is rendered by the renderer (render_ids) and sent token-in, exactly
+    like turns 2+, so one renderer owns the entire trajectory."""
+
+    def test_turn0_uses_completions_with_token_ids(self, cumulative_gateway_full):
+        server, mock_vllm = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-completions/v1", api_key="dummy")
+        oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])
+
+        assert len(mock_vllm.request_log) == 1
+        req = mock_vllm.request_log[0]
+        # Turn 0 went to /v1/completions (token-in), NOT /chat/completions.
+        assert "messages" not in req
+        assert isinstance(req["prompt"], list) and all(isinstance(t, int) for t in req["prompt"])
+
+    def test_turn0_prompt_equals_render_ids(self, cumulative_gateway_full):
+        server, mock_vllm = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-render/v1", api_key="dummy")
+        oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])
+
+        expected = _MockRendererFull().render_ids([{"role": "user", "content": "Hello"}])
+        assert mock_vllm.request_log[0]["prompt"] == expected
+
+    def test_turn0_returns_parsed_message(self, cumulative_gateway_full):
+        """Turn 0's completion is parsed via the renderer too (not raw worker text)."""
+        server, _ = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-parse/v1", api_key="dummy")
+        resp = oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])
+        assert resp.choices[0].message.content == "parsed answer"  # parsed, not "Hello from mock!"
+
+    def test_single_renderer_trajectory_no_seam(self, cumulative_gateway_full):
+        """The seam fix: turn 1's prompt extends turn 0's render_ids output +
+        completion byte-for-byte — both produced by the same renderer, so there is
+        no chat-template/renderer boundary mismatch."""
+        server, mock_vllm = cumulative_gateway_full
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/t0-seam/v1", api_key="dummy")
+
+        oai.chat.completions.create(model="m", messages=[{"role": "user", "content": "Hello"}])  # turn 0
+        oai.chat.completions.create(  # turn 1
+            model="m",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "More"},
+            ],
+        )
+
+        turn0_prompt = _MockRendererFull().render_ids([{"role": "user", "content": "Hello"}])
+        # mock_vllm echoes the prompt as prompt_token_ids and returns completion [10,11,12].
+        turn1_prompt = mock_vllm.request_log[1]["prompt"]
+        assert turn1_prompt[: len(turn0_prompt) + 3] == turn0_prompt + [10, 11, 12]

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
@@ -1,0 +1,136 @@
+"""Cumulative token mode over the in-process ``local_handler`` (e.g. Tinker).
+
+The HTTP-worker path is covered by ``test_cumulative_token_mode.py``. These
+tests cover the local-handler branch added so backends without a vLLM
+``/v1/completions`` worker (Tinker runs in-process) get the same drift-free
+prefix-extension: turn 2+ samples directly from pre-tokenized prompt IDs built
+by the renderer, and the accumulator ingests the result.
+
+Tests drive the proxy methods directly (no HTTP server) via ``asyncio.run`` to
+avoid a pytest-asyncio dependency.
+"""
+
+import asyncio
+import json
+
+from rllm_model_gateway.proxy import ReverseProxy
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+
+class _State:
+    weight_version = 0
+
+
+class _Request:
+    """Minimal stand-in: the cumulative-local paths only read request.state."""
+
+    state = _State()
+
+
+def _make_proxy(local_handler):
+    """ReverseProxy wired for the local cumulative path (no router/worker)."""
+    return ReverseProxy(
+        router=None,
+        store=MemoryTraceStore(),
+        sync_traces=True,
+        local_handler=local_handler,
+        cumulative_token_mode=True,
+        renderer=None,  # accumulator state is set directly in these tests
+    )
+
+
+def _completion_handler(record):
+    """Fake Tinker token-path handler: echoes ``prompt`` as prompt_token_ids,
+    returns a fixed 2-token completion. Records the body it was called with."""
+
+    async def handler(body):
+        record.append(body)
+        return {
+            "id": "cmpl-x",
+            "object": "text_completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "next action",
+                    "token_ids": [91, 92],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2]},
+                }
+            ],
+            "prompt_token_ids": body["prompt"],
+            "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
+        }
+
+    return handler
+
+
+def test_cumulative_local_non_streaming_ingests_and_translates():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])  # turn 1: prompt + completion already captured
+    bridged = [1, 2, 3, 4, 5, 6, 7]  # what the renderer would produce for turn 2
+
+    completions_body = {"prompt": bridged, "add_special_tokens": False, "model": "q"}
+    resp = asyncio.run(
+        proxy._handle_cumulative_non_streaming(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            completions_body,
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    # The local handler was called with the pre-tokenized prompt, not messages.
+    assert record and record[0]["prompt"] == bridged
+    assert "messages" not in record[0]
+
+    # Response is translated back to chat format for the agent.
+    body = json.loads(resp.body)
+    assert resp.status_code == 200
+    assert body["object"] == "chat.completion"
+    assert body["choices"][0]["message"] == {"role": "assistant", "content": "next action"}
+
+    # Accumulator advanced: prefix-extension holds (bridged starts with prev prompt+completion).
+    assert acc.turn_count == 2
+    assert acc.prev_prompt_ids == bridged
+    assert acc.prev_completion_ids == [91, 92]
+    assert acc.cumulative_ids[: len([1, 2, 3, 4, 5])] == [1, 2, 3, 4, 5]
+
+
+def test_cumulative_local_streaming_emits_sse_and_ingests():
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    bridged = [1, 2, 3, 4, 5, 6, 7]
+
+    resp = asyncio.run(
+        proxy._handle_cumulative_streaming_local(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            {"prompt": bridged},
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    chunks = []
+
+    async def drain():
+        async for c in resp.body_iterator:
+            chunks.append(c if isinstance(c, str) else c.decode())
+
+    asyncio.run(drain())
+
+    assert any('"role": "assistant"' in c for c in chunks)
+    assert any('"next action"' in c for c in chunks)
+    assert chunks[-1].strip().endswith("[DONE]")
+    # Same ingest as non-streaming.
+    assert acc.turn_count == 2 and acc.prev_completion_ids == [91, 92]

--- a/rllm-model-gateway/tests/unit/test_renderer_injection.py
+++ b/rllm-model-gateway/tests/unit/test_renderer_injection.py
@@ -1,0 +1,57 @@
+"""Cumulative-mode renderer injection into create_app.
+
+The gateway stays free of tinker/Fireworks deps: for models prime-rl lacks, the
+in-process GatewayManager builds the renderer on the rllm side and injects it.
+These tests cover the gateway-side contract (accept an injected renderer; reject
+one without a bridge) without importing rllm.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rllm_model_gateway.models import GatewayConfig
+from rllm_model_gateway.server import _renderer_has_bridge, create_app
+
+
+class _FakeBridgeRenderer:
+    has_bridge = True
+
+    def bridge_to_next_turn(self, *a, **k):
+        return None
+
+
+class _FakeNoBridgeRenderer:
+    has_bridge = False
+
+
+def test_renderer_has_bridge_flag_and_default_renderer():
+    assert _renderer_has_bridge(_FakeBridgeRenderer()) is True
+    assert _renderer_has_bridge(_FakeNoBridgeRenderer()) is False
+
+    class DefaultRenderer:  # prime-rl's no-bridge fallback, detected by name
+        pass
+
+    assert _renderer_has_bridge(DefaultRenderer()) is False
+
+    class Qwen3Renderer:  # prime-rl hand-coded renderer (no has_bridge attr)
+        pass
+
+    assert _renderer_has_bridge(Qwen3Renderer()) is True
+
+
+def test_create_app_accepts_injected_renderer():
+    cfg = GatewayConfig(cumulative_token_mode=True)  # no model needed when injected
+    app = create_app(config=cfg, renderer=_FakeBridgeRenderer())
+    assert app is not None
+
+
+def test_create_app_rejects_injected_renderer_without_bridge():
+    cfg = GatewayConfig(cumulative_token_mode=True)
+    with pytest.raises(ValueError, match="no cross-turn bridge"):
+        create_app(config=cfg, renderer=_FakeNoBridgeRenderer())
+
+
+def test_create_app_requires_model_when_not_injected():
+    cfg = GatewayConfig(cumulative_token_mode=True)  # no model, no injection
+    with pytest.raises(ValueError, match="requires 'model'"):
+        create_app(config=cfg)

--- a/rllm-model-gateway/tests/unit/test_token_accumulator.py
+++ b/rllm-model-gateway/tests/unit/test_token_accumulator.py
@@ -243,3 +243,67 @@ class TestExtractNewMessages:
             {"role": "tool", "content": "result"},
             {"role": "user", "content": "thanks"},
         ]
+
+
+class TestDivergenceDiagnostics:
+    """The reset-cause diagnostics that distinguish prefix mutation vs shrink."""
+
+    def _acc(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(renderer=_MockRenderer())
+        base = [{"role": "system", "content": "s"}, {"role": "user", "content": "u0"}]
+        acc.ingest_turn([1, 2, 3], [4, 5])
+        acc.update_prefix(base)
+        return acc, base
+
+    def test_divergence_clean_on_append_only_extension(self):
+        acc, base = self._acc()
+        ext = base + [{"role": "assistant", "content": "a0"}, {"role": "user", "content": "u1"}]
+        assert acc.is_cumulative(ext) is True
+        assert acc.divergence(ext) == ("clean", -1)
+
+    def test_divergence_changed_when_prefix_message_mutated(self):
+        acc, _ = self._acc()
+        mutated = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u0-EDITED"},  # msg 1 changed
+            {"role": "assistant", "content": "a0"},
+        ]
+        assert acc.is_cumulative(mutated) is False
+        assert acc.divergence(mutated) == ("changed", 1)
+
+    def test_divergence_shrunk_on_summarization(self):
+        acc, _ = self._acc()
+        shorter = [{"role": "system", "content": "s"}]  # history collapsed
+        assert acc.is_cumulative(shorter) is False
+        assert acc.divergence(shorter) == ("shrunk", 1)
+
+    def test_divergence_duplicate_on_identical_resend(self):
+        acc, base = self._acc()
+        # Re-send the exact same messages the gateway already folded (a retry).
+        assert acc.is_cumulative(list(base)) is False  # len == message_count
+        assert acc.divergence(list(base)) == ("duplicate", 2)
+
+    def test_resample_completion_preserves_chain(self):
+        acc, _ = self._acc()  # turn 1 folded: prev_prompt=[1,2,3], prev_completion=[4,5]
+        acc.resample_completion([9, 9, 9])
+        assert acc.prev_completion_ids == [9, 9, 9]  # completion swapped
+        assert acc.prev_prompt_ids == [1, 2, 3]  # prompt unchanged
+        assert acc.turn_count == 1  # NOT advanced — same turn re-sampled
+        assert acc.message_count == 2  # unchanged
+
+    def test_record_outcome_and_reset(self):
+        acc, _ = self._acc()
+        acc.record_outcome("length", 16384)
+        assert acc.last_finish_reason == "length"
+        assert acc.last_completion_len == 16384
+        acc.reset()
+        assert acc.last_finish_reason is None
+        assert acc.last_completion_len == 0
+
+    def test_reset_accepts_reason(self):
+        acc, _ = self._acc()
+        acc.reset("prefix not append-only: msg 1 (role=user) changed")
+        assert acc.turn_count == 0 and acc.message_count == 0
+        assert acc._prefix_msg_fingerprints == []

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -18,6 +18,7 @@ is inherited from ``TinkerEngine``.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import dataclasses
 import logging
 from typing import Any
@@ -28,7 +29,9 @@ from typing_extensions import override
 from rllm.engine.rollout.rollout_engine import ModelOutput
 from rllm.engine.rollout.tinker_engine import (
     TinkerEngine,
+    _convert_openai_messages,
     _flat_token_input_length,
+    _prepare_messages_with_tools,
 )
 from rllm.engine.rollout.types import (
     TinkerTokenInput,
@@ -49,6 +52,39 @@ _TRANSIENT_ERROR_MARKERS = (
     "_SSETruncationError",
     "closed the SSE stream mid-generation",
 )
+
+
+# Per-request inference headers (e.g. Fireworks session-affinity) injected into
+# DeploymentSampler requests. ``DeploymentSampler.async_completions_stream`` only
+# forwards body params and a fixed set of client-level headers, so there is no
+# per-call header hook; we patch ``_inference_headers`` to merge whatever the
+# current async context stashed here. A ContextVar is async-safe — each rollout
+# task carries its own copy, so concurrent trajectories don't clobber each
+# other's session-affinity key.
+_per_request_headers: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar("rllm_fw_request_headers", default=None)
+
+
+def _install_inference_header_patch() -> None:
+    """Patch ``DeploymentSampler._inference_headers`` to merge per-request headers.
+
+    Idempotent: re-imports / repeated calls are no-ops.
+    """
+    orig = DeploymentSampler._inference_headers
+    if getattr(orig, "_rllm_session_affinity_patch", False):
+        return
+
+    def _inference_headers(self):  # noqa: ANN001 - matches SDK signature
+        headers = orig(self)
+        extra = _per_request_headers.get()
+        if extra:
+            headers = {**headers, **extra}
+        return headers
+
+    _inference_headers._rllm_session_affinity_patch = True  # type: ignore[attr-defined]
+    DeploymentSampler._inference_headers = _inference_headers
+
+
+_install_inference_header_patch()
 
 
 class _EmptyCompletionIdsError(RuntimeError):
@@ -86,6 +122,11 @@ class FireworksEngine(TinkerEngine):
     ``TinkerTokenOutput`` are fully supported.
     """
 
+    # Signals the gateway handler to forward a per-trajectory ``rllm_session_id``
+    # so this engine can set Fireworks session-affinity headers (prefix-cache
+    # reuse across a rollout's turns). Other engines ignore the session id.
+    supports_session_affinity = True
+
     def __init__(
         self,
         tokenizer: Tokenizer,
@@ -100,6 +141,7 @@ class FireworksEngine(TinkerEngine):
         sample_timeout: int = 600,
         processor=None,
         router_replay: bool = False,
+        cumulative_token_mode: bool = False,
         **kwargs,
     ):
         """
@@ -137,13 +179,63 @@ class FireworksEngine(TinkerEngine):
         self.train_sampling_params = dict((sampling_params or {}).get("train", {}))
         self.val_sampling_params = dict((sampling_params or {}).get("val", {}))
 
-        # Chat template parser (same setup as TinkerEngine bypass mode)
-        self.bypass_render_with_parser = True
-        self.chat_parser = ChatTemplateParser.get_parser(
-            tokenizer,
-            processor=processor,
-            disable_thinking=disable_thinking,
-        )
+        # Rendering setup.
+        #
+        # Cumulative token mode: the gateway renders EVERY turn (turn-0 via the
+        # renderer's render_ids, turns 2+ via bridge_to_next_turn) and parses the
+        # completion via the renderer too, so the engine is a pure token-in /
+        # token-out sampler — it never renders messages or parses completions.
+        # We therefore build no ChatTemplateParser (which would crash here for
+        # models whose Jinja template the parser's equivalence self-check can't
+        # render, e.g. GLM) and no tinker renderer. assemble_model_output uses the
+        # raw-decode branch; get_model_response (the chat path) is never called.
+        self.cumulative_token_mode = cumulative_token_mode
+        self.raw_token_mode = cumulative_token_mode
+        self.renderer = None
+        if cumulative_token_mode:
+            self.chat_parser = None
+            self.bypass_render_with_parser = False
+            self.sample_timeout = sample_timeout
+            self.router_replay = router_replay
+            self.sampling_client = sampler
+            return
+        # Non-cumulative. Default: ChatTemplateParser bypass mode (Jinja
+        # chat-template models). Some models (e.g. DeepSeek-V4) ship no Jinja
+        # chat_template — they use a hand-rolled encoder exposed via the
+        # tinker/Fireworks renderer. Fall back to that renderer, using the
+        # non-bypass path the inherited assemble_model_output already supports.
+        try:
+            self.chat_parser = ChatTemplateParser.get_parser(
+                tokenizer,
+                processor=processor,
+                disable_thinking=disable_thinking,
+            )
+            self.bypass_render_with_parser = True
+        except Exception as err:
+            from tinker_cookbook import renderers as tc_renderers
+
+            from rllm.renderers._fw_register import ensure_registered
+            from rllm.renderers._tinker import tinker_renderer_name
+
+            model_name = getattr(tokenizer, "name_or_path", None)
+            ensure_registered()
+            renderer_name = tinker_renderer_name(model_name)
+            if renderer_name is None:
+                raise ValueError(
+                    f"FireworksEngine: tokenizer for {model_name!r} has no Jinja chat_template "
+                    "and no tinker/Fireworks renderer is registered for it. Add the model to "
+                    "rllm.renderers._tinker._FW_MODEL_RENDERER, or serve a model with a chat "
+                    "template."
+                ) from err
+            logger.info(
+                "No usable chat_template for %r (%s); rendering via tinker/Fireworks renderer %r.",
+                model_name,
+                err,
+                renderer_name,
+            )
+            self.chat_parser = None
+            self.bypass_render_with_parser = False
+            self.renderer = tc_renderers.get_renderer(renderer_name, tokenizer)
 
         self.sample_timeout = sample_timeout
         self.router_replay = router_replay
@@ -155,21 +247,39 @@ class FireworksEngine(TinkerEngine):
 
     @override
     async def get_model_response(self, messages: list[dict], **kwargs) -> ModelOutput:
+        if self.raw_token_mode:
+            raise RuntimeError(
+                "FireworksEngine is in cumulative_token_mode (token-in/token-out only): the "
+                "gateway renders every turn, so get_model_response (message rendering) must not "
+                "be called. This means turn-0 fell back to the chat path because the gateway "
+                "renderer could not render the initial messages — fix the renderer/renderer_family "
+                "(it must not resolve to DefaultRenderer) rather than the engine."
+            )
         application_id = kwargs.pop("application_id", None)
 
         tools = kwargs.pop("tools", [])
         accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.accumulate_reasoning)
         reasoning_effort = kwargs.pop("reasoning_effort", self.reasoning_effort)
 
-        prompt = self.chat_parser.parse(
-            messages,
-            add_generation_prompt=True,
-            is_first_msg=True,
-            tools=tools,
-            reasoning_effort=reasoning_effort,
-            accumulate_reasoning=accumulate_reasoning,
-        )
-        token_input = self.tokenizer.encode(prompt, add_special_tokens=False)
+        if self.bypass_render_with_parser:
+            prompt = self.chat_parser.parse(
+                messages,
+                add_generation_prompt=True,
+                is_first_msg=True,
+                tools=tools,
+                reasoning_effort=reasoning_effort,
+                accumulate_reasoning=accumulate_reasoning,
+            )
+            token_input = self.tokenizer.encode(prompt, add_special_tokens=False)
+        else:
+            # No chat_template: render via the tinker/Fireworks renderer (same
+            # path as TinkerEngine's non-bypass mode; parsed back by the
+            # inherited assemble_model_output).
+            converted = self._convert_images_to_content_list(messages)
+            tinker_messages = _convert_openai_messages(converted)
+            if tools:
+                tinker_messages = _prepare_messages_with_tools(self.renderer, tinker_messages, tools)
+            token_input = self.renderer.build_generation_prompt(tinker_messages).to_ints()
 
         if application_id is not None:
             kwargs["user"] = application_id
@@ -237,6 +347,10 @@ class FireworksEngine(TinkerEngine):
         requested_max_tokens = sampling_params.pop("max_tokens", requested_max_tokens)
         max_tokens = self._prepare_max_tokens(requested_max_tokens, input_length)
 
+        # Per-trajectory session id (gateway forwards it for affinity); it must
+        # NOT leak into the request body, so pop it before building sampling params.
+        session_id = kwargs.pop("rllm_session_id", None)
+
         for key in ("temperature", "top_p", "top_k", "user", "reasoning_effort"):
             if key in kwargs:
                 sampling_params[key] = kwargs.pop(key)
@@ -247,10 +361,21 @@ class FireworksEngine(TinkerEngine):
         if self.router_replay:
             sampling_params["include_routing_matrix"] = True
 
+        # Fireworks routes requests carrying the same session id to the same
+        # replica, so its per-replica prompt-prefix KV is reused across a
+        # trajectory's turns. Set once per turn from the trajectory id.
+        session_headers = None
+        if session_id:
+            session_headers = {
+                "x-multi-turn-session-id": str(session_id),
+                "x-session-affinity": str(session_id),
+            }
+
         raw, server_metrics = await self._completions_with_retry(
             prompt_ids,
             max_tokens,
             sampling_params,
+            session_headers=session_headers,
         )
 
         choice = raw["choices"][0]
@@ -296,21 +421,30 @@ class FireworksEngine(TinkerEngine):
         prompt_ids: list[int],
         max_tokens: int,
         sampling_kwargs: dict[str, Any],
+        session_headers: dict[str, str] | None = None,
     ) -> tuple[dict[str, Any], dict | None]:
         """Call ``DeploymentSampler.async_completions_stream`` with transient-error retries.
 
-        Returns (response_dict, server_metrics_dict)."""
+        ``session_headers``, when given, are merged into the request's HTTP
+        headers (via the ``_inference_headers`` patch) so Fireworks routes this
+        request to the trajectory's pinned replica. Returns
+        (response_dict, server_metrics_dict)."""
 
         for attempt in range(_MAX_SAMPLE_ATTEMPTS):
             try:
-                result, server_metrics = await self.sampling_client.async_completions_stream(
-                    prompt=prompt_ids,
-                    max_tokens=max_tokens,
-                    raw_output=True,
-                    logprobs=True,
-                    http_timeout=self.sample_timeout,
-                    **sampling_kwargs,
-                )
+                token = _per_request_headers.set(session_headers) if session_headers else None
+                try:
+                    result, server_metrics = await self.sampling_client.async_completions_stream(
+                        prompt=prompt_ids,
+                        max_tokens=max_tokens,
+                        raw_output=True,
+                        logprobs=True,
+                        http_timeout=self.sample_timeout,
+                        **sampling_kwargs,
+                    )
+                finally:
+                    if token is not None:
+                        _per_request_headers.reset(token)
                 metrics_dict = {k: v for k, v in dataclasses.asdict(server_metrics).items() if v is not None} if server_metrics else None
                 choice = (result.get("choices") or [{}])[0]
                 completion_ids = (choice.get("raw_output") or {}).get("completion_token_ids") or []

--- a/rllm/engine/rollout/tinker_engine.py
+++ b/rllm/engine/rollout/tinker_engine.py
@@ -339,7 +339,16 @@ class TinkerEngine(RolloutEngine):
         sampled_sequence = cast(TinkerTokenOutput, token_output)
         response_tokens, logprobs = sampled_sequence.tokens, sampled_sequence.logprobs
 
-        if self.bypass_render_with_parser:
+        if getattr(self, "raw_token_mode", False):
+            # Cumulative token mode: the gateway re-parses the completion token IDs
+            # with the renderer (renderer.parse_response) to build the structured
+            # assistant message, so the engine does no parsing — just expose the
+            # raw decoded text (used only as the gateway's fallback) plus the raw
+            # token IDs. No chat_parser / renderer is built in this mode.
+            content = self.tokenizer.decode(response_tokens, skip_special_tokens=True)  # type: ignore
+            reasoning = ""
+            tool_calls = []
+        elif self.bypass_render_with_parser:
             assert self.chat_parser is not None, "chat_parser must be set when bypass_render_with_parser=True"
             parsed_output = self.chat_parser.parse_completion(response_tokens)
             content = parsed_output.get("content", "")

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -4,7 +4,7 @@ Two classes share most of the lifecycle (uvicorn-on-thread or subprocess,
 trace store, session API). They differ in how upstream workers are
 registered and what request-body injection the middleware applies.
 
-* :class:`GatewayManager` — training. Workers come from a verl/tinker
+* :class:`GatewayManager` — training. Workers come from a verl/tinker/fireworks
   rollout engine via :meth:`start(rollout_engine)`. Injects ``logprobs``
   and ``return_token_ids`` into request bodies (vLLM needs both for the
   loss math downstream).
@@ -159,8 +159,8 @@ class GatewayManager:
         from rllm.gateway.tunnel import parse_tunnel
 
         self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
-        # The gateway always pins ``body.model`` to whatever the trainer is serving
-        self.model: str | None = config.get("model", {}).get("name", None)
+        _model_cfg = config.get("model", {})
+        self.model: str | None = _model_cfg.get("tokenizer_model") or _model_cfg.get("name", None)
 
         # Cumulative token mode: drift-free multi-turn token forwarding. The
         # gateway loads the tokenizer from the served model path. renderers
@@ -207,11 +207,11 @@ class GatewayManager:
         """Start the gateway and register inference workers.
 
         For VerlEngine: registers the existing vLLM server addresses.
-        For TinkerEngine: creates an in-process handler (no sidecar needed).
+        For TinkerEngine / FireworksEngine: creates an in-process handler (no sidecar needed).
         """
         engine_cls = type(rollout_engine).__name__
 
-        if engine_cls == "TinkerEngine":
+        if engine_cls in ("TinkerEngine", "FireworksEngine"):
             # In-process handler — no HTTP backend, no worker registration
             from rllm.gateway.tinker_adapter import create_tinker_handler
 
@@ -227,6 +227,7 @@ class GatewayManager:
             for url in worker_urls:
                 worker_id = self.client.add_worker(url=url)
                 logger.info("Registered worker %s -> %s", worker_id, url)
+
         else:
             logger.warning("Unknown engine type %s — no workers registered", engine_cls)
 
@@ -384,6 +385,40 @@ class GatewayManager:
         self._process.terminate()
         raise TimeoutError(f"Gateway did not become healthy within {_HEALTH_POLL_TIMEOUT}s")
 
+    def _build_cumulative_renderer(self) -> Any:
+        """Build the cumulative-mode renderer on the rllm side for injection.
+
+        Returns ``None`` when cumulative mode is off or no model is set (the
+        gateway then builds a prime-rl renderer from config itself). Routes via
+        ``rllm.renderers.resolve``: prime-rl for supported models (token bridge),
+        the tinker/Fireworks adapter (with a generic bridge) for the rest
+        (DeepSeek-V4, Gemma-4, …).
+        """
+        if not self.cumulative_token_mode or not self.model:
+            return None
+        try:
+            from transformers import AutoTokenizer
+
+            from rllm.renderers import resolve
+
+            tokenizer = AutoTokenizer.from_pretrained(self.model)
+            family = self.renderer_family if self.renderer_family and self.renderer_family != "auto" else None
+            renderer = resolve(self.model, tokenizer, renderer_family=family)
+            logger.info(
+                "Injecting %s for cumulative token mode (model=%s, has_bridge=%s)",
+                type(renderer).__name__,
+                self.model,
+                getattr(renderer, "has_bridge", "?"),
+            )
+            return renderer
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                "Could not build a cumulative-mode renderer for %s (%s); the gateway will build a prime-rl renderer from config instead.",
+                self.model,
+                err,
+            )
+            return None
+
     def _start_thread(self, local_handler: Any = None) -> None:
         """Start gateway in a background thread using create_app + uvicorn."""
         import uvicorn
@@ -401,7 +436,15 @@ class GatewayManager:
             cumulative_token_mode=self.cumulative_token_mode,
             renderer_family=self.renderer_family,
         )
-        app = create_app(config=gw_config, local_handler=local_handler)
+
+        # In-process (thread) mode: build the cumulative-mode renderer here, on the
+        # rllm side, and inject it. This keeps the gateway package free of
+        # tinker/Fireworks deps while still supporting models prime-rl lacks (e.g.
+        # DeepSeek-V4) — rllm.renderers.resolve routes those to the tinker/Fireworks
+        # renderer with a generic cross-turn bridge. prime-rl-supported models
+        # resolve to prime-rl (token bridge), same as before.
+        injected_renderer = self._build_cumulative_renderer()
+        app = create_app(config=gw_config, local_handler=local_handler, renderer=injected_renderer)
 
         uvi_config = uvicorn.Config(
             app,

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -17,6 +17,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from rllm.engine.rollout.tinker_engine import TinkerEngine
+from rllm.workflows import TerminationEvent, TerminationReason
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,82 @@ def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
     return result
 
 
+def _termination_http_error(reason: TerminationReason) -> Exception:
+    """Map a ``TerminationEvent`` to a non-retryable OpenAI-style 400.
+
+    For CLI harnesses the agent loop runs inside the sandbox, so the only way
+    to stop it is the HTTP response — a 500 makes the LLM client retry the
+    (still-too-long) call until the harness run-timeout SIGKILLs it, stalling
+    the whole group. ``context_length_exceeded`` maps to a NON-retryable
+    ContextWindowExceededError in litellm/openai SDKs, so the agent raises and
+    the rollout returns immediately with the turns so far.
+    """
+    from fastapi import HTTPException
+
+    is_prompt_limit = reason == TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED
+    return HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": f"Rollout terminated: {reason}. The conversation exceeded the model's prompt window.",
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded" if is_prompt_limit else "rollout_terminated",
+                "param": "messages",
+            }
+        },
+    )
+
+
+async def _token_prompt_completion(
+    engine: TinkerEngine,
+    request_body: dict[str, Any],
+    prompt_ids: list[int],
+    sampling_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Sample from a pre-tokenized prompt (cumulative-token mode).
+
+    Bypasses message rendering entirely: ``prompt_ids`` is fed straight to the
+    engine's token-input sampler. Returns a **completions-style** response dict
+    (``choices[0].text`` + ``token_ids``, root ``prompt_token_ids``,
+    ``logprobs.token_logprobs``) — the exact shape the gateway's cumulative-turn
+    handler extracts token IDs from and translates back to chat format.
+    """
+    token_output = await engine.get_token_output_from_token_input(prompt_ids, **sampling_kwargs)
+    model_output = engine.assemble_model_output(prompt_ids, token_output)
+
+    # Text the agent sees as the assistant turn (same precedence as the chat path).
+    text = model_output.content or model_output.text or ""
+    out_prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else list(prompt_ids)
+    completion_ids = list(model_output.completion_ids) if model_output.completion_ids else []
+    logprobs = model_output.logprobs or []
+    finish_reason = model_output.finish_reason or "stop"
+    prompt_len = model_output.prompt_length or len(out_prompt_ids)
+    completion_len = model_output.completion_length or len(completion_ids)
+
+    return {
+        "id": f"cmpl-{uuid.uuid4().hex[:12]}",
+        "object": "text_completion",
+        "created": int(time.time()),
+        "model": request_body.get("model", getattr(engine, "model_name", "default")),
+        "choices": [
+            {
+                "index": 0,
+                "text": text,
+                "token_ids": completion_ids,
+                "finish_reason": finish_reason,
+                "logprobs": {"token_logprobs": logprobs},
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_len,
+            "completion_tokens": completion_len,
+            "total_tokens": prompt_len + completion_len,
+        },
+        "prompt_token_ids": out_prompt_ids,
+        "weight_version": getattr(model_output, "weight_version", None),
+    }
+
+
 def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
     """Return an async handler that calls TinkerEngine in-process.
 
@@ -50,24 +127,50 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
     """
 
     async def handler(request_body: dict[str, Any]) -> dict[str, Any]:
+        # Sampling params shared by the chat and pre-tokenized paths.
+        sampling_kwargs: dict[str, Any] = {}
+        if request_body.get("temperature") is not None:
+            sampling_kwargs["temperature"] = request_body["temperature"]
+        if request_body.get("top_p") is not None:
+            sampling_kwargs["top_p"] = request_body["top_p"]
+        if request_body.get("top_k") is not None:
+            sampling_kwargs["top_k"] = request_body["top_k"]
+        if request_body.get("max_tokens") is not None:
+            sampling_kwargs["max_tokens"] = request_body["max_tokens"]
+        if request_body.get("max_completion_tokens") is not None:
+            sampling_kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
+
+        # Per-trajectory session id (injected by the gateway) — forwarded only to
+        # engines that use it for inference session affinity (Fireworks prefix-cache
+        # reuse across a rollout's turns). Popped so it never reaches a chat body.
+        session_id = request_body.pop("rllm_session_id", None)
+        if session_id and getattr(engine, "supports_session_affinity", False):
+            sampling_kwargs["rllm_session_id"] = session_id
+
+        # Cumulative-token-mode path: the gateway rewrites turn 2+ to a
+        # completions-style request whose ``prompt`` is raw token IDs built by
+        # ``renderers.bridge_to_next_turn`` (= prior turns' prompt+completion
+        # tokens + the new messages). Sample straight from those tokens — no
+        # re-render, no re-tokenization — so the sequence the optimizer trains on
+        # is byte-for-byte what was generated. Mirrors the vLLM /v1/completions
+        # path the HTTP backend uses for the same feature.
+        prompt = request_body.get("prompt")
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            try:
+                return await _token_prompt_completion(engine, request_body, prompt, sampling_kwargs)
+            except TerminationEvent as e:
+                raise _termination_http_error(e.reason) from e
+
         messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
-
-        kwargs: dict[str, Any] = {}
+        kwargs = dict(sampling_kwargs)
         if tools:
             kwargs["tools"] = tools
-        if request_body.get("temperature") is not None:
-            kwargs["temperature"] = request_body["temperature"]
-        if request_body.get("top_p") is not None:
-            kwargs["top_p"] = request_body["top_p"]
-        if request_body.get("top_k") is not None:
-            kwargs["top_k"] = request_body["top_k"]
-        if request_body.get("max_tokens") is not None:
-            kwargs["max_tokens"] = request_body["max_tokens"]
-        if request_body.get("max_completion_tokens") is not None:
-            kwargs["max_completion_tokens"] = request_body["max_completion_tokens"]
 
-        model_output = await engine.get_model_response(messages, **kwargs)
+        try:
+            model_output = await engine.get_model_response(messages, **kwargs)
+        except TerminationEvent as e:
+            raise _termination_http_error(e.reason) from e
 
         response_text = model_output.content or model_output.text or ""
         prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else []

--- a/rllm/renderers/__init__.py
+++ b/rllm/renderers/__init__.py
@@ -1,0 +1,62 @@
+"""rLLM-native renderer layer.
+
+A single token-level renderer interface for training, with a registry that routes
+each model to the strongest available backend:
+
+- **prime-rl** (``renderers``) — token-level with a real cross-turn
+  ``bridge_to_next_turn``; preferred for RL multi-turn rollouts.
+- **tinker-cookbook / Fireworks** (``training.renderer``) — broader model
+  coverage (DeepSeek-V4-Flash, Gemma-4, Ministral-3, Kimi-K2.7-code, …), adapted
+  to the same interface.
+
+Typical use::
+
+    from rllm.renderers import resolve
+
+    renderer = resolve("Qwen/Qwen3-8B", tokenizer)            # -> prime-rl (bridge)
+    renderer = resolve("deepseek-ai/DeepSeek-V4-Flash", tok)  # -> Fireworks adapter
+    ids = renderer.render_ids(messages, add_generation_prompt=True)
+    parsed = renderer.parse_response(completion_ids)
+    nxt = renderer.bridge_to_next_turn(prev_prompt, prev_completion, new_msgs)
+"""
+
+from __future__ import annotations
+
+from rllm.renderers._fw_register import FIREWORKS_AVAILABLE
+from rllm.renderers._prime import PRIME_AVAILABLE
+from rllm.renderers._tinker import TINKER_AVAILABLE
+from rllm.renderers.registry import (
+    Backend,
+    RendererResolution,
+    describe,
+    resolve,
+    select_backend,
+)
+from rllm.renderers.types import (
+    Message,
+    ParsedResponse,
+    RenderedTokens,
+    Renderer,
+    ToolCall,
+    ToolSpec,
+)
+
+__all__ = [
+    # Types / protocol
+    "Renderer",
+    "RenderedTokens",
+    "ParsedResponse",
+    "ToolCall",
+    "ToolSpec",
+    "Message",
+    # Registry
+    "resolve",
+    "select_backend",
+    "describe",
+    "Backend",
+    "RendererResolution",
+    # Backend availability
+    "PRIME_AVAILABLE",
+    "TINKER_AVAILABLE",
+    "FIREWORKS_AVAILABLE",
+]

--- a/rllm/renderers/_common.py
+++ b/rllm/renderers/_common.py
@@ -1,0 +1,89 @@
+"""Backend-agnostic normalization helpers shared by the renderer backends."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from rllm.renderers.types import ToolSpec
+from rllm.tools.tool_base import ToolCall
+
+
+def iter_tool_specs(
+    tools: list[ToolSpec] | list[dict[str, Any]] | None,
+) -> list[ToolSpec]:
+    """Normalize a heterogeneous ``tools`` argument to a list of :class:`ToolSpec`.
+
+    Accepts native ``ToolSpec`` objects, OpenAI-style ``{"type": "function",
+    "function": {...}}`` dicts, and bare ``{"name", "description", "parameters"}``
+    dicts. Non-function tool dicts are skipped (mirrors
+    ``TinkerEngine._build_messages_with_tools``).
+    """
+    if not tools:
+        return []
+    out: list[ToolSpec] = []
+    for tool in tools:
+        if isinstance(tool, ToolSpec):
+            out.append(tool)
+            continue
+        if not isinstance(tool, dict):
+            raise TypeError(f"Unrecognized tool spec type: {type(tool)}")
+        if "function" in tool:
+            if tool.get("type", "function") != "function":
+                continue
+            func = tool["function"]
+        elif "name" in tool:
+            func = tool
+        else:
+            # Not a recognizable function tool (e.g. {"type": "web_search"}); skip.
+            continue
+        out.append(
+            ToolSpec(
+                name=func["name"],
+                description=func.get("description", ""),
+                parameters=func.get("parameters", {}),
+            )
+        )
+    return out
+
+
+def normalize_tool_calls(raw_tool_calls: Any) -> list[ToolCall]:
+    """Convert backend tool-call objects to rLLM :class:`ToolCall` (name/arguments).
+
+    Handles prime-rl / tinker-cookbook ``ToolCall(function=FunctionBody(...))``,
+    flat ``ToolCall(name, arguments)``, and dict forms. Mirrors the conversion in
+    ``TinkerEngine._parse_tinker_message``.
+    """
+    if not raw_tool_calls:
+        return []
+    calls: list[ToolCall] = []
+    for tc in raw_tool_calls:
+        if isinstance(tc, ToolCall):
+            calls.append(tc)
+        elif hasattr(tc, "function"):
+            args = tc.function.arguments
+            calls.append(
+                ToolCall(
+                    name=tc.function.name,
+                    arguments=json.loads(args) if isinstance(args, str) else args,
+                )
+            )
+        elif hasattr(tc, "name") and hasattr(tc, "arguments"):
+            args = tc.arguments
+            calls.append(
+                ToolCall(
+                    name=tc.name,
+                    arguments=json.loads(args) if isinstance(args, str) else (args or {}),
+                )
+            )
+        elif isinstance(tc, dict):
+            args = tc.get("arguments", {})
+            calls.append(
+                ToolCall(
+                    name=tc.get("name", ""),
+                    arguments=json.loads(args) if isinstance(args, str) else (args or {}),
+                )
+            )
+        else:
+            raise TypeError(f"Unrecognized tool_call type: {type(tc)}")
+    return calls

--- a/rllm/renderers/_fw_register.py
+++ b/rllm/renderers/_fw_register.py
@@ -1,0 +1,52 @@
+"""Activate the Fireworks cookbook renderers.
+
+``fireworks-training-cookbook`` ships renderers (``deepseek_v4``, ``gemma4``,
+``kimi_k27_code``, ``glm5``, ``minimax_m2``, ``nemotron``, plus disaggregate
+re-registrations of ``qwen3`` / ``deepseekv3`` / ``nemotron3`` / ``gpt_oss``)
+that register themselves with ``tinker_cookbook.renderers`` **only when the
+``training.renderer`` package is imported**. Nothing in rLLM imported it, so
+those renderers were installed but unreachable via ``get_renderer``.
+
+The actual import is deferred to :func:`ensure_registered` (called from the
+tinker backend when it builds a renderer), so merely importing ``rllm.renderers``
+does not pull in the cookbook. ``FIREWORKS_AVAILABLE`` reports importability
+cheaply via ``find_spec``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _detect() -> bool:
+    # Probe the top-level ``training`` package only (no import of its submodules),
+    # so the availability flag stays cheap. The real import + registration happens
+    # in ``ensure_registered``.
+    try:
+        return importlib.util.find_spec("training") is not None
+    except Exception as err:  # noqa: BLE001 - parent package import can fail
+        logger.debug("Fireworks cookbook not importable: %s", err)
+        return False
+
+
+FIREWORKS_AVAILABLE: bool = _detect()
+
+_registered: bool = False
+
+
+def ensure_registered() -> bool:
+    """Import ``training.renderer`` once so its renderers register with
+    tinker_cookbook. Idempotent; returns whether registration succeeded."""
+    global _registered
+    if _registered:
+        return True
+    try:
+        import training.renderer  # noqa: F401  (import side effect registers renderers)
+
+        _registered = True
+    except Exception as err:  # noqa: BLE001
+        logger.debug("Fireworks cookbook renderers unavailable: %s", err)
+    return _registered

--- a/rllm/renderers/_prime.py
+++ b/rllm/renderers/_prime.py
@@ -1,0 +1,185 @@
+"""prime-rl (``renderers``) backend, adapted to the native :class:`Renderer`.
+
+prime-rl renderers already speak the native token-level contract (``render_ids`` /
+``parse_response`` / ``get_stop_token_ids`` / ``bridge_to_next_turn``). This
+wrapper only normalizes the boundary types — tools in (→ prime ``ToolSpec``) and
+results out (→ native ``RenderedTokens`` / ``ParsedResponse`` with rLLM
+``ToolCall``) — so a resolved renderer behaves identically regardless of backend.
+
+This is the RL-preferred backend: it is the only one whose ``bridge_to_next_turn``
+can return a real prefix-extension (drift-free multi-turn token forwarding).
+
+Heavy imports are deferred: ``import rllm.renderers`` only checks that the
+``renderers`` package is importable (via ``find_spec``); the package itself —
+which pulls in ``transformers`` — is imported on first use.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from typing import Any
+
+from rllm.renderers._common import iter_tool_specs, normalize_tool_calls
+from rllm.renderers.types import Message, ParsedResponse, RenderedTokens, ToolSpec
+
+logger = logging.getLogger(__name__)
+
+PRIME_AVAILABLE: bool = importlib.util.find_spec("renderers") is not None
+
+_prime_module: Any | None = None
+_model_renderer_map: dict[str, str] | None = None
+
+
+def _prime():
+    """Lazily import and cache the prime-rl ``renderers`` package."""
+    global _prime_module
+    if _prime_module is None:
+        import renderers as _module  # type: ignore
+
+        _prime_module = _module
+    return _prime_module
+
+
+def _model_map() -> dict[str, str]:
+    """Lazily import and cache prime-rl's ``MODEL_RENDERER_MAP``."""
+    global _model_renderer_map
+    if _model_renderer_map is None:
+        try:
+            from renderers.base import MODEL_RENDERER_MAP  # type: ignore
+
+            _model_renderer_map = dict(MODEL_RENDERER_MAP)
+        except Exception as err:  # noqa: BLE001
+            logger.debug("Could not load prime-rl MODEL_RENDERER_MAP: %s", err)
+            _model_renderer_map = {}
+    return _model_renderer_map
+
+
+def prime_supports(model_name: str | None) -> bool:
+    """True iff prime-rl has a hand-coded renderer for ``model_name``.
+
+    Auto-detect is exact-match on the HF id (prefix matching is intentionally
+    off upstream), so we check membership in ``MODEL_RENDERER_MAP`` rather than
+    trusting ``create_renderer`` (which always returns a ``DefaultRenderer``
+    fallback for unknown ids).
+    """
+    if not PRIME_AVAILABLE or not model_name:
+        return False
+    return model_name in _model_map()
+
+
+def _to_prime_tools(tools: list[ToolSpec] | list[dict[str, Any]] | None):
+    specs = iter_tool_specs(tools)
+    if not specs:
+        return None
+    from renderers.base import ToolSpec as PrimeToolSpec  # type: ignore
+
+    return [PrimeToolSpec(name=s.name, description=s.description, parameters=s.parameters) for s in specs]
+
+
+def _wrap_rendered(rt: Any) -> RenderedTokens:
+    return RenderedTokens(
+        token_ids=list(rt.token_ids),
+        message_indices=getattr(rt, "message_indices", None),
+        multi_modal_data=getattr(rt, "multi_modal_data", None),
+    )
+
+
+def _wrap_parsed(pr: Any) -> ParsedResponse:
+    return ParsedResponse(
+        content=getattr(pr, "content", "") or "",
+        reasoning_content=getattr(pr, "reasoning_content", "") or "",
+        tool_calls=normalize_tool_calls(getattr(pr, "tool_calls", None)),
+    )
+
+
+class PrimeRenderer:
+    """Native-protocol wrapper over a prime-rl renderer instance."""
+
+    backend = "prime"
+
+    def __init__(self, renderer: Any):
+        self._renderer = renderer
+        self.is_default = type(renderer).__name__ == "DefaultRenderer"
+        # DefaultRenderer's bridge always returns None; hand-coded renderers have
+        # a real cross-turn bridge.
+        self.has_bridge = not self.is_default
+
+    @property
+    def name(self) -> str:
+        return type(self._renderer).__name__
+
+    def render(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+    ) -> RenderedTokens:
+        return _wrap_rendered(
+            self._renderer.render(
+                messages,
+                tools=_to_prime_tools(tools),
+                add_generation_prompt=add_generation_prompt,
+            )
+        )
+
+    def render_ids(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+    ) -> list[int]:
+        return list(
+            self._renderer.render_ids(
+                messages,
+                tools=_to_prime_tools(tools),
+                add_generation_prompt=add_generation_prompt,
+            )
+        )
+
+    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+        return _wrap_parsed(self._renderer.parse_response(token_ids))
+
+    def get_stop_token_ids(self) -> list[int]:
+        return list(self._renderer.get_stop_token_ids())
+
+    def bridge_to_next_turn(
+        self,
+        previous_prompt_ids: list[int],
+        previous_completion_ids: list[int],
+        new_messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+    ) -> RenderedTokens | None:
+        rendered = self._renderer.bridge_to_next_turn(
+            previous_prompt_ids,
+            previous_completion_ids,
+            new_messages,
+            tools=_to_prime_tools(tools),
+        )
+        return None if rendered is None else _wrap_rendered(rendered)
+
+
+def make_prime_renderer(
+    tokenizer: Any,
+    *,
+    renderer_family: str = "auto",
+    preserve_all_thinking: bool = False,
+    preserve_thinking_between_tool_calls: bool = False,
+    tool_parser: str | None = None,
+    reasoning_parser: str | None = None,
+) -> PrimeRenderer:
+    """Build a :class:`PrimeRenderer` via prime-rl ``create_renderer``."""
+    if not PRIME_AVAILABLE:
+        raise RuntimeError("prime-rl 'renderers' package is not installed. Install it with: pip install renderers")
+    renderer = _prime().create_renderer(
+        tokenizer,
+        renderer=renderer_family,
+        tool_parser=tool_parser,
+        reasoning_parser=reasoning_parser,
+        preserve_all_thinking=preserve_all_thinking,
+        preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+    )
+    return PrimeRenderer(renderer)

--- a/rllm/renderers/_tinker.py
+++ b/rllm/renderers/_tinker.py
@@ -1,0 +1,335 @@
+"""tinker-cookbook / Fireworks backend, adapted to the native :class:`Renderer`.
+
+The tinker-cookbook ``Renderer`` (and the Fireworks cookbook subclasses layered
+on top via ``training.renderer``) is a *message-level* abstraction. This adapter
+exposes it through the native token-level contract so models prime-rl lacks —
+DeepSeek-V4-Flash, Gemma-4, Ministral-3, Kimi-K2.7-code — are reachable for
+training, **including a working cross-turn ``bridge_to_next_turn``**.
+
+The bridge is generic: ``build_generation_prompt`` is itself
+``bos + Σ render_message(m) + _get_generation_suffix()``, so the next-turn prompt
+is the prior turn's *sampled* tokens (kept verbatim, anchored at the turn-close
+token) followed by ``render_message`` for each new non-assistant message plus the
+assistant opener. This preserves historical thinking the model actually emitted,
+which a naive full re-render would strip. Validated byte-for-byte against
+prime-rl's hand-coded bridge for the Qwen3 / Qwen3.5 families.
+
+It lives here (in ``rllm``, where tinker-cookbook is already a dependency) rather
+than in the model gateway, which stays free of tinker/Fireworks deps — the
+gateway receives a built renderer by injection (in-process mode) and only ever
+calls ``bridge_to_next_turn`` / reads ``.token_ids``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from typing import Any
+
+from rllm.renderers._common import iter_tool_specs, normalize_tool_calls
+from rllm.renderers.types import Message, ParsedResponse, RenderedTokens, ToolSpec
+
+logger = logging.getLogger(__name__)
+
+TINKER_AVAILABLE: bool = importlib.util.find_spec("tinker_cookbook") is not None
+# The bridge is native (built on tinker primitives), so it's available whenever
+# tinker-cookbook is.
+BRIDGE_AVAILABLE: bool = TINKER_AVAILABLE
+
+
+# HF model id -> registered renderer name, for models the upstream
+# ``model_info.get_recommended_renderer_name`` does not know (Fireworks-cookbook
+# additions that prime-rl also lacks). The registry consults prime-rl first, so
+# only prime-rl gaps need to appear here. Extend as the cookbook adds models.
+_FW_MODEL_RENDERER: dict[str, str] = {
+    "deepseek-ai/DeepSeek-V4-Flash": "deepseek_v4",
+    "google/gemma-4-E2B-it": "gemma4",
+    "mistralai/Ministral-3-3B-Instruct-2512": "mistral",
+}
+
+
+def tinker_renderer_name(model_name: str | None) -> str | None:
+    """Resolve a tinker/Fireworks renderer name for ``model_name``, or ``None``.
+
+    Checks the rLLM-side Fireworks override map first (because upstream
+    ``model_info`` lags new models and does not know the cookbook additions),
+    then falls back to ``model_info.get_recommended_renderer_name``.
+    """
+    if not TINKER_AVAILABLE or not model_name:
+        return None
+    if model_name in _FW_MODEL_RENDERER:
+        return _FW_MODEL_RENDERER[model_name]
+    try:
+        from tinker_cookbook import model_info
+
+        return model_info.get_recommended_renderer_name(model_name)
+    except KeyError:
+        return None
+    except Exception as err:  # noqa: BLE001
+        logger.debug("model_info lookup failed for %s: %s", model_name, err)
+        return None
+
+
+def _convert_messages(messages: list[Message]) -> list[Message]:
+    """Convert OpenAI-style message dicts to tinker-cookbook Messages.
+
+    Mirrors ``TinkerEngine._convert_openai_messages`` so rendered tokens match
+    the existing engine path.
+    """
+    from tinker_cookbook.renderers.base import ToolCall as TinkerToolCall
+
+    out: list[Message] = []
+    for msg in messages:
+        tinker_msg: Message = {"role": msg["role"], "content": msg.get("content") or ""}
+        if "name" in msg:
+            tinker_msg["name"] = msg["name"]
+        if "tool_call_id" in msg:
+            tinker_msg["tool_call_id"] = msg["tool_call_id"]
+        if "tool_calls" in msg:
+            tinker_msg["tool_calls"] = [TinkerToolCall.model_validate(tc) for tc in msg["tool_calls"]]
+        out.append(tinker_msg)
+    return out
+
+
+def _to_tinker_tool_specs(tools: list[ToolSpec] | list[dict[str, Any]] | None):
+    specs = iter_tool_specs(tools)
+    if not specs:
+        return []
+    from tinker_cookbook.renderers.base import ToolSpec as TinkerToolSpec
+
+    return [TinkerToolSpec(name=s.name, description=s.description, parameters=s.parameters) for s in specs]
+
+
+class TinkerAdapter:
+    """Native-protocol adapter over a tinker-cookbook / Fireworks renderer."""
+
+    backend = "tinker"
+
+    def __init__(self, renderer: Any, tokenizer: Any, renderer_name: str | None = None):
+        self._renderer = renderer
+        self._tokenizer = tokenizer
+        self.name = renderer_name or type(renderer).__name__
+        self._close_ids: list[int] | None = None
+        self.has_bridge = True
+
+    @property
+    def has_extension_property(self) -> bool:
+        return bool(getattr(self._renderer, "has_extension_property", False))
+
+    def _prepare(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec] | list[dict[str, Any]] | None,
+    ) -> list[Message]:
+        tinker_messages = _convert_messages(messages)
+        tool_specs = _to_tinker_tool_specs(tools)
+        if not tool_specs:
+            return tinker_messages
+        # Fold tool declarations into a conversation prefix, pulling a leading
+        # system message into the prefix's system slot (mirrors
+        # TinkerEngine._build_messages_with_tools).
+        system_prompt = ""
+        if tinker_messages and tinker_messages[0]["role"] == "system":
+            content = tinker_messages[0].get("content") or ""
+            system_prompt = content if isinstance(content, str) else ""
+            remaining = tinker_messages[1:]
+        else:
+            remaining = tinker_messages
+        prefix = self._renderer.create_conversation_prefix_with_tools(tool_specs, system_prompt)
+        return list(prefix) + list(remaining)
+
+    def render_ids(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+    ) -> list[int]:
+        prepared = self._prepare(messages, tools)
+        if add_generation_prompt:
+            model_input = self._renderer.build_generation_prompt(prepared)
+        else:
+            # Render the full conversation with no trailing generation prompt.
+            # build_supervised_example returns (ModelInput, weights); the token
+            # ids are independent of the loss mask. Requires a complete
+            # conversation (ending in an assistant turn).
+            model_input, _weights = self._renderer.build_supervised_example(prepared)
+        return list(model_input.to_ints())
+
+    def render(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+    ) -> RenderedTokens:
+        return RenderedTokens(token_ids=self.render_ids(messages, tools=tools, add_generation_prompt=add_generation_prompt))
+
+    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+        message, _termination = self._renderer.parse_response(token_ids)
+        content = message["content"]
+        reasoning = ""
+        if isinstance(content, list):
+            text_parts = [p for p in content if p.get("type") == "text"]
+            think_parts = [p for p in content if p.get("type") == "thinking"]
+            content = "\n".join(p["text"] for p in text_parts)
+            reasoning = "\n".join(p["thinking"] for p in think_parts)
+        return ParsedResponse(
+            content=content or "",
+            reasoning_content=reasoning,
+            tool_calls=normalize_tool_calls(message.get("tool_calls")),
+        )
+
+    def _close_token_ids(self) -> list[int]:
+        """Turn-close (stop) token ids, e.g. ``<|im_end|>`` / EOS. Cached."""
+        if self._close_ids is not None:
+            return self._close_ids
+        ids: list[int] = []
+        unk = getattr(self._tokenizer, "unk_token_id", None)
+        for stop in self._renderer.get_stop_sequences():
+            if isinstance(stop, int):
+                ids.append(stop)
+                continue
+            # String stop -> token id. Prefer a single special-token id;
+            # otherwise encode and keep only if it is exactly one token.
+            tid = self._tokenizer.convert_tokens_to_ids(stop)
+            if isinstance(tid, int) and tid >= 0 and tid != unk:
+                ids.append(tid)
+                continue
+            encoded = self._tokenizer.encode(stop, add_special_tokens=False)
+            if len(encoded) == 1:
+                ids.append(encoded[0])
+            else:
+                logger.debug("Dropping multi-token stop sequence %r (%d tokens)", stop, len(encoded))
+        self._close_ids = ids
+        return ids
+
+    def get_stop_token_ids(self) -> list[int]:
+        return list(self._close_token_ids())
+
+    def get_stop_sequences(self) -> list[str] | list[int]:
+        """Passthrough for callers that want raw stop strings/ids (not in the
+        native Protocol, but several rLLM engines consume string stops)."""
+        return self._renderer.get_stop_sequences()
+
+    @staticmethod
+    def _trim_to_turn_close(
+        previous_prompt_ids: list[int],
+        previous_completion_ids: list[int],
+        close_ids: set[int],
+        synthesize_close: int | None,
+    ) -> list[int] | None:
+        """Longest prefix of ``prev_prompt + prev_completion`` ending at a
+        turn-close token (scanning only within the completion), or — on a
+        truncated prior turn with no close — the sequence plus a synthesized
+        close. ``None`` if neither is possible. Mirrors prime-rl's
+        ``trim_to_turn_close``."""
+        ids = list(previous_prompt_ids) + list(previous_completion_ids)
+        for idx in range(len(ids) - 1, len(previous_prompt_ids) - 1, -1):
+            if ids[idx] in close_ids:
+                return ids[: idx + 1]
+        if synthesize_close is None:
+            return None
+        return ids + [synthesize_close]
+
+    # A synthetic ``[user, assistant(tool_call)]`` anchor used to render the new
+    # turn's delta. The trailing assistant (with a tool call) reproduces the real
+    # boundary the new messages follow — needed because some renderers merge tool
+    # results into the preceding turn and pair them with the assistant's calls.
+    _DELTA_SENTINEL: list[Message] = [
+        {"role": "user", "content": "x"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "_b", "type": "function", "function": {"name": "_", "arguments": "{}"}}],
+        },
+    ]
+
+    def _render_delta(self, new_messages: list[Message], close_set: set[int]) -> list[int] | None:
+        """Render the new turn's tokens (framing + next assistant opener).
+
+        Renders ``build_generation_prompt(sentinel + new_messages)`` and returns
+        everything after the sentinel's last turn-close token. Going through
+        ``build_generation_prompt`` (not per-message ``render_message``) is what
+        makes this correct for tool turns: renderers do turn-level preprocessing
+        there — merging consecutive tool results into one user turn, pairing them
+        with the assistant's calls, rejecting raw ``tool`` role in
+        ``render_message`` (DeepSeek-V4). Splitting on the *count* of close tokens
+        the sentinel emits (stable regardless of current-vs-historical assistant
+        rendering) locates where the new turn begins.
+        """
+        try:
+            sentinel = _convert_messages(self._DELTA_SENTINEL)
+            new_conv = _convert_messages(new_messages)
+            anchor_ids = self._renderer.build_supervised_example(sentinel)[0].to_ints()
+            full = self._renderer.build_generation_prompt(sentinel + new_conv).to_ints()
+        except Exception as err:  # noqa: BLE001 - renderer can't handle these messages
+            logger.debug("tinker delta render failed: %s", err)
+            return None
+        n_close = sum(1 for t in anchor_ids if t in close_set)
+        if n_close == 0:
+            return None
+        seen = 0
+        for i, tok_id in enumerate(full):
+            if tok_id in close_set:
+                seen += 1
+                if seen == n_close:
+                    return full[i + 1 :]
+        return None
+
+    def bridge_to_next_turn(
+        self,
+        previous_prompt_ids: list[int],
+        previous_completion_ids: list[int],
+        new_messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+    ) -> RenderedTokens | None:
+        """Extend the prior turn's verbatim tokens with the new turn's framing.
+
+        Returns ``None`` (caller falls back to a full re-render) when the
+        prefix-extension contract can't be proven: assistant content in the new
+        slice (would re-tokenize sampled tokens), a truncated prior with no
+        recoverable close token, multimodal content, or a renderer that can't
+        render the new messages.
+        """
+        if not previous_prompt_ids or not new_messages:
+            return None
+        if any(m.get("role") == "assistant" for m in new_messages):
+            return None
+        if any(not isinstance(m.get("content", ""), str) for m in new_messages):
+            return None
+        close_ids = self._close_token_ids()
+        if not close_ids:
+            return None
+        close_set = set(close_ids)
+
+        anchor = self._trim_to_turn_close(previous_prompt_ids, previous_completion_ids, close_set, close_ids[0])
+        if anchor is None:
+            return None
+
+        delta = self._render_delta(new_messages, close_set)
+        if delta is None:
+            return None
+        return RenderedTokens(token_ids=anchor + delta)
+
+
+def make_tinker_renderer(
+    name: str,
+    tokenizer: Any,
+    image_processor: Any | None = None,
+) -> TinkerAdapter:
+    """Build a :class:`TinkerAdapter` via tinker-cookbook ``get_renderer``.
+
+    Imports the Fireworks cookbook registrations as a side effect so names like
+    ``deepseek_v4`` / ``gemma4`` resolve.
+    """
+    if not TINKER_AVAILABLE:
+        raise RuntimeError("tinker_cookbook is not installed. Install it with: pip install tinker-cookbook")
+    from tinker_cookbook import renderers as tc_renderers
+
+    from rllm.renderers._fw_register import ensure_registered
+
+    ensure_registered()  # make cookbook renderers (deepseek_v4, gemma4, …) resolvable
+    renderer = tc_renderers.get_renderer(name, tokenizer, image_processor=image_processor)
+    return TinkerAdapter(renderer, tokenizer, renderer_name=name)

--- a/rllm/renderers/registry.py
+++ b/rllm/renderers/registry.py
@@ -1,0 +1,139 @@
+"""Model → renderer-backend resolution for rLLM training.
+
+``resolve`` returns a native :class:`~rllm.renderers.types.Renderer` for a model,
+choosing the backend by precedence (RL-first):
+
+1. **prime-rl** when the model is in prime-rl's ``MODEL_RENDERER_MAP`` — the only
+   backend with a real ``bridge_to_next_turn`` (drift-free multi-turn token
+   forwarding), so a model present in both ecosystems is routed here.
+2. **tinker-cookbook / Fireworks** for models prime-rl lacks (DeepSeek-V4-Flash,
+   Gemma-4, Ministral-3, Kimi-K2.7-code, …).
+3. **DefaultRenderer** (prime-rl's ``apply_chat_template`` fallback) as a last
+   resort — single-turn correct, ``bridge_to_next_turn`` always ``None``.
+
+Two explicit overrides mirror the existing config knobs:
+
+- ``renderer_family`` (prime-rl style, e.g. ``"qwen3.5"``) forces the prime-rl
+  backend — same field the model gateway already uses.
+- ``renderer_name`` (tinker style, e.g. ``"qwen3_5"`` / ``"deepseek_v4"``) forces
+  the tinker/Fireworks backend — same field ``TinkerEngine`` already accepts.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from rllm.renderers import _prime, _tinker
+from rllm.renderers.types import Renderer
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["Backend", "RendererResolution", "select_backend", "describe", "resolve"]
+
+
+class Backend(str, Enum):
+    PRIME = "prime"
+    TINKER = "tinker"
+    DEFAULT = "default"
+
+
+@dataclass
+class RendererResolution:
+    """The routing decision for a model, without instantiating anything."""
+
+    backend: Backend
+    renderer_name: str | None = None
+    renderer_family: str | None = None
+    has_bridge: bool = False
+
+
+def _infer_model_name(model_name: str | None, tokenizer: Any) -> str | None:
+    if model_name:
+        return model_name
+    return getattr(tokenizer, "name_or_path", None)
+
+
+def select_backend(
+    model_name: str | None,
+    *,
+    renderer_name: str | None = None,
+    renderer_family: str | None = None,
+) -> RendererResolution:
+    """Decide which backend serves ``model_name`` (pure — no tokenizer load)."""
+    if renderer_family:
+        return RendererResolution(Backend.PRIME, renderer_family=renderer_family, has_bridge=True)
+    if renderer_name:
+        return RendererResolution(Backend.TINKER, renderer_name=renderer_name, has_bridge=_tinker.BRIDGE_AVAILABLE)
+    if _prime.prime_supports(model_name):
+        return RendererResolution(Backend.PRIME, renderer_family="auto", has_bridge=True)
+    tname = _tinker.tinker_renderer_name(model_name)
+    if tname is not None:
+        return RendererResolution(Backend.TINKER, renderer_name=tname, has_bridge=_tinker.BRIDGE_AVAILABLE)
+    return RendererResolution(Backend.DEFAULT, renderer_family="auto", has_bridge=False)
+
+
+def describe(
+    model_name: str | None,
+    *,
+    renderer_name: str | None = None,
+    renderer_family: str | None = None,
+) -> RendererResolution:
+    """Alias of :func:`select_backend`, for logging / CLI introspection."""
+    return select_backend(model_name, renderer_name=renderer_name, renderer_family=renderer_family)
+
+
+def resolve(
+    model_name: str | None,
+    tokenizer: Any,
+    *,
+    renderer_name: str | None = None,
+    renderer_family: str | None = None,
+    image_processor: Any | None = None,
+    **prime_kwargs: Any,
+) -> Renderer:
+    """Resolve a native :class:`Renderer` for ``model_name``.
+
+    ``prime_kwargs`` (``preserve_all_thinking``, ``tool_parser``, …) are forwarded
+    to the prime-rl backend and ignored by the tinker backend.
+    """
+    model_name = _infer_model_name(model_name, tokenizer)
+    decision = select_backend(model_name, renderer_name=renderer_name, renderer_family=renderer_family)
+
+    if decision.backend is Backend.PRIME:
+        renderer = _prime.make_prime_renderer(tokenizer, renderer_family=decision.renderer_family or "auto", **prime_kwargs)
+        logger.info(
+            "Renderer for %r -> prime-rl %s (bridge=%s)",
+            model_name,
+            renderer.name,
+            renderer.has_bridge,
+        )
+        return renderer
+
+    if decision.backend is Backend.TINKER:
+        renderer = _tinker.make_tinker_renderer(decision.renderer_name, tokenizer, image_processor=image_processor)
+        logger.info(
+            "Renderer for %r -> tinker/fireworks %r (no token bridge)",
+            model_name,
+            decision.renderer_name,
+        )
+        return renderer
+
+    # DEFAULT: prime-rl's apply_chat_template fallback (single-turn correct).
+    if _prime.PRIME_AVAILABLE:
+        renderer = _prime.make_prime_renderer(tokenizer, renderer_family="auto", **prime_kwargs)
+        logger.warning(
+            "No hand-coded renderer for %r; falling back to %s (no token bridge, multi-turn RL will full-re-render each turn). Pass renderer_family/renderer_name to override.",
+            model_name,
+            renderer.name,
+        )
+        return renderer
+
+    raise ValueError(
+        f"Could not resolve a renderer for model_name={model_name!r}: it is not in "
+        "prime-rl's MODEL_RENDERER_MAP, has no tinker/Fireworks renderer, and the "
+        "prime-rl 'renderers' package (needed for the DefaultRenderer fallback) is "
+        "not installed. Install 'renderers', or pass renderer_name explicitly."
+    )

--- a/rllm/renderers/types.py
+++ b/rllm/renderers/types.py
@@ -1,0 +1,112 @@
+"""Native rLLM renderer types and the :class:`Renderer` protocol.
+
+rLLM speaks a single, token-level renderer interface for training (mirroring the
+shape of the ``renderers`` / prime-rl package, which is the only backend with a
+real cross-turn ``bridge_to_next_turn``). Concrete backends — the prime-rl
+renderers and the tinker-cookbook / Fireworks renderers — are adapted to this
+interface in :mod:`rllm.renderers._prime` and :mod:`rllm.renderers._tinker`.
+
+These types are intentionally self-contained: importing this module does **not**
+require either backend to be installed, so ``isinstance`` checks, type hints, and
+the registry routing logic all work in a minimal environment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from rllm.tools.tool_base import ToolCall
+
+__all__ = [
+    "Message",
+    "ToolCall",
+    "ToolSpec",
+    "RenderedTokens",
+    "ParsedResponse",
+    "Renderer",
+]
+
+# A chat message is a plain dict (OpenAI-style: role / content / tool_calls …).
+# Both backends accept this shape, so we don't impose a stricter TypedDict here.
+Message = dict[str, Any]
+
+
+@dataclass
+class ToolSpec:
+    """A single callable tool, backend-agnostic.
+
+    Mirrors both ``renderers.base.ToolSpec`` and
+    ``tinker_cookbook.renderers.base.ToolSpec`` (identical fields), so it can be
+    converted to either at the backend boundary.
+    """
+
+    name: str
+    description: str = ""
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RenderedTokens:
+    """Result of rendering messages to token IDs.
+
+    Field names match prime-rl's ``RenderedTokens`` so callers that read
+    ``.token_ids`` (e.g. the model gateway's ``TokenAccumulator``) work against
+    either the native or the prime-rl object.
+    """
+
+    token_ids: list[int]
+    # Per-token attribution to its source message index (``-1`` = structural
+    # scaffolding). ``None`` when the backend does not provide it.
+    message_indices: list[int] | None = None
+    multi_modal_data: Any | None = None
+
+
+@dataclass
+class ParsedResponse:
+    """Structured assistant turn parsed from sampled token IDs."""
+
+    content: str = ""
+    reasoning_content: str = ""
+    tool_calls: list[ToolCall] = field(default_factory=list)
+
+
+@runtime_checkable
+class Renderer(Protocol):
+    """Token-level renderer interface used across rLLM training.
+
+    The contract is prime-rl's: render messages → token IDs, parse completion
+    IDs → a structured turn, and (for RL multi-turn) extend a prior turn without
+    re-rendering history. ``bridge_to_next_turn`` returning ``None`` is always a
+    valid answer — it tells the caller "I can't prove the prefix-extension
+    contract, fall back to a full re-render."
+    """
+
+    def render(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+    ) -> RenderedTokens: ...
+
+    def render_ids(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+    ) -> list[int]: ...
+
+    def parse_response(self, token_ids: list[int]) -> ParsedResponse: ...
+
+    def get_stop_token_ids(self) -> list[int]: ...
+
+    def bridge_to_next_turn(
+        self,
+        previous_prompt_ids: list[int],
+        previous_completion_ids: list[int],
+        new_messages: list[Message],
+        *,
+        tools: list[ToolSpec] | list[dict[str, Any]] | None = None,
+    ) -> RenderedTokens | None: ...

--- a/rllm/trainer/fireworks/fireworks_backend.py
+++ b/rllm/trainer/fireworks/fireworks_backend.py
@@ -227,6 +227,9 @@ class FireworksBackend(TinkerBackend):
                 accumulate_reasoning=rollout_extra.pop("accumulate_reasoning", False),
                 reasoning_effort=rollout_extra.pop("reasoning_effort", "medium"),
                 router_replay=cfg.rllm.algorithm.get("router_replay", "disabled") == "R3",
+                # Cumulative token mode → the gateway renders/parses every turn;
+                # the engine is a pure token-in/token-out sampler (no chat_parser).
+                cumulative_token_mode=cfg.rllm.get("gateway", {}).get("cumulative_token_mode", False),
                 **rollout_extra,
             )
             return self.rollout_engine

--- a/tests/test_fireworks_engine_cumulative.py
+++ b/tests/test_fireworks_engine_cumulative.py
@@ -1,0 +1,79 @@
+"""FireworksEngine cumulative-token-mode (pure token-in/token-out) behavior.
+
+In cumulative mode the gateway renders every turn and parses every completion
+via the renderer, so the engine must be a pure sampler: it builds NO
+ChatTemplateParser (which would crash in __init__ for models whose Jinja
+template the parser's equivalence self-check can't render, e.g. GLM) and
+assemble_model_output returns raw-decoded text instead of parsing.
+"""
+
+import pytest
+
+pytest.importorskip("fireworks", reason="Fireworks SDK not installed")
+
+from rllm.engine.rollout.fireworks_engine import FireworksEngine
+from rllm.engine.rollout.tinker_engine import TinkerEngine
+
+
+class _BoomTokenizer:
+    """Any attribute access raises — proves the engine never consults the
+    tokenizer for parser/renderer setup in cumulative mode (the GLM crash path)."""
+
+    name_or_path = "zai-org/GLM-5.1"
+
+    def __getattr__(self, key):
+        raise RuntimeError(f"tokenizer.{key} must not be touched in cumulative mode")
+
+
+class _DecodeTokenizer:
+    def decode(self, ids, skip_special_tokens=True):
+        return "DECODED:" + ",".join(map(str, ids))
+
+
+class _DummySampler:
+    pass
+
+
+class _Seq:
+    tokens = [10, 11, 12]
+    logprobs = [0.0, 0.0, 0.0]
+    stop_reason = "stop"
+
+
+def _make_engine():
+    return FireworksEngine(
+        tokenizer=_BoomTokenizer(),
+        sampler=_DummySampler(),
+        max_prompt_length=100,
+        max_response_length=50,
+        max_model_length=200,
+        cumulative_token_mode=True,
+    )
+
+
+def test_cumulative_construct_skips_chat_template_parser():
+    eng = _make_engine()
+    assert eng.chat_parser is None
+    assert eng.renderer is None
+    assert eng.raw_token_mode is True
+    assert eng.bypass_render_with_parser is False
+
+
+def test_raw_assemble_decodes_without_parsing():
+    eng = _make_engine()
+    eng.tokenizer = _DecodeTokenizer()
+    out = TinkerEngine.assemble_model_output(eng, [1, 2, 3], _Seq())
+    assert out.content == "DECODED:10,11,12"
+    assert out.reasoning == ""
+    assert out.tool_calls == []
+    assert out.completion_ids == [10, 11, 12]
+    assert out.prompt_ids == [1, 2, 3]
+
+
+def test_get_model_response_rejected_in_cumulative_mode():
+    """The chat (message-rendering) path must not be reachable in cumulative mode."""
+    import asyncio
+
+    eng = _make_engine()
+    with pytest.raises(RuntimeError, match="cumulative_token_mode"):
+        asyncio.run(eng.get_model_response([{"role": "user", "content": "hi"}]))

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,0 +1,302 @@
+"""Tests for the rLLM-native renderer layer (rllm.renderers).
+
+Routing tests are pure (no tokenizer / network). Render/parse/bridge tests are
+guarded: they load a cached HF tokenizer and skip if unavailable (offline CI).
+
+NOTE: this file lives at ``tests/`` root (not ``tests/renderers/``) on purpose —
+a ``tests/renderers/`` package would land on ``sys.path`` under pytest's prepend
+import mode and shadow prime-rl's top-level ``renderers`` package.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import rllm.renderers as R
+from rllm.renderers import Backend
+from rllm.renderers._common import iter_tool_specs, normalize_tool_calls
+from rllm.renderers.types import ParsedResponse, RenderedTokens, ToolCall, ToolSpec
+
+# --- Models with cached tokenizers used by the guarded integration tests. ---
+PRIME_MODEL = "Qwen/Qwen3-8B"  # in prime-rl MODEL_RENDERER_MAP -> token bridge
+FW_ONLY_MODEL = "deepseek-ai/DeepSeek-V4-Flash"  # prime-rl gap -> tinker/FW adapter
+
+
+def _load(model: str):
+    try:
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained(model)
+    except Exception as err:  # noqa: BLE001 - offline / not cached
+        pytest.skip(f"tokenizer {model} unavailable: {err}")
+
+
+def _hf_ids(tok, messages):
+    out = tok.apply_chat_template(messages, tokenize=True, add_generation_prompt=True)
+    if hasattr(out, "keys"):  # BatchEncoding
+        return list(out["input_ids"])
+    if hasattr(out, "ids"):  # Encoding
+        return list(out.ids)
+    return list(out)
+
+
+# ----------------------------- pure routing -----------------------------
+
+
+def test_availability_flags_are_bools():
+    for flag in (R.PRIME_AVAILABLE, R.TINKER_AVAILABLE, R.FIREWORKS_AVAILABLE):
+        assert isinstance(flag, bool)
+
+
+@pytest.mark.skipif(not R.PRIME_AVAILABLE, reason="prime-rl not installed")
+def test_prime_model_routes_to_prime_with_bridge():
+    d = R.select_backend("Qwen/Qwen3-8B")
+    assert d.backend is Backend.PRIME
+    assert d.has_bridge is True
+
+
+@pytest.mark.skipif(not R.TINKER_AVAILABLE, reason="tinker_cookbook not installed")
+def test_fw_only_model_routes_to_tinker():
+    from rllm.renderers import _tinker
+
+    d = R.select_backend("deepseek-ai/DeepSeek-V4-Flash")
+    assert d.backend is Backend.TINKER
+    assert d.renderer_name == "deepseek_v4"
+    # The tinker/Fireworks backend now carries a generic cross-turn bridge.
+    assert d.has_bridge is _tinker.BRIDGE_AVAILABLE
+
+
+def test_unknown_model_routes_to_default():
+    d = R.select_backend("nonexistent-org/Totally-Unknown-Model-9000")
+    assert d.backend is Backend.DEFAULT
+    assert d.has_bridge is False
+
+
+def test_explicit_family_forces_prime():
+    d = R.select_backend("nonexistent-org/Unknown", renderer_family="qwen3.5")
+    assert d.backend is Backend.PRIME
+    assert d.renderer_family == "qwen3.5"
+    assert d.has_bridge is True
+
+
+def test_explicit_name_forces_tinker():
+    d = R.select_backend("nonexistent-org/Unknown", renderer_name="deepseek_v4")
+    assert d.backend is Backend.TINKER
+    assert d.renderer_name == "deepseek_v4"
+
+
+# ----------------------------- pure helpers -----------------------------
+
+
+def test_iter_tool_specs_openai_and_bare_and_passthrough():
+    openai = {
+        "type": "function",
+        "function": {"name": "add", "description": "d", "parameters": {"x": 1}},
+    }
+    bare = {"name": "sub", "parameters": {"y": 2}}
+    native = ToolSpec(name="mul")
+    specs = iter_tool_specs([openai, bare, native])
+    assert [s.name for s in specs] == ["add", "sub", "mul"]
+    assert specs[0].parameters == {"x": 1}
+    assert specs[0].description == "d"
+
+
+def test_iter_tool_specs_skips_non_function_and_empty():
+    assert iter_tool_specs(None) == []
+    assert iter_tool_specs([{"type": "web_search"}]) == []
+
+
+def test_normalize_tool_calls_variants():
+    class _Fn:
+        def __init__(self, name, args):
+            self.name, self.arguments = name, args
+
+    class _ObjWithFunction:
+        def __init__(self, name, args):
+            self.function = _Fn(name, args)
+
+    out = normalize_tool_calls(
+        [
+            {"name": "a", "arguments": {"k": 1}},
+            {"name": "b", "arguments": '{"k": 2}'},  # string args -> parsed
+            _ObjWithFunction("c", '{"k": 3}'),
+            ToolCall(name="d", arguments={"k": 4}),
+        ]
+    )
+    assert [tc.name for tc in out] == ["a", "b", "c", "d"]
+    assert out[1].arguments == {"k": 2}
+    assert out[2].arguments == {"k": 3}
+    assert normalize_tool_calls(None) == []
+
+
+# --------------------- guarded integration (render) ---------------------
+
+
+@pytest.mark.skipif(not R.PRIME_AVAILABLE, reason="prime-rl not installed")
+def test_prime_render_parity_with_hf_template():
+    tok = _load(PRIME_MODEL)
+    r = R.resolve(PRIME_MODEL, tok)
+    assert r.backend == "prime" and r.has_bridge is True
+    msgs = [{"role": "user", "content": "hi"}]
+    ids = r.render_ids(msgs, add_generation_prompt=True)
+    assert ids == _hf_ids(tok, msgs)
+
+
+@pytest.mark.skipif(not R.PRIME_AVAILABLE, reason="prime-rl not installed")
+def test_prime_bridge_extends_prefix_byte_for_byte():
+    tok = _load(PRIME_MODEL)
+    r = R.resolve(PRIME_MODEL, tok)
+    msgs = [{"role": "user", "content": "What is 2+2?"}]
+    prompt_ids = r.render_ids(msgs, add_generation_prompt=True)
+    completion_ids = tok.encode("4", add_special_tokens=False)
+    bridged = r.bridge_to_next_turn(prompt_ids, completion_ids, [{"role": "user", "content": "And 3+3?"}])
+    assert isinstance(bridged, RenderedTokens)
+    prefix = prompt_ids + completion_ids
+    assert bridged.token_ids[: len(prefix)] == prefix
+
+
+@pytest.mark.skipif(not R.TINKER_AVAILABLE, reason="tinker_cookbook not installed")
+def test_tinker_adapter_renders_fw_only_model():
+    tok = _load(FW_ONLY_MODEL)
+    r = R.resolve(FW_ONLY_MODEL, tok)
+    assert r.backend == "tinker"
+    msgs = [{"role": "user", "content": "hi"}]
+    ids = r.render_ids(msgs, add_generation_prompt=True)
+    assert isinstance(ids, list) and len(ids) > 0 and all(isinstance(i, int) for i in ids)
+    parsed = r.parse_response(tok.encode("ok", add_special_tokens=False))
+    assert isinstance(parsed, ParsedResponse)
+
+
+@pytest.mark.skipif(not R.TINKER_AVAILABLE, reason="tinker_cookbook not installed")
+def test_tinker_adapter_bridge_extends_prefix_for_fw_model():
+    """The generic bridge unlocks cumulative-token mode for a model prime-rl
+    lacks (DeepSeek-V4): it extends the verbatim prior tokens byte-for-byte."""
+    from rllm.renderers import _tinker
+
+    if not _tinker.BRIDGE_AVAILABLE:
+        pytest.skip("gateway tinker bridge unavailable")
+    tok = _load(FW_ONLY_MODEL)
+    r = R.resolve(FW_ONLY_MODEL, tok)
+    assert r.has_bridge is True
+    prompt_ids = r.render_ids([{"role": "user", "content": "hi"}], add_generation_prompt=True)
+    completion_ids = tok.encode("</think>hello", add_special_tokens=False) + [1]  # clean EOS
+    bridged = r.bridge_to_next_turn(prompt_ids, completion_ids, [{"role": "user", "content": "bye"}])
+    assert isinstance(bridged, RenderedTokens)
+    prefix = prompt_ids + completion_ids
+    assert bridged.token_ids[: len(prefix)] == prefix
+    # Assistant content in the new slice is refused (would re-tokenize sampled tokens).
+    assert r.bridge_to_next_turn(prompt_ids, completion_ids, [{"role": "assistant", "content": "x"}]) is None
+
+
+@pytest.mark.skipif(not R.PRIME_AVAILABLE or not R.TINKER_AVAILABLE, reason="need both backends")
+def test_tinker_bridge_matches_prime_gold():
+    """The generic tinker bridge equals prime-rl's hand-coded bridge byte-for-byte
+    for a model both ecosystems support (Qwen3.5)."""
+    from rllm.renderers import _tinker
+
+    if not _tinker.BRIDGE_AVAILABLE:
+        pytest.skip("gateway tinker bridge unavailable")
+    tok = _load("Qwen/Qwen3.5-4B")
+    prime = R.resolve("Qwen/Qwen3.5-4B", tok)  # prime backend
+    tinker = R.resolve("Qwen/Qwen3.5-4B", tok, renderer_name="qwen3_5")  # tinker backend
+    prev_prompt = prime.render_ids([{"role": "user", "content": "hi"}], add_generation_prompt=True)
+    prev_completion = tok.encode("hello", add_special_tokens=False) + [tok.convert_tokens_to_ids("<|im_end|>")]
+    new = [{"role": "user", "content": "bye"}]
+    g = prime.bridge_to_next_turn(prev_prompt, prev_completion, new)
+    t = tinker.bridge_to_next_turn(prev_prompt, prev_completion, new)
+    assert g is not None and t is not None
+    assert list(t.token_ids) == list(g.token_ids)
+
+
+@pytest.mark.skipif(not R.TINKER_AVAILABLE, reason="tinker_cookbook not installed")
+def test_tinker_adapter_parity_when_forced():
+    """A model in both ecosystems renders identically via the tinker adapter
+    (forced by name) and HF apply_chat_template."""
+    tok = _load(PRIME_MODEL)
+    r = R.resolve(PRIME_MODEL, tok, renderer_name="qwen3")
+    assert r.backend == "tinker"
+    msgs = [{"role": "user", "content": "hi"}]
+    assert r.render_ids(msgs, add_generation_prompt=True) == _hf_ids(tok, msgs)
+
+
+# --------------------- tool-call bridge parity ---------------------
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def _decode(tok, ids) -> str:
+    return "".join(tok.decode([i]) for i in ids)
+
+
+@pytest.mark.skipif(not R.PRIME_AVAILABLE or not R.TINKER_AVAILABLE, reason="need both backends")
+def test_tinker_bridge_matches_prime_gold_with_tool_result():
+    """Tool-result bridge: the tinker adapter equals prime-rl's hand-coded
+    bridge byte-for-byte for Qwen3.5 (a model both ecosystems support)."""
+    from rllm.renderers import _tinker
+
+    if not _tinker.BRIDGE_AVAILABLE:
+        pytest.skip("gateway tinker bridge unavailable")
+    tok = _load("Qwen/Qwen3.5-4B")
+    prime = R.resolve("Qwen/Qwen3.5-4B", tok)
+    tinker = R.resolve("Qwen/Qwen3.5-4B", tok, renderer_name="qwen3_5")
+    prev_prompt = prime.render_ids(
+        [{"role": "system", "content": "s"}, {"role": "user", "content": "weather in SF?"}],
+        tools=_TOOLS,
+        add_generation_prompt=True,
+    )
+    im_end = tok.convert_tokens_to_ids("<|im_end|>")
+    prev_completion = tok.encode(
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "SF"}}\n</tool_call>',
+        add_special_tokens=False,
+    ) + [im_end]
+    new = [{"role": "tool", "content": "sunny 72F", "tool_call_id": "c1", "name": "get_weather"}]
+    g = prime.bridge_to_next_turn(prev_prompt, prev_completion, new, tools=_TOOLS)
+    t = tinker.bridge_to_next_turn(prev_prompt, prev_completion, new, tools=_TOOLS)
+    assert g is not None and t is not None
+    assert list(t.token_ids) == list(g.token_ids)
+
+
+@pytest.mark.skipif(not R.TINKER_AVAILABLE, reason="tinker_cookbook not installed")
+def test_deepseek_v4_bridge_merges_tool_results():
+    """DeepSeek-V4 (no prime-rl renderer): the bridge keeps prior tokens verbatim
+    and merges consecutive tool results into a single user turn — matching the
+    renderer's own ``build_generation_prompt`` framing."""
+    from rllm.renderers import _tinker
+
+    if not _tinker.BRIDGE_AVAILABLE:
+        pytest.skip("gateway tinker bridge unavailable")
+    tok = _load(FW_ONLY_MODEL)
+    r = R.resolve(FW_ONLY_MODEL, tok)
+    assert r.backend == "tinker" and r.has_bridge is True
+    prev_prompt = r.render_ids([{"role": "user", "content": "weather?"}], add_generation_prompt=True)
+    # Simulated sampled assistant turn (a tool call) ending at EOS (token id 1).
+    prev_completion = tok.encode("</think>\n\nchecking", add_special_tokens=False) + [1]
+    t1 = {"role": "tool", "content": "SF: sunny", "tool_call_id": "c1", "name": "get_weather"}
+    t2 = {"role": "tool", "content": "NY: rainy", "tool_call_id": "c2", "name": "get_weather"}
+
+    out = r.bridge_to_next_turn(prev_prompt, prev_completion, [t1, t2])
+    assert out is not None
+    prefix = prev_prompt + prev_completion
+    assert out.token_ids[: len(prefix)] == prefix  # prior tokens kept verbatim
+    delta = _decode(tok, out.token_ids[len(prefix) :])
+    # Two tool results merge into ONE user turn (not two), then the assistant opener.
+    assert delta.count("<｜User｜>") == 1
+    assert delta.count("<tool_result>") == 2
+    assert delta.rstrip().endswith("<think>")
+
+    # Single tool result + assistant content in the new slice is still refused.
+    assert r.bridge_to_next_turn(prev_prompt, prev_completion, [t1]) is not None
+    assert r.bridge_to_next_turn(prev_prompt, prev_completion, [{"role": "assistant", "content": "x"}]) is None

--- a/tests/test_tinker_adapter_cumulative.py
+++ b/tests/test_tinker_adapter_cumulative.py
@@ -1,0 +1,91 @@
+"""Tinker adapter: pre-tokenized prompt path for cumulative token mode.
+
+When the gateway runs in ``cumulative_token_mode``, turn 2+ arrives at the
+in-process handler as a completions-style request whose ``prompt`` is raw token
+IDs (built by ``renderers.bridge_to_next_turn``). The handler must sample
+straight from those tokens — bypassing message rendering — and return a
+completions-style body the gateway can extract token IDs from.
+
+Uses a fake engine so no Tinker service / model is required.
+"""
+
+import asyncio
+
+from rllm.gateway.tinker_adapter import create_tinker_handler
+
+
+class _ModelOutput:
+    text = "ls -la"
+    content = "ls -la"
+    reasoning = ""
+    tool_calls = []
+    prompt_ids = [1, 2, 3, 4]
+    completion_ids = [10, 11]
+    logprobs = [-0.1, -0.2]
+    prompt_length = 4
+    completion_length = 2
+    finish_reason = "stop"
+
+
+class _FakeEngine:
+    model_name = "qwen"
+
+    def __init__(self):
+        self.token_input = None
+        self.messages = None
+
+    async def get_token_output_from_token_input(self, token_input, **kwargs):
+        self.token_input = token_input
+        self.sampling_kwargs = kwargs
+        return "sampled"
+
+    def assemble_model_output(self, token_input, token_output):
+        return _ModelOutput()
+
+    async def get_model_response(self, messages, **kwargs):
+        self.messages = messages
+        return _ModelOutput()
+
+
+def test_token_prompt_path_samples_from_tokens():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"prompt": [1, 2, 3, 4], "temperature": 0.7, "model": "qwen"}))
+
+    # Sampled directly from the token IDs — message rendering bypassed.
+    assert engine.token_input == [1, 2, 3, 4]
+    assert engine.messages is None
+    assert engine.sampling_kwargs.get("temperature") == 0.7
+
+    # Completions-style body the gateway's cumulative handler understands.
+    assert resp["object"] == "text_completion"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+    assert resp["choices"][0]["text"] == "ls -la"
+    assert resp["choices"][0]["token_ids"] == [10, 11]
+    assert resp["choices"][0]["logprobs"]["token_logprobs"] == [-0.1, -0.2]
+
+
+def test_chat_path_unchanged_by_token_branch():
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    resp = asyncio.run(handler({"messages": [{"role": "user", "content": "hi"}], "model": "qwen"}))
+
+    assert engine.messages == [{"role": "user", "content": "hi"}]
+    assert engine.token_input is None  # token path not taken
+    assert resp["object"] == "chat.completion"
+    assert resp["choices"][0]["message"]["content"] == "ls -la"
+    assert resp["prompt_token_ids"] == [1, 2, 3, 4]
+
+
+def test_non_int_prompt_falls_through_to_chat():
+    """A string ``prompt`` (or none) must not trigger the token path."""
+    engine = _FakeEngine()
+    handler = create_tinker_handler(engine)
+
+    # No messages and a string prompt: should still go down the chat path
+    # (messages defaulting to []), not the token path.
+    asyncio.run(handler({"prompt": "hello", "messages": [{"role": "user", "content": "hi"}]}))
+    assert engine.token_input is None
+    assert engine.messages == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
Focused replacement for the `feat/native-renderers` PR (which had accumulated unrelated metrics / sandbox / harness / aux-loss / verl-0.8 / cookbook changes) **and** PR #696. This is just the renderer work, rebased clean on `main`.

## Two parts

### 1. Native renderer layer (`rllm/renderers/`)
One token-level `Renderer` protocol — `render_ids` / `parse_response` / `get_stop_token_ids` / `bridge_to_next_turn` — over two ecosystems:
- **prime-rl** (`_prime.py`): passthrough (already token-level, has a real bridge).
- **tinker-cookbook / Fireworks** (`_tinker.py`): adapter that lifts the message-level renderer to the token-level protocol, **including a generic cross-turn bridge** (built from the renderer's own primitives, validated byte-for-byte vs prime-rl's for Qwen3/3.5).
- `registry.resolve()` routes each model **RL-first**: prime-rl exact-match → tinker/FW adapter → DefaultRenderer. The gateway builds/injects the renderer via `resolve()`, so models prime-rl lacks (DeepSeek-V4, …) get a bridge while the gateway package stays free of tinker/Fireworks deps.

### 2. Cumulative-mode unification — one renderer owns the whole trajectory
Previously the trajectory was tokenized by **two** renderers: turn 0 by the engine's `ChatTemplateParser` (HF `apply_chat_template`), turns 2+ by the gateway renderer's bridge. That seam only coincidentally agreed per model (Qwen) and crashed construction for models the parser's self-check can't render (**GLM**).

- The gateway now renders **turn 0** via `renderer.render_ids` and bridges turns 2+ — both from the same renderer — and parses every completion via `renderer.parse_response`.
- `FireworksEngine` is a pure token-in/token-out sampler in cumulative mode (builds **no** `ChatTemplateParser`), fixing the GLM `get_parser` crash at its source.

## Scope
24 files: `rllm/renderers/*`, the gateway/engine cumulative wiring (`proxy.py`, `server.py`, `token_accumulator.py`, `manager.py`, `tinker_adapter.py`, `fireworks_engine.py`, `tinker_engine.py`, `fireworks_backend.py`), tests, and `RENDERER_MERGE_PLAN.md`. **Deliberately excluded** from the old branch: per-task metrics, sandbox download, harness logging, ECHO/aux-loss, verl-0.8 backend changes, and the cookbook scripts. Main's `manager.py` `server_addresses` fix is preserved.

## Tests / lint
73 passing (renderer parity + bridge + DeepSeek-V4; turn-0-via-renderer + single-renderer **no-seam**; FireworksEngine cumulative construct / raw-assemble / rejects-chat-path). `ruff check` + `ruff format` both clean (fixed the formatting the original branch left unrun).

## Before merge
- Qwen byte-parity gate: confirm `render_ids`-turn-0 yields the same training rows as the old chat-path turn-0 (the one behavior change for already-working models).
- GLM end-to-end smoke via `train_fireworks_glm5p2.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)