### PR TITLE
fix(gateway): replay duplicate resends in place instead of resetting the accumulator

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -189,6 +189,28 @@ class ReverseProxy:
                             "new_roles": [m.get("role") for m in plan.new_messages],
                         },
                     )
+                elif plan.action == "replay" and acc.prev_prompt_ids:
+                    # Duplicate resend (upstream retry): the conversation did not
+                    # advance. Regenerate from the same prompt and overwrite this
+                    # turn in place instead of resetting — keeps drift-free state
+                    # and avoids a spurious segment break for a single step. A
+                    # fresh sample (not a cached one) is returned, so a retry that
+                    # depends on resampling still makes progress.
+                    logger.info(
+                        "TokenAccumulator duplicate session=%s turn=%d age_s=%s: regenerating in place, no reset",
+                        session_id,
+                        acc.turn_count,
+                        plan.diagnostics.get("age_s", "?"),
+                    )
+                    return await self._handle_cumulative_turn(
+                        request,
+                        request_body,
+                        session_id,
+                        acc,
+                        list(acc.prev_prompt_ids),
+                        originally_requested_logprobs,
+                        replay=True,
+                    )
                 else:
                     acc.reset(plan.reason, diagnostics=plan.diagnostics)
 
@@ -287,11 +309,16 @@ class ReverseProxy:
         acc: TokenAccumulator,
         token_ids: list[int],
         originally_requested_logprobs: bool = False,
+        *,
+        replay: bool = False,
     ) -> Response:
         """Rewrite chat/completions to /v1/completions with pre-tokenized prompt.
 
-        ``token_ids`` is the full bridge-extended prompt for this turn, built
-        by ``acc.build_next_prompt`` in ``handle()``.
+        ``token_ids`` is the full bridge-extended prompt for this turn, built by
+        ``acc.build_next_prompt`` in ``handle()`` — or, when ``replay`` is set,
+        the prior turn's prompt being regenerated after a duplicate resend.
+        ``replay`` overwrites the current turn in place (``advance=False``)
+        instead of recording a new one.
 
         Respects the original stream setting: if the client requested streaming,
         we stream from vLLM and translate completions chunks to chat format in
@@ -305,7 +332,7 @@ class ReverseProxy:
         completions_body["add_special_tokens"] = False
 
         if is_stream:
-            return await self._handle_cumulative_streaming(request, request_body, completions_body, session_id, acc, token_ids)
+            return await self._handle_cumulative_streaming(request, request_body, completions_body, session_id, acc, token_ids, replay=replay)
         return await self._handle_cumulative_non_streaming(
             request,
             request_body,
@@ -314,6 +341,7 @@ class ReverseProxy:
             acc,
             token_ids,
             originally_requested_logprobs,
+            replay=replay,
         )
 
     async def _handle_cumulative_non_streaming(
@@ -325,6 +353,8 @@ class ReverseProxy:
         acc: TokenAccumulator,
         token_ids: list[int],
         originally_requested_logprobs: bool = False,
+        *,
+        replay: bool = False,
     ) -> Response:
         """Non-streaming cumulative turn: send pre-tokenized prompt, return JSON.
 
@@ -368,7 +398,7 @@ class ReverseProxy:
         prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
         completion_token_ids = extract_completion_token_ids(response_body)
 
-        acc.ingest_turn(prompt_token_ids, completion_token_ids)
+        acc.ingest_turn(prompt_token_ids, completion_token_ids, advance=not replay)
         acc.update_prefix(request_body.get("messages", []))
 
         # Translate to chat format
@@ -403,12 +433,18 @@ class ReverseProxy:
         session_id: str,
         acc: TokenAccumulator,
         token_ids: list[int],
+        *,
+        replay: bool = False,
     ) -> StreamingResponse:
-        """Streaming cumulative turn: stream from vLLM, translate chunks to chat format."""
+        """Streaming cumulative turn: stream from vLLM, translate chunks to chat format.
+
+        ``replay`` overwrites the current turn in place (duplicate resend) rather
+        than recording a new one.
+        """
         if self.local_handler is not None:
             # In-process backends (Tinker) don't stream; synthesize an SSE
             # stream from a single pre-tokenized completion call.
-            return await self._handle_cumulative_streaming_local(request, request_body, completions_body, session_id, acc, token_ids)
+            return await self._handle_cumulative_streaming_local(request, request_body, completions_body, session_id, acc, token_ids, replay=replay)
 
         completions_body["stream"] = True
 
@@ -524,7 +560,7 @@ class ReverseProxy:
                     prompt_ids = trace.prompt_token_ids or token_ids
                     completion_ids = trace.completion_token_ids
 
-                    acc.ingest_turn(prompt_ids, completion_ids)
+                    acc.ingest_turn(prompt_ids, completion_ids, advance=not replay)
                     acc.update_prefix(request_body.get("messages", []))
 
                     task = asyncio.create_task(self._safe_store(trace.trace_id, trace.session_id, trace.model_dump()))
@@ -545,12 +581,17 @@ class ReverseProxy:
         session_id: str,
         acc: TokenAccumulator,
         token_ids: list[int],
+        *,
+        replay: bool = False,
     ) -> StreamingResponse:
         """Cumulative streaming via the in-process handler (fake-streaming).
 
         The local handler returns a full completion in one shot; we ingest its
         token IDs into the accumulator, translate to chat format, and emit it as
         a synthesized SSE stream (role → content+tokens → finish → [DONE]).
+
+        ``replay`` overwrites the current turn in place (duplicate resend) rather
+        than recording a new one.
         """
         assert self.local_handler is not None
         t0 = time.perf_counter()
@@ -561,7 +602,7 @@ class ReverseProxy:
 
         prompt_token_ids = extract_prompt_token_ids(response_body) or token_ids
         completion_token_ids = extract_completion_token_ids(response_body)
-        acc.ingest_turn(prompt_token_ids, completion_token_ids)
+        acc.ingest_turn(prompt_token_ids, completion_token_ids, advance=not replay)
         acc.update_prefix(request_body.get("messages", []))
 
         choices = response_body.get("choices") or []

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -45,7 +45,9 @@ class ResetReason(str, Enum):
     #: Incoming list is byte-identical to the snapshot we already processed —
     #: the conversation did **not advance**. Almost always an upstream retry /
     #: duplicate request; the log's ``age_s`` (seconds since the snapshot) tells
-    #: you whether it was a fast resend.
+    #: you whether it was a fast resend. Handled as a **replay** (regenerate +
+    #: overwrite the turn in place), not a reset — so it's the one classification
+    #: carried in :class:`TurnPlan` that does not drop state.
     DUPLICATE = "duplicate"
 
     #: The messages *covering the snapshot prefix* changed: the list is shorter
@@ -86,9 +88,11 @@ _REL_PREFIX_CHANGED = "prefix_changed"
 class TurnPlan:
     """How an incoming request should be handled against the current snapshot.
 
-    ``action`` is ``"extend"`` (build a cumulative bridge from ``new_messages``)
-    or ``"reset"`` (drop state and re-ingest as turn-0, logging ``reason``).
-    ``diagnostics`` carries the structural facts for the reset log.
+    ``action`` is ``"extend"`` (build a cumulative bridge from ``new_messages``),
+    ``"replay"`` (a duplicate resend — regenerate from the accumulated prompt and
+    overwrite the current turn in place, no reset), or ``"reset"`` (drop state and
+    re-ingest as turn-0, logging ``reason``). ``diagnostics`` carries the
+    structural facts for the reset/replay log.
     """
 
     action: str
@@ -208,11 +212,13 @@ class TokenAccumulator:
     def plan_turn(self, messages: list[dict[str, Any]]) -> TurnPlan:
         """Decide how to handle an incoming chat request for an active session.
 
-        Returns a :class:`TurnPlan`: either ``extend`` (with the new messages to
-        bridge) or ``reset`` (with the classified :class:`ResetReason` and
-        diagnostics for the log). Does not call the renderer — a structurally
-        valid extension that the renderer later declines is surfaced separately
-        by the caller as :attr:`ResetReason.RENDERER_NO_BRIDGE`.
+        Returns a :class:`TurnPlan`: ``extend`` (bridge the new messages),
+        ``replay`` (a duplicate resend — regenerate from the same prompt and
+        overwrite the current turn in place, no reset), or ``reset`` (with the
+        classified :class:`ResetReason` and diagnostics for the log). Does not
+        call the renderer — a structurally valid extension that the renderer
+        later declines is surfaced separately by the caller as
+        :attr:`ResetReason.RENDERER_NO_BRIDGE`.
         """
         relation = self._classify_prefix(messages)
         diag: dict[str, Any] = {"incoming_len": len(messages), "relation": relation}
@@ -229,7 +235,11 @@ class TokenAccumulator:
         if relation == _REL_DUPLICATE:
             if self._snapshot_mono is not None:
                 diag["age_s"] = round(time.monotonic() - self._snapshot_mono, 2)
-            return TurnPlan(action="reset", reason=ResetReason.DUPLICATE, diagnostics=diag)
+            # Identical resend (upstream retry): the conversation did not advance.
+            # Regenerate from the same prompt and overwrite this turn in place —
+            # do NOT reset (that would drop drift-free state and break the segment
+            # for a single step).
+            return TurnPlan(action="replay", reason=ResetReason.DUPLICATE, diagnostics=diag)
 
         # _REL_PREFIX_CHANGED
         diag.update(self._divergence_diag(messages))
@@ -316,17 +326,23 @@ class TokenAccumulator:
         self._prefix_fps = []
         self._snapshot_mono = None
 
-    def ingest_turn(self, prompt_token_ids: list[int], completion_token_ids: list[int]) -> None:
+    def ingest_turn(self, prompt_token_ids: list[int], completion_token_ids: list[int], *, advance: bool = True) -> None:
         """Record the token IDs from a completed turn.
 
         ``prompt_token_ids`` is the full prompt the turn was sampled from (turn
         1: the chat-rendered prompt; later turns: the bridge output we built).
         ``completion_token_ids`` is what the model produced. Together they form
         ``previous_prompt`` / ``previous_completion`` for the next bridge call.
+
+        ``advance=False`` overwrites the most recent turn in place without bumping
+        ``turn_count`` — used when replaying a duplicate resend, where the
+        conversation did not move forward but the regenerated tokens replace the
+        prior sample.
         """
         self.prev_prompt_ids = list(prompt_token_ids)
         self.prev_completion_ids = list(completion_token_ids)
-        self.turn_count += 1
+        if advance:
+            self.turn_count += 1
 
     def update_prefix(self, messages: list[dict[str, Any]]) -> None:
         """Snapshot the current message list as the verified prefix."""

--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
@@ -134,3 +134,31 @@ def test_cumulative_local_streaming_emits_sse_and_ingests():
     assert chunks[-1].strip().endswith("[DONE]")
     # Same ingest as non-streaming.
     assert acc.turn_count == 2 and acc.prev_completion_ids == [91, 92]
+
+
+def test_cumulative_local_replay_regenerates_in_place_without_advancing():
+    """A duplicate resend regenerates (fresh sample) and overwrites the turn in
+    place — handler is called again, turn_count does not advance, no reset."""
+    record = []
+    proxy = _make_proxy(_completion_handler(record))
+
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])  # turn 1
+    acc.update_prefix([{"role": "user", "content": "x"}])
+
+    resp = asyncio.run(
+        proxy._handle_cumulative_non_streaming(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            {"prompt": [1, 2, 3], "add_special_tokens": False, "model": "q"},
+            "sess1",
+            acc,
+            [1, 2, 3],  # same prompt the turn was sampled from
+            replay=True,
+        )
+    )
+
+    assert resp.status_code == 200
+    assert record and record[0]["prompt"] == [1, 2, 3]  # regenerated, not cached
+    assert acc.turn_count == 1  # overwritten in place, NOT advanced
+    assert acc.prev_completion_ids == [91, 92]  # fresh sample replaced the old one

--- a/rllm-model-gateway/tests/unit/test_token_accumulator.py
+++ b/rllm-model-gateway/tests/unit/test_token_accumulator.py
@@ -50,6 +50,17 @@ class TestTokenAccumulator:
         assert acc.prev_prompt_ids == [1, 2, 3]
         assert acc.prev_completion_ids == [10, 11]
 
+    def test_ingest_replay_overwrites_turn_in_place(self):
+        from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+        acc = TokenAccumulator(renderer=_MockRenderer())
+        acc.ingest_turn([1, 2, 3], [10, 11])
+        # Replay a duplicate: same prompt, fresh completion, no turn advance.
+        acc.ingest_turn([1, 2, 3], [99], advance=False)
+        assert acc.turn_count == 1  # unchanged — same logical step
+        assert acc.prev_completion_ids == [99]
+        assert acc.cumulative_ids == [1, 2, 3, 99]
+
     def test_should_rewrite_false_on_first_turn(self):
         from rllm_model_gateway.token_accumulator import TokenAccumulator
 
@@ -279,7 +290,8 @@ class TestPlanTurnClassification:
         msgs = [{"role": "user", "content": "Hello"}]
         acc = self._seed(msgs)
         plan = acc.plan_turn([{"role": "user", "content": "Hello"}])  # byte-identical
-        assert plan.action == "reset"
+        # A duplicate is replayed in place (regenerate + overwrite), NOT reset.
+        assert plan.action == "replay"
         assert plan.reason is ResetReason.DUPLICATE
         # age_s is populated from the snapshot time (>= 0).
         assert plan.diagnostics.get("age_s") is not None


### PR DESCRIPTION
## Problem

In cumulative-token mode, an identical resend (an upstream timeout/retry of a turn already processed) was classified as a **reset**: `plan_turn` returned `action="reset"` with `ResetReason.DUPLICATE`, so the proxy dropped the drift-free token state, re-tokenized from text as a fresh turn-0, and forced a spurious **segment break for a single step**.

## Fix (minimal change vs `terminal-rl`)

Handle `DUPLICATE` as a **replay**: regenerate from the same accumulated prompt and **overwrite the current turn in place** — no reset.

- **`token_accumulator.py`**: `plan_turn` returns `action="replay"` for `DUPLICATE`; `ingest_turn(..., advance=False)` overwrites the current turn without bumping `turn_count`.
- **`proxy.py`**: `handle()` replays from `acc.prev_prompt_ids` via `_handle_cumulative_turn(replay=True)`, plumbed through the cumulative handlers as `advance=not replay`. One INFO log per duplicate (`regenerating in place, no reset`).

A **fresh sample** (not a cached one) is returned, and each duplicate still costs a real generation. That matters: a retry loop that depends on resampling — e.g. terminus2's context-length summarization fallback — still makes progress, and the generation latency naturally rate-limits the loop. (An earlier revision of this PR returned a *cached* response via a single-flight layer; testing on terminus2/tmax showed that traps such loops into a tight ~0.8s busy-spin by removing both the latency and the fresh-sample variation. Reverted to this minimal, regenerate-in-place approach.)

**Out of scope:** coalescing concurrent in-flight duplicates — rare in practice and not worth the added complexity.

## Diff
4 files, +118/−21. `reset()` / `ResetReason` / the prefix-changed + empty-delta + renderer-no-bridge reset paths are unchanged.

## Testing
- `test_token_accumulator.py`: duplicate now expects `action="replay"`; added an `ingest_turn(advance=False)` in-place-overwrite test.
- `test_cumulative_token_mode_local.py`: added a proxy-level test that a replay regenerates (handler called), overwrites in place, and does **not** advance `turn_count`.
- 31 passed; pinned `ruff@0.11.4` check + format clean.

> Targets `terminal-rl` (where the gateway/accumulator live), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)