### PR TITLE
fix(engine): unify renderer rendering+parsing in shared TinkerEngine (both backends)

### DIFF
--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -139,6 +139,7 @@ class FireworksEngine(TinkerEngine):
         sample_timeout: int = 600,
         processor=None,
         router_replay: bool = False,
+        bypass_render_with_parser: bool = False,
         renderer_name: str | None = None,
         renderer_family: str = "auto",
         **kwargs,
@@ -187,26 +188,32 @@ class FireworksEngine(TinkerEngine):
         # when it is explicitly pinned, or when auto-detection lands on a
         # Fireworks-cookbook renderer (a model chat_parser can't serve). prime-rl
         # models under plain auto keep the existing chat_parser path (no regression).
-        from rllm.renderers import resolve
+        #
+        # bypass_render_with_parser=True is an explicit escape hatch: force
+        # ChatTemplateParser and skip the unified renderer entirely.
+        if bypass_render_with_parser:
+            self.unified_renderer = None
+        else:
+            from rllm.renderers import resolve
 
-        res = resolve(
-            getattr(tokenizer, "name_or_path", None),
-            tokenizer,
-            backend="fireworks",
-            family=renderer_family,
-            renderer_name=renderer_name,
-        )
-        explicit = renderer_name is not None or renderer_family != "auto"
-        self.unified_renderer = res.renderer if (res.source == "tinker" or (explicit and res.source != "chat_template")) else None
-        if self.unified_renderer is not None:
-            logger.info("FireworksEngine rendering via %s renderer (%s)", res.name, res.source)
-        elif explicit and res.source == "chat_template":
-            logger.warning(
-                "renderer_family=%r / renderer_name=%r did not resolve a native renderer for %s; using ChatTemplateParser.",
-                renderer_family,
-                renderer_name,
+            res = resolve(
                 getattr(tokenizer, "name_or_path", None),
+                tokenizer,
+                backend="fireworks",
+                family=renderer_family,
+                renderer_name=renderer_name,
             )
+            explicit = renderer_name is not None or renderer_family != "auto"
+            self.unified_renderer = res.renderer if (res.source == "tinker" or (explicit and res.source != "chat_template")) else None
+            if self.unified_renderer is not None:
+                logger.info("FireworksEngine rendering via %s renderer (%s)", res.name, res.source)
+            elif explicit and res.source == "chat_template":
+                logger.warning(
+                    "renderer_family=%r / renderer_name=%r did not resolve a native renderer for %s; using ChatTemplateParser.",
+                    renderer_family,
+                    renderer_name,
+                    getattr(tokenizer, "name_or_path", None),
+                )
 
         # No tinker_cookbook renderer on this path; the unified renderer (above) or
         # chat_parser owns rendering+parsing — both handled by the shared TinkerEngine.

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -21,7 +21,7 @@ import asyncio
 import contextvars
 import dataclasses
 import logging
-from typing import Any, cast
+from typing import Any
 
 from fireworks.training.sdk import DeploymentSampler
 from typing_extensions import override
@@ -197,8 +197,8 @@ class FireworksEngine(TinkerEngine):
             renderer_name=renderer_name,
         )
         explicit = renderer_name is not None or renderer_family != "auto"
-        self.renderer = res.renderer if (res.source == "tinker" or (explicit and res.source != "chat_template")) else None
-        if self.renderer is not None:
+        self.unified_renderer = res.renderer if (res.source == "tinker" or (explicit and res.source != "chat_template")) else None
+        if self.unified_renderer is not None:
             logger.info("FireworksEngine rendering via %s renderer (%s)", res.name, res.source)
         elif explicit and res.source == "chat_template":
             logger.warning(
@@ -208,55 +208,18 @@ class FireworksEngine(TinkerEngine):
                 getattr(tokenizer, "name_or_path", None),
             )
 
-        # bypass_render_with_parser reflects who owns rendering+parsing: True means
-        # ChatTemplateParser (built below); False means the unified renderer does.
-        # The flag was previously hardcoded True even with a renderer active, which
-        # was a lie — and is why assemble_model_output asserted on a None chat_parser.
-        self.bypass_render_with_parser = self.renderer is None
-        self.chat_parser = None if self.renderer is not None else ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=disable_thinking)
+        # No tinker_cookbook renderer on this path; the unified renderer (above) or
+        # chat_parser owns rendering+parsing — both handled by the shared TinkerEngine.
+        # ``renderer`` stays None so the shared legacy/VLM branch is never reached here.
+        self.renderer = None
+        # bypass_render_with_parser reflects who owns rendering+parsing: True =
+        # ChatTemplateParser (built below); False = the unified renderer.
+        self.bypass_render_with_parser = self.unified_renderer is None
+        self.chat_parser = None if self.unified_renderer is not None else ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=disable_thinking)
 
         self.sample_timeout = sample_timeout
         self.router_replay = router_replay
         self.sampling_client = sampler
-
-    @override
-    def assemble_model_output(self, token_input, token_output) -> ModelOutput:
-        """Assemble the ModelOutput, parsing the completion via the unified renderer.
-
-        When a unified renderer is active, chat_parser is None, so the parent's
-        chat_parser path can't run. Parse the completion through the renderer's
-        ``parse_response`` (a ``ParsedResponse``) instead. Falls back to the
-        inherited (chat_parser) path otherwise. This covers both turn 0
-        (``get_model_response``) and turns 1+ (the gateway's token-prompt path),
-        which both call ``assemble_model_output``.
-        """
-        if self.renderer is None:
-            return super().assemble_model_output(token_input, token_output)
-
-        sampled = cast(TinkerTokenOutput, token_output)
-        response_tokens, logprobs = sampled.tokens, sampled.logprobs
-        parsed = self.renderer.parse_response(response_tokens)
-
-        prompt_ids: list[int] = []
-        for elem in token_input:
-            chunk_tokens = getattr(elem, "tokens", None)  # tinker.EncodedTextChunk -> ints
-            if chunk_tokens is not None:
-                prompt_ids.extend(chunk_tokens)
-            else:
-                prompt_ids.append(elem)
-
-        return ModelOutput(
-            text=self.tokenizer.decode(response_tokens, skip_special_tokens=True),
-            content=parsed.content or "",
-            reasoning=parsed.reasoning_content or "",
-            tool_calls=parsed.tool_calls or [],
-            prompt_ids=prompt_ids,
-            completion_ids=response_tokens,
-            logprobs=logprobs,
-            prompt_length=_flat_token_input_length(token_input),
-            completion_length=len(response_tokens),
-            finish_reason=sampled.stop_reason,
-        )
 
     # ------------------------------------------------------------------
     # Token-in / token-out override
@@ -270,18 +233,12 @@ class FireworksEngine(TinkerEngine):
         accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.accumulate_reasoning)
         reasoning_effort = kwargs.pop("reasoning_effort", self.reasoning_effort)
 
-        if self.renderer is not None:
-            token_input = self.renderer.render_ids(messages, tools=tools or None, add_generation_prompt=True)
-        else:
-            prompt = self.chat_parser.parse(
-                messages,
-                add_generation_prompt=True,
-                is_first_msg=True,
-                tools=tools,
-                reasoning_effort=reasoning_effort,
-                accumulate_reasoning=accumulate_reasoning,
-            )
-            token_input = self.tokenizer.encode(prompt, add_special_tokens=False)
+        token_input = self._render_prompt_token_input(
+            messages,
+            tools=tools,
+            reasoning_effort=reasoning_effort,
+            accumulate_reasoning=accumulate_reasoning,
+        )
 
         if application_id is not None:
             kwargs["user"] = application_id

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -178,8 +178,6 @@ class FireworksEngine(TinkerEngine):
         self.train_sampling_params = dict((sampling_params or {}).get("train", {}))
         self.val_sampling_params = dict((sampling_params or {}).get("val", {}))
 
-        self.bypass_render_with_parser = True
-
         # Resolve the renderer the same way the gateway does, so the engine renders
         # turn 0 with the same renderer the gateway uses for the turn-1+ cumulative
         # bridge. resolve() auto-detects Fireworks-cookbook models (e.g. GLM-5.2 ->
@@ -210,7 +208,11 @@ class FireworksEngine(TinkerEngine):
                 getattr(tokenizer, "name_or_path", None),
             )
 
-        # Chat template parser — only when no unified renderer is active.
+        # bypass_render_with_parser reflects who owns rendering+parsing: True means
+        # ChatTemplateParser (built below); False means the unified renderer does.
+        # The flag was previously hardcoded True even with a renderer active, which
+        # was a lie — and is why assemble_model_output asserted on a None chat_parser.
+        self.bypass_render_with_parser = self.renderer is None
         self.chat_parser = None if self.renderer is not None else ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=disable_thinking)
 
         self.sample_timeout = sample_timeout

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -21,7 +21,7 @@ import asyncio
 import contextvars
 import dataclasses
 import logging
-from typing import Any
+from typing import Any, cast
 
 from fireworks.training.sdk import DeploymentSampler
 from typing_extensions import override
@@ -216,6 +216,45 @@ class FireworksEngine(TinkerEngine):
         self.sample_timeout = sample_timeout
         self.router_replay = router_replay
         self.sampling_client = sampler
+
+    @override
+    def assemble_model_output(self, token_input, token_output) -> ModelOutput:
+        """Assemble the ModelOutput, parsing the completion via the unified renderer.
+
+        When a unified renderer is active, chat_parser is None, so the parent's
+        chat_parser path can't run. Parse the completion through the renderer's
+        ``parse_response`` (a ``ParsedResponse``) instead. Falls back to the
+        inherited (chat_parser) path otherwise. This covers both turn 0
+        (``get_model_response``) and turns 1+ (the gateway's token-prompt path),
+        which both call ``assemble_model_output``.
+        """
+        if self.renderer is None:
+            return super().assemble_model_output(token_input, token_output)
+
+        sampled = cast(TinkerTokenOutput, token_output)
+        response_tokens, logprobs = sampled.tokens, sampled.logprobs
+        parsed = self.renderer.parse_response(response_tokens)
+
+        prompt_ids: list[int] = []
+        for elem in token_input:
+            chunk_tokens = getattr(elem, "tokens", None)  # tinker.EncodedTextChunk -> ints
+            if chunk_tokens is not None:
+                prompt_ids.extend(chunk_tokens)
+            else:
+                prompt_ids.append(elem)
+
+        return ModelOutput(
+            text=self.tokenizer.decode(response_tokens, skip_special_tokens=True),
+            content=parsed.content or "",
+            reasoning=parsed.reasoning_content or "",
+            tool_calls=parsed.tool_calls or [],
+            prompt_ids=prompt_ids,
+            completion_ids=response_tokens,
+            logprobs=logprobs,
+            prompt_length=_flat_token_input_length(token_input),
+            completion_length=len(response_tokens),
+            finish_reason=sampled.stop_reason,
+        )
 
     # ------------------------------------------------------------------
     # Token-in / token-out override

--- a/rllm/engine/rollout/tinker_engine.py
+++ b/rllm/engine/rollout/tinker_engine.py
@@ -196,6 +196,12 @@ class TinkerEngine(RolloutEngine):
         self.bypass_render_with_parser = bypass_render_with_parser
         self.accumulate_reasoning = accumulate_reasoning
         self.reasoning_effort = reasoning_effort
+        # Optional unified renderer (rllm.renderers). When set, it owns prompt
+        # rendering and completion parsing for both backends; ``renderer`` (the
+        # tinker_cookbook renderer) and ``chat_parser`` remain the fallbacks.
+        # Base TinkerEngine leaves this None (no behavior change); FireworksEngine
+        # sets it via rllm.renderers.resolve.
+        self.unified_renderer = None
 
         self.train_sampling_params = dict(sampling_params.get("train", {})) if sampling_params else {}
         self.val_sampling_params = dict(sampling_params.get("val", {})) if sampling_params else {}
@@ -339,7 +345,14 @@ class TinkerEngine(RolloutEngine):
         sampled_sequence = cast(TinkerTokenOutput, token_output)
         response_tokens, logprobs = sampled_sequence.tokens, sampled_sequence.logprobs
 
-        if self.bypass_render_with_parser:
+        if self.unified_renderer is not None:
+            # Unified rllm.renderers layer (prime-rl / Fireworks-cookbook): parse
+            # the completion into a ParsedResponse. Shared by both backends.
+            parsed = self.unified_renderer.parse_response(response_tokens)
+            content = parsed.content or ""
+            reasoning = parsed.reasoning_content or ""
+            tool_calls = parsed.tool_calls or []
+        elif self.bypass_render_with_parser:
             assert self.chat_parser is not None, "chat_parser must be set when bypass_render_with_parser=True"
             parsed_output = self.chat_parser.parse_completion(response_tokens)
             content = parsed_output.get("content", "")
@@ -374,6 +387,32 @@ class TinkerEngine(RolloutEngine):
             finish_reason=finish_reason,
         )
 
+    def _render_prompt_token_input(self, messages: list[dict], *, tools=None, reasoning_effort=None, accumulate_reasoning=None):
+        """Render messages to this engine's token input. Shared by both backends.
+
+        Order mirrors ``assemble_model_output``'s parse branches: unified
+        rllm.renderers renderer (``render_ids``) -> ChatTemplateParser
+        (text -> encode) -> tinker_cookbook renderer (``build_generation_prompt``
+        chunks, incl. VLM image chunks).
+        """
+        if self.unified_renderer is not None:
+            return self.unified_renderer.render_ids(messages, tools=tools or None, add_generation_prompt=True)
+        if self.bypass_render_with_parser:
+            prompt = self.chat_parser.parse(  # type: ignore
+                messages,
+                add_generation_prompt=True,
+                is_first_msg=True,
+                tools=tools,
+                reasoning_effort=reasoning_effort,
+                accumulate_reasoning=accumulate_reasoning,
+            )
+            return self.tokenizer.encode(prompt, add_special_tokens=False)  # type: ignore
+        converted_messages = self._convert_images_to_content_list(messages)
+        tinker_messages = _convert_openai_messages(converted_messages)
+        if tools:
+            tinker_messages = _prepare_messages_with_tools(self.renderer, tinker_messages, tools)
+        return self.renderer.build_generation_prompt(tinker_messages).chunks  # type: ignore
+
     @override
     async def _get_model_response(self, messages: list[dict], **kwargs) -> ModelOutput:
         """
@@ -398,27 +437,12 @@ class TinkerEngine(RolloutEngine):
         accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.accumulate_reasoning)
         reasoning_effort = kwargs.pop("reasoning_effort", self.reasoning_effort)
 
-        if self.bypass_render_with_parser:
-            # Use ChatTemplateParser
-            prompt = self.chat_parser.parse(  # type: ignore
-                messages,
-                add_generation_prompt=True,
-                is_first_msg=True,
-                tools=tools,
-                reasoning_effort=reasoning_effort,
-                accumulate_reasoning=accumulate_reasoning,
-            )
-            token_input = self.tokenizer.encode(prompt, add_special_tokens=False)  # type: ignore
-        else:
-            # Use Tinker renderer
-            # Convert images, then convert OpenAI messages to renderer format
-            converted_messages = self._convert_images_to_content_list(messages)
-            tinker_messages = _convert_openai_messages(converted_messages)
-            # Inject tool definitions via renderer if tools are provided
-            if tools:
-                tinker_messages = _prepare_messages_with_tools(self.renderer, tinker_messages, tools)
-            # Build prompt using renderer
-            token_input: TinkerTokenInput = self.renderer.build_generation_prompt(tinker_messages).chunks  # type: ignore
+        token_input = self._render_prompt_token_input(
+            messages,
+            tools=tools,
+            reasoning_effort=reasoning_effort,
+            accumulate_reasoning=accumulate_reasoning,
+        )
 
         sampled_sequence = await self.get_token_output_from_token_input(token_input=token_input, **kwargs)
         return self.assemble_model_output(token_input=token_input, token_output=sampled_sequence)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -229,10 +229,12 @@ def test_fireworks_engine_skips_chatparser_when_renderer_pinned(qwen_tokenizer):
     pinned = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler(), renderer_family="qwen3")
     assert pinned.renderer is not None
     assert pinned.chat_parser is None
+    assert pinned.bypass_render_with_parser is False  # renderer owns rendering+parsing
 
     default = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler())
     assert default.renderer is None
     assert default.chat_parser is not None
+    assert default.bypass_render_with_parser is True
 
 
 def test_cookbook_renderer_name_prefix_match():

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -286,3 +286,25 @@ def test_assemble_model_output_uses_renderer_when_chat_parser_absent(qwen_tokeni
     assert out.prompt_ids == [1, 2, 3]
     assert isinstance(out.content, str)
     assert isinstance(out.tool_calls, list)
+
+
+def test_fireworks_engine_explicit_bypass_overrides_renderer(qwen_tokenizer):
+    """bypass_render_with_parser=True is an explicit escape hatch: force
+    ChatTemplateParser and skip the unified renderer, even when one is pinned."""
+    pytest.importorskip("tinker")
+    try:
+        from rllm.engine.rollout.fireworks_engine import FireworksEngine
+    except Exception as e:
+        pytest.skip(f"FireworksEngine import failed: {e}")
+
+    class _StubSampler: ...
+
+    engine = FireworksEngine(
+        tokenizer=qwen_tokenizer,
+        sampler=_StubSampler(),
+        renderer_family="qwen3",  # would normally pin the unified renderer
+        bypass_render_with_parser=True,
+    )
+    assert engine.unified_renderer is None
+    assert engine.chat_parser is not None
+    assert engine.bypass_render_with_parser is True

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -256,3 +256,31 @@ def test_resolve_cookbook_does_not_crash_when_absent(qwen_tokenizer, monkeypatch
     monkeypatch.setattr(qwen_tokenizer, "name_or_path", "zai-org/GLM-5.2", raising=False)
     res = resolve("zai-org/GLM-5.2", qwen_tokenizer)
     assert res.source in ("tinker", "chat_template")
+
+
+def test_assemble_model_output_uses_renderer_when_chat_parser_absent(qwen_tokenizer):
+    """With a unified renderer active (chat_parser=None), assemble_model_output must
+    parse the completion via the renderer instead of asserting chat_parser is set."""
+    pytest.importorskip("tinker")
+    try:
+        from rllm.engine.rollout.fireworks_engine import FireworksEngine
+    except Exception as e:
+        pytest.skip(f"FireworksEngine import failed: {e}")
+
+    class _StubSampler: ...
+
+    class _StubOutput:
+        def __init__(self, tokens):
+            self.tokens = tokens
+            self.logprobs = [0.0] * len(tokens)
+            self.stop_reason = "stop"
+
+    engine = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler(), renderer_family="qwen3")
+    assert engine.renderer is not None and engine.chat_parser is None
+
+    completion = qwen_tokenizer.encode("hello", add_special_tokens=False) + engine.renderer.get_stop_token_ids()[:1]
+    out = engine.assemble_model_output([1, 2, 3], _StubOutput(completion))  # must not raise
+    assert out.completion_ids == completion
+    assert out.prompt_ids == [1, 2, 3]
+    assert isinstance(out.content, str)
+    assert isinstance(out.tool_calls, list)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -227,12 +227,12 @@ def test_fireworks_engine_skips_chatparser_when_renderer_pinned(qwen_tokenizer):
     class _StubSampler: ...
 
     pinned = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler(), renderer_family="qwen3")
-    assert pinned.renderer is not None
+    assert pinned.unified_renderer is not None
     assert pinned.chat_parser is None
     assert pinned.bypass_render_with_parser is False  # renderer owns rendering+parsing
 
     default = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler())
-    assert default.renderer is None
+    assert default.unified_renderer is None
     assert default.chat_parser is not None
     assert default.bypass_render_with_parser is True
 
@@ -278,9 +278,9 @@ def test_assemble_model_output_uses_renderer_when_chat_parser_absent(qwen_tokeni
             self.stop_reason = "stop"
 
     engine = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler(), renderer_family="qwen3")
-    assert engine.renderer is not None and engine.chat_parser is None
+    assert engine.unified_renderer is not None and engine.chat_parser is None
 
-    completion = qwen_tokenizer.encode("hello", add_special_tokens=False) + engine.renderer.get_stop_token_ids()[:1]
+    completion = qwen_tokenizer.encode("hello", add_special_tokens=False) + engine.unified_renderer.get_stop_token_ids()[:1]
     out = engine.assemble_model_output([1, 2, 3], _StubOutput(completion))  # must not raise
     assert out.completion_ids == completion
     assert out.prompt_ids == [1, 2, 3]


### PR DESCRIPTION
## Problem

After #702 (skip `ChatTemplateParser` when a unified renderer is active), the first response crashed:
```
assemble_model_output: AssertionError: chat_parser must be set when bypass_render_with_parser=True
```
The input (prompt) path used the unified renderer, but the output (completion-parse) path still required `chat_parser`. My first fix patched this as a **FireworksEngine override** — but per review, the right place is the **shared `TinkerEngine`**, so both the Tinker and Fireworks backends render+parse through one unified path (the original "one renderer layer for all backends" goal). `TinkerEngine` had the same limitation anyway (its `model_info` recommender doesn't know GLM / cookbook models).

## Fix (shared, in `TinkerEngine`)

- **`TinkerEngine`**: add `self.unified_renderer` (default `None`) and a shared `_render_prompt_token_input` helper. Both `assemble_model_output` (parse) and the render path now branch in the same order:
  1. unified `rllm.renderers` renderer (`render_ids` / `parse_response` → `ParsedResponse`),
  2. `ChatTemplateParser` (text → encode / `parse_completion`),
  3. `tinker_cookbook` renderer (`build_generation_prompt` chunks, incl. **VLM** image chunks).
  Base behavior is unchanged — `unified_renderer` stays `None` for the Tinker backend, so its `chat_parser` / tinker-renderer / VLM paths are fully preserved.
- **`FireworksEngine`**: sets `self.unified_renderer` via `rllm.renderers.resolve` and reuses the shared render+parse. **Dropped** its `assemble_model_output` override and inline render. `bypass_render_with_parser` now honestly reflects ownership (`= unified_renderer is None`).

No external code reads `rollout_engine.renderer` (verified), so introducing `unified_renderer` is safe.

## Testing
- `unified_renderer` is set (and `chat_parser=None`, `bypass=False`) when pinned; `assemble_model_output` parses via the renderer with no `chat_parser`.
- 15 renderer tests + 55 engine tests pass. (1 fail / 4 errors are pre-existing env issues: `verl` not installed, `torch.LongTensor` — unrelated.) ruff clean.

Stacks on #702. With this merged, GLM-5.2 cumulative training runs end-to-end, and the renderer path is unified across the Tinker and Fireworks backends.

### Known follow-up (out of scope)
`completer.py` still hard-requires `chat_parser is not None`; a Completer-based path with a unified renderer would need the same treatment. The gateway training path doesn't use Completer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)