### PR TITLE
fix(renderers): auto-detect Fireworks-cookbook models (GLM-5.2); skip ChatTemplateParser

### DIFF
--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -178,30 +178,39 @@ class FireworksEngine(TinkerEngine):
         self.train_sampling_params = dict((sampling_params or {}).get("train", {}))
         self.val_sampling_params = dict((sampling_params or {}).get("val", {}))
 
-        # Chat template parser (same setup as TinkerEngine bypass mode)
         self.bypass_render_with_parser = True
-        self.chat_parser = ChatTemplateParser.get_parser(
-            tokenizer,
-            processor=processor,
-            disable_thinking=disable_thinking,
-        )
 
-        # Opt-in unified renderer: when a renderer is pinned (e.g.
-        # renderer_name="deepseek_v4" for models prime-rl doesn't cover), render
-        # rollout prompts through the same renderer the gateway uses for
-        # cumulative mode. Default (None/auto) keeps the chat-template path so
-        # existing Fireworks models are unaffected.
+        # Unified renderer: when a renderer is pinned (renderer_family != "auto",
+        # e.g. "glm-5", or renderer_name like "deepseek_v4"), render turn-0
+        # prompts through the same renderer the gateway uses for the cumulative
+        # bridge — so engine and gateway agree across turns. When active we skip
+        # ChatTemplateParser entirely: its construction eagerly runs
+        # apply_chat_template (verify_equivalence), which some served templates
+        # reject (e.g. GLM-5.2 -> "'str object' has no attribute 'items'").
         self.renderer = None
         if renderer_name is not None or renderer_family != "auto":
-            from rllm.renderers import get_renderer
+            from rllm.renderers import resolve
 
-            self.renderer = get_renderer(
+            res = resolve(
                 getattr(tokenizer, "name_or_path", None),
                 tokenizer,
                 backend="fireworks",
                 family=renderer_family,
                 renderer_name=renderer_name,
             )
+            if res.source == "chat_template":
+                logger.warning(
+                    "renderer_family=%r / renderer_name=%r did not resolve a native renderer for %s; falling back to ChatTemplateParser.",
+                    renderer_family,
+                    renderer_name,
+                    getattr(tokenizer, "name_or_path", None),
+                )
+            else:
+                self.renderer = res.renderer
+                logger.info("FireworksEngine rendering via %s renderer (%s)", res.name, res.source)
+
+        # Chat template parser — only when no unified renderer is active.
+        self.chat_parser = None if self.renderer is not None else ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=disable_thinking)
 
         self.sample_timeout = sample_timeout
         self.router_replay = router_replay

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -180,34 +180,35 @@ class FireworksEngine(TinkerEngine):
 
         self.bypass_render_with_parser = True
 
-        # Unified renderer: when a renderer is pinned (renderer_family != "auto",
-        # e.g. "glm-5", or renderer_name like "deepseek_v4"), render turn-0
-        # prompts through the same renderer the gateway uses for the cumulative
-        # bridge — so engine and gateway agree across turns. When active we skip
-        # ChatTemplateParser entirely: its construction eagerly runs
-        # apply_chat_template (verify_equivalence), which some served templates
-        # reject (e.g. GLM-5.2 -> "'str object' has no attribute 'items'").
-        self.renderer = None
-        if renderer_name is not None or renderer_family != "auto":
-            from rllm.renderers import resolve
+        # Resolve the renderer the same way the gateway does, so the engine renders
+        # turn 0 with the same renderer the gateway uses for the turn-1+ cumulative
+        # bridge. resolve() auto-detects Fireworks-cookbook models (e.g. GLM-5.2 ->
+        # "glm5") with no config. We adopt the unified renderer — and skip
+        # ChatTemplateParser, whose eager apply_chat_template check rejects some
+        # served templates (GLM-5.2 -> "'str object' has no attribute 'items'") —
+        # when it is explicitly pinned, or when auto-detection lands on a
+        # Fireworks-cookbook renderer (a model chat_parser can't serve). prime-rl
+        # models under plain auto keep the existing chat_parser path (no regression).
+        from rllm.renderers import resolve
 
-            res = resolve(
+        res = resolve(
+            getattr(tokenizer, "name_or_path", None),
+            tokenizer,
+            backend="fireworks",
+            family=renderer_family,
+            renderer_name=renderer_name,
+        )
+        explicit = renderer_name is not None or renderer_family != "auto"
+        self.renderer = res.renderer if (res.source == "tinker" or (explicit and res.source != "chat_template")) else None
+        if self.renderer is not None:
+            logger.info("FireworksEngine rendering via %s renderer (%s)", res.name, res.source)
+        elif explicit and res.source == "chat_template":
+            logger.warning(
+                "renderer_family=%r / renderer_name=%r did not resolve a native renderer for %s; using ChatTemplateParser.",
+                renderer_family,
+                renderer_name,
                 getattr(tokenizer, "name_or_path", None),
-                tokenizer,
-                backend="fireworks",
-                family=renderer_family,
-                renderer_name=renderer_name,
             )
-            if res.source == "chat_template":
-                logger.warning(
-                    "renderer_family=%r / renderer_name=%r did not resolve a native renderer for %s; falling back to ChatTemplateParser.",
-                    renderer_family,
-                    renderer_name,
-                    getattr(tokenizer, "name_or_path", None),
-                )
-            else:
-                self.renderer = res.renderer
-                logger.info("FireworksEngine rendering via %s renderer (%s)", res.name, res.source)
 
         # Chat template parser — only when no unified renderer is active.
         self.chat_parser = None if self.renderer is not None else ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=disable_thinking)

--- a/rllm/renderers/registry.py
+++ b/rllm/renderers/registry.py
@@ -5,9 +5,13 @@ Priority:
    style, e.g. ``"deepseek_v4"``).
 2. prime-rl native renderer if the model is in its ``MODEL_RENDERER_MAP``
    (hand-tuned, parity-tested, first-class ``bridge_to_next_turn``).
-3. Tinker / Fireworks-cookbook renderer wrapped by ``TinkerRendererAdapter``
-   (the path for models prime-rl doesn't cover yet, e.g. DeepSeek-V4).
+3. Fireworks-cookbook renderer (``glm5``, ``deepseek_v4``, ...) auto-detected by
+   model-family prefix and wrapped by ``TinkerRendererAdapter`` — the path for
+   models prime-rl doesn't cover (e.g. GLM-5.2). No config needed.
 4. ``ChatTemplateAdapter`` fallback (logged loudly; bridge prefix-check guards).
+
+This resolution is used by both the gateway (turns 1+ bridge) and FireworksEngine
+(turn-0 render), so a given model resolves to the *same* renderer on both sides.
 """
 
 from __future__ import annotations
@@ -28,20 +32,38 @@ class Backend(str, Enum):
     FIREWORKS = "fireworks"
 
 
-# Models prime-rl doesn't cover, served via a tinker-style renderer name. The
-# renderer class is resolved through tinker_cookbook.renderers.get_renderer;
-# Fireworks-cookbook renderers self-register on import (see _FW_MODULES).
-_TINKER_NAME_BY_MODEL: dict[str, str] = {
-    "deepseek-ai/DeepSeek-V4": "deepseek_v4",
-    "deepseek-ai/DeepSeek-V4-Flash": "deepseek_v4",
-}
-
-# Candidate import paths that register Fireworks-cookbook renderers. Imported
-# lazily and best-effort — only present on a box with the cookbook installed.
-_FW_MODULES: tuple[str, ...] = (
-    "fireworks_cookbook.renderers.deepseek_v4",
-    "fireworks_training_cookbook.renderers.deepseek_v4",
+# Fireworks-cookbook renderer names (training/renderer/__init__.py registers
+# glm5, deepseek_v4, gemma4, kimi_k27_code, minimax_m2, ...), keyed by canonical
+# HF-id prefix. The cookbook ships the renderer *implementations* but no
+# model->renderer map, and tinker_cookbook's recommender doesn't know these
+# models — so we own the mapping. prime-rl's exact-match map is tried first, so
+# this only catches models prime-rl doesn't cover (e.g. GLM-5.2). Family-level:
+# one cookbook renderer serves a whole minor series (glm5 -> GLM-5.x). Prefix
+# match (not exact) so new point releases resolve without a code change; extend
+# as the cookbook adds families.
+_FW_COOKBOOK_BY_PREFIX: tuple[tuple[str, str], ...] = (
+    ("zai-org/glm-5", "glm5"),
+    ("deepseek-ai/deepseek-v4", "deepseek_v4"),
 )
+
+# Import paths that register the Fireworks cookbook's renderers (they self-register
+# into tinker_cookbook's registry on import). ``training.renderer`` is the package
+# name on a Fireworks box (cf. ``from training.utils import ...``). Best-effort —
+# only present where the cookbook is installed.
+_FW_MODULES: tuple[str, ...] = (
+    "training.renderer",
+    "fireworks_cookbook.renderers",
+    "fireworks_training_cookbook.renderers",
+)
+
+
+def _cookbook_renderer_name(model_name: str) -> str | None:
+    """Fireworks-cookbook renderer name for *model_name*, or None."""
+    n = (model_name or "").lower()
+    for prefix, rname in _FW_COOKBOOK_BY_PREFIX:
+        if n.startswith(prefix):
+            return rname
+    return None
 
 
 @dataclass
@@ -79,12 +101,21 @@ def _ensure_fw_registered() -> None:
 def _tinker_adapter(renderer_name: str, tokenizer: Any, *, model: str = "") -> TinkerRendererAdapter:
     from tinker_cookbook import renderers as tk  # type: ignore
 
-    try:
-        inner = tk.get_renderer(renderer_name, tokenizer, model_name=model or None)
-    except Exception:
-        _ensure_fw_registered()
-        inner = tk.get_renderer(renderer_name, tokenizer, model_name=model or None)
+    # Import the Fireworks cookbook first so its renderers (glm5, deepseek_v4, ...)
+    # are registered before we ask for one by name.
+    _ensure_fw_registered()
+    inner = tk.get_renderer(renderer_name, tokenizer, model_name=model or None)
     return TinkerRendererAdapter(inner)
+
+
+def _try_tinker_adapter(renderer_name: str, tokenizer: Any, *, model: str = "") -> TinkerRendererAdapter | None:
+    """Build a tinker/cookbook adapter, or None if the renderer can't be loaded
+    (e.g. the Fireworks cookbook isn't installed on this box)."""
+    try:
+        return _tinker_adapter(renderer_name, tokenizer, model=model)
+    except Exception as e:  # noqa: BLE001 - resolution must never hard-fail
+        logger.debug("tinker/cookbook renderer %r unavailable: %s", renderer_name, e)
+        return None
 
 
 def resolve(
@@ -113,18 +144,27 @@ def resolve(
     if renderer is not None:
         return RendererResolution(renderer, "prime", type(renderer).__name__)
 
-    # 3. Tinker / Fireworks-cookbook renderer for known models.
-    tk_name = _TINKER_NAME_BY_MODEL.get(name)
-    if tk_name:
-        return RendererResolution(_tinker_adapter(tk_name, tokenizer, model=name), "tinker", tk_name)
+    # 3. Fireworks-cookbook renderer for families prime-rl doesn't cover (e.g. GLM-5.2).
+    ck = _cookbook_renderer_name(name)
+    if ck:
+        adapter = _try_tinker_adapter(ck, tokenizer, model=name)
+        if adapter is not None:
+            return RendererResolution(adapter, "tinker", ck)
+        logger.warning(
+            "Model %r maps to Fireworks-cookbook renderer %r, but it could not be loaded (is the Fireworks cookbook 'training.renderer' importable here?). Falling back.",
+            name,
+            ck,
+        )
 
-    # 3b. Tinker auto-recommendation (covers models tinker_cookbook knows).
+    # 3b. Tinker auto-recommendation (covers base models tinker_cookbook knows).
     try:
         from tinker_cookbook import model_info  # type: ignore
 
         rec = model_info.get_recommended_renderer_name(name)
         if rec:
-            return RendererResolution(_tinker_adapter(rec, tokenizer, model=name), "tinker", rec)
+            adapter = _try_tinker_adapter(rec, tokenizer, model=name)
+            if adapter is not None:
+                return RendererResolution(adapter, "tinker", rec)
     except Exception:
         pass
 

--- a/rllm/trainer/fireworks/fireworks_backend.py
+++ b/rllm/trainer/fireworks/fireworks_backend.py
@@ -216,6 +216,10 @@ class FireworksBackend(TinkerBackend):
 
             cfg = self.full_config
             rollout_extra = dict(cfg.get("rollout_engine", {}))
+            # Render turn-0 prompts with the same renderer the gateway uses for
+            # the cumulative bridge (rllm.gateway.renderer_family), so engine and
+            # gateway agree across turns. renderer_name still flows via rollout_extra.
+            renderer_family = cfg.rllm.gateway.get("renderer_family", "auto") if cfg.rllm.get("gateway") else "auto"
             self.rollout_engine = FireworksEngine(
                 tokenizer=self.tokenizer,
                 sampler=self.sampling_client,
@@ -226,6 +230,7 @@ class FireworksBackend(TinkerBackend):
                 disable_thinking=rollout_extra.pop("disable_thinking", False),
                 accumulate_reasoning=rollout_extra.pop("accumulate_reasoning", False),
                 reasoning_effort=rollout_extra.pop("reasoning_effort", "medium"),
+                renderer_family=renderer_family,
                 router_replay=cfg.rllm.algorithm.get("router_replay", "disabled") == "R3",
                 **rollout_extra,
             )

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -212,3 +212,24 @@ def test_token_accumulator_extends_with_adapter():
     assert next_prompt is not None
     prev = prompt + completion
     assert next_prompt[: len(prev)] == prev
+
+
+def test_fireworks_engine_skips_chatparser_when_renderer_pinned(qwen_tokenizer):
+    """Pinning renderer_family must use the unified renderer and skip building
+    ChatTemplateParser, whose eager verify_equivalence runs apply_chat_template
+    and crashes on some served templates (e.g. GLM-5.2). Default keeps chat_parser."""
+    pytest.importorskip("tinker")
+    try:
+        from rllm.engine.rollout.fireworks_engine import FireworksEngine
+    except Exception as e:
+        pytest.skip(f"FireworksEngine import failed: {e}")
+
+    class _StubSampler: ...
+
+    pinned = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler(), renderer_family="qwen3")
+    assert pinned.renderer is not None
+    assert pinned.chat_parser is None
+
+    default = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler())
+    assert default.renderer is None
+    assert default.chat_parser is not None

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -233,3 +233,26 @@ def test_fireworks_engine_skips_chatparser_when_renderer_pinned(qwen_tokenizer):
     default = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler())
     assert default.renderer is None
     assert default.chat_parser is not None
+
+
+def test_cookbook_renderer_name_prefix_match():
+    """Fireworks-cookbook models auto-detect by family prefix (no config), incl.
+    point releases prime-rl's exact-match map doesn't list (GLM-5.2)."""
+    from rllm.renderers.registry import _cookbook_renderer_name
+
+    assert _cookbook_renderer_name("zai-org/GLM-5.2") == "glm5"
+    assert _cookbook_renderer_name("zai-org/GLM-5") == "glm5"
+    assert _cookbook_renderer_name("zai-org/GLM-5.1") == "glm5"
+    assert _cookbook_renderer_name("deepseek-ai/DeepSeek-V4") == "deepseek_v4"
+    assert _cookbook_renderer_name("deepseek-ai/DeepSeek-V4-Flash") == "deepseek_v4"
+    # Not cookbook families (prime-rl / fallback handle these):
+    assert _cookbook_renderer_name("Qwen/Qwen3-8B") is None
+    assert _cookbook_renderer_name("zai-org/GLM-4.5-Air") is None
+
+
+def test_resolve_cookbook_does_not_crash_when_absent(qwen_tokenizer, monkeypatch):
+    """A cookbook-family model still resolves cleanly (to the cookbook renderer if
+    installed, else the chat-template fallback) — resolution never hard-fails."""
+    monkeypatch.setattr(qwen_tokenizer, "name_or_path", "zai-org/GLM-5.2", raising=False)
+    res = resolve("zai-org/GLM-5.2", qwen_tokenizer)
+    assert res.source in ("tinker", "chat_template")


### PR DESCRIPTION
## Problem

Training GLM-5.2 on Fireworks crashes at engine init:
```
jinja2.exceptions.UndefinedError: 'str object' has no attribute 'items'
  ... ChatTemplateParser.get_parser → verify_equivalence → apply_chat_template (GLM-5.2 template)
```
`FireworksEngine` built `ChatTemplateParser` unconditionally, and `get_parser` eagerly runs `apply_chat_template` on probe messages — GLM-5.2's served template rejects them.

GLM **is** supported via the Fireworks cookbook's `glm5` renderer, but nothing auto-routed to it:
- prime-rl's `MODEL_RENDERER_MAP` is exact-match and has `GLM-5`/`GLM-5.1` but **not `GLM-5.2`**.
- The Fireworks cookbook ships renderer *implementations* (`glm5`, `deepseek_v4`, `gemma4`, ...) but **no model→renderer map**.
- `tinker_cookbook`'s recommender doesn't know GLM or DeepSeek-V4 (both error).

So the engine fell through to the crashing `chat_parser`, and the only workaround was pinning `renderer_family=glm-5` (and even that only configured the gateway, not the engine).

## Fix — auto-detect, no config needed

- **`registry.py`**: `resolve()` now owns a Fireworks-cookbook **family-prefix map** (`GLM-5.x → glm5`, `DeepSeek-V4 → deepseek_v4`), consulted right after prime-rl's exact-match map. It imports `training.renderer` so the cookbook renderers self-register, and degrades gracefully (never hard-fails) if the cookbook isn't installed. Extend the map as the cookbook adds families.
- **`fireworks_backend.py`**: passes `rllm.gateway.renderer_family` to `FireworksEngine`, so engine and gateway read the same config.
- **`fireworks_engine.py`**: resolves the renderer **the same way the gateway does (always)** — so the engine's **turn-0** render and the gateway's **turn-1+** bridge pick the *same* renderer. It adopts the unified renderer (and **skips `ChatTemplateParser`**, avoiding the crash) when pinned or when auto-detection lands on a cookbook renderer. prime-rl models under plain `auto` keep the existing `chat_parser` path — **no regression for working qwen runs**.

**Result:** GLM-5.2 trains with **zero renderer config** — `auto` resolves to the cookbook `glm5` renderer on both engine and gateway. `renderer_family` / `renderer_name` still work as explicit overrides.

## Testing
- Cookbook prefix mapping (`GLM-5.x→glm5`, `DeepSeek-V4→deepseek_v4`, non-families→None), graceful fallback when the cookbook is absent, and engine adopt/skip logic.
- Full renderer suite: **14 pass**, ruff clean.
- Note: the GLM cookbook renderer is only importable on a Fireworks box (cookbook installed), so the GLM end-to-end resolution isn't exercised in offline CI — the prefix mapping and fallback are. Watch the engine's first log line: `FireworksEngine rendering via glm5 renderer (tinker)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)