### PR TITLE
fix(viewer): allow '@'/'#' in run ids so `rllm view` loads terminal-bench runs

### DIFF
--- a/rllm/eval/visualizer.py
+++ b/rllm/eval/visualizer.py
@@ -28,6 +28,7 @@ import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
 
 # --------------------------------------------------------------------------- #
 # Filesystem layer                                                            #
@@ -859,8 +860,12 @@ def _make_handler(root_path: Path, html_factory):
       * ``GET /api/runs/<id>/episodes/<file>``    → one episode JSON
       * other GETs                                → 404 (no static fall-through)
     """
-    safe_id = re.compile(r"^[A-Za-z0-9._-]+$")
-    safe_file = re.compile(r"^episode_[A-Za-z0-9._-]+\.json$")
+    # Run dirs / episode files routinely contain '@' (e.g. "terminal-bench@2.0")
+    # and '#' (model#deployment), so permit them. Path-traversal is still
+    # blocked by the ".."/"/"/"\\" checks below plus the _under_root guard,
+    # which both run *after* URL-decoding in do_GET.
+    safe_id = re.compile(r"^[A-Za-z0-9._@#-]+$")
+    safe_file = re.compile(r"^episode_[A-Za-z0-9._@#-]+\.json$")
     resolved_root = root_path.resolve()
 
     def _is_safe_run_id(rid: str) -> bool:
@@ -920,7 +925,7 @@ def _make_handler(root_path: Path, html_factory):
 
             m = re.match(r"^/api/runs/([^/]+)/index$", path)
             if m:
-                run_id = m.group(1)
+                run_id = unquote(m.group(1))
                 if not _is_safe_run_id(run_id):
                     return self.send_error(400, "Bad run id")
                 run_dir = (root_path / run_id).resolve()
@@ -933,7 +938,7 @@ def _make_handler(root_path: Path, html_factory):
 
             m = re.match(r"^/api/runs/([^/]+)/episodes/([^/]+)$", path)
             if m:
-                run_id, fname = m.group(1), m.group(2)
+                run_id, fname = unquote(m.group(1)), unquote(m.group(2))
                 if not _is_safe_run_id(run_id) or not safe_file.match(fname):
                     return self.send_error(400, "Bad path")
                 target = (root_path / run_id / "episodes" / fname).resolve()


### PR DESCRIPTION
## Problem
`rllm view <run>` fails to load the episode list with **`Failed to load episode index: Error: HTTP 400`** whenever the run directory name contains `@` or `#` — the default for terminal-bench runs (`terminal-bench@2.0_...`) and `model#deployment` runs.

The SPA shell loads fine, then calls `GET /api/runs/<run-id>/index`. The browser percent-encodes `@`→`%40`, but the server-side handler in `rllm/eval/visualizer.py`:
1. validated the **still-encoded** id against `^[A-Za-z0-9._-]+$`, so `%`/`@`/`#` were rejected with `400 Bad run id`; and
2. never URL-decoded the id, so even a relaxed regex would then 404 on the filesystem lookup.

Reproduces both locally and on a remote machine (it's not a port-forwarding issue, despite how it first presents).

## Fix
- `urllib.parse.unquote` the run id and episode filename before validation + lookup, on both the `/index` and `/episodes/<file>` routes.
- Permit `@`/`#` in `safe_id` / `safe_file`.

Path-traversal protection is unchanged: the `".."/"/"/"\\"` guard in `_is_safe_run_id` and the `_under_root` resolve-check both run on the **decoded** value, so encoded traversal (e.g. `%2e%2e%2f`) is still rejected.

## Test
Booted the handler against `~/.rllm/eval_results` and hit the previously-failing routes for `terminal-bench@2.0_accounts_fireworks_models_deepseek-v4-flash_20260626_025350`:
- `GET /api/runs/<id>/index` → **200**, 89 episodes
- `GET /api/runs/<id>/episodes/<file>` → **200**

🤖 Generated with [Claude Code](https://claude.com/claude-code)