### PR TITLE
feat(sft): VerlSFTBackend (verl 0.8.0 FSDP) + bump to main

### DIFF
--- a/cookbooks/agent_frameworks/train_verl.sh
+++ b/cookbooks/agent_frameworks/train_verl.sh
@@ -31,9 +31,9 @@ python -u train.py \
     data.max_response_length=20480 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -52,7 +52,7 @@ python -u train.py \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=32768 \
+    actor_rollout_ref.rollout.max_model_len=32768 \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=4 \

--- a/cookbooks/deepcoder/train_verl.sh
+++ b/cookbooks/deepcoder/train_verl.sh
@@ -23,9 +23,9 @@ python -u train.py \
     data.max_response_length=16384 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -42,7 +42,7 @@ python -u train.py \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.mode=async \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=32768 \
+    actor_rollout_ref.rollout.max_model_len=32768 \
     actor_rollout_ref.rollout.temperature=0.6 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=4 \

--- a/cookbooks/finqa/train_verl.sh
+++ b/cookbooks/finqa/train_verl.sh
@@ -24,9 +24,9 @@ python -u train.py \
     data.max_response_length=4096 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -45,7 +45,7 @@ python -u train.py \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=16384 \
+    actor_rollout_ref.rollout.max_model_len=16384 \
     actor_rollout_ref.rollout.temperature=0.6 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=4 \

--- a/cookbooks/frozenlake/train_verl.sh
+++ b/cookbooks/frozenlake/train_verl.sh
@@ -23,9 +23,9 @@ python -u train.py \
     data.max_response_length=2048 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -42,7 +42,7 @@ python -u train.py \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.mode=async \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=8192 \
+    actor_rollout_ref.rollout.max_model_len=8192 \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=4 \

--- a/cookbooks/geo3k/train_verl.sh
+++ b/cookbooks/geo3k/train_verl.sh
@@ -23,9 +23,9 @@ python -u train.py \
     data.max_response_length=2048 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=2e-5 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -40,7 +40,7 @@ python -u train.py \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.mode=async \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=8192 \
+    actor_rollout_ref.rollout.max_model_len=8192 \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=4 \

--- a/cookbooks/math/train_verl.sh
+++ b/cookbooks/math/train_verl.sh
@@ -23,9 +23,9 @@ python -u train.py \
     data.max_response_length=4096 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -42,7 +42,7 @@ python -u train.py \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.mode=async \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=8192 \
+    actor_rollout_ref.rollout.max_model_len=8192 \
     actor_rollout_ref.rollout.temperature=0.6 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=8 \

--- a/cookbooks/math_tool_agent/train_verl.sh
+++ b/cookbooks/math_tool_agent/train_verl.sh
@@ -23,9 +23,9 @@ python -u train.py \
     data.max_response_length=20480 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -44,7 +44,7 @@ python -u train.py \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=true \
     +actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=32768 \
+    actor_rollout_ref.rollout.max_model_len=32768 \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=4 \

--- a/cookbooks/solver_judge_flow/train_verl.sh
+++ b/cookbooks/solver_judge_flow/train_verl.sh
@@ -23,9 +23,9 @@ python -u train.py \
     data.max_response_length=1024 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=32 \
-    +actor_rollout_ref.model.lora.alpha=32 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=32 \
+    actor_rollout_ref.model.lora.alpha=32 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \
@@ -42,7 +42,7 @@ python -u train.py \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.mode=async \
     actor_rollout_ref.rollout.enforce_eager=False \
-    +actor_rollout_ref.rollout.max_model_len=32768 \
+    actor_rollout_ref.rollout.max_model_len=32768 \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=4 \

--- a/docs/backends/verl.mdx
+++ b/docs/backends/verl.mdx
@@ -22,7 +22,6 @@ rLLM drives verl from its own `UnifiedTrainer` rather than running verl's `RayPP
 - **No reward model.** `reward.reward_model.enable=True` is rejected at startup. Compute rewards inside your workflow via a `RewardFunction` so they flow through the same path as the Tinker backend.
 - **No in-reward KL.** `algorithm.use_kl_in_reward=True` is rejected at startup. KL-in-loss is supported — setting `rllm.algorithm.kl_beta>0` (or `actor_rollout_ref.actor.kl_loss_coef>0`) automatically enables it; the loss term runs inside verl's actor worker.
 - **Async rollout only.** `actor_rollout_ref.rollout.mode` must be `async`.
-- **New EngineWorker path only.** `trainer.use_legacy_worker_impl` is forced to `disable`.
 - **Shared rLLM/Verl knobs.** rLLM keeps a small table of shared keys (e.g. `algorithm.adv_estimator ↔ rllm.algorithm.adv_estimator`, `actor.kl_loss_coef ↔ rllm.algorithm.kl_beta`, `actor.clip_ratio ↔ rllm.algorithm.eps_clip`) in sync at runtime. New configs should use `rllm.*`. Existing Verl-native shared-key CLI overrides still work, but they warn because that path is deprecated. If both sides conflict, the `rllm.*` value wins. See [Configuration](/training/configuration#bidirectional-config-sync) for the full list.
 
 <Note>

--- a/examples/countdown/unified_trainer/train_countdown_unified_verl.sh
+++ b/examples/countdown/unified_trainer/train_countdown_unified_verl.sh
@@ -44,7 +44,6 @@ python -m examples.countdown.unified_trainer.train_countdown_unified_verl \
     rllm.stepwise_advantage.enable=False \
     rllm.stepwise_advantage.mode=per_step \
     trainer.critic_warmup=0 \
-    trainer.use_legacy_worker_impl=disable \
     trainer.logger=['console','wandb'] \
     trainer.project_name='rllm-countdown' \
     trainer.experiment_name='countdown-unified-verl' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ tinker = [
 
 fireworks = [
     "fireworks-ai[training]==1.2.0a79 ; python_version >= '3.11'",
-    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
+    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@bba676c6d00bd595f9453e0b2165b7457a01e0d5#subdirectory=training ; python_version >= '3.11'",
 ]
 
 opentelemetry = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,14 +75,14 @@ dev = [
 ]
 
 verl = [
-    "transformers>=4.55.0,<5.0.0",
+    "transformers>=5.5.3",
     "numpy",
-    "verl==0.7.1",
+    "verl==0.8.0",
     "ray",
     "torch>=2.10.0",
     "torchvision>=0.23.0",
-    "vllm==0.17.0",
-    "flash-attn==2.8.1",
+    "vllm==0.22.1",
+    "flash-attn==2.8.3",
     "qwen-vl-utils",
 ]
 

--- a/rllm/cli/sft.py
+++ b/rllm/cli/sft.py
@@ -28,7 +28,8 @@ from rllm.cli._ui import console, fail
 # Model / backend
 @click.option("--model", default="Qwen/Qwen3.5-4B", help="Model name/path (default: Qwen/Qwen3.5-4B).")
 @click.option("--backend", default="tinker", type=click.Choice(["tinker", "verl", "fireworks"]), help="SFT backend (default: tinker).")
-@click.option("--lora-rank", default=32, type=int, help="LoRA rank (default: 32).")
+@click.option("--gpus", default=1, type=int, help="GPUs per node for the distributed (verl) backend's torchrun launcher (default: 1).")
+@click.option("--lora-rank", default=32, type=int, help="LoRA rank; 0 = full fine-tuning (default: 32).")
 # Hyperparameters
 @click.option("--lr", default=1e-5, type=float, help="Learning rate (default: 1e-5).")
 @click.option("--batch-size", default=32, type=int, help="Training batch size (default: 32).")
@@ -51,6 +52,7 @@ def sft_cmd(
     max_examples: int | None,
     model: str,
     backend: str,
+    gpus: int,
     lora_rank: int,
     lr: float,
     batch_size: int,
@@ -114,6 +116,10 @@ def sft_cmd(
     if experiment is None:
         experiment = dataset or (Path(train_file).stem if train_file else "sft")
 
+    # The verl backend runs under torchrun; route --gpus to its native
+    # trainer.n_gpus_per_node (hosted backends ignore it).
+    overrides = {"trainer": {"n_gpus_per_node": gpus}} if backend == "verl" else None
+
     spec = SFTSpec(
         model=model,
         train_dataset=train_dataset,
@@ -130,6 +136,7 @@ def sft_cmd(
         project=project,
         experiment=experiment,
         output_dir=output_dir,
+        overrides=overrides,
     )
 
     # Build + configure the backend up front (local, no provisioning) so the
@@ -141,7 +148,9 @@ def sft_cmd(
     except SFTConfigError as e:
         fail(str(e))
     cfg = be.config
-    resolved_model = cfg.model.get("name", model)
+    # tinker/fireworks expose model.name; verl uses model.path. Fall back to the
+    # CLI --model for either.
+    resolved_model = cfg.model.get("name") or cfg.model.get("path") or model
     tokenizer_model = cfg.model.get("tokenizer_model")
 
     rows = [
@@ -150,7 +159,7 @@ def sft_cmd(
     if tokenizer_model and tokenizer_model != resolved_model:
         rows.append(("Tokenizer", f"[dim]{tokenizer_model}[/]"))
     rows += [
-        ("Backend", f"[val]{backend}[/]"),
+        ("Backend", f"[val]{backend}[/]" + (f"  [dim]({gpus} GPU{'s' if gpus != 1 else ''}, torchrun)[/]" if backend == "verl" else "")),
         ("Train data", f"[val]{source_label}[/]  [dim]({len(train_dataset)} examples)[/]"),
         ("Val data", f"[dim]{len(val_dataset)} examples[/]" if val_dataset else "[dim]none[/]"),
         ("LoRA rank", f"[dim]{lora_rank}[/]"),

--- a/rllm/engine/rollout/verl_engine.py
+++ b/rllm/engine/rollout/verl_engine.py
@@ -7,7 +7,7 @@ from typing import cast
 import torch
 from omegaconf import DictConfig
 from typing_extensions import override
-from verl.experimental.agent_loop.agent_loop import AsyncLLMServerManager
+from verl.workers.rollout.llm_server import LLMServerClient
 
 from rllm.engine.rollout.rollout_engine import ModelOutput, RolloutEngine
 from rllm.engine.rollout.types import Processor, TokenInput, Tokenizer, TokenOutput, VerlTokenOutput
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class VerlEngine(RolloutEngine):
-    def __init__(self, config: DictConfig, server_manager: AsyncLLMServerManager, tokenizer: Tokenizer, processor: Processor | None = None, **kwargs):
+    def __init__(self, config: DictConfig, server_manager: LLMServerClient, tokenizer: Tokenizer, processor: Processor | None = None, **kwargs):
         super().__init__()
         self.config = config
 
@@ -64,7 +64,7 @@ class VerlEngine(RolloutEngine):
         input_length = len(token_input)
         application_id = kwargs.pop("application_id", str(uuid.uuid4()))
         enforce_max_prompt_length = kwargs.pop("enforce_max_prompt_length", True)
-        # Multimodal: verl's AsyncLLMServerManager.generate accepts image_data /
+        # Multimodal: verl's LLMServerClient.generate accepts image_data /
         # video_data (list of PIL.Image / video tensors) and the underlying
         # vLLM server expands the per-image <|image_pad|> placeholder in
         # ``prompt_ids`` based on each image's actual grid size.

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -336,7 +336,7 @@ class GatewayManager:
 
     def _ensure_verl_engine_workers(self, rollout_engine: VerlEngine) -> list[str]:
         """Get or create worker URLs for the VerlEngine."""
-        addresses = rollout_engine.server_manager._server_id_to_handle.keys()
+        addresses = rollout_engine.server_addresses
         return [f"http://{addr}" if not addr.startswith("http") else addr for addr in addresses]
 
     # -- Internal ------------------------------------------------------------

--- a/rllm/trainer/agent_sft_trainer.py
+++ b/rllm/trainer/agent_sft_trainer.py
@@ -25,9 +25,9 @@ if TYPE_CHECKING:
     from rllm.trainer.sft.backend import SFTBackend
     from rllm.trainer.sft.spec import SFTSpec
 
-# Backends available today. verl lands in milestone 4.
-_IMPLEMENTED = {"tinker", "fireworks"}
-_PLANNED = {"verl"}
+# Backends available today.
+_IMPLEMENTED = {"tinker", "fireworks", "verl"}
+_PLANNED: set[str] = set()
 
 
 def _inside_torchrun() -> bool:
@@ -75,12 +75,50 @@ class AgentSFTTrainer:
             from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
 
             return FireworksSFTBackend(self.spec)
+        if name == "verl":
+            from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+            return VerlSFTBackend(self.spec)
         if name in _PLANNED:
             raise SFTConfigError(f"SFT backend {name!r} is not wired yet. Use backend='tinker' or 'fireworks' for now.")
         raise SFTConfigError(f"Unknown SFT backend {name!r}. Available: {', '.join(sorted(_IMPLEMENTED))}.")
 
     def _launch_distributed(self, backend: SFTBackend) -> None:
-        # The torchrun launcher for distributed backends (verl) is not wired
-        # yet. Until then, distributed backends must be run inside an existing
-        # torchrun process group.
-        raise SFTConfigError(f"Backend {backend.name!r} requires a distributed launcher (not wired yet). Run inside torchrun, or use a managed backend (tinker/fireworks).")
+        """Spawn ``torchrun`` for a distributed backend (verl) and run its loop.
+
+        ``prepare()`` has already materialized the data (parquet) and built the
+        config; we serialize the config and re-enter under a torchrun process
+        group via :mod:`rllm.trainer.sft.verl_entry`, which calls the backend's
+        ``run_sft``. ``RLLM_SFT_IN_TORCHRUN`` marks the child so a nested
+        dispatch would call ``fit()`` directly instead of relaunching.
+        """
+        import subprocess
+        import sys
+
+        cfg = backend.config
+        nproc = int(cfg.trainer.get("n_gpus_per_node", 1) or 1)
+        nnodes = int(cfg.trainer.get("nnodes", 1) or 1)
+        config_path = backend.serialize_config()
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            f"--nnodes={nnodes}",
+            f"--nproc_per_node={nproc}",
+            "-m",
+            "rllm.trainer.sft.verl_entry",
+            "--config",
+            config_path,
+        ]
+        env = {**os.environ, "RLLM_SFT_IN_TORCHRUN": "1"}
+        # verl's worker refuses to start when ROCR_VISIBLE_DEVICES (an AMD/ROCm
+        # var) and CUDA_VISIBLE_DEVICES are both set. On NVIDIA hosts ROCR is a
+        # stray cluster default; drop it so CUDA_VISIBLE_DEVICES wins.
+        if env.get("ROCR_VISIBLE_DEVICES") and env.get("CUDA_VISIBLE_DEVICES"):
+            env.pop("ROCR_VISIBLE_DEVICES", None)
+        print(f"[rllm sft] launching torchrun: nnodes={nnodes} nproc_per_node={nproc}\n  config: {config_path}")
+        result = subprocess.run(cmd, env=env)
+        if result.returncode != 0:
+            raise SFTConfigError(f"verl SFT torchrun exited with code {result.returncode}. See the torchrun output above.")

--- a/rllm/trainer/sft/verl_backend.py
+++ b/rllm/trainer/sft/verl_backend.py
@@ -1,0 +1,190 @@
+"""verl SFT backend.
+
+Wraps verl 0.8.0's FSDP SFT trainer (``verl.trainer.sft_trainer``). Unlike the
+hosted backends (tinker/fireworks), verl SFT is a monolithic FSDP loop that must
+run inside a ``torchrun`` process group, so ``requires_distributed = True`` and
+the dispatcher spawns the launcher (see
+:meth:`rllm.trainer.agent_sft_trainer.AgentSFTTrainer._launch_distributed`).
+
+The data seam is verl's ``data.custom_cls``: we point it at
+:class:`rllm.trainer.verl.sft_dataset.RLLMSFTDataset`, which reads the curated
+``{"messages": [...]}`` parquet rows and applies rLLM's tokenize/mask method.
+``verl``/``torch`` are imported lazily inside :meth:`fit` (and the launcher entry)
+so the module — and the dispatcher that imports it — stay importable without the
+verl stack present.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from omegaconf import DictConfig, OmegaConf
+
+from rllm.trainer.sft.backend import SFTBackend, SFTConfigError, validate_messages_dataset
+
+logger = logging.getLogger(__name__)
+
+# verl's hydra config package (composed for the full sft_trainer_engine schema).
+_VERL_CONFIG_MODULE = "verl.trainer.config"
+_VERL_CONFIG_NAME = "sft_trainer_engine"
+
+# rLLM dataset injected via verl's data.custom_cls (pkg:// import path).
+_CUSTOM_CLS_PATH = "pkg://rllm.trainer.verl.sft_dataset"
+_CUSTOM_CLS_NAME = "RLLMSFTDataset"
+
+# SFTSpec.lr_schedule -> verl optim.lr_scheduler_type. verl 0.8.0 ships
+# constant/cosine/wsd; "linear" has no direct analogue, so fall back to cosine.
+_LR_SCHEDULE_MAP = {"constant": "constant", "cosine": "cosine", "linear": "cosine"}
+
+
+class VerlSFTBackend(SFTBackend):
+    """Supervised fine-tuning on verl's FSDP trainer (multi-GPU, torchrun)."""
+
+    name = "verl"
+    requires_distributed = True
+
+    # -- contract -----------------------------------------------------------
+
+    def validate_spec(self) -> None:
+        validate_messages_dataset(self.spec.train_dataset, "train")
+        if self.spec.val_dataset is not None:
+            validate_messages_dataset(self.spec.val_dataset, "val")
+        if self.spec.lr_schedule not in _LR_SCHEDULE_MAP:
+            raise SFTConfigError(f"Unsupported lr_schedule {self.spec.lr_schedule!r} for verl. Use one of {sorted(_LR_SCHEDULE_MAP)}.")
+        if self.spec.lr_schedule == "linear":
+            logger.warning("verl has no 'linear' LR schedule; using 'cosine' instead.")
+
+    def _compose_base(self) -> DictConfig:
+        """Compose verl's full ``sft_trainer_engine`` config (all sub-groups)."""
+        from hydra import compose, initialize_config_module
+        from hydra.core.global_hydra import GlobalHydra
+
+        GlobalHydra.instance().clear()
+        with initialize_config_module(config_module=_VERL_CONFIG_MODULE, version_base=None):
+            cfg = compose(config_name=_VERL_CONFIG_NAME)
+        return cfg
+
+    def build_config(self) -> DictConfig:
+        """SFTSpec -> verl ``sft_trainer_engine`` DictConfig.
+
+        Only keys already present in verl's schema are overridden, plus the one
+        rLLM-specific addition ``data.rllm.tokenize_and_mask_method`` (read by
+        ``RLLMSFTDataset``). LoRA is opt-in: ``lora_rank == 0`` => full FT.
+        """
+        spec = self.spec
+        base = self._compose_base()
+        # data.rllm is a new sub-tree verl doesn't declare; open struct to add it.
+        OmegaConf.set_struct(base, False)
+
+        lora_rank = int(spec.lora_rank or 0)
+        max_token_len = max(int(spec.max_length), 8192)
+        overrides = OmegaConf.create(
+            {
+                "model": {
+                    "path": spec.model,
+                    "lora_rank": lora_rank,
+                    "lora_alpha": (2 * lora_rank if lora_rank else 16),
+                    "use_remove_padding": True,
+                    "enable_gradient_checkpointing": True,
+                },
+                "data": {
+                    "train_batch_size": int(spec.batch_size),
+                    "micro_batch_size_per_gpu": 1,
+                    "max_length": int(spec.max_length),
+                    "max_token_len_per_gpu": max_token_len,
+                    "use_dynamic_bsz": True,
+                    "messages_key": "messages",
+                    "pad_mode": "no_padding",
+                    "truncation": "right",
+                    "custom_cls": {"path": _CUSTOM_CLS_PATH, "name": _CUSTOM_CLS_NAME},
+                    "rllm": {"tokenize_and_mask_method": spec.tokenize_method},
+                },
+                "optim": {
+                    "lr": float(spec.lr),
+                    "lr_scheduler_type": _LR_SCHEDULE_MAP[spec.lr_schedule],
+                },
+                "trainer": {
+                    "total_epochs": int(spec.epochs),
+                    "save_freq": int(spec.save_freq),
+                    "test_freq": int(spec.val_freq),
+                    "project_name": spec.project,
+                    "experiment_name": spec.experiment or "default",
+                    "logger": ["console", "wandb"],
+                    "default_local_dir": spec.output_dir or self._default_local_dir(),
+                },
+            }
+        )
+        cfg = OmegaConf.merge(base, overrides)
+        if spec.overrides:
+            cfg = OmegaConf.merge(cfg, OmegaConf.create(spec.overrides))
+        self._config = cfg
+        return cfg
+
+    def _default_local_dir(self) -> str:
+        from rllm import paths
+
+        exp = self.spec.experiment or "default"
+        return paths.rllm_path("sft_runs", self.spec.project, exp)
+
+    @property
+    def workdir(self) -> str:
+        """Scratch dir for the materialized parquet + serialized launch config."""
+        d = os.path.join(self.config.trainer.default_local_dir, "_verl_inputs")
+        os.makedirs(d, exist_ok=True)
+        return d
+
+    def prepare_data(self) -> None:
+        """Materialize the in-memory ``messages`` datasets to parquet on disk.
+
+        verl's trainer builds its datasets itself from ``data.train_files`` /
+        ``data.val_files``, so the curated rows must cross the torchrun boundary
+        as parquet. We always re-write rather than trust a registry path so any
+        SFTSpec source (registered dataset, ``--train-file``, curation output)
+        works identically.
+        """
+        cfg = self.config
+        train_path = os.path.join(self.workdir, "train.parquet")
+        self._write_messages_parquet(self.spec.train_dataset, train_path)
+        cfg.data.train_files = train_path
+        if self.spec.val_dataset is not None:
+            val_path = os.path.join(self.workdir, "val.parquet")
+            self._write_messages_parquet(self.spec.val_dataset, val_path)
+            cfg.data.val_files = val_path
+        else:
+            cfg.data.val_files = None
+            # No val set -> disable verl's periodic validation.
+            cfg.trainer.test_freq = -1
+
+    @staticmethod
+    def _write_messages_parquet(dataset, path: str) -> None:
+        import pandas as pd
+
+        # Normalize messages to plain list[dict] so the parquet round-trips
+        # cleanly regardless of source (registry => list; pandas --train-file
+        # => np.ndarray of dicts).
+        def _norm(messages):
+            return [dict(m) for m in messages]
+
+        rows = [{"messages": _norm(row["messages"])} for row in dataset.get_data()]
+        pd.DataFrame(rows).to_parquet(path, index=False)
+        logger.info("Wrote %d SFT rows to %s", len(rows), path)
+
+    @property
+    def checkpoint_dir(self) -> str:
+        return self.config.trainer.default_local_dir
+
+    def serialize_config(self) -> str:
+        """Persist the resolved config for the torchrun launcher; return its path."""
+        path = os.path.join(self.workdir, "verl_sft_config.yaml")
+        OmegaConf.save(self.config, path)
+        return path
+
+    def fit(self) -> None:
+        """Run verl's FSDP SFT loop. Must be called inside a torchrun group."""
+        from verl.trainer.sft_trainer import run_sft
+        from verl.utils.device import auto_set_device
+
+        cfg = self.config
+        auto_set_device(cfg)
+        run_sft(cfg)

--- a/rllm/trainer/sft/verl_entry.py
+++ b/rllm/trainer/sft/verl_entry.py
@@ -1,0 +1,56 @@
+"""torchrun entry point for the verl SFT backend.
+
+The dispatcher (:meth:`AgentSFTTrainer._launch_distributed`) materializes the
+curated data to parquet, serializes the resolved verl config, then spawns::
+
+    torchrun --standalone --nnodes=1 --nproc_per_node=<gpus> \
+        -m rllm.trainer.sft.verl_entry --config <verl_sft_config.yaml>
+
+Each rank loads the same serialized config and runs verl's FSDP SFT loop. The
+config is already fully composed (verl defaults + SFTSpec overrides + the
+parquet ``data.train_files``), so no hydra composition happens here — we mirror
+verl's own ``sft_trainer.main`` (``auto_set_device`` then ``run_sft``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def _isolate_compile_caches() -> None:
+    """Give each torchrun rank its own Triton/Inductor cache dir.
+
+    All ranks otherwise compile the same kernels (e.g. Triton's ``cuda_utils``)
+    into one shared ``~/.triton/cache`` path concurrently and race, surfacing as
+    ``cuda_utils...so: cannot open shared object file``. Per-rank dirs make each
+    compile independent. Must run before torch/verl/triton are imported.
+    """
+    rank = os.environ.get("LOCAL_RANK") or os.environ.get("RANK") or "0"
+    base = os.path.join("/tmp", f"rllm_sft_compile_rank{rank}")
+    os.environ.setdefault("TRITON_CACHE_DIR", os.path.join(base, "triton"))
+    os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", os.path.join(base, "inductor"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="rLLM verl SFT torchrun entry")
+    parser.add_argument("--config", required=True, help="Path to the serialized verl SFT config (yaml).")
+    args = parser.parse_args()
+
+    _isolate_compile_caches()
+
+    from omegaconf import OmegaConf
+
+    config = OmegaConf.load(args.config)
+
+    # Imported here (not at module top) so the module stays importable without
+    # the verl stack, and so torch/verl init happens inside the process group.
+    from verl.trainer.sft_trainer import run_sft
+    from verl.utils.device import auto_set_device
+
+    auto_set_device(config)
+    run_sft(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/rllm/trainer/verl/agent_workflow_trainer.py
+++ b/rllm/trainer/verl/agent_workflow_trainer.py
@@ -11,7 +11,6 @@ import torch
 from omegaconf import OmegaConf
 from tensordict import TensorDict
 from verl import DataProto
-from verl.experimental.agent_loop.agent_loop import AsyncLLMServerManager
 from verl.protocol import pad_dataproto_to_divisor
 from verl.single_controller.ray import RayWorkerGroup
 from verl.trainer.ppo.core_algos import (
@@ -112,22 +111,17 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
     def init_workers(self):
         super().init_workers()
 
-        servers = zip(
-            self.async_rollout_manager.server_addresses,
-            self.async_rollout_manager.server_handles,
-            strict=True,
-        )
-        server_manager = AsyncLLMServerManager(
-            self.config,
-            servers=servers,
-            load_balancer_handle=self.async_rollout_manager.global_load_balancer,
-        )
+        # verl 0.8.0: the unified engine exposes an LLMServerClient via the
+        # LLMServerManager that RayPPOTrainer.init_workers() created. Reuse it
+        # instead of the removed experimental AsyncLLMServerManager.
+        server_client = self.llm_server_manager.get_client()
         rollout_engine = VerlEngine(
             config=self.config,
-            server_manager=server_manager,
+            server_manager=server_client,
             tokenizer=self.tokenizer,
             processor=self.processor,
         )
+        rollout_engine.server_addresses = self.llm_server_manager.get_addresses()
 
         # Create episode logger if enabled in config
         episode_logger = None
@@ -342,24 +336,18 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                         batch.meta_info["images_seqlens"] = images_seqlens_all
                     batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
 
-                    # recompute old_log_probs
-                    # Mirror verl's RayPPOTrainer._compute_old_log_prob: the new EngineWorker
-                    # path (use_legacy_worker_impl == "disable") takes a TensorDict in no-padding
-                    # format; the legacy AsyncActorRolloutRefWorker takes a DataProto directly.
+                    # recompute old_log_probs (verl's RayPPOTrainer._compute_old_log_prob): the
+                    # EngineWorker takes a TensorDict in no-padding format.
                     with marked_timer("old_log_prob", timing_raw, color="blue"):
-                        if self.use_legacy_worker_impl == "disable":
-                            batch_td = batch.to_tensordict()
-                            batch_td = left_right_2_no_padding(batch_td)
-                            tu.assign_non_tensor(batch_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
-                            old_log_prob_output = self.actor_rollout_wg.compute_log_prob(batch_td)
-                            # New worker returns TensorDict in no-padding format
-                            entropy = tu.get(old_log_prob_output, "entropy")
-                            log_probs = tu.get(old_log_prob_output, "log_probs")
-                            entropy = no_padding_2_padding(entropy, batch_td)
-                            log_probs = no_padding_2_padding(log_probs, batch_td)
-                            old_log_prob = DataProto.from_tensordict(tu.get_tensordict({"old_log_probs": log_probs.float(), "entropys": entropy.float()}))
-                        else:
-                            old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
+                        batch_td = batch.to_tensordict()
+                        batch_td = left_right_2_no_padding(batch_td)
+                        tu.assign_non_tensor(batch_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
+                        old_log_prob_output = self.actor_rollout_wg.compute_log_prob(batch_td)
+                        entropy = tu.get(old_log_prob_output, "entropy")
+                        log_probs = tu.get(old_log_prob_output, "log_probs")
+                        entropy = no_padding_2_padding(entropy, batch_td)
+                        log_probs = no_padding_2_padding(log_probs, batch_td)
+                        old_log_prob = DataProto.from_tensordict(tu.get_tensordict({"old_log_probs": log_probs.float(), "entropys": entropy.float()}))
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = batch.batch["response_mask"]
                         loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
@@ -375,27 +363,21 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                     if self.use_reference_policy:
                         # compute reference log_prob
                         with marked_timer("ref", timing_raw, color="olive"):
-                            if self.use_legacy_worker_impl == "disable":
-                                # Reuse batch_td from old_log_prob, but override the metadata for
-                                # the ref step (verl's RayPPOTrainer._compute_ref_log_prob pattern).
-                                # When ref_in_actor (LoRA), we use the actor worker's compute_log_prob
-                                # with no_lora_adapter=True so the base model is used for ref.
-                                ref_metadata = {"calculate_entropy": False, "compute_loss": False}
-                                if self.ref_in_actor:
-                                    ref_metadata["no_lora_adapter"] = True
-                                tu.assign_non_tensor(batch_td, **ref_metadata)
-                                if self.ref_in_actor:
-                                    ref_log_prob_output = self.actor_rollout_wg.compute_log_prob(batch_td)
-                                else:
-                                    ref_log_prob_output = self.ref_policy_wg.compute_ref_log_prob(batch_td)
-                                ref_lp = tu.get(ref_log_prob_output, "log_probs")
-                                ref_lp = no_padding_2_padding(ref_lp, batch_td)
-                                ref_log_prob = DataProto.from_tensordict(tu.get_tensordict({"ref_log_prob": ref_lp.float()}))
+                            # Reuse batch_td from old_log_prob, but override the metadata for
+                            # the ref step (verl's RayPPOTrainer._compute_ref_log_prob pattern).
+                            # When ref_in_actor (LoRA), we use the actor worker's compute_log_prob
+                            # with no_lora_adapter=True so the base model is used for ref.
+                            ref_metadata = {"calculate_entropy": False, "compute_loss": False}
+                            if self.ref_in_actor:
+                                ref_metadata["no_lora_adapter"] = True
+                            tu.assign_non_tensor(batch_td, **ref_metadata)
+                            if self.ref_in_actor:
+                                ref_log_prob_output = self.actor_rollout_wg.compute_log_prob(batch_td)
                             else:
-                                if not self.ref_in_actor:
-                                    ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
-                                else:
-                                    ref_log_prob = self.actor_rollout_wg.compute_ref_log_prob(batch)
+                                ref_log_prob_output = self.ref_policy_wg.compute_ref_log_prob(batch_td)
+                            ref_lp = tu.get(ref_log_prob_output, "log_probs")
+                            ref_lp = no_padding_2_padding(ref_lp, batch_td)
+                            ref_log_prob = DataProto.from_tensordict(tu.get_tensordict({"ref_log_prob": ref_lp.float()}))
                             batch = batch.union(ref_log_prob)
 
                     # compute values
@@ -477,27 +459,23 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
 
                     # implement critic warmup
                     if self.config.trainer.critic_warmup <= self.global_steps:
-                        # Mirror verl's RayPPOTrainer._update_actor: meta_info goes onto the
-                        # DataProto for the legacy worker; the new EngineWorker path needs a
+                        # Mirror verl's RayPPOTrainer._update_actor: the EngineWorker path needs a
                         # TensorDict in no-padding format with training metadata set via
                         # tu.assign_non_tensor.
                         batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
                         batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
-                        if self.use_legacy_worker_impl == "disable":
-                            ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
-                            update_batch = batch.to_tensordict()
-                            update_batch = left_right_2_no_padding(update_batch)
-                            tu.assign_non_tensor(
-                                update_batch,
-                                calculate_entropy=(self.config.actor_rollout_ref.actor.entropy_coeff != 0.0),
-                                global_batch_size=ppo_mini_batch_size,
-                                mini_batch_size=ppo_mini_batch_size,
-                                epochs=self.config.actor_rollout_ref.actor.ppo_epochs,
-                                seed=self.config.actor_rollout_ref.actor.data_loader_seed,
-                                dataloader_kwargs={"shuffle": self.config.actor_rollout_ref.actor.shuffle},
-                            )
-                        else:
-                            update_batch = batch
+                        ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+                        update_batch = batch.to_tensordict()
+                        update_batch = left_right_2_no_padding(update_batch)
+                        tu.assign_non_tensor(
+                            update_batch,
+                            calculate_entropy=(self.config.actor_rollout_ref.actor.entropy_coeff != 0.0),
+                            global_batch_size=ppo_mini_batch_size,
+                            mini_batch_size=ppo_mini_batch_size,
+                            epochs=self.config.actor_rollout_ref.actor.ppo_epochs,
+                            seed=self.config.actor_rollout_ref.actor.data_loader_seed,
+                            dataloader_kwargs={"shuffle": self.config.actor_rollout_ref.actor.shuffle},
+                        )
 
                         # update actor
                         with marked_timer("update_actor", timing_raw, color="red"):
@@ -694,17 +672,14 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                 combined_batch = DataProto.concat(batches_for_distill)
                 combined_batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
 
-                if self.use_legacy_worker_impl == "disable":
-                    # New worker path: convert to TensorDict + no-padding, then convert back.
-                    cb_td = combined_batch.to_tensordict()
-                    cb_td = left_right_2_no_padding(cb_td)
-                    tu.assign_non_tensor(cb_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
-                    old_log_prob_output = self.actor_rollout_wg.compute_log_prob(cb_td)
-                    log_probs = tu.get(old_log_prob_output, "log_probs")
-                    log_probs = no_padding_2_padding(log_probs, cb_td)
-                    old_log_prob = DataProto.from_tensordict(tu.get_tensordict({"old_log_probs": log_probs.float()}))
-                else:
-                    old_log_prob = self.actor_rollout_wg.compute_log_prob(combined_batch)
+                # Convert to TensorDict + no-padding, then convert back.
+                cb_td = combined_batch.to_tensordict()
+                cb_td = left_right_2_no_padding(cb_td)
+                tu.assign_non_tensor(cb_td, calculate_entropy=True, compute_loss=False, temperature=self.config.actor_rollout_ref.rollout.temperature)
+                old_log_prob_output = self.actor_rollout_wg.compute_log_prob(cb_td)
+                log_probs = tu.get(old_log_prob_output, "log_probs")
+                log_probs = no_padding_2_padding(log_probs, cb_td)
+                old_log_prob = DataProto.from_tensordict(tu.get_tensordict({"old_log_probs": log_probs.float()}))
                 combined_batch = combined_batch.union(old_log_prob)
 
                 # Compute distillation advantages

--- a/rllm/trainer/verl/async_agent_loop.py
+++ b/rllm/trainer/verl/async_agent_loop.py
@@ -1,118 +1,37 @@
-from __future__ import annotations
+"""Fully-async / separated-mode rollout classes.
 
-import asyncio
-from typing import Any
+rLLM used to hand-roll the fully-async + partial-rollout rollout machinery here,
+subclassing verl's pre-0.8 experimental ``AsyncLLMServerManager`` / ``AgentLoopWorker``.
+verl 0.8.0 removed those APIs and upstreamed the very same machinery (same class
+names, same partial-rollout ``generate`` loop) into
+``verl.experimental.fully_async_policy.fully_async_rollouter``, rebuilt on the new
+``LLMServerClient`` / ``LLMServerManager`` architecture:
 
-import ray
-import torch
-from omegaconf import DictConfig
-from verl.experimental.agent_loop.agent_loop import (
-    AgentLoopManager,
-    AgentLoopWorker,
-    AsyncLLMServerManager,
-    TokenOutput,
+* ``FullyAsyncLLMServerClient`` — ``LLMServerClient`` whose ``generate`` resumes an
+  aborted (preempted) rollout when ``async_training.partial_rollout`` is enabled.
+  This replaces the old ``FullyAsyncLLMServerManager(AsyncLLMServerManager)`` and is
+  the object handed to ``VerlEngine`` as ``server_manager``.
+* ``FullyAsyncLLMServerManager`` — ``LLMServerManager`` that owns/launches the rollout
+  replicas (hybrid + standalone). In 0.8.0 the *manager* owns the servers, not the
+  ``AgentLoopManager``; mint the client via ``get_client(client_cls=FullyAsyncLLMServerClient)``.
+* ``FullyAsyncAgentLoopManager`` — ``AgentLoopManager`` with ``generate_sequences_single``
+  / ``_select_best_worker`` (the per-worker dispatch rLLM relies on).
+
+The dedicated ``FullyAsyncAgentLoopWorker`` is gone: partial-rollout now lives in the
+*client*, so the stock ``AgentLoopWorker`` (which takes the client) is sufficient.
+
+We simply re-export the upstream implementations so the rest of rLLM keeps a stable
+import path.
+"""
+
+from verl.experimental.fully_async_policy.fully_async_rollouter import (
+    FullyAsyncAgentLoopManager,
+    FullyAsyncLLMServerClient,
+    FullyAsyncLLMServerManager,
 )
-from verl.protocol import DataProto
-from verl.single_controller.ray import RayResourcePool, RayWorkerGroup
-from verl.utils.ray_utils import auto_await
-from verl.utils.rollout_trace import rollout_trace_op
 
-
-class FullyAsyncLLMServerManager(AsyncLLMServerManager):
-    @rollout_trace_op
-    async def generate(
-        self,
-        request_id,
-        *,
-        prompt_ids: list[int],
-        sampling_params: dict[str, Any],
-        image_data: list[Any] | None = None,
-        video_data: list[Any] | None = None,
-    ) -> TokenOutput:
-        limit_key = None
-        if "max_tokens" in sampling_params:
-            limit_key = "max_tokens"
-        elif "max_new_tokens" in sampling_params:
-            limit_key = "max_new_tokens"
-        original_max_tokens = sampling_params.get(limit_key) if limit_key else None
-
-        final_output = TokenOutput(token_ids=[], log_probs=[], num_preempted=0)
-        min_global_steps, max_global_steps = None, None
-
-        while True:
-            output = await super().generate(
-                request_id=request_id,
-                prompt_ids=prompt_ids + final_output.token_ids,
-                sampling_params=sampling_params,
-                image_data=image_data,
-                video_data=video_data,
-            )
-
-            final_output.token_ids.extend(output.token_ids)
-            if output.log_probs is not None:
-                final_output.log_probs.extend(output.log_probs)
-            if output.routed_experts is not None:
-                if final_output.routed_experts is None:
-                    final_output.routed_experts = output.routed_experts
-                else:
-                    final_output.routed_experts = torch.cat([final_output.routed_experts, output.routed_experts], dim=0)
-            if output.num_preempted is not None:
-                final_output.num_preempted += output.num_preempted
-            final_output.stop_reason = output.stop_reason
-
-            global_steps = output.extra_fields.get("global_steps", None)
-            if min_global_steps is None:
-                min_global_steps = global_steps
-            max_global_steps = global_steps
-
-            if original_max_tokens is not None:
-                sampling_params[limit_key] = original_max_tokens - len(final_output.token_ids)
-                if len(final_output.token_ids) >= original_max_tokens:
-                    final_output.stop_reason = "length"
-                    break
-
-            if output.stop_reason not in ("aborted", "abort") or not self.config.async_training.partial_rollout:
-                break
-
-        final_output.extra_fields["global_steps"] = global_steps
-        final_output.extra_fields["min_global_steps"] = min_global_steps
-        final_output.extra_fields["max_global_steps"] = max_global_steps
-        return final_output
-
-
-@ray.remote
-class FullyAsyncAgentLoopWorker(AgentLoopWorker):
-    def __init__(
-        self,
-        config: DictConfig,
-        servers: list[tuple[str, ray.actor.ActorHandle]],
-        load_balancer_handle: ray.actor.ActorHandle,
-        reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
-    ):
-        self.server_manager = FullyAsyncLLMServerManager(config, servers, load_balancer_handle)
-        super().__init__(config, servers, load_balancer_handle, reward_loop_worker_handles)
-
-
-class FullyAsyncAgentLoopManager(AgentLoopManager):
-    def __init__(
-        self,
-        config: DictConfig,
-        worker_group: RayWorkerGroup = None,
-        rollout_resource_pool: RayResourcePool = None,
-        reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
-    ):
-        self.agent_loop_workers_class = FullyAsyncAgentLoopWorker
-        super().__init__(config, worker_group, rollout_resource_pool, reward_loop_worker_handles)
-
-    @auto_await
-    async def generate_sequences_single(self, prompts: DataProto) -> DataProto:
-        worker = self._select_best_worker()
-        output_future = worker.generate_sequences.remote(prompts)
-        return await asyncio.wrap_future(output_future.future())
-
-    def _select_best_worker(self):
-        if not hasattr(self, "_worker_index"):
-            self._worker_index = 0
-        worker = self.agent_loop_workers[self._worker_index]
-        self._worker_index = (self._worker_index + 1) % len(self.agent_loop_workers)
-        return worker
+__all__ = [
+    "FullyAsyncAgentLoopManager",
+    "FullyAsyncLLMServerClient",
+    "FullyAsyncLLMServerManager",
+]

--- a/rllm/trainer/verl/ray_runtime_env.py
+++ b/rllm/trainer/verl/ray_runtime_env.py
@@ -109,11 +109,4 @@ def get_ppo_ray_runtime_env():
     # Only set working_dir=None when the job config doesn't specify one (avoid merge conflict)
     if job_runtime_env.get("working_dir") is None:
         runtime_env["working_dir"] = None
-    # Apply rLLM's verl patches (PR #5881 backport, dynamic-batch sync, etc.) on every
-    # Ray worker process so the patches take effect inside FSDP workers — driver-side
-    # monkey-patches do not propagate. The hook function is lazy and idempotent.
-    if job_runtime_env.get("worker_process_setup_hook") is None:
-        # Ray expects a dotted import path (no colon); it does
-        # ``module.rpartition('.') -> module + attr`` to load the hook.
-        runtime_env["worker_process_setup_hook"] = "rllm.trainer.verl.patch.apply_all_verl_patches"
     return runtime_env

--- a/rllm/trainer/verl/sft_dataset.py
+++ b/rllm/trainer/verl/sft_dataset.py
@@ -1,6 +1,7 @@
 import logging
 
 import torch
+from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset
 
 from rllm.parser import ChatTemplateParser
@@ -108,9 +109,34 @@ class RLLMSFTDataset(MultiTurnSFTDataset):
 
         input_ids = torch.tensor(tokens, dtype=torch.long)
         loss_mask = torch.tensor(loss_mask, dtype=torch.long)
+
+        # verl 0.8.0 keys the loss path off ``pad_mode`` (injected into the batch
+        # by SFTTrainer). ``no_padding`` (the SFT default) expects each sample as
+        # an *unpadded* 1-D ``{input_ids, position_ids, loss_mask}`` that the
+        # SFTTensorCollator nests + flattens; ``sft_loss`` reads ``loss_mask``
+        # directly. ``right`` pads to ``max_length`` and the loss reads
+        # ``response_mask``. We mirror ``MultiTurnSFTDataset.__getitem__`` for
+        # both so the loss mask always lands on the assistant tokens this class
+        # computed.
+        if self.pad_mode == DatasetPadMode.NO_PADDING:
+            sequence_length = input_ids.shape[0]
+            if sequence_length > self.max_length:
+                if self.truncation == "error":
+                    raise ValueError(f"{sequence_length=} is larger than {self.max_length=}")
+                # left/right truncation both keep the head here, matching verl's
+                # no_padding branch (it only right-truncates).
+                input_ids = input_ids[: self.max_length]
+                loss_mask = loss_mask[: self.max_length]
+            position_ids = torch.arange(input_ids.shape[0], dtype=torch.long)
+            return {
+                "input_ids": input_ids,
+                "position_ids": position_ids,
+                "loss_mask": loss_mask,
+            }
+
         attention_mask = torch.tensor([1] * len(tokens), dtype=torch.long)
 
-        # Handle sequence length
+        # Handle sequence length (pad_mode == "right")
         sequence_length = input_ids.shape[0]
         if sequence_length < self.max_length:
             # Pad sequences
@@ -147,4 +173,7 @@ class RLLMSFTDataset(MultiTurnSFTDataset):
             "attention_mask": attention_mask,
             "position_ids": position_ids,
             "loss_mask": loss_mask,
+            # verl 0.8.0's right/left_right sft_loss reads ``response_mask``;
+            # ours is the assistant-token loss mask.
+            "response_mask": loss_mask,
         }

--- a/rllm/trainer/verl/train_agent_ppo.py
+++ b/rllm/trainer/verl/train_agent_ppo.py
@@ -69,92 +69,37 @@ class TaskRunner:
     def add_actor_rollout_worker(self, config):
         """Add actor rollout worker based on the actor strategy."""
         from verl.single_controller.ray import RayWorkerGroup
+        from verl.workers.engine_workers import ActorRolloutRefWorker
 
-        use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
+        actor_rollout_cls = ActorRolloutRefWorker
+        ray_worker_group_cls = RayWorkerGroup
 
-        # use new model engine implementation
-        if use_legacy_worker_impl == "disable":
-            from verl.workers.engine_workers import ActorRolloutRefWorker
-
-            actor_rollout_cls = ActorRolloutRefWorker
-            ray_worker_group_cls = RayWorkerGroup
-
-            lora_rank = config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
-            if lora_rank <= 0:
-                lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
-            ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
-            # NOTE: In new model engine, ref policy and actor rollout are in same ActorRolloutRefWorker,
-            # while in legacy model engine, ref policy is in a separate ActorRolloutRefWorker.
-            if need_reference_policy(config) and not ref_in_actor:
-                role = Role.ActorRolloutRef
-            else:
-                role = Role.ActorRollout
-            self.role_worker_mapping[role] = ray.remote(actor_rollout_cls)
-            self.mapping[role] = "global_pool"
-            return actor_rollout_cls, ray_worker_group_cls
-
-        # Note: sync mode validation is now handled in RolloutConfig.__post_init__
-        # Always use async worker since sync mode is deprecated and rejected
-        if config.actor_rollout_ref.actor.strategy in {"fsdp", "fsdp2"}:
-            from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker
-
-            actor_rollout_cls = AsyncActorRolloutRefWorker
-            ray_worker_group_cls = RayWorkerGroup
-
-        elif config.actor_rollout_ref.actor.strategy == "megatron":
-            from verl.workers.megatron_workers import AsyncActorRolloutRefWorker
-
-            actor_rollout_cls = AsyncActorRolloutRefWorker
-            ray_worker_group_cls = RayWorkerGroup
-
+        lora_rank = config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
+        if lora_rank <= 0:
+            lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
+        ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        if need_reference_policy(config) and not ref_in_actor:
+            role = Role.ActorRolloutRef
         else:
-            raise NotImplementedError
-
-        self.role_worker_mapping[Role.ActorRollout] = ray.remote(actor_rollout_cls)
-        self.mapping[Role.ActorRollout] = "global_pool"
+            role = Role.ActorRollout
+        self.role_worker_mapping[role] = ray.remote(actor_rollout_cls)
+        self.mapping[role] = "global_pool"
         return actor_rollout_cls, ray_worker_group_cls
 
     def add_critic_worker(self, config):
         """Add critic worker to role mapping."""
-        use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
-        if config.critic.strategy in {"fsdp", "fsdp2"}:
-            if use_legacy_worker_impl in ["auto", "enable"]:
-                from verl.workers.fsdp_workers import CriticWorker
-            elif use_legacy_worker_impl == "disable":
-                # we don't need to specialize critic worker. Just use TrainingWorker
-                from verl.workers.engine_workers import TrainingWorker
+        from verl.workers.engine_workers import TrainingWorker
 
-                CriticWorker = TrainingWorker
-                print("Using new worker implementation")
-            else:
-                raise ValueError(f"Invalid use_legacy_worker_impl: {use_legacy_worker_impl}")
-
-        elif config.critic.strategy == "megatron":
-            # TODO: switch this to TrainingWorker as well
-            if use_legacy_worker_impl in ["auto", "enable"]:
-                from verl.workers.megatron_workers import CriticWorker
-            elif use_legacy_worker_impl == "disable":
-                from verl.workers.engine_workers import TrainingWorker
-
-                CriticWorker = TrainingWorker
-                print("Using new worker implementation")
-        else:
-            raise NotImplementedError
-
-        self.role_worker_mapping[Role.Critic] = ray.remote(CriticWorker)
+        self.role_worker_mapping[Role.Critic] = ray.remote(TrainingWorker)
         self.mapping[Role.Critic] = "global_pool"
 
     def add_ref_policy_worker(self, config, ref_policy_cls):
-        """Add reference policy worker if KL loss or KL reward is used."""
-        # Ref policy has been fused into ActorRolloutRefWorker in new model engine,
-        # we don't need to add a separate ref policy worker group.
-        use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
-        if use_legacy_worker_impl == "disable":
-            return
+        """Add reference policy worker if KL loss or KL reward is used.
 
-        if config.algorithm.use_kl_in_reward or config.actor_rollout_ref.actor.use_kl_loss:
-            self.role_worker_mapping[Role.RefPolicy] = ray.remote(ref_policy_cls)
-            self.mapping[Role.RefPolicy] = "global_pool"
+        Note: Ref policy is fused into ActorRolloutRefWorker in the unified engine,
+        so this is a no-op.
+        """
+        return
 
     def init_resource_pool_mgr(self, config):
         """Initialize resource pool manager."""
@@ -270,11 +215,6 @@ class TaskRunner:
 
         else:
             raise ValueError("TaskRunner.run requires workflow_class. The legacy agent_class + env_class and agent_run_func paths have been removed; port your agent to a Workflow or AgentFlow.")
-
-        # Apply NCCL dynamic batch sync patch (fixes verl#5750)
-        from rllm.trainer.verl.patch import patch_verl_dynamic_batch_sync
-
-        patch_verl_dynamic_batch_sync()
 
         trainer.init_workers()
         try:

--- a/rllm/trainer/verl/verl_backend.py
+++ b/rllm/trainer/verl/verl_backend.py
@@ -26,6 +26,7 @@ from verl.trainer.ppo.utils import Role, WorkerType, need_reference_policy
 from verl.utils import tensordict_utils as tu
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.metric import reduce_metrics
+from verl.workers.rollout.llm_server import LLMServerManager
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
 
 from rllm.data.utils import interleave_tasks
@@ -187,17 +188,22 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         if self.ref_in_actor:
             self.ref_policy_wg = self.actor_rollout_wg
 
-        self.async_rollout_manager = AgentLoopManager.create(
+        self.llm_server_manager = LLMServerManager.create(
             config=config,
             worker_group=self.actor_rollout_wg,
             rollout_resource_pool=actor_rollout_resource_pool,
+        )
+
+        self.async_rollout_manager = AgentLoopManager.create(
+            config=config,
+            llm_client=self.llm_server_manager.get_client(),
         )
 
         ckpt_cfg = omega_conf_to_dataclass(config.actor_rollout_ref.rollout.checkpoint_engine)
         self.checkpoint_manager = CheckpointEngineManager(
             config=ckpt_cfg,
             trainer=self.actor_rollout_wg,
-            replicas=self.async_rollout_manager.rollout_replicas,
+            replicas=self.llm_server_manager.get_replicas(),
         )
         self.checkpoint_manager.sleep_replicas()
 
@@ -208,7 +214,7 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         Rollout servers are launched by FullyAsyncAgentLoopManager in standalone
         mode (worker_group=None), using config.actor_rollout_ref.rollout.nnodes/n_gpus_per_node.
         """
-        from rllm.trainer.verl.async_agent_loop import FullyAsyncAgentLoopManager
+        from rllm.trainer.verl.async_agent_loop import FullyAsyncAgentLoopManager, FullyAsyncLLMServerClient, FullyAsyncLLMServerManager
 
         config = self.config
         wg_kwargs = build_wg_kwargs(config, self.device_name)
@@ -256,17 +262,25 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         if self.ref_in_actor:
             self.ref_policy_wg = self.actor_rollout_wg
 
-        # Standalone rollout servers (no worker_group; resources from rollout.nnodes/n_gpus_per_node)
-        self.async_rollout_manager = FullyAsyncAgentLoopManager.create(
+        # verl 0.8.0: the LLMServerManager (not the AgentLoopManager) owns/launches the
+        # rollout replicas. Standalone servers => worker_group=None (resources come from
+        # rollout.nnodes/n_gpus_per_node). The AgentLoopManager then drives them via a
+        # partial-rollout client minted from the manager.
+        self.llm_server_manager = FullyAsyncLLMServerManager.create(
             config=config,
             worker_group=None,
+            rollout_resource_pool=None,
+        )
+        self.async_rollout_manager = FullyAsyncAgentLoopManager.create(
+            config=config,
+            llm_client=self.llm_server_manager.get_client(client_cls=FullyAsyncLLMServerClient),
         )
 
         ckpt_cfg = omega_conf_to_dataclass(config.actor_rollout_ref.rollout.checkpoint_engine)
         self.checkpoint_manager = CheckpointEngineManager(
             config=ckpt_cfg,
             trainer=self.actor_rollout_wg,
-            replicas=self.async_rollout_manager.rollout_replicas,
+            replicas=self.llm_server_manager.get_replicas(),
         )
 
     # =========================================================================
@@ -315,22 +329,22 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
         else:
             logger.warning("RayWorkerGroup.set_loss_fn not available — skipping custom loss injection")
 
-        servers = zip(self.async_rollout_manager.server_addresses, self.async_rollout_manager.server_handles, strict=True)
+        # Both paths obtain the rollout client from the LLMServerManager; the separated
+        # path uses the partial-rollout-aware client so preempted rollouts can resume.
         if self.is_separated:
-            from rllm.trainer.verl.async_agent_loop import FullyAsyncLLMServerManager
+            from rllm.trainer.verl.async_agent_loop import FullyAsyncLLMServerClient
 
-            server_manager = FullyAsyncLLMServerManager(self.config, servers=servers, load_balancer_handle=self.async_rollout_manager.global_load_balancer)
+            server_client = self.llm_server_manager.get_client(client_cls=FullyAsyncLLMServerClient)
         else:
-            from verl.experimental.agent_loop.agent_loop import AsyncLLMServerManager
-
-            server_manager = AsyncLLMServerManager(self.config, servers=servers, load_balancer_handle=self.async_rollout_manager.global_load_balancer)
+            server_client = self.llm_server_manager.get_client()
 
         self.rollout_engine = VerlEngine(
             config=self.config,
-            server_manager=server_manager,
+            server_manager=server_client,
             tokenizer=self.tokenizer,
             processor=self.processor,
         )
+        self.rollout_engine.server_addresses = self.llm_server_manager.get_addresses()
 
         self.algorithm_config = kwargs.get("algorithm_config")
 
@@ -347,6 +361,20 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
             )
             if async_cfg.get("partial_rollout", False) and self.config.rllm.get("remote_runtime", {}).get("enabled", False):
                 raise ValueError("VerlBackend: async_training.partial_rollout is not supported with remote_runtime; set it to false.")
+            # Separated mode does trainer->rollout weight sync via verl's 'nccl' checkpoint
+            # engine, which imports cupy. verl's checkpoint_engine/__init__ swallows a missing
+            # cupy in a silent try/except, so the failure otherwise surfaces only as a confusing
+            # "ValueError: Checkpoint engine nccl not registered" deep in actor_init_model.
+            # Fail fast here with an actionable message instead.
+            try:
+                import cupy  # noqa: F401
+            except ImportError as e:
+                raise RuntimeError(
+                    "Separated/async training (rllm.async_training.enable=true) requires cupy for "
+                    "verl's 'nccl' checkpoint engine (trainer->rollout weight sync). Install the wheel "
+                    "matching your CUDA toolkit: `pip install cupy-cuda12x` (CUDA 12.x) or "
+                    "`pip install cupy-cuda13x` (CUDA 13.x)."
+                ) from e
         if self.config.rllm.stepwise_advantage.mode != "broadcast":
             # automatically set the stepwise_advantage_mode to "broadcast", the warning is already shown in AlgorithmConfig.from_config
             self.config.rllm.stepwise_advantage.mode = "broadcast"
@@ -456,8 +484,7 @@ class VerlBackend(BackendProtocol[Iterable, DataProto]):
     def _get_aggregate_dp_size(self) -> int | None:
         """Compute the LCM of DP sizes across all active worker-group meshes.
 
-        Mesh names target the new EngineWorker path (verl_launcher pins
-        ``use_legacy_worker_impl='disable'``):
+        Mesh names target the EngineWorker path:
         - actor_rollout_wg -> ``engine_workers.ActorRolloutRefWorker``
             registers ``"actor"`` and ``"ref"``.
         - ref_policy_wg   -> same ``ActorRolloutRefWorker`` as actor_rollout_wg,

--- a/rllm/trainer/verl/verl_launcher.py
+++ b/rllm/trainer/verl/verl_launcher.py
@@ -33,7 +33,6 @@ class VerlTaskRunner(TaskRunner):
         print(f"VerlTaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
         sync_config(config, hydra_overrides=hydra_overrides)
         OmegaConf.resolve(config)
-        config.trainer.use_legacy_worker_impl = "disable"
         pprint(OmegaConf.to_container(config))
 
         is_separated = config.rllm.get("async_training", {}).get("enable", False)

--- a/scripts/install_megatron.sh
+++ b/scripts/install_megatron.sh
@@ -1,36 +1,29 @@
 #!/bin/bash
 # Install Megatron-related dependencies for rLLM.
-#
-# These packages require special build flags that cannot be expressed
-# in pyproject.toml. Run this AFTER installing the verl backend:
-#   uv pip install -e ".[verl]" --torch-backend=<cu128|cu129|cu130|...>
-#
-# Usage:
-#   bash scripts/install_megatron.sh <cu128|cu129|cu130|...>
 
 set -euo pipefail
 
-TORCH_BACKEND="${1:?Usage: bash scripts/install_megatron.sh <torch-backend, e.g. cu128 or cu129>}"
 echo "=== Megatron dependency installer for rLLM ==="
-echo "TORCH_BACKEND=${TORCH_BACKEND}"
 
 echo "[1/5] Installing nvidia-modelopt..."
 uv pip install 'nvidia-modelopt>=0.37.0'
 
 echo "[2/5] Installing transformer-engine (this may take a while)..."
-MAX_JOBS=128 uv pip install --no-cache --no-build-isolation "transformer_engine[pytorch]==2.10" --torch-backend="${TORCH_BACKEND}"
+MAX_JOBS=128 uv pip install --no-cache --no-build-isolation "transformer_engine[pytorch]==2.11"
 
 # megatron-core > 0.15.0 required for numpy>=2.0.0 compatibility
 echo "[3/5] Installing megatron-core..."
-uv pip install --no-deps megatron-core==0.16.1 
+uv pip install --no-deps megatron-core==0.17.1 
 
 echo "[4/5] Installing megatron-bridge..."
-uv pip install --no-deps megatron-bridge==0.3.1
+# Pinned to 691a377f (2026-05-19): "Add external trainer integration helpers (#3813)"
+# verl 0.8.0 requires LinearForLastLayer which was added in this commit (unreleased, post-v0.4.2).
+uv pip install --no-deps git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@691a377f
 
 echo "[5/5] Installing NVIDIA Apex (required for gradient accumulation fusion)..."
 APEX_PARALLEL_BUILD=8 APEX_CPP_EXT=1 APEX_CUDA_EXT=1 \
     uv pip install -v --no-cache --no-build-isolation \
-    git+https://github.com/NVIDIA/apex.git --torch-backend="${TORCH_BACKEND}"
+    git+https://github.com/NVIDIA/apex.git
 
 echo ""
 echo "=== Megatron dependencies installed successfully ==="

--- a/tests/cli/test_sft_command.py
+++ b/tests/cli/test_sft_command.py
@@ -56,8 +56,27 @@ def test_sft_missing_dataset(runner, tmp_rllm_home):
     assert "Could not load" in result.output
 
 
-def test_sft_verl_backend_reports_milestone(runner, tmp_rllm_home):
+def test_sft_verl_backend_dispatches_to_launcher(runner, tmp_rllm_home, monkeypatch):
+    """`--backend verl` is wired: it reaches the torchrun launcher (mocked)."""
+    from omegaconf import OmegaConf
+
+    from rllm.trainer.agent_sft_trainer import AgentSFTTrainer
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    monkeypatch.delenv("RLLM_SFT_IN_TORCHRUN", raising=False)
+    monkeypatch.delenv("RANK", raising=False)
+    # Skip the real verl/hydra config build + parquet materialization.
+    monkeypatch.setattr(
+        VerlSFTBackend,
+        "build_config",
+        lambda self: OmegaConf.create({"model": {"path": self.spec.model}, "trainer": {"default_local_dir": "/tmp/x", "n_gpus_per_node": 2}}),
+    )
+    monkeypatch.setattr(VerlSFTBackend, "prepare_data", lambda self: None)
+    launched = {}
+    monkeypatch.setattr(AgentSFTTrainer, "_launch_distributed", lambda self, be: launched.setdefault("name", be.name))
+
     name = _register_toy()
-    result = runner.invoke(cli, ["sft", name, "--backend", "verl"])
-    assert result.exit_code == 1
-    assert "not wired yet" in result.output
+    result = runner.invoke(cli, ["sft", name, "--backend", "verl", "--gpus", "2"])
+    assert "not wired yet" not in result.output
+    assert launched.get("name") == "verl"
+    assert result.exit_code == 0

--- a/tests/trainer/test_sft_dispatcher.py
+++ b/tests/trainer/test_sft_dispatcher.py
@@ -80,14 +80,69 @@ def test_dispatch_fireworks_runs_lifecycle(monkeypatch):
     assert calls == ["fit"]
 
 
-def test_dispatch_planned_backends_raise():
-    with pytest.raises(SFTConfigError, match="not wired yet"):
-        AgentSFTTrainer(_spec(), backend="verl").train()
+def test_dispatch_verl_uses_distributed_launcher(monkeypatch):
+    """verl is distributed: train() routes to the torchrun launcher, not fit()."""
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    monkeypatch.delenv("RLLM_SFT_IN_TORCHRUN", raising=False)
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.setattr(VerlSFTBackend, "validate_spec", lambda self: None)
+    monkeypatch.setattr(VerlSFTBackend, "build_config", lambda self: None)
+    monkeypatch.setattr(VerlSFTBackend, "prepare_data", lambda self: None)
+    launched = []
+    monkeypatch.setattr(AgentSFTTrainer, "_launch_distributed", lambda self, be: launched.append(be.name))
+    AgentSFTTrainer(_spec(), backend="verl").train()
+    assert launched == ["verl"]
+
+
+def test_dispatch_verl_runs_fit_inside_torchrun(monkeypatch):
+    """Inside an existing process group, verl runs fit() directly (no relaunch)."""
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    monkeypatch.setenv("RLLM_SFT_IN_TORCHRUN", "1")
+    monkeypatch.setattr(VerlSFTBackend, "validate_spec", lambda self: None)
+    monkeypatch.setattr(VerlSFTBackend, "build_config", lambda self: None)
+    monkeypatch.setattr(VerlSFTBackend, "prepare_data", lambda self: None)
+    calls = []
+    monkeypatch.setattr(VerlSFTBackend, "fit", lambda self: calls.append("fit"))
+    monkeypatch.setattr(AgentSFTTrainer, "_launch_distributed", lambda self, be: calls.append("launch"))
+    AgentSFTTrainer(_spec(), backend="verl").train()
+    assert calls == ["fit"]
 
 
 def test_dispatch_unknown_backend_raises():
     with pytest.raises(SFTConfigError, match="Unknown SFT backend"):
         AgentSFTTrainer(_spec(), backend="nope").train()
+
+
+def test_verl_build_config_maps_spec():
+    """VerlSFTBackend translates the SFTSpec into verl's sft_trainer_engine schema."""
+    pytest.importorskip("verl")
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    spec = _spec(lr=2e-5, epochs=2, batch_size=16, max_length=4096, tokenize_method="cumulative", lr_schedule="cosine", lora_rank=0, overrides={"trainer": {"n_gpus_per_node": 4}})
+    cfg = VerlSFTBackend(spec).build_config()
+    assert cfg.model.path == spec.model
+    assert cfg.model.lora_rank == 0  # full FT
+    assert cfg.data.train_batch_size == 16
+    assert cfg.data.max_length == 4096
+    assert cfg.data.pad_mode == "no_padding"
+    assert cfg.data.messages_key == "messages"
+    assert cfg.data.custom_cls.path == "pkg://rllm.trainer.verl.sft_dataset"
+    assert cfg.data.custom_cls.name == "RLLMSFTDataset"
+    assert cfg.data.rllm.tokenize_and_mask_method == "cumulative"
+    assert cfg.optim.lr == 2e-5
+    assert cfg.optim.lr_scheduler_type == "cosine"
+    assert cfg.trainer.total_epochs == 2
+    assert cfg.trainer.n_gpus_per_node == 4  # routed from --gpus via overrides
+
+
+def test_verl_linear_schedule_falls_back_to_cosine():
+    pytest.importorskip("verl")
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    cfg = VerlSFTBackend(_spec(lr_schedule="linear")).build_config()
+    assert cfg.optim.lr_scheduler_type == "cosine"
 
 
 def test_fireworks_build_config_uses_fireworks_template():


### PR DESCRIPTION
## Summary

Completes the deferred **`VerlSFTBackend`** (milestone 5 of the eval→curate→SFT design) so `rllm sft --backend verl` runs a real multi-GPU FSDP fine-tune, and brings this branch up to **verl 0.8.0** by merging `main`.

Two things land together because verl 0.8.0 rewrote the SFT path (`SFTTrainer(config)` builds its own datasets; engine config renamed `sft_trainer` → `sft_trainer_engine`; `model.partial_pretrain` → `model.path`), so the backend has to target the new API:

- **Merge `main`** → pulls in the verl 0.8.0 upgrade (#671) + fireworks-cookbook pin (#686). The bulk of the diff (cookbooks, `rllm/trainer/verl/*`, `pyproject.toml`, megatron script) is that already-reviewed merge; the net-new work is the SFT backend below.
- **`VerlSFTBackend`** — the new code.

## What's new (`VerlSFTBackend`)

- **`rllm/trainer/sft/verl_backend.py`** — composes verl's full `sft_trainer_engine` config via `initialize_config_module`, maps `SFTSpec` → native schema, injects `RLLMSFTDataset` through `data.custom_cls` (+ `data.rllm.tokenize_and_mask_method`), materializes the curated `{"messages": …}` rows to parquet, and runs verl's `run_sft` under torchrun. LoRA is opt-in (`lora_rank=0` ⇒ full FT). Uses `pad_mode=no_padding` (the mode whose loss reads `loss_mask`).
- **`rllm/trainer/sft/verl_entry.py`** — torchrun entry: per-rank `TRITON_CACHE_DIR` (avoids the multi-rank `cuda_utils.so` compile race) → `auto_set_device` + `run_sft`.
- **`agent_sft_trainer.py`** — registers verl in `_make_backend`; implements `_launch_distributed` (spawns `torchrun --standalone --nproc_per_node=<gpus> -m rllm.trainer.sft.verl_entry`, strips a stray `ROCR_VISIBLE_DEVICES`).
- **`rllm/cli/sft.py`** — adds `--gpus` (routed to `trainer.n_gpus_per_node`); summary panel reads `model.path` for verl.
- **`rllm/trainer/verl/sft_dataset.py`** — `RLLMSFTDataset.__getitem__` now honors verl 0.8.0's `pad_mode`: `no_padding` returns unpadded `{input_ids, position_ids, loss_mask}`; `right` keeps padding and also emits `response_mask`.
- **Tests** — verl dispatch + `build_config` mapping coverage; the two stale "not wired yet" assertions are updated. `21 passed, 1 skipped`; `ruff` clean.

## E2E validated (8×H100, this box)

Ran the whole loop end to end:

```bash
rllm eval math500 --model qwen/qwen3.6-35b-a3b --attempts 4 --concurrency 100 \
  --temperature 0.7 --top-p 0.95 --max-tokens 16384
rllm dataset from-eval <run_id> --name math500-rft --filter solved --select correct --dedup
rllm sft math500-rft --backend verl --gpus 8 --model Qwen/Qwen3-4B --lora-rank 0 \
  --lr 1e-5 --lr-schedule cosine --batch-size 32 --epochs 1 --max-length 8192
```

- **Eval**: 80.8% (1615/2000), pass@4 96.4%, 0 errors.
- **Curate**: 1615 correct traces registered as `math500-rft`.
- **SFT**: full fine-tune of Qwen3-4B, CE loss **0.71 → 0.27** over 50 steps (cosine LR → 0), logged to wandb. Final DCP checkpoint saved, clean exit.

Found & fixed during bring-up: `ROCR_VISIBLE_DEVICES` collision, multi-rank Triton compile race, and the verl 0.8.0 `loss_mask`/`no_padding` loss contract.

## Notes

- SFT/FSDP needs neither vllm 0.22 nor transformers 5, so the env runs on verl 0.8.0 with the existing torch 2.10 / transformers 4.57 / flash-attn 2.8.1 stack.
- Composes verl's config directly (no separate `verl.yaml` template) — fewer files, no stale `defaults:` to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)