### PR TITLE
Classify infra/grading failures distinctly across eval + train

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -537,6 +537,16 @@ def _run_eval(
     for k, v in sorted(result.pass_at.items()):
         res_rows.append((f"pass@{k}", f"[bold]{v * 100:.1f}%[/]"))
 
+    # Per-category completion breakdown (env_done / timeout / verifier_timeout / ...),
+    # infra-error reasons highlighted so a flaky endpoint or broken verifier is
+    # visible at a glance instead of hiding inside a single "Errors" count.
+    if result.termination_breakdown:
+        from rllm.types import INFRA_ERROR_REASONS
+
+        infra_vals = {r.value for r in INFRA_ERROR_REASONS}
+        parts = [f"[{'red' if reason in infra_vals else 'dim'}]{reason} {count}[/]" for reason, count in sorted(result.termination_breakdown.items(), key=lambda kv: (-kv[1], kv[0]))]
+        res_rows.append(("Terminations", "  ".join(parts)))
+
     # Display signal breakdown if any
     if result.signal_averages:
         for sig_name, sig_avg in result.signal_averages.items():

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -35,7 +35,7 @@ from rllm.data.utils import task_from_row
 from rllm.engine.trace_converter import compute_step_metrics, trace_record_to_step
 from rllm.eval.types import EvalOutput
 from rllm.gateway.manager import container_reachable_url
-from rllm.types import AgentConfig, Episode, Step, Task, TerminationReason, Trajectory, flow_accepts_env, run_agent_flow
+from rllm.types import INFRA_ERROR_REASONS, AgentConfig, Episode, Step, Task, TerminationReason, Trajectory, flow_accepts_env, run_agent_flow, termination_reason_from_error
 from rllm.utils import colorful_print
 
 if TYPE_CHECKING:
@@ -738,9 +738,19 @@ class AgentFlowEngine:
         for signal in eval_output.signals:
             enriched.metrics[signal.name] = signal.value
 
-        # Harness sets TIMEOUT/ERROR itself; a clean exit is ENV_DONE. (Length /
-        # turn-cap aren't reliably recoverable from gateway traces on this path.)
-        if enriched.termination_reason is None:
+        if eval_output.error:
+            # Grading ITSELF failed (verifier timeout/crash, missing/empty/unparseable
+            # reward file, tests-dir upload). The reward is not a real task score, so
+            # route it to an infra TerminationReason (VERIFIER_TIMEOUT for a known
+            # phase, else GRADING_ERROR) — training filters it and eval counts it as
+            # an error. Don't clobber a harness-set infra reason (e.g. the agent
+            # already SANDBOX_ERROR'd): that's the root cause, first-write-wins.
+            if enriched.termination_reason not in INFRA_ERROR_REASONS:
+                enriched.termination_reason = termination_reason_from_error(eval_output.error, default=TerminationReason.GRADING_ERROR)
+            enriched.metadata.setdefault("error", {"error_type": eval_output.error, "message": eval_output.metadata.get("error", "")})
+        elif enriched.termination_reason is None:
+            # Harness sets TIMEOUT/ERROR itself; a clean exit is ENV_DONE. (Length /
+            # turn-cap aren't reliably recoverable from gateway traces on this path.)
             enriched.termination_reason = TerminationReason.ENV_DONE
         return enriched
 

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -50,6 +50,29 @@ logger = logging.getLogger(__name__)
 _MIN_FD_LIMIT = 8192
 
 
+def _step_returned_nothing(step) -> bool:
+    """True when a model call produced no usable output — empty content AND no tool
+    calls. A dead/erroring upstream (proxy down, API failure) looks like this; a
+    legitimate tool-only turn does not (it carries ``tool_calls``)."""
+    content = (getattr(step.model_output, "content", None) or "").strip() if getattr(step, "model_output", None) else ""
+    if content:
+        return False
+    msgs = getattr(step, "chat_completions", None)
+    last = msgs[-1] if msgs else None
+    tool_calls = last.get("tool_calls") if isinstance(last, dict) else None
+    return not tool_calls
+
+
+def _no_usable_model_output(episode: Episode) -> bool:
+    """The agent produced nothing usable: it made no model calls at all (no
+    traces captured), or every call came back empty. Both are the signature of a
+    downed upstream / unreachable gateway (e.g. the LiteLLM proxy dying, an auth
+    or tunnel failure) — which otherwise looks identical to a clean ENV_DONE with
+    reward 0. A legit failed rollout has real completions, so it isn't flagged."""
+    steps = [s for traj in episode.trajectories for s in traj.steps]
+    return not steps or all(_step_returned_nothing(s) for s in steps)
+
+
 class EnrichMismatchError(RuntimeError):
     """Raised when gateway traces don't align with the agent's reported steps.
 
@@ -545,6 +568,10 @@ class AgentFlowEngine:
                         continue
                     if self.raise_on_error:
                         raise
+                    # Classify the failure: a phase-tagged reason (e.g. setup →
+                    # SANDBOX_ERROR) wins; otherwise map the exception class name
+                    # (sandbox/harbor errors → their reason) and fall back to ERROR.
+                    reason = getattr(e, "_rllm_termination_reason", None) or termination_reason_from_error(type(e).__name__, default=TerminationReason.ERROR)
                     return (
                         task_id,
                         rollout_idx,
@@ -553,8 +580,8 @@ class AgentFlowEngine:
                             id=uid,
                             task=task_for_episode,
                             is_correct=False,
-                            termination_reason=TerminationReason.ERROR,
-                            metadata={"error": {"message": str(e)}},
+                            termination_reason=reason,
+                            metadata={"error": {"message": str(e), "error_type": type(e).__name__}},
                         ),
                     )
 
@@ -628,13 +655,25 @@ class AgentFlowEngine:
 
         # Offload hook setup (blocking Modal/docker I/O) to the executor.
         t = time.perf_counter()
-        ctx: TaskContext = await loop.run_in_executor(
-            self.executor,
-            self.hooks.setup,
-            task_obj,
-            self.agent_flow,
-            uid,
-        )
+        try:
+            ctx: TaskContext = await loop.run_in_executor(
+                self.executor,
+                self.hooks.setup,
+                task_obj,
+                self.agent_flow,
+                uid,
+            )
+        except BaseException as e:
+            # Setup is sandbox provisioning + per-task verifier resolution — a
+            # failure here is infra, not the policy. Tag it so the retry path
+            # classifies SANDBOX_ERROR instead of a generic ERROR (unless the
+            # exception name already maps to a more specific reason).
+            try:
+                if getattr(e, "_rllm_termination_reason", None) is None:
+                    e._rllm_termination_reason = TerminationReason.SANDBOX_ERROR
+            except Exception:
+                pass
+            raise
         _timings["time/setup_s"] = time.perf_counter() - t
 
         try:
@@ -738,7 +777,16 @@ class AgentFlowEngine:
         for signal in eval_output.signals:
             enriched.metrics[signal.name] = signal.value
 
-        if eval_output.error:
+        if _no_usable_model_output(enriched) and not enriched.is_correct and enriched.termination_reason not in INFRA_ERROR_REASONS:
+            # The agent produced nothing usable — no LLM calls at all, or every
+            # call came back empty: a downed/erroring upstream (proxy died, auth or
+            # tunnel failure), NOT a clean rollout. The reward (0) is meaningless;
+            # this is the root cause, so it beats a downstream grading_error and the
+            # ENV_DONE default. (A harness-set infra reason already wins, above; a
+            # *correct* rollout is never reclassified.)
+            enriched.termination_reason = TerminationReason.MODEL_ERROR
+            enriched.metadata.setdefault("error", {"error_type": "EmptyCompletion", "message": "no usable model output — no LLM calls or all completions empty (upstream/proxy/gateway failure)"})
+        elif eval_output.error:
             # Grading ITSELF failed (verifier timeout/crash, missing/empty/unparseable
             # reward file, tests-dir upload). The reward is not a real task score, so
             # route it to an infra TerminationReason (VERIFIER_TIMEOUT for a known

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -533,7 +533,7 @@ class AgentFlowEngine:
 
                     timing_str = _format_timing_breakdown(episode.metrics)
                     colorful_print(
-                        f"[{uid}] Rollout completed. Rewards: [{', '.join(reward_strs)}]{timing_str}, Termination: {episode.termination_reason}",
+                        f"[{uid}] Rewards: [{', '.join(reward_strs)}]{timing_str}, Termination: {episode.termination_reason}",
                         fg="green" if episode.is_correct else "yellow",
                     )
 

--- a/rllm/eval/module_evaluator.py
+++ b/rllm/eval/module_evaluator.py
@@ -78,8 +78,12 @@ class PythonModuleEvaluator:
         try:
             result = self.fn(**kwargs)
         except Exception as e:
+            # The verifier code itself crashed — a grading-infra failure, not a
+            # legitimate reward 0. Carry the real exception class so it's visible
+            # in metrics; the engine maps any non-timeout grading error to
+            # GRADING_ERROR and filters the reward from training.
             logger.exception("Verifier %s raised: %s", self.module_name, e)
-            return EvalOutput(reward=0.0, is_correct=False, metadata={"error": f"verifier exception: {e}"})
+            return EvalOutput(reward=0.0, is_correct=False, error=type(e).__name__, metadata={"error": f"verifier exception: {e}"})
 
         return _coerce_eval_result(result)
 
@@ -171,5 +175,6 @@ def _coerce_eval_result(result: object) -> EvalOutput:
         return EvalOutput(
             reward=0.0,
             is_correct=False,
+            error="VerifierOutputParseError",
             metadata={"error": f"Cannot coerce {type(result).__name__} to reward"},
         )

--- a/rllm/eval/results.py
+++ b/rllm/eval/results.py
@@ -22,6 +22,10 @@ class EvalItem:
     error: str | None = None
     signals: dict[str, float] = field(default_factory=dict)
     attempt: int = 0
+    # Coarse outcome bucket (TerminationReason.value), e.g. "env_done", "timeout",
+    # "verifier_timeout", "grading_error". Lets the report break failures down by
+    # cause — agent timeouts vs infra/grading errors vs genuine wrong answers.
+    termination_reason: str | None = None
 
 
 def _pass_at_k(per_task_counts: list[tuple[int, int]], k: int) -> float:
@@ -60,6 +64,9 @@ class EvalResult:
     timestamp: str = ""
     attempts: int = 1
     pass_at: dict[int, float] = field(default_factory=dict)
+    # Count of rollouts per termination_reason (e.g. {"env_done": 95,
+    # "timeout": 66, "verifier_timeout": 3}). The per-category error rate.
+    termination_breakdown: dict[str, int] = field(default_factory=dict)
 
     @classmethod
     def from_items(cls, dataset_name: str, model: str, agent: str, items: list[EvalItem], attempts: int = 1) -> EvalResult:
@@ -93,6 +100,12 @@ class EvalResult:
                 signal_counts[name] = signal_counts.get(name, 0) + 1
         signal_averages = {name: signal_sums[name] / signal_counts[name] for name in signal_sums}
 
+        # Per-category outcome counts (agent timeouts vs infra/grading errors vs done).
+        termination_breakdown: dict[str, int] = {}
+        for item in items:
+            key = item.termination_reason or "unknown"
+            termination_breakdown[key] = termination_breakdown.get(key, 0) + 1
+
         return cls(
             dataset_name=dataset_name,
             model=model,
@@ -106,6 +119,7 @@ class EvalResult:
             timestamp=timestamp,
             attempts=attempts,
             pass_at=pass_at,
+            termination_breakdown=termination_breakdown,
         )
 
     def summary_table(self) -> str:
@@ -119,6 +133,10 @@ class EvalResult:
         ]
         for k, v in sorted(self.pass_at.items()):
             lines.append(f"  pass@{k}:    {v * 100:.1f}%")
+        if self.termination_breakdown:
+            lines.append("  Terminations:")
+            for reason, count in sorted(self.termination_breakdown.items(), key=lambda kv: (-kv[1], kv[0])):
+                lines.append(f"    {reason}: {count}")
         return "\n".join(lines)
 
     def save(self, path: str | None = None) -> str:
@@ -150,7 +168,19 @@ class EvalResult:
             "signal_averages": self.signal_averages,
             "attempts": self.attempts,
             "pass_at": {str(k): v for k, v in self.pass_at.items()},
-            "items": [{"idx": item.idx, "attempt": item.attempt, "reward": item.reward, "is_correct": item.is_correct, "error": item.error, "signals": item.signals} for item in self.items],
+            "termination_breakdown": self.termination_breakdown,
+            "items": [
+                {
+                    "idx": item.idx,
+                    "attempt": item.attempt,
+                    "reward": item.reward,
+                    "is_correct": item.is_correct,
+                    "error": item.error,
+                    "signals": item.signals,
+                    "termination_reason": item.termination_reason,
+                }
+                for item in self.items
+            ],
         }
 
         with open(path, "w", encoding="utf-8") as f:
@@ -165,7 +195,15 @@ class EvalResult:
             data = json.load(f)
 
         items = [
-            EvalItem(idx=item["idx"], reward=item["reward"], is_correct=item["is_correct"], error=item.get("error"), signals=item.get("signals", {}), attempt=item.get("attempt", 0))
+            EvalItem(
+                idx=item["idx"],
+                reward=item["reward"],
+                is_correct=item["is_correct"],
+                error=item.get("error"),
+                signals=item.get("signals", {}),
+                attempt=item.get("attempt", 0),
+                termination_reason=item.get("termination_reason"),
+            )
             for item in data["items"]
         ]
 
@@ -182,4 +220,5 @@ class EvalResult:
             timestamp=data.get("timestamp", ""),
             attempts=data.get("attempts", 1),
             pass_at={int(k): v for k, v in data.get("pass_at", {}).items()},
+            termination_breakdown=data.get("termination_breakdown", {}),
         )

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 from rllm.eval.results import EvalItem, EvalResult
 from rllm.hooks import FixedEvaluation, SandboxTaskHooks
-from rllm.types import AgentFlow, Evaluator, TerminationReason
+from rllm.types import INFRA_ERROR_REASONS, AgentFlow, Evaluator
 
 if TYPE_CHECKING:
     from rllm.gateway.manager import GatewayManager
@@ -155,10 +155,18 @@ async def run_dataset(
             items.append(EvalItem(idx=task_idx, attempt=attempt, reward=0.0, is_correct=False, error="missing episode"))
             continue
 
+        # An infra/grading failure (sandbox/setup/verifier/grading) means the
+        # reward isn't a real task score — surface it as an error so it's counted
+        # separately from genuine task failures. An agent TIMEOUT is NOT an error
+        # here: it's graded on partial state, so its reward stands.
+        reason = episode.termination_reason
         error_msg = None
-        if episode.termination_reason == TerminationReason.ERROR:
+        if reason in INFRA_ERROR_REASONS:
             err = (episode.metadata or {}).get("error") or {}
-            error_msg = err.get("message") if isinstance(err, dict) else str(err)
+            if isinstance(err, dict):
+                error_msg = err.get("error_type") or err.get("message") or reason.value
+            else:
+                error_msg = str(err) or reason.value
 
         signals: dict[str, float] = {}
         if episode.trajectories:
@@ -180,6 +188,7 @@ async def run_dataset(
                 is_correct=bool(episode.is_correct),
                 signals=signals,
                 error=error_msg,
+                termination_reason=reason.value if reason is not None else None,
             )
         )
         if error_msg is None:

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -16,7 +16,7 @@ import logging
 from pathlib import Path
 
 from rllm.eval.types import EvalOutput, Signal
-from rllm.sandbox.protocol import Sandbox
+from rllm.sandbox.protocol import Sandbox, SandboxCommandTimeout
 from rllm.types import Episode, Task
 
 logger = logging.getLogger(__name__)
@@ -59,6 +59,7 @@ class ShellScriptEvaluator:
             return EvalOutput(
                 reward=0.0,
                 is_correct=False,
+                error="AddTestsDirError",
                 metadata={"error": f"no {tests_dir} directory"},
             )
 
@@ -70,13 +71,25 @@ class ShellScriptEvaluator:
         except Exception:
             pass
 
-        # Upload to /tests/ (Harbor convention — scripts may reference /tests/*.py)
-        self.sandbox.upload_dir(str(tests_dir), "/tests")
+        # Upload to /tests/ (Harbor convention — scripts may reference /tests/*.py).
+        # A failed upload means the verifier can't run — a grading-infra failure,
+        # not a task score; tag it so the engine doesn't read it as reward 0.
+        try:
+            self.sandbox.upload_dir(str(tests_dir), "/tests")
+        except Exception as e:
+            logger.warning("Failed to upload tests dir for %s: %s", task.id, e)
+            return EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                error="AddTestsDirError",
+                metadata={"error": f"failed to upload tests dir: {e}"},
+            )
 
         if not (tests_dir / script_name).exists():
             return EvalOutput(
                 reward=0.0,
                 is_correct=False,
+                error="AddTestsDirError",
                 metadata={"error": f"verifier script {script_name} not found in {tests_dir}"},
             )
 
@@ -92,6 +105,18 @@ class ShellScriptEvaluator:
                 f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
                 timeout=self.verifier_timeout,
                 user=v_user,
+            )
+        except SandboxCommandTimeout as e:
+            # The verifier itself blew its time budget — a grading-infra
+            # failure, NOT "agent scored 0". Tag it (Harbor's VerifierTimeoutError)
+            # so the engine routes it to VERIFIER_TIMEOUT and training drops the
+            # untrustworthy reward instead of training on a spurious zero.
+            logger.warning("Verifier timed out after %ss for %s: %s", self.verifier_timeout, task.id, e)
+            return EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                error="VerifierTimeoutError",
+                metadata={"error": f"verifier timed out after {self.verifier_timeout}s"},
             )
         except Exception as e:
             # Verifier exit != 0 is the *expected* outcome when an agent
@@ -113,29 +138,51 @@ class ShellScriptEvaluator:
 
 
 def _read_reward_from_sandbox(sandbox: Sandbox, paths: list[str], user: str | None = None) -> EvalOutput:
-    """Try reading reward from the sandbox at each path in order."""
+    """Try reading reward from the sandbox at each path in order.
+
+    Distinguishes grading-infra failures from a legitimate ``reward=0`` by
+    setting :attr:`EvalOutput.error` (Harbor-aligned names): an unparseable
+    file → ``VerifierOutputParseError``, an empty file → ``RewardFileEmptyError``,
+    no file at all → ``RewardFileNotFoundError``. The engine promotes these to
+    ``GRADING_ERROR`` so the untrustworthy reward is filtered from training.
+    """
+    saw_empty = False
     for path in paths:
         try:
             check = sandbox.exec(f"test -f {path} && echo yes || echo no", timeout=10, user=user).strip()
             if check != "yes":
                 continue
             raw = sandbox.exec(f"cat {path}", timeout=10, user=user).strip()
-            if not raw:
-                continue
+        except Exception as e:
+            logger.debug("Could not read reward from %s: %s", path, e)
+            continue
+        if not raw:
+            saw_empty = True
+            continue
+        try:
             if path.endswith(".txt"):
                 reward = float(raw)
                 return EvalOutput(reward=reward, is_correct=reward >= 1.0)
             return _parse_reward_json(raw)
         except Exception as e:
-            logger.debug("Could not read reward from %s: %s", path, e)
-            continue
+            logger.warning("Could not parse reward file %s: %s", path, e)
+            return EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                error="VerifierOutputParseError",
+                metadata={"error": f"could not parse reward file {path}: {e}"},
+            )
 
-    # A missing reward file means the verifier produced no verdict — a verifier/infra
-    # failure, NOT a legitimate score of 0 (a correctly-failing verifier writes reward 0).
-    # Raise so it surfaces as an explicit error (the engine maps it to a task error),
-    # distinguishable from an agent that genuinely scored 0. Mirrors harbor's
-    # RewardFileNotFoundError.
-    raise RuntimeError(f"no reward file found at any of: {paths}")
+    # A missing reward file means the verifier produced no verdict — a verifier/
+    # infra failure, NOT a legitimate score of 0 (a correctly-failing verifier
+    # writes reward 0). Surface it as a typed grading error (Harbor-aligned
+    # names) so the engine promotes it to GRADING_ERROR and the untrustworthy
+    # reward is filtered, distinguishable from an agent that genuinely scored 0.
+    if saw_empty:
+        logger.warning("Reward file present but empty at one of: %s", paths)
+        return EvalOutput(reward=0.0, is_correct=False, error="RewardFileEmptyError", metadata={"error": "reward file present but empty"})
+    logger.warning("No reward file found at any of: %s", paths)
+    return EvalOutput(reward=0.0, is_correct=False, error="RewardFileNotFoundError", metadata={"error": "no reward file found"})
 
 
 def _parse_reward_json(raw: str) -> EvalOutput:

--- a/rllm/eval/types.py
+++ b/rllm/eval/types.py
@@ -28,3 +28,10 @@ class EvalOutput:
     is_correct: bool
     signals: list[Signal] = field(default_factory=list)
     metadata: dict = field(default_factory=dict)
+    # Set when grading ITSELF failed (verifier timeout/crash, missing reward
+    # file, ...) — distinct from a legitimate ``reward=0``. Carries the
+    # exception class name (Harbor-aligned where applicable, e.g.
+    # ``"VerifierTimeoutError"``, ``"RewardFileNotFoundError"``). The engine
+    # promotes this to an infra ``TerminationReason`` so the reward isn't
+    # mistaken for a real task failure. ``None`` means grading succeeded.
+    error: str | None = None

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -31,13 +31,14 @@ from __future__ import annotations
 import logging
 import os
 import shlex
+import time
 import uuid
 from abc import abstractmethod
 
 from rllm.env import env_int
 from rllm.sandbox.protocol import Sandbox, SandboxCommandTimeout
 from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
-from rllm.types import AgentConfig, Episode, Task, TerminationReason, Trajectory
+from rllm.types import AgentConfig, Episode, Task, TerminationReason, Trajectory, termination_reason_from_error
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,12 @@ class BaseCliHarness(SandboxedAgentFlow):
     # unset, the task's own agent_timeout governs (so eval honors each
     # benchmark's per-task budget). Captured at import; configure() flips it on.
     run_timeout_is_cap: bool = "RLLM_HARNESS_RUN_TIMEOUT_S" in os.environ
+    # Grace added to the *exec* timeout over the agent's budget so an in-sandbox
+    # driver that self-limits at the budget (terminus2) has time to record its
+    # outcome and exit cleanly before the backend SIGKILLs the exec. The agent
+    # still only "feels" ``_effective_timeout``; this just keeps the kill from
+    # racing the sentinel write.
+    timeout_grace_s: int = env_int("RLLM_HARNESS_TIMEOUT_GRACE_S", 60)
 
     def configure(self, overrides: dict) -> dict:
         """Consume CLI overrides this harness understands, then defer to the base.
@@ -113,6 +120,33 @@ class BaseCliHarness(SandboxedAgentFlow):
             exports = "; ".join(f"export {k}={shlex.quote(v)}" for k, v in env.items() if v is not None)
             command = f"{exports}; {command}"
         return sandbox.exec(command, timeout=timeout, user=self.agent_user)
+
+    def _effective_timeout(self, task: Task) -> float:
+        """The agent's wall-clock budget for this task, in seconds.
+
+        The task's own ``agent_timeout`` applies, but an operator-set
+        ``RLLM_HARNESS_RUN_TIMEOUT_S`` / ``--agent-timeout`` is a hard ceiling
+        over it (``run_timeout_is_cap``). Shared by :meth:`run` (to size the
+        exec timeout + classify a wall-clock kill) and by harnesses that hand
+        the same budget to an in-sandbox driver.
+        """
+        per_task = task.metadata.get("agent_timeout")
+        if per_task is None:
+            return float(self.run_timeout)
+        if self.run_timeout_is_cap:
+            return min(float(per_task), float(self.run_timeout))
+        return float(per_task)
+
+    def _read_outcome(self, sandbox: Sandbox) -> dict | None:
+        """Structured outcome an in-sandbox driver may have written.
+
+        Returns ``{"exception_type": str|None, "message": str}`` when a driver
+        recorded one (an empty ``exception_type`` means it finished cleanly), or
+        ``None`` when there's no sentinel — in which case :meth:`run` falls back
+        to the elapsed-vs-budget heuristic. Base CLI harnesses run an opaque
+        binary and write nothing, so this is ``None``; terminus2 overrides it.
+        """
+        return None
 
     @staticmethod
     def infer_provider(model_name: str) -> str:
@@ -330,24 +364,20 @@ class BaseCliHarness(SandboxedAgentFlow):
         self.write_configs(sandbox, task, config, env_vars)
 
         instruction = str(task.instruction).strip()
-        # The task's own agent_timeout (from task.toml) applies, but an
-        # operator-set RLLM_HARNESS_RUN_TIMEOUT_S / --agent-timeout is a hard
-        # ceiling over it — otherwise a task declaring e.g. 3600s would ignore a
-        # 1800s cap meant to bound training-rollout wall-clock.
-        per_task = task.metadata.get("agent_timeout")
-        if per_task is None:
-            timeout = float(self.run_timeout)
-        elif self.run_timeout_is_cap:
-            timeout = min(float(per_task), float(self.run_timeout))
-        else:
-            timeout = float(per_task)
+        budget = self._effective_timeout(task)
+        # Give the exec a grace window over the agent's budget: a driver that
+        # self-limits at ``budget`` (terminus2) gets to record its outcome before
+        # this kills it. Harnesses without a driver just get a slightly later
+        # hard kill, which the elapsed backstop below still classifies as TIMEOUT.
+        exec_timeout = budget + self.timeout_grace_s
         cmd = self.build_invocation(instruction, task, config)
 
+        start = time.monotonic()
         try:
-            self._exec_agent(sandbox, cmd, timeout=timeout, env=env_vars)
+            self._exec_agent(sandbox, cmd, timeout=exec_timeout, env=env_vars)
         except SandboxCommandTimeout as e:
-            # Expected, not a failure: the agent spent its budget and the captured
-            # steps are still scored. TIMEOUT lets compact filtering skip it.
+            # The backend killed the exec at the wall — the agent spent its budget.
+            # Captured steps are still scored; TIMEOUT lets compact filtering skip it.
             logger.info("%s reached its time budget: %s", type(self).__name__, e)
             return self._outcome_episode(task, termination_reason=TerminationReason.TIMEOUT)
         except Exception as e:
@@ -358,6 +388,33 @@ class BaseCliHarness(SandboxedAgentFlow):
                 termination_reason=TerminationReason.ERROR,
                 error={"message": str(e), "error_type": type(e).__name__},
             )
+        elapsed = time.monotonic() - start
 
-        # Clean exit: the engine marks this ENV_DONE.
+        # Prefer the driver's own verdict when it left one: it knows whether the
+        # agent declared completion or hit a phase timeout (AgentTimeoutError,
+        # ContextLengthExceededError, ...). A masked exit code (e.g. ``| tee``
+        # swallowing the kill) can't be trusted, so the sentinel — not the exit
+        # status — is authoritative when present.
+        outcome = self._read_outcome(sandbox)
+        if outcome is not None:
+            exc_type = outcome.get("exception_type")
+            if exc_type:
+                reason = termination_reason_from_error(exc_type, default=TerminationReason.ERROR)
+                logger.info("%s outcome: %s -> %s", type(self).__name__, exc_type, reason)
+                return self._outcome_episode(
+                    task,
+                    termination_reason=reason,
+                    error={"message": outcome.get("message", ""), "error_type": exc_type},
+                )
+            # Driver finished cleanly (declared done) → ENV_DONE, even past the wall.
+            return self._outcome_episode(task, termination_reason=None)
+
+        # No sentinel (opaque CLI, or the driver was killed before writing one):
+        # an exec that ran essentially to the wall is a wall-clock timeout whose
+        # exit code got masked — the failure mode this backstop exists to catch.
+        if budget > 0 and elapsed >= budget * 0.95:
+            logger.info("%s ran to its wall-clock budget (%.0fs/%.0fs) with no clean exit; marking TIMEOUT", type(self).__name__, elapsed, budget)
+            return self._outcome_episode(task, termination_reason=TerminationReason.TIMEOUT)
+
+        # Clean exit well within budget: the engine marks this ENV_DONE.
         return self._outcome_episode(task, termination_reason=None)

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -381,11 +381,23 @@ class BaseCliHarness(SandboxedAgentFlow):
             logger.info("%s reached its time budget: %s", type(self).__name__, e)
             return self._outcome_episode(task, termination_reason=TerminationReason.TIMEOUT)
         except Exception as e:
-            # Traces up to the failure still drive enrichment; mark ERROR.
-            logger.warning("%s execution failed: %s", type(self).__name__, e)
+            # The backend collapses "sandbox died mid-run" and "the CLI exited
+            # non-zero on a live box" into the same generic exception, so probe
+            # liveness to tell them apart: a dead box is infra (SANDBOX_ERROR,
+            # reward untrustworthy), a non-zero exit on a live box is ERROR.
+            # Traces up to the failure still drive enrichment either way.
+            reason = TerminationReason.ERROR
+            alive = getattr(sandbox, "is_alive", None)
+            if callable(alive):
+                try:
+                    if not alive():
+                        reason = TerminationReason.SANDBOX_ERROR
+                except Exception:  # is_alive must not raise, but never let the probe mask the real failure
+                    logger.debug("is_alive probe raised after exec failure", exc_info=True)
+            logger.warning("%s execution failed (%s): %s", type(self).__name__, reason.value, e)
             return self._outcome_episode(
                 task,
-                termination_reason=TerminationReason.ERROR,
+                termination_reason=reason,
                 error={"message": str(e), "error_type": type(e).__name__},
             )
         elapsed = time.monotonic() - start

--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -376,9 +376,38 @@ class BaseCliHarness(SandboxedAgentFlow):
         try:
             self._exec_agent(sandbox, cmd, timeout=exec_timeout, env=env_vars)
         except SandboxCommandTimeout as e:
-            # The backend killed the exec at the wall — the agent spent its budget.
+            # The exec ended at the wall — either the agent really spent its
+            # budget, or the backend lost the command's completion (e.g. a
+            # dropped long-poll connection) and only its client-side timer
+            # fired. The driver's sentinel survives either way and is
+            # authoritative: a clean sentinel means the agent finished fine.
+            logger.info("%s exec ended at the wall: %s", type(self).__name__, e)
+            outcome = self._read_outcome(sandbox)
+            if outcome is not None:
+                exc_type = outcome.get("exception_type")
+                if not exc_type:
+                    # Transport loss: the driver finished cleanly but the exec's
+                    # completion never reached us. Label ENV_DONE (reward is
+                    # valid) and leave an audit marker in episode metadata —
+                    # not an infra error, but it must be visible in tracking.
+                    logger.warning(
+                        "%s exec hit the wall but the sentinel shows a clean finish — the backend lost the exec completion in transport (recovered; labeling ENV_DONE)",
+                        type(self).__name__,
+                    )
+                    return self._outcome_episode(
+                        task,
+                        termination_reason=None,
+                        error={"error_type": "ExecCompletionLost", "message": f"exec completion lost in transport; recovered via sentinel: {e}"},
+                    )
+                reason = termination_reason_from_error(exc_type, default=TerminationReason.TIMEOUT)
+                logger.info("%s outcome after exec timeout: %s -> %s", type(self).__name__, exc_type, reason)
+                return self._outcome_episode(
+                    task,
+                    termination_reason=reason,
+                    error={"message": outcome.get("message", ""), "error_type": exc_type},
+                )
+            # No sentinel: the driver really was killed at the wall.
             # Captured steps are still scored; TIMEOUT lets compact filtering skip it.
-            logger.info("%s reached its time budget: %s", type(self).__name__, e)
             return self._outcome_episode(task, termination_reason=TerminationReason.TIMEOUT)
         except Exception as e:
             # The backend collapses "sandbox died mid-run" and "the CLI exited

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -37,6 +37,10 @@ _VENV_DIR = "/opt/terminus2-venv"
 _DRIVER_PATH = "/opt/terminus2/driver.py"
 _INSTRUCTION_PATH = "/tmp/terminus2/instruction.txt"
 _LOGS_DIR = "/tmp/terminus2/logs"
+# The driver records a structured outcome here (Harbor ExceptionInfo-shaped) so
+# the harness can label TIMEOUT / AGENT_SETUP_TIMEOUT / ... by the agent's actual
+# verdict instead of an exit code the ``| tee`` pipeline would mask.
+_OUTCOME_PATH = "/tmp/terminus2/outcome.json"
 
 
 def _install_script(harbor_version: str, py_version: str) -> str:
@@ -129,11 +133,44 @@ class Terminus2Harness(BaseCliHarness):
             "RLLM_TERMINUS_RECORD": "1" if self.record_terminal_session else "0",
             "RLLM_TERMINUS_INSTRUCTION_FILE": _INSTRUCTION_PATH,
             "RLLM_TERMINUS_LOGS_DIR": _LOGS_DIR,
+            "RLLM_TERMINUS_OUTCOME_FILE": _OUTCOME_PATH,
+            # The driver self-limits the agent loop at this budget and records an
+            # AgentTimeoutError, so the timeout is labelled correctly even though
+            # the outer ``| tee`` exec masks the kill's exit code. The harness's
+            # exec gets a grace window beyond this (see BaseCliHarness.run).
+            "RLLM_TERMINUS_AGENT_TIMEOUT_S": str(self._effective_timeout(task)),
         }
         # Only pass a turn cap when one is set; absent var = no artificial limit.
         if self.max_turns is not None:
             env["RLLM_TERMINUS_MAX_TURNS"] = str(self.max_turns)
         return env
+
+    def _read_outcome(self, sandbox: Sandbox) -> dict | None:
+        """Read the driver's outcome sentinel (Harbor ExceptionInfo-shaped).
+
+        Returns ``{"exception_type", "message"}`` when the driver recorded a
+        failure, ``{}`` (present, no exception) on a clean finish, or ``None``
+        when the file is absent/unreadable — e.g. the driver was SIGKILLed
+        before it could write, in which case run() applies its elapsed backstop.
+        """
+        import json
+
+        try:
+            raw = sandbox.exec(f"cat {shlex.quote(_OUTCOME_PATH)} 2>/dev/null || true", timeout=15, user=self.agent_user).strip()
+        except Exception as e:
+            logger.debug("terminus2 outcome read failed: %s", e)
+            return None
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except Exception as e:
+            logger.debug("terminus2 outcome parse failed: %s", e)
+            return None
+        info = data.get("exception_info")
+        if info:
+            return {"exception_type": info.get("exception_type"), "message": info.get("exception_message", "")}
+        return {}
 
     def write_configs(
         self,
@@ -168,15 +205,19 @@ class Terminus2Harness(BaseCliHarness):
 # ---------------------------------------------------------------------------
 _DRIVER_SCRIPT = r'''
 import asyncio
+import json
 import logging
 import os
 import shutil
+import traceback
+from datetime import datetime
 from pathlib import Path
 
 from harbor.agents.terminus_2.terminus_2 import Terminus2
 from harbor.environments.base import BaseEnvironment, ExecResult
 from harbor.models.agent.context import AgentContext
 from harbor.models.environment_type import EnvironmentType
+from harbor.trial.errors import AgentSetupTimeoutError, AgentTimeoutError
 
 log = logging.getLogger("terminus2-driver")
 
@@ -295,12 +336,54 @@ async def _main():
         suppress_max_turns_warning=True,
     )
     ctx = AgentContext()
-    log.info("terminus2-driver: model=%s workdir=%s parser=%s max_turns=%s", model, workdir, parser, max_turns)
-    await agent.setup(env)
-    await agent.run(instruction, env, ctx)
+    # Budgets: self-limit the agent loop so a wall-clock kill is recorded as a
+    # typed AgentTimeoutError (mirrors harbor Trial), instead of relying on the
+    # outer exec's exit code which the `| tee` pipeline masks. 0/unset = no cap.
+    agent_timeout = float(os.environ.get("RLLM_TERMINUS_AGENT_TIMEOUT_S", "0")) or None
+    setup_timeout = float(os.environ.get("RLLM_TERMINUS_SETUP_TIMEOUT_S", "0")) or None
+    outcome_file = os.environ.get("RLLM_TERMINUS_OUTCOME_FILE")
+    log.info("terminus2-driver: model=%s workdir=%s parser=%s max_turns=%s agent_timeout=%s", model, workdir, parser, max_turns, agent_timeout)
+
+    exc_info = None
+    try:
+        if setup_timeout:
+            try:
+                await asyncio.wait_for(agent.setup(env), timeout=setup_timeout)
+            except asyncio.TimeoutError:
+                raise AgentSetupTimeoutError(f"Agent setup timed out after {setup_timeout}s")
+        else:
+            await agent.setup(env)
+        if agent_timeout:
+            try:
+                await asyncio.wait_for(agent.run(instruction, env, ctx), timeout=agent_timeout)
+            except asyncio.TimeoutError:
+                raise AgentTimeoutError(f"Agent execution timed out after {agent_timeout}s")
+        else:
+            await agent.run(instruction, env, ctx)
+    except BaseException as e:  # noqa: BLE001 — record the verdict, never crash the exec
+        # Captures harbor's typed timeouts plus ContextLengthExceededError /
+        # OutputLengthExceededError raised inside agent.run.
+        exc_info = {
+            "exception_type": type(e).__name__,
+            "exception_message": str(e),
+            "exception_traceback": traceback.format_exc(),
+            "occurred_at": datetime.now().isoformat(),
+        }
+        log.warning("terminus2-driver agent phase failed: %s: %s", type(e).__name__, e)
+
+    # Mirror harbor's ExceptionInfo; exit 0 regardless so the agent's partial
+    # container state survives for the verifier (a timeout is still graded).
+    if outcome_file:
+        try:
+            Path(outcome_file).parent.mkdir(parents=True, exist_ok=True)
+            Path(outcome_file).write_text(json.dumps({"exception_info": exc_info, "finished": exc_info is None}))
+        except Exception as e:
+            log.warning("terminus2-driver failed to write outcome file: %s", e)
+
     log.info(
-        "terminus2-driver done: episodes=%s in_tokens=%s out_tokens=%s",
+        "terminus2-driver done: episodes=%s in_tokens=%s out_tokens=%s exc=%s",
         (ctx.metadata or {}).get("n_episodes"), ctx.n_input_tokens, ctx.n_output_tokens,
+        (exc_info or {}).get("exception_type"),
     )
 
 

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -89,7 +89,7 @@ class Terminus2Harness(BaseCliHarness):
     stdout_log_path = "/tmp/terminus2.log"
 
     # ---- Terminus-2 knobs (overridable via agent kwargs / configure) ----
-    harbor_version: str = "0.3.0"
+    harbor_version: str = "0.13.2"  # match the host venv; 0.3.0 is far too old (no harbor.trial.errors, ancient Terminus-2)
     terminus_python: str = "3.12"
     parser_name: str = "json"  # "json" or "xml"
     # Temperature the agent requests; in `rllm eval`/training the gateway
@@ -217,7 +217,19 @@ from harbor.agents.terminus_2.terminus_2 import Terminus2
 from harbor.environments.base import BaseEnvironment, ExecResult
 from harbor.models.agent.context import AgentContext
 from harbor.models.environment_type import EnvironmentType
-from harbor.trial.errors import AgentSetupTimeoutError, AgentTimeoutError
+
+
+# Defined locally on purpose: harbor 0.3.0 (the version installed in the sandbox)
+# has no ``harbor.trial.errors`` module. Only the class *names* matter — the
+# harness maps them to a TerminationReason via the exception_type string in the
+# outcome sentinel, so matching Harbor's names is all that's needed.
+class AgentSetupTimeoutError(asyncio.TimeoutError):
+    pass
+
+
+class AgentTimeoutError(asyncio.TimeoutError):
+    pass
+
 
 log = logging.getLogger("terminus2-driver")
 

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -55,8 +55,10 @@ def _install_script(harbor_version: str, py_version: str) -> str:
     return rf"""
 set -e
 export DEBIAN_FRONTEND=noninteractive
-# Marker keeps this a no-op on a snapshot that already baked the install.
-if [ -f {_VENV_DIR}/.terminus2-ready ]; then
+# Skip only when harbor is ALREADY at the pinned version — this self-heals a
+# snapshot that baked an older harbor. A bare "ready" marker would let a stale
+# (e.g. 0.3.0) harbor stand, which crashes the modern driver.
+if [ -x {_VENV_DIR}/bin/python ] && {_VENV_DIR}/bin/python -c "import importlib.metadata as _m, sys; sys.exit(0 if _m.version('harbor') == '{harbor_version}' else 1)" 2>/dev/null; then
     exit 0
 fi
 # tmux + `script` (util-linux) + ps (procps) are what Terminus-2's TmuxSession
@@ -73,8 +75,12 @@ if ! command -v uv >/dev/null 2>&1; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 export PATH="$HOME/.local/bin:$PATH"
-# Private interpreter + venv; harbor and its deps live only here.
-uv venv --python {shlex.quote(py_version)} {_VENV_DIR}
+# Private interpreter + venv; harbor and its deps live only here. Create the venv
+# only if missing (don't clobber an existing one), then install/upgrade harbor to
+# the pinned version in place — so a 0.3.0 snapshot self-heals to {harbor_version}.
+if [ ! -x {_VENV_DIR}/bin/python ]; then
+    uv venv --python {shlex.quote(py_version)} {_VENV_DIR}
+fi
 uv pip install --python {_VENV_DIR}/bin/python {shlex.quote("harbor==" + harbor_version)}
 touch {_VENV_DIR}/.terminus2-ready
 """

--- a/rllm/integrations/harbor/trial_helper.py
+++ b/rllm/integrations/harbor/trial_helper.py
@@ -241,23 +241,6 @@ def trial_result_to_reward(result) -> tuple[float | None, bool, str | None]:
 # Unified single-task execution
 # ---------------------------------------------------------------------------
 
-# Map harbor exception_type strings to rllm TerminationReason.
-_EXCEPTION_TYPE_MAP: dict[str, Any] | None = None
-
-
-def _get_exception_type_map() -> dict[str, Any]:
-    """Lazily build the exception-type → TerminationReason map."""
-    global _EXCEPTION_TYPE_MAP
-    if _EXCEPTION_TYPE_MAP is None:
-        from rllm.types import TerminationReason
-
-        _EXCEPTION_TYPE_MAP = {
-            "AgentTimeoutError": TerminationReason.TIMEOUT,
-            "ContextLengthExceededError": TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED,
-            "OutputLengthExceededError": TerminationReason.MAX_RESPONSE_LENGTH_EXCEEDED,
-        }
-    return _EXCEPTION_TYPE_MAP
-
 
 def map_termination_reason(
     finished: bool,
@@ -266,17 +249,17 @@ def map_termination_reason(
 ):
     """Derive TerminationReason from harbor trial outcome.
 
-    Shared by both eval and training paths.
+    Shared by both eval and training paths. Delegates the exception-type
+    rollup to :func:`rllm.types.termination_reason_from_error` so the harbor
+    runtime and the in-sandbox CLI harness classify failures identically.
     """
-    from rllm.types import TerminationReason
+    from rllm.types import TerminationReason, termination_reason_from_error
 
     if finished:
         return TerminationReason.ENV_DONE
     if timed_out:
         return TerminationReason.TIMEOUT
-    if exception_type:
-        return _get_exception_type_map().get(exception_type, TerminationReason.ERROR)
-    return TerminationReason.ERROR
+    return termination_reason_from_error(exception_type, default=TerminationReason.ERROR)
 
 
 @dataclasses.dataclass

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -86,6 +86,7 @@ def _enable_tcp_keepalive(client) -> None:
     except Exception:
         logger.warning("Could not enable TCP keepalive on Daytona SDK pools (SDK internals changed?)", exc_info=True)
 
+
 # atexit-tracked sandboxes; terminated on process exit to avoid leaks.
 _LIVE_SANDBOXES: weakref.WeakSet = weakref.WeakSet()
 _LIVE_LOCK = threading.Lock()
@@ -457,10 +458,7 @@ class DaytonaSandbox:
                     # exit-124 path below, where the shell `timeout` killed the
                     # command and reported back). The command may have finished
                     # and its completion been lost in transport — say so.
-                    raise SandboxCommandTimeout(
-                        f"No exec response within {int(timeout) + 60}s in sandbox {self.name} "
-                        f"(command may have completed; response lost in transport): {command[:200]}"
-                    ) from e
+                    raise SandboxCommandTimeout(f"No exec response within {int(timeout) + 60}s in sandbox {self.name} (command may have completed; response lost in transport): {command[:200]}") from e
                 raise
             stdout = response.result or ""
             exit_code = response.exit_code

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -22,6 +22,7 @@ import shlex
 import tarfile
 import threading
 import time
+import uuid
 import weakref
 from pathlib import Path
 
@@ -35,6 +36,55 @@ logger = logging.getLogger(__name__)
 # finite value to belt-and-suspenders against leaked sandboxes if the
 # process is SIGKILL'd (atexit won't fire then).
 _DEFAULT_AUTO_STOP_INTERVAL = 30  # minutes; mirrors ModalSandbox's 30-min timeout
+
+# Commands allowed to run longer than this ride a session (async submit +
+# short polls) instead of the one-shot exec endpoint. The one-shot exec
+# carries the whole command on a single HTTP request that stays byte-silent
+# until completion, and Daytona's toolbox proxy silently drops idle flows
+# after ~4 minutes (measured 2026-07-01: sleep 240 delivered, sleep 270/330
+# lost) — the completion is then unreachable and the call blocks until the
+# SDK read timeout, mislabeling long-finished commands as timeouts.
+_SESSION_EXEC_THRESHOLD_S = env_float("RLLM_DAYTONA_SESSION_EXEC_THRESHOLD_S", 180.0)
+_SESSION_EXEC_POLL_S = env_float("RLLM_DAYTONA_SESSION_EXEC_POLL_S", 15.0)
+_SESSION_EXEC_MAX_POLL_FAILURES = 5
+
+
+def _enable_tcp_keepalive(client) -> None:
+    """Inject TCP keepalive into the SDK's HTTP pools (defense-in-depth).
+
+    An L4 middlebox on the toolbox path silently drops flows idle for
+    ~245-250s (measured 2026-07-01), black-holing responses of long
+    requests. Kernel keepalive probes every 60s reset that idle timer
+    (validated: a 400s one-shot exec delivers with these options, and is
+    always lost without them). Sessions + polling remain the primary
+    defense for long execs; this also protects every other SDK call.
+
+    Reaches into SDK internals (no public hook: ``DaytonaConfig`` doesn't
+    expose ``socket_options`` and the toolbox client is cloned at
+    construction), so it is strictly best-effort — never fails the caller.
+    """
+    import socket as _socket
+
+    opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+    for name, val in (("TCP_KEEPIDLE", 60), ("TCP_KEEPINTVL", 60), ("TCP_KEEPCNT", 5)):
+        if hasattr(_socket, name):  # Linux; macOS/Windows lack some of these
+            opts.append((_socket.IPPROTO_TCP, getattr(_socket, name), val))
+    try:
+        import urllib3.connection
+
+        base = list(urllib3.connection.HTTPConnection.default_socket_options)
+        from daytona_api_client.rest import RESTClientObject as _ApiREST
+        from daytona_toolbox_api_client.rest import RESTClientObject as _ToolboxREST
+
+        for attr, rest_cls in (("_api_client", _ApiREST), ("_toolbox_api_client", _ToolboxREST)):
+            api = getattr(client, attr, None)
+            if api is None or not hasattr(api, "configuration"):
+                continue
+            api.configuration.socket_options = base + opts
+            api.rest_client = rest_cls(api.configuration)
+        logger.debug("TCP keepalive enabled on Daytona SDK HTTP pools")
+    except Exception:
+        logger.warning("Could not enable TCP keepalive on Daytona SDK pools (SDK internals changed?)", exc_info=True)
 
 # atexit-tracked sandboxes; terminated on process exit to avoid leaks.
 _LIVE_SANDBOXES: weakref.WeakSet = weakref.WeakSet()
@@ -253,6 +303,7 @@ class DaytonaSandbox:
         # Client init
         daytona_config = kwargs.pop("daytona_config", None)
         self._client = Daytona(daytona_config) if daytona_config is not None else Daytona()
+        _enable_tcp_keepalive(self._client)
 
         # Build common parameters
         base_kwargs: dict = {
@@ -378,25 +429,41 @@ class DaytonaSandbox:
         run = _build_exec_command(command, self._persistent_env, user)
         wrapped = f"bash -c {_shell_quote(run)}"
 
-        exec_kwargs: dict = {}
         if timeout is not None:
             t = int(timeout)
             # SIGTERM at t, SIGKILL 10s later if it ignores TERM. Exit 124
             # (TERM) / 137 (KILL) flag the timeout below.
             wrapped = f"timeout -k 10 {t} {wrapped}"
-            # SDK timeout as a backstop, set beyond the shell timeout so the
-            # deterministic shell `timeout` is what fires first.
-            exec_kwargs["timeout"] = t + 60
 
-        try:
-            response = self._sandbox.process.exec(wrapped, **exec_kwargs)
-        except Exception as e:  # noqa: BLE001 — map an SDK-level timeout to the protocol type
-            if timeout is not None and _looks_like_timeout(e):
-                raise SandboxCommandTimeout(f"Command hit its {int(timeout)}s timeout in sandbox {self.name}: {command[:200]}") from e
-            raise
-
-        stdout = response.result or ""
-        exit_code = response.exit_code
+        if timeout is not None and timeout > _SESSION_EXEC_THRESHOLD_S:
+            # Long command: a one-shot exec would ride a single idle HTTP
+            # request that NAT middleboxes drop after ~4 minutes of silence,
+            # so its completion could never be delivered (see
+            # _SESSION_EXEC_THRESHOLD_S). Untimed execs stay one-shot: they
+            # are quick housekeeping calls in practice, and the TCP-keepalive
+            # layer (_enable_tcp_keepalive) protects any that straggle.
+            stdout, exit_code = self._exec_session(wrapped, timeout, command)
+        else:
+            exec_kwargs: dict = {}
+            if timeout is not None:
+                # SDK timeout as a backstop, set beyond the shell timeout so the
+                # deterministic shell `timeout` is what fires first.
+                exec_kwargs["timeout"] = int(timeout) + 60
+            try:
+                response = self._sandbox.process.exec(wrapped, **exec_kwargs)
+            except Exception as e:  # noqa: BLE001 — map an SDK-level timeout to the protocol type
+                if timeout is not None and _looks_like_timeout(e):
+                    # SDK-level timeout = NO response was received (unlike the
+                    # exit-124 path below, where the shell `timeout` killed the
+                    # command and reported back). The command may have finished
+                    # and its completion been lost in transport — say so.
+                    raise SandboxCommandTimeout(
+                        f"No exec response within {int(timeout) + 60}s in sandbox {self.name} "
+                        f"(command may have completed; response lost in transport): {command[:200]}"
+                    ) from e
+                raise
+            stdout = response.result or ""
+            exit_code = response.exit_code
 
         if timeout is not None and exit_code in (124, 137):
             # `timeout` killed it: 124 = exited on SIGTERM, 137 = SIGKILL'd after
@@ -421,6 +488,61 @@ class DaytonaSandbox:
             )
             raise RuntimeError(f"Command failed (exit {exit_code}) in sandbox {self.name}: {command}\n{tail}")
         return stdout
+
+    def _exec_session(self, wrapped: str, timeout: float | None, command: str) -> tuple[str, int]:
+        """Run ``wrapped`` via a session command: async submit, then short polls.
+
+        Each poll is its own short-lived HTTP request, so no connection ever
+        sits idle long enough for the toolbox proxy to drop it — unlike
+        ``process.exec``, which waits for the completion on one idle long-poll.
+        The in-sandbox coreutils ``timeout`` (already baked into ``wrapped``)
+        remains the deterministic killer; the poll deadline below (same +60s
+        grace the one-shot path gives the SDK) only catches a daemon that
+        lost the command entirely.
+        """
+        from daytona.common.process import SessionExecuteRequest
+
+        proc = self._sandbox.process
+        session_id = f"rllm-exec-{uuid.uuid4().hex[:12]}"
+        proc.create_session(session_id)
+        try:
+            submitted = proc.execute_session_command(session_id, SessionExecuteRequest(command=wrapped, run_async=True))
+            cmd_id = submitted.cmd_id
+            deadline = None if timeout is None else time.monotonic() + float(timeout) + 60.0
+            poll_failures = 0
+            # Adaptive poll: fast at first so short-lived commands that merely
+            # *allow* a long budget (cached install, quick verifier) don't pay
+            # a full poll interval, decaying to the steady-state interval.
+            poll_s = 1.0
+            while True:
+                time.sleep(poll_s)
+                poll_s = min(poll_s * 2, _SESSION_EXEC_POLL_S)
+                try:
+                    cmd = proc.get_session_command(session_id, cmd_id)
+                    poll_failures = 0
+                except Exception as e:  # noqa: BLE001 — a transient API blip must not kill a long rollout
+                    poll_failures += 1
+                    if poll_failures >= _SESSION_EXEC_MAX_POLL_FAILURES:
+                        raise
+                    logger.warning("Session exec poll %d/%d failed in sandbox %s: %s", poll_failures, _SESSION_EXEC_MAX_POLL_FAILURES, self.name, e)
+                    continue
+                if cmd.exit_code is not None:
+                    exit_code = int(cmd.exit_code)
+                    break
+                if deadline is not None and time.monotonic() > deadline:
+                    raise SandboxCommandTimeout(f"Command hit its {int(timeout)}s timeout in sandbox {self.name} (poll deadline): {command[:200]}")
+            try:
+                logs = proc.get_session_command_logs(session_id, cmd_id)
+                stdout = (logs.stdout or "") + (logs.stderr or "")
+            except Exception as e:  # noqa: BLE001 — output is best-effort; the exit code is what gates
+                logger.warning("Session exec log fetch failed in sandbox %s: %s", self.name, e)
+                stdout = ""
+            return stdout, exit_code
+        finally:
+            try:
+                proc.delete_session(session_id)
+            except Exception:
+                logger.debug("Session cleanup failed for %s", session_id, exc_info=True)
 
     def upload_file(self, local_path: str, remote_path: str) -> None:
         """Upload a single file via Daytona's native ``fs.upload_file``."""

--- a/rllm/trainer/algorithms/config.py
+++ b/rllm/trainer/algorithms/config.py
@@ -148,6 +148,7 @@ class CompactFilteringConfig:
     mask_sandbox_error: bool = False
     mask_agent_setup_timeout: bool = False
     mask_env_start_timeout: bool = False
+    mask_model_error: bool = False
 
     @classmethod
     def from_config(cls, config: DictConfig) -> "CompactFilteringConfig":
@@ -183,6 +184,7 @@ class CompactFilteringConfig:
             or (self.mask_sandbox_error and termination_reason == TerminationReason.SANDBOX_ERROR)
             or (self.mask_agent_setup_timeout and termination_reason == TerminationReason.AGENT_SETUP_TIMEOUT)
             or (self.mask_env_start_timeout and termination_reason == TerminationReason.ENV_START_TIMEOUT)
+            or (self.mask_model_error and termination_reason == TerminationReason.MODEL_ERROR)
         )
 
 

--- a/rllm/trainer/algorithms/config.py
+++ b/rllm/trainer/algorithms/config.py
@@ -140,6 +140,14 @@ class CompactFilteringConfig:
     mask_timeout: bool = False
     mask_unknown: bool = False
     mask_error: bool = False
+    # Infra/grading failures: the reward isn't a real task score (verifier timed
+    # out/crashed, sandbox or setup died), so it shouldn't enter the loss. These
+    # default False in the dataclass for back-compat; base.yaml turns them on.
+    mask_verifier_timeout: bool = False
+    mask_grading_error: bool = False
+    mask_sandbox_error: bool = False
+    mask_agent_setup_timeout: bool = False
+    mask_env_start_timeout: bool = False
 
     @classmethod
     def from_config(cls, config: DictConfig) -> "CompactFilteringConfig":
@@ -170,6 +178,11 @@ class CompactFilteringConfig:
             or (self.mask_timeout and termination_reason == TerminationReason.TIMEOUT)
             or (self.mask_unknown and termination_reason == TerminationReason.UNKNOWN)
             or (self.mask_error and termination_reason == TerminationReason.ERROR)
+            or (self.mask_verifier_timeout and termination_reason == TerminationReason.VERIFIER_TIMEOUT)
+            or (self.mask_grading_error and termination_reason == TerminationReason.GRADING_ERROR)
+            or (self.mask_sandbox_error and termination_reason == TerminationReason.SANDBOX_ERROR)
+            or (self.mask_agent_setup_timeout and termination_reason == TerminationReason.AGENT_SETUP_TIMEOUT)
+            or (self.mask_env_start_timeout and termination_reason == TerminationReason.ENV_START_TIMEOUT)
         )
 
 

--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -28,7 +28,7 @@ from rllm.trainer.algorithms import (
 from rllm.trainer.algorithms.transform import transform_episodes_to_trajectory_groups
 from rllm.trainer.metrics_aggregator import MetricsAggregator
 from rllm.trainer.sync_coordinator import SyncCoordinator
-from rllm.types import Episode, TerminationReason, TrajectoryGroup
+from rllm.types import INFRA_ERROR_REASONS, Episode, TerminationReason, TrajectoryGroup
 
 logger = logging.getLogger(__name__)
 
@@ -370,6 +370,9 @@ class TrajectoryGroupBuffer:
                     f"episode/termination_reason/{r.value}",
                     1.0 if reason == r else 0.0,
                 )
+            # Aggregate infra/grading-failure rate (sandbox/setup/verifier/grading),
+            # so it's trackable without summing the per-reason series by hand.
+            self._aggregator.record("episode/infra_error", 1.0 if reason in INFRA_ERROR_REASONS else 0.0)
             for k, v in ep.metrics.items():
                 try:
                     self._aggregator.record(f"episode/{k}", float(v))

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -113,7 +113,10 @@ accumulate_reasoning: False
 mask_truncated_samples: False
 filter_token_mismatch: True
 
-# Compact filtering
+# Compact filtering. ``enable`` is the master switch (off by default for
+# back-compat); when on, a rollout whose termination_reason is masked here is
+# excluded from the loss. The infra/grading reasons default True because their
+# reward is not a real task score (verifier timed out/crashed, sandbox died).
 compact_filtering:
   enable: False
   mask_max_prompt_length_exceeded: True
@@ -123,6 +126,11 @@ compact_filtering:
   mask_timeout: True
   mask_unknown: False
   mask_error: True
+  mask_verifier_timeout: True
+  mask_grading_error: True
+  mask_sandbox_error: True
+  mask_agent_setup_timeout: True
+  mask_env_start_timeout: True
 
 # Rejection sampling
 rejection_sample:

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -131,6 +131,7 @@ compact_filtering:
   mask_sandbox_error: True
   mask_agent_setup_timeout: True
   mask_env_start_timeout: True
+  mask_model_error: True
 
 # Rejection sampling
 rejection_sample:

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -42,7 +42,7 @@ from rllm.trainer.backend_protocol import BackendProtocol
 from rllm.trainer.buffer import TrajectoryGroupBuffer
 from rllm.trainer.metrics_aggregator import MetricsAggregator
 from rllm.trainer.sync_coordinator import SyncCoordinator, SyncCoordinatorConfig
-from rllm.types import Episode, TerminationReason, TrajectoryGroup
+from rllm.types import INFRA_ERROR_REASONS, Episode, TerminationReason, TrajectoryGroup
 from rllm.utils import EpisodeLogger, Tracking, extract_source_metadata
 from rllm.workflows.store import Store
 from rllm.workflows.workflow import Workflow
@@ -502,6 +502,9 @@ class UnifiedTrainer:
         total_counts = max(sum(termination_counts.values()), 1)
         for r in TerminationReason:
             trainer_state.metrics[f"batch/termination_reason/{r.value}"] = termination_counts[r.value] / total_counts
+        # Aggregate infra/grading-failure rate (sandbox/setup/verifier/grading),
+        # mirroring the buffer/async path's episode/infra_error.
+        trainer_state.metrics["batch/infra_error"] = sum(termination_counts[r.value] for r in INFRA_ERROR_REASONS) / total_counts
 
         # stage 2: transform episodes to trajectory groups (sync)
         trajectory_groups, transform_metrics = transform_episodes_to_trajectory_groups(trainer_state.episodes, self.transform_config, self.cf_config, traj_grouping_hook=self.traj_grouping_hook)

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -50,6 +50,7 @@ class TerminationReason(Enum):
     VERIFIER_TIMEOUT = "verifier_timeout"
     GRADING_ERROR = "grading_error"
     SANDBOX_ERROR = "sandbox_error"
+    MODEL_ERROR = "model_error"  # upstream/API/proxy failure — every model completion came back empty
 
 
 # Reasons whose reward is NOT a trustworthy training signal: an infra or grading
@@ -64,6 +65,7 @@ INFRA_ERROR_REASONS = frozenset(
         TerminationReason.VERIFIER_TIMEOUT,
         TerminationReason.GRADING_ERROR,
         TerminationReason.SANDBOX_ERROR,
+        TerminationReason.MODEL_ERROR,
     }
 )
 
@@ -91,11 +93,13 @@ _ERROR_TYPE_TO_REASON: dict[str, TerminationReason] = {
     "RewardFileNotFoundError": TerminationReason.GRADING_ERROR,
     "RewardFileEmptyError": TerminationReason.GRADING_ERROR,
     "VerifierOutputParseError": TerminationReason.GRADING_ERROR,
-    # Environment/sandbox (harbor.environments.base + rllm.sandbox.protocol)
+    # Environment/sandbox (harbor.environments.base + rllm.sandbox.protocol + backends)
     "HealthcheckError": TerminationReason.SANDBOX_ERROR,
     "SandboxBuildFailedError": TerminationReason.SANDBOX_ERROR,
     "MemoryLimitExceededError": TerminationReason.SANDBOX_ERROR,
     "SnapshotNotFound": TerminationReason.SANDBOX_ERROR,
+    "DaytonaValidationError": TerminationReason.SANDBOX_ERROR,
+    "DaytonaError": TerminationReason.SANDBOX_ERROR,
 }
 
 

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -39,9 +39,80 @@ class TerminationReason(Enum):
     MAX_RESPONSE_LENGTH_EXCEEDED = "max_response_length_exceeded"
     ENV_DONE = "env_done"
     MAX_TURNS_EXCEEDED = "max_turns_exceeded"
-    TIMEOUT = "timeout"
+    TIMEOUT = "timeout"  # agent execution wall-clock budget — reward is still graded on partial state
     UNKNOWN = "unknown"
     ERROR = "error"
+    # Infra/grading failures: the reward (if any) reflects an infrastructure or
+    # grading breakdown, not the policy's behavior. Distinguished so training can
+    # filter them and eval can count them as errors rather than task failures.
+    AGENT_SETUP_TIMEOUT = "agent_setup_timeout"
+    ENV_START_TIMEOUT = "env_start_timeout"
+    VERIFIER_TIMEOUT = "verifier_timeout"
+    GRADING_ERROR = "grading_error"
+    SANDBOX_ERROR = "sandbox_error"
+
+
+# Reasons whose reward is NOT a trustworthy training signal: an infra or grading
+# failure produced it (or no reward at all). Training filters these; eval counts
+# them as errors. TIMEOUT (agent wall-clock) is deliberately excluded — that
+# rollout is real and graded on partial state, so its reward is valid.
+INFRA_ERROR_REASONS = frozenset(
+    {
+        TerminationReason.ERROR,
+        TerminationReason.AGENT_SETUP_TIMEOUT,
+        TerminationReason.ENV_START_TIMEOUT,
+        TerminationReason.VERIFIER_TIMEOUT,
+        TerminationReason.GRADING_ERROR,
+        TerminationReason.SANDBOX_ERROR,
+    }
+)
+
+
+# Canonical map from an exception class name to a coarse TerminationReason.
+# Mirrors Harbor's granular failure taxonomy (harbor.trial.errors,
+# harbor.verifier.verifier, harbor.llms.base, harbor.environments.base) so the
+# in-sandbox CLI path and the harbor-runtime path classify identically. The exact
+# class name is preserved on the episode (metadata.error_type); this is only the
+# coarse rollup used for filtering and per-category metrics.
+_ERROR_TYPE_TO_REASON: dict[str, TerminationReason] = {
+    # Phase timeouts (harbor.trial.errors)
+    "AgentTimeoutError": TerminationReason.TIMEOUT,
+    "AgentSetupTimeoutError": TerminationReason.AGENT_SETUP_TIMEOUT,
+    "EnvironmentStartTimeoutError": TerminationReason.ENV_START_TIMEOUT,
+    "VerifierTimeoutError": TerminationReason.VERIFIER_TIMEOUT,
+    # Model/context (harbor.llms.base)
+    "ContextLengthExceededError": TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED,
+    "OutputLengthExceededError": TerminationReason.MAX_RESPONSE_LENGTH_EXCEEDED,
+    # Agent process (harbor.agents.installed.base)
+    "NonZeroAgentExitCodeError": TerminationReason.ERROR,
+    # Verifier/grading (harbor.verifier.verifier)
+    "AddTestsDirError": TerminationReason.GRADING_ERROR,
+    "DownloadVerifierDirError": TerminationReason.GRADING_ERROR,
+    "RewardFileNotFoundError": TerminationReason.GRADING_ERROR,
+    "RewardFileEmptyError": TerminationReason.GRADING_ERROR,
+    "VerifierOutputParseError": TerminationReason.GRADING_ERROR,
+    # Environment/sandbox (harbor.environments.base + rllm.sandbox.protocol)
+    "HealthcheckError": TerminationReason.SANDBOX_ERROR,
+    "SandboxBuildFailedError": TerminationReason.SANDBOX_ERROR,
+    "MemoryLimitExceededError": TerminationReason.SANDBOX_ERROR,
+    "SnapshotNotFound": TerminationReason.SANDBOX_ERROR,
+}
+
+
+def termination_reason_from_error(
+    error_type: str | None,
+    default: TerminationReason = TerminationReason.ERROR,
+) -> TerminationReason:
+    """Map an exception class name to a coarse :class:`TerminationReason`.
+
+    Unknown names fall back to ``default``: callers pass
+    :attr:`TerminationReason.GRADING_ERROR` when the failure came from the
+    verifier/grader, and the more general :attr:`TerminationReason.ERROR`
+    otherwise.
+    """
+    if not error_type:
+        return default
+    return _ERROR_TYPE_TO_REASON.get(error_type, default)
 
 
 class TerminationEvent(Exception):

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -189,3 +189,31 @@ def test_env_flow_receives_sandbox_and_container_url():
 
     assert seen["env"] is sandbox
     assert seen["base_url"].startswith("http://host.docker.internal:9131/")
+
+
+def test_no_usable_model_output_detects_dead_upstream():
+    """No LLM calls at all, or every call empty (no content, no tool_calls) =
+    downed upstream — the signal _finish_episode promotes to MODEL_ERROR instead
+    of a clean ENV_DONE."""
+    from types import SimpleNamespace as NS
+
+    from rllm.engine.agentflow_engine import _no_usable_model_output, _step_returned_nothing
+
+    def step(content, tool_calls=None):
+        return NS(model_output=NS(content=content), chat_completions=[{"role": "assistant", "content": content, "tool_calls": tool_calls}])
+
+    assert _step_returned_nothing(step("")) is True
+    assert _step_returned_nothing(step("ls -la")) is False
+    assert _step_returned_nothing(step("", tool_calls=[{"id": "1"}])) is False  # tool-only turn is real work
+
+    assert _no_usable_model_output(NS(trajectories=[NS(steps=[step(""), step("")])])) is True  # dead proxy
+    assert _no_usable_model_output(NS(trajectories=[NS(steps=[])])) is True  # no LLM calls (the broken-eval case)
+    assert _no_usable_model_output(NS(trajectories=[NS(steps=[step(""), step("echo hi")])])) is False  # partial — real work
+
+
+def test_infra_taxonomy_membership_and_mapping():
+    from rllm.types import INFRA_ERROR_REASONS, TerminationReason, termination_reason_from_error
+
+    assert TerminationReason.MODEL_ERROR in INFRA_ERROR_REASONS
+    assert termination_reason_from_error("DaytonaValidationError") == TerminationReason.SANDBOX_ERROR
+    assert termination_reason_from_error("EmptyCompletion", default=TerminationReason.MODEL_ERROR) == TerminationReason.MODEL_ERROR

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -154,6 +154,72 @@ class TestShellScriptEvaluator:
         out = ev.evaluate(task, _episode())
         assert out.reward == 0.0
         assert "no" in out.metadata.get("error", "")
+        assert out.error == "AddTestsDirError"
+
+
+class TestShellScriptEvaluatorErrorTagging:
+    """Grading-infra failures set EvalOutput.error (Harbor-aligned) so the engine
+    routes them to an infra TerminationReason instead of a spurious reward 0."""
+
+    def test_verifier_timeout_tagged(self, tmp_path):
+        from rllm.sandbox.protocol import SandboxCommandTimeout
+
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={})
+        base_exec = sb.exec
+
+        def exec_with_verifier_timeout(cmd, timeout=None, user=None):
+            if "/tests/test.sh" in cmd:
+                raise SandboxCommandTimeout("verifier timed out")
+            return base_exec(cmd, timeout=timeout, user=user)
+
+        sb.exec = exec_with_verifier_timeout
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.error == "VerifierTimeoutError"
+        assert out.reward == 0.0
+
+    def test_no_reward_file_tagged(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.error == "RewardFileNotFoundError"
+
+    def test_empty_reward_file_tagged(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": ""})  # present but empty
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.error == "RewardFileEmptyError"
+
+    def test_unparseable_reward_tagged(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.json": "not-json{{"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.error == "VerifierOutputParseError"
+
+    def test_upload_failure_tagged(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={})
+
+        def boom(src, dst):
+            raise RuntimeError("upload failed")
+
+        sb.upload_dir = boom
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.error == "AddTestsDirError"
+
+    def test_legit_zero_is_not_tagged(self, tmp_path):
+        """A real reward of 0 (verifier ran, wrote 0) is NOT an error."""
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "0.0"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.reward == 0.0
+        assert out.error is None
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +312,8 @@ def evaluate(metadata, trajectory):
         assert out.reward == 0.0
         assert out.is_correct is False
         assert "boom" in out.metadata["error"]
+        # The exception class is carried so the engine can route it to GRADING_ERROR.
+        assert out.error == "RuntimeError"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -133,16 +133,18 @@ class TestShellScriptEvaluator:
         out = ev.evaluate(task, _episode())
         assert out.reward == 1.0
 
-    def test_no_reward_file_raises(self, tmp_path):
+    def test_no_reward_file_is_infra_error_not_score_zero(self, tmp_path):
         bench = _bench(tmp_path)
         sb = _FakeSandbox(files={})  # nothing written
         ev = ShellScriptEvaluator(sandbox=sb)
         task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
 
         # A missing reward file means the verifier produced no verdict — a verifier/infra
-        # failure, distinct from a legitimate score of 0 — so it surfaces as an error.
-        with pytest.raises(RuntimeError, match="no reward file"):
-            ev.evaluate(task, _episode())
+        # failure, distinct from a legitimate score of 0 — so it surfaces as a typed
+        # grading error (was a bare RuntimeError before the error taxonomy).
+        out = ev.evaluate(task, _episode())
+        assert out.error == "RewardFileNotFoundError"
+        assert out.is_correct is False
 
     def test_missing_tests_dir_short_circuits(self, tmp_path):
         bench = tmp_path / "bench-no-tests"

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -138,6 +138,30 @@ def test_run_marks_error_on_cli_failure():
     assert "message" in result.metadata["error"]
 
 
+def test_run_marks_sandbox_error_when_box_died_mid_run():
+    """A dead sandbox surfaces as a generic exec failure; the is_alive() probe
+    distinguishes it from a benign CLI crash and marks SANDBOX_ERROR (infra)."""
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox(fail_on_substring="opencode --model")
+    sandbox.is_alive = lambda: False  # box is gone
+
+    result = h.run(_make_task(), _make_config(), env=sandbox)
+
+    assert result.termination_reason == TerminationReason.SANDBOX_ERROR
+    assert result.metadata["error"]["error_type"] == "RuntimeError"
+
+
+def test_run_marks_error_when_cli_failed_but_box_alive():
+    """A non-zero CLI exit on a *live* box stays ERROR, not SANDBOX_ERROR."""
+    h = OpenCodeHarness()
+    sandbox = FakeSandbox(fail_on_substring="opencode --model")
+    sandbox.is_alive = lambda: True  # box is healthy; the agent just failed
+
+    result = h.run(_make_task(), _make_config(), env=sandbox)
+
+    assert result.termination_reason == TerminationReason.ERROR
+
+
 def test_run_marks_timeout_on_budget_exhaustion():
     """Hitting the wall-clock budget (SandboxCommandTimeout) is expected, not a
     failure: the captured steps are still scored, and the run is marked TIMEOUT

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -152,6 +152,63 @@ def test_run_marks_timeout_on_budget_exhaustion():
     assert "error" not in result.metadata
 
 
+# ---------------------------------------------------------------------------
+# Outcome sentinel (in-sandbox driver verdict) + wall-clock backstop. A driver
+# like terminus2 records why it stopped; run() trusts that over the exit code
+# (which ``| tee`` masks). Without a sentinel, an exec that ran ~to the budget
+# is classified TIMEOUT regardless of a masked clean-looking exit.
+# ---------------------------------------------------------------------------
+
+
+class _DriverHarness(OpenCodeHarness):
+    """OpenCode harness with a stubbed driver outcome, to drive run()'s sentinel path."""
+
+    outcome: dict | None = None
+
+    def _read_outcome(self, sandbox):  # type: ignore[override]
+        return self.outcome
+
+
+def test_run_sentinel_agent_timeout_maps_to_timeout():
+    h = _DriverHarness()
+    h.outcome = {"exception_type": "AgentTimeoutError", "message": "Agent execution timed out after 60.0s"}
+    result = h.run(_make_task(), _make_config(), env=FakeSandbox())
+    assert result.termination_reason == TerminationReason.TIMEOUT
+
+
+def test_run_sentinel_verifier_timeout_distinct_from_agent_timeout():
+    h = _DriverHarness()
+    h.outcome = {"exception_type": "VerifierTimeoutError", "message": "verifier timed out"}
+    result = h.run(_make_task(), _make_config(), env=FakeSandbox())
+    assert result.termination_reason == TerminationReason.VERIFIER_TIMEOUT
+    assert result.metadata["error"]["error_type"] == "VerifierTimeoutError"
+
+
+def test_run_sentinel_clean_finish_beats_elapsed_backstop(monkeypatch):
+    """A driver that finished cleanly is ENV_DONE even past the wall clock —
+    the sentinel is authoritative, so the elapsed heuristic must not fire."""
+    import rllm.harnesses.cli_harness as mod
+
+    ticks = iter([0.0, 10_000.0])
+    monkeypatch.setattr(mod.time, "monotonic", lambda: next(ticks))
+    h = _DriverHarness()
+    h.outcome = {}  # sentinel present, no exception → clean finish
+    result = h.run(_make_task(), _make_config(), env=FakeSandbox())
+    assert result.termination_reason is None  # ENV_DONE, not TIMEOUT
+
+
+def test_run_elapsed_backstop_marks_timeout_when_exit_masked(monkeypatch):
+    """No sentinel + ran ~to the budget with a clean-looking exit (the ``| tee``
+    masking case) → TIMEOUT, reconstructed from the clock."""
+    import rllm.harnesses.cli_harness as mod
+
+    ticks = iter([0.0, 10_000.0])  # elapsed >> 0.95 * run_timeout
+    monkeypatch.setattr(mod.time, "monotonic", lambda: next(ticks))
+    h = OpenCodeHarness()  # base harness writes no sentinel
+    result = h.run(_make_task(), _make_config(), env=FakeSandbox())
+    assert result.termination_reason == TerminationReason.TIMEOUT
+
+
 @pytest.mark.parametrize(
     ("workdir", "expected_prefix"),
     [

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -690,3 +690,47 @@ def test_gateway_api_key_resolution(monkeypatch, metadata: dict, env_value: str 
     config = AgentConfig(base_url="http://gw/v1", model="gpt-4o", session_uid="eval-0", metadata=metadata)
 
     assert BaseCliHarness.gateway_api_key(config, "OPENAI_API_KEY") == expected
+
+
+# ---------------------------------------------------------------------------
+# Exec timeout + sentinel: a SandboxCommandTimeout does not necessarily mean
+# the agent spent its budget — the backend may have lost the exec completion
+# in transport (e.g. a NAT dropping the idle long-poll; 2026-07-01). The
+# sentinel is authoritative there too.
+# ---------------------------------------------------------------------------
+
+
+def test_run_exec_timeout_with_clean_sentinel_recovers_env_done():
+    """Transport-lost completion: exec 'timed out' but the driver finished
+    cleanly → ENV_DONE with an ExecCompletionLost audit marker, not TIMEOUT."""
+    h = _DriverHarness()
+    h.outcome = {}  # sentinel present, no exception → driver finished fine
+    sandbox = FakeSandbox(timeout_on_substring="opencode --model")
+
+    result = h.run(_make_task(), _make_config(), env=sandbox)
+
+    assert result.termination_reason is None  # ENV_DONE
+    assert result.metadata["error"]["error_type"] == "ExecCompletionLost"
+
+
+def test_run_exec_timeout_with_typed_sentinel_maps_reason():
+    """Exec timeout + a typed driver verdict → the verdict's reason wins."""
+    h = _DriverHarness()
+    h.outcome = {"exception_type": "AgentTimeoutError", "message": "budget spent"}
+    sandbox = FakeSandbox(timeout_on_substring="opencode --model")
+
+    result = h.run(_make_task(), _make_config(), env=sandbox)
+
+    assert result.termination_reason == TerminationReason.TIMEOUT
+    assert result.metadata["error"]["error_type"] == "AgentTimeoutError"
+
+
+def test_run_exec_timeout_without_sentinel_stays_timeout():
+    """No sentinel to consult → the exec timeout is taken at face value."""
+    h = _DriverHarness()
+    h.outcome = None
+    sandbox = FakeSandbox(timeout_on_substring="opencode --model")
+
+    result = h.run(_make_task(), _make_config(), env=sandbox)
+
+    assert result.termination_reason == TerminationReason.TIMEOUT

--- a/tests/integration/test_daytona_exec_delivery.py
+++ b/tests/integration/test_daytona_exec_delivery.py
@@ -1,0 +1,104 @@
+"""Live regression tests: Daytona exec completions must be DELIVERED, not
+silently dropped.
+
+Background (2026-07-01): the SDK's one-shot ``process.exec`` rides a single
+HTTP request that stays byte-silent until the command completes. NAT
+middleboxes on the client path (measured: WSL2, drop threshold ~245-250s of
+idle) silently discard the flow, black-holing the response — the command
+finishes in the sandbox but exec() blocks until its read timeout and gets
+mislabeled as a wall-clock timeout. rllm defends with (1) session-based exec
+for long budgets and (2) TCP keepalive on the SDK pools.
+
+Gating:
+  DAYTONA_API_KEY        — required for all tests here (~40s sandbox roundtrips).
+  RLLM_LIVE_SLOW=1       — additionally required for the >4-minute drop-line
+                           tests, which prove delivery PAST the NAT idle
+                           threshold and take ~5-6 minutes each.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+requires_daytona = pytest.mark.skipif(
+    not os.environ.get("DAYTONA_API_KEY"),
+    reason="DAYTONA_API_KEY env var required",
+)
+
+requires_slow = pytest.mark.skipif(
+    os.environ.get("RLLM_LIVE_SLOW") != "1",
+    reason="RLLM_LIVE_SLOW=1 required (test idles >4min past the NAT drop threshold)",
+)
+
+# Past the measured drop line (~245-250s idle) with margin; a regression makes
+# the exec block until its read timeout instead of returning at ~SLEEP_S.
+DROP_LINE_SLEEP_S = 300
+
+
+@pytest.fixture(scope="module")
+def live_sandbox():
+    """A raw SDK sandbox wrapped in DaytonaSandbox's exec (bypassing create)."""
+    daytona = pytest.importorskip("daytona")
+    from rllm.sandbox.backends.daytona import DaytonaSandbox, _enable_tcp_keepalive
+
+    client = daytona.Daytona()
+    _enable_tcp_keepalive(client)
+    raw = client.create()
+    sb = DaytonaSandbox.__new__(DaytonaSandbox)
+    sb.name = raw.id[:8]
+    sb._closed = False
+    sb._persistent_env = {}
+    sb._sandbox = raw
+    try:
+        yield sb
+    finally:
+        raw.delete()
+
+
+@requires_daytona
+def test_session_path_delivers_quickly(live_sandbox):
+    """A long-budget exec rides the session path and still returns promptly
+    when the command is short — delivery machinery works end to end."""
+    t0 = time.monotonic()
+    out = live_sandbox.exec("sleep 20; echo ALIVE", timeout=300)  # > threshold → session
+    wall = time.monotonic() - t0
+    assert "ALIVE" in out
+    assert wall < 60, f"session exec took {wall:.0f}s for a 20s command"
+
+
+@requires_daytona
+@requires_slow
+def test_session_path_delivers_past_nat_drop_line(live_sandbox):
+    """THE regression: a command idling past the NAT drop threshold must
+    return its output — with the old one-shot path this lost the response
+    100% of the time (bisect 2026-07-01: 250/260/270/300/315/330s all lost)."""
+    t0 = time.monotonic()
+    out = live_sandbox.exec(f"sleep {DROP_LINE_SLEEP_S}; echo DELIVERED", timeout=600)
+    wall = time.monotonic() - t0
+    assert "DELIVERED" in out
+    assert wall < DROP_LINE_SLEEP_S + 60, (
+        f"exec returned only after {wall:.0f}s for a {DROP_LINE_SLEEP_S}s command — "
+        "completion was lost and recovered by a timeout, not delivered"
+    )
+
+
+@requires_daytona
+@requires_slow
+def test_keepalive_keeps_one_shot_alive_past_drop_line(live_sandbox, monkeypatch):
+    """Defense-in-depth layer: with TCP keepalive injected (module fixture),
+    even the one-shot path survives past the drop line. Forces one-shot by
+    raising the session threshold above the command budget."""
+    import rllm.sandbox.backends.daytona as daytona_mod
+
+    monkeypatch.setattr(daytona_mod, "_SESSION_EXEC_THRESHOLD_S", 10_000.0)
+    t0 = time.monotonic()
+    out = live_sandbox.exec(f"sleep {DROP_LINE_SLEEP_S}; echo KA_DELIVERED", timeout=600)
+    wall = time.monotonic() - t0
+    assert "KA_DELIVERED" in out
+    assert wall < DROP_LINE_SLEEP_S + 60, (
+        f"one-shot exec with keepalive returned only after {wall:.0f}s — "
+        "keepalive did not keep the flow alive"
+    )

--- a/tests/integration/test_daytona_exec_delivery.py
+++ b/tests/integration/test_daytona_exec_delivery.py
@@ -79,10 +79,7 @@ def test_session_path_delivers_past_nat_drop_line(live_sandbox):
     out = live_sandbox.exec(f"sleep {DROP_LINE_SLEEP_S}; echo DELIVERED", timeout=600)
     wall = time.monotonic() - t0
     assert "DELIVERED" in out
-    assert wall < DROP_LINE_SLEEP_S + 60, (
-        f"exec returned only after {wall:.0f}s for a {DROP_LINE_SLEEP_S}s command — "
-        "completion was lost and recovered by a timeout, not delivered"
-    )
+    assert wall < DROP_LINE_SLEEP_S + 60, f"exec returned only after {wall:.0f}s for a {DROP_LINE_SLEEP_S}s command — completion was lost and recovered by a timeout, not delivered"
 
 
 @requires_daytona
@@ -98,7 +95,4 @@ def test_keepalive_keeps_one_shot_alive_past_drop_line(live_sandbox, monkeypatch
     out = live_sandbox.exec(f"sleep {DROP_LINE_SLEEP_S}; echo KA_DELIVERED", timeout=600)
     wall = time.monotonic() - t0
     assert "KA_DELIVERED" in out
-    assert wall < DROP_LINE_SLEEP_S + 60, (
-        f"one-shot exec with keepalive returned only after {wall:.0f}s — "
-        "keepalive did not keep the flow alive"
-    )
+    assert wall < DROP_LINE_SLEEP_S + 60, f"one-shot exec with keepalive returned only after {wall:.0f}s — keepalive did not keep the flow alive"

--- a/tests/integration/test_daytona_exec_delivery.py
+++ b/tests/integration/test_daytona_exec_delivery.py
@@ -92,7 +92,15 @@ def test_keepalive_keeps_one_shot_alive_past_drop_line(live_sandbox, monkeypatch
 
     monkeypatch.setattr(daytona_mod, "_SESSION_EXEC_THRESHOLD_S", 10_000.0)
     t0 = time.monotonic()
-    out = live_sandbox.exec(f"sleep {DROP_LINE_SLEEP_S}; echo KA_DELIVERED", timeout=600)
+    try:
+        out = live_sandbox.exec(f"sleep {DROP_LINE_SLEEP_S}; echo KA_DELIVERED", timeout=600)
+    except Exception as e:
+        wall = time.monotonic() - t0
+        if wall < DROP_LINE_SLEEP_S and "timed out" not in str(e).lower():
+            # A fast server-side 5xx is a Daytona blip, not the delivery-loss
+            # regression this test guards (loss = hanging to the read timeout).
+            pytest.skip(f"transient Daytona error after {wall:.0f}s: {e!r:.120}")
+        raise
     wall = time.monotonic() - t0
     assert "KA_DELIVERED" in out
     assert wall < DROP_LINE_SLEEP_S + 60, f"one-shot exec with keepalive returned only after {wall:.0f}s — keepalive did not keep the flow alive"

--- a/tests/sandbox/test_daytona_backend.py
+++ b/tests/sandbox/test_daytona_backend.py
@@ -284,3 +284,147 @@ def test_ephemeral_opt_out_sets_never_delete(monkeypatch):
     kw = captured["kwargs"]
     assert kw["ephemeral"] is False
     assert kw["auto_delete_interval"] == -1
+
+
+# ---------------------------------------------------------------------------
+# silent-drop regression: long execs must ride sessions, not one idle long-poll
+#
+# Background (2026-07-01): `process.exec` carries the whole command on a single
+# HTTP request that stays byte-silent until completion. NAT middleboxes (e.g.
+# WSL2's) silently drop flows idle >~245-250s, black-holing the response — the
+# command finishes but exec() blocks until the SDK read timeout and gets
+# mislabeled as a wall-clock timeout. Long execs therefore MUST use the
+# session API (async submit + short polls). These tests pin that contract.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSessionProcess:
+    """Fake `sandbox.process` with the session API; one-shot exec is a trap.
+
+    ``polls_until_done`` controls how many get_session_command calls return
+    "still running" before exit_code appears. ``poll_errors`` injects that
+    many transient failures first.
+    """
+
+    def __init__(self, exit_code=0, stdout="session-out", stderr="", polls_until_done=2, poll_errors=0):
+        self.exit_code_final = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.polls_until_done = polls_until_done
+        self.poll_errors = poll_errors
+        self.polls = 0
+        self.one_shot_calls = 0
+        self.created_sessions: list[str] = []
+        self.deleted_sessions: list[str] = []
+        self.submitted: list[object] = []
+
+    # -- one-shot endpoint: must NOT be used for long commands ----------------
+    def exec(self, command, **kwargs):
+        self.one_shot_calls += 1
+        return SimpleNamespace(result="one-shot-out", exit_code=0)
+
+    # -- session API -----------------------------------------------------------
+    def create_session(self, session_id):
+        self.created_sessions.append(session_id)
+
+    def execute_session_command(self, session_id, req):
+        self.submitted.append(req)
+        return SimpleNamespace(cmd_id="cmd-1")
+
+    def get_session_command(self, session_id, cmd_id):
+        if self.poll_errors > 0:
+            self.poll_errors -= 1
+            raise RuntimeError("transient API blip")
+        self.polls += 1
+        if self.polls >= self.polls_until_done:
+            return SimpleNamespace(exit_code=self.exit_code_final)
+        return SimpleNamespace(exit_code=None)
+
+    def get_session_command_logs(self, session_id, cmd_id):
+        return SimpleNamespace(stdout=self.stdout, stderr=self.stderr)
+
+    def delete_session(self, session_id):
+        self.deleted_sessions.append(session_id)
+
+
+def _make_session_sandbox(monkeypatch, **proc_kwargs):
+    pytest.importorskip("daytona")  # _exec_session imports SessionExecuteRequest lazily
+    proc = _FakeSessionProcess(**proc_kwargs)
+    sb = DaytonaSandbox.__new__(DaytonaSandbox)
+    sb.name = "test"
+    sb._closed = False
+    sb._persistent_env = {}
+    sb._sandbox = SimpleNamespace(process=proc)
+    monkeypatch.setattr(daytona_mod.time, "sleep", lambda s: None)
+    return sb, proc
+
+
+def test_long_exec_routes_via_session_not_one_shot(monkeypatch):
+    """timeout > threshold ⇒ session API; the droppable one-shot is untouched."""
+    sb, proc = _make_session_sandbox(monkeypatch)
+    out = sb.exec("sleep 300; echo hi", timeout=600)
+    assert out == "session-out"
+    assert proc.one_shot_calls == 0
+    assert proc.created_sessions and proc.deleted_sessions == proc.created_sessions
+    # async submit with the shell-timeout wrapper baked into the command
+    assert getattr(proc.submitted[0], "run_async", None) is True
+    assert "timeout -k 10 600" in proc.submitted[0].command
+
+
+def test_short_and_untimed_execs_stay_one_shot(monkeypatch):
+    """timeout ≤ threshold (and None) keep the cheap one-shot path."""
+    sb, proc = _make_session_sandbox(monkeypatch)
+    assert sb.exec("echo hi", timeout=30) == "one-shot-out"
+    assert sb.exec("echo hi") == "one-shot-out"
+    assert proc.one_shot_calls == 2
+    assert proc.created_sessions == []
+
+
+def test_session_exec_returns_completion_after_polls(monkeypatch):
+    """The regression itself: a long exec RETURNS its output — never hangs."""
+    sb, proc = _make_session_sandbox(monkeypatch, stdout="DONE\n", polls_until_done=5)
+    assert sb.exec("long-job", timeout=300) == "DONE\n"
+    assert proc.polls == 5
+
+
+def test_session_exec_budget_kill_raises_command_timeout(monkeypatch):
+    """exit 124 from the in-sandbox `timeout` still maps to SandboxCommandTimeout."""
+    sb, _ = _make_session_sandbox(monkeypatch, exit_code=124)
+    with pytest.raises(SandboxCommandTimeout):
+        sb.exec("sleep 999", timeout=200)
+
+
+def test_session_exec_nonzero_raises_runtime_error(monkeypatch):
+    sb, _ = _make_session_sandbox(monkeypatch, exit_code=3, stdout="boom")
+    with pytest.raises(RuntimeError) as ei:
+        sb.exec("bad-job", timeout=300)
+    assert not isinstance(ei.value, SandboxCommandTimeout)
+
+
+def test_session_exec_tolerates_transient_poll_failures(monkeypatch):
+    """A few flaky polls must not kill a long rollout."""
+    sb, proc = _make_session_sandbox(monkeypatch, poll_errors=3, polls_until_done=1)
+    assert sb.exec("long-job", timeout=300) == "session-out"
+    assert proc.deleted_sessions  # cleanup still ran
+
+
+def test_session_exec_persistent_poll_failures_raise(monkeypatch):
+    sb, proc = _make_session_sandbox(monkeypatch, poll_errors=99)
+    with pytest.raises(RuntimeError, match="transient API blip"):
+        sb.exec("long-job", timeout=300)
+    assert proc.deleted_sessions  # cleanup even on failure
+
+
+def test_session_exec_poll_deadline_raises_command_timeout(monkeypatch):
+    """A daemon that lost the command entirely hits the poll deadline."""
+    sb, proc = _make_session_sandbox(monkeypatch, polls_until_done=10**9)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(daytona_mod.time, "monotonic", lambda: clock["t"])
+
+    def advance(_s):
+        clock["t"] += 30.0
+
+    monkeypatch.setattr(daytona_mod.time, "sleep", advance)
+    with pytest.raises(SandboxCommandTimeout, match="poll deadline"):
+        sb.exec("lost-job", timeout=200)
+    assert proc.deleted_sessions

--- a/tests/sandbox/test_sandboxed_flow.py
+++ b/tests/sandbox/test_sandboxed_flow.py
@@ -15,7 +15,7 @@ def test_configure_applies_known_overrides_and_returns_leftovers():
     # no overrides → defaults untouched, nothing left over.
     assert flow.configure({}) == {}
     assert flow.sandbox_backend == "docker"
-    assert flow.max_concurrent == 4
+    assert flow.max_concurrent == 64  # class default (raised from 4 upstream)
 
     leftovers = flow.configure({"sandbox_backend": "daytona", "sandbox_concurrency": 2, "made_up_flag": 1})
     assert flow.sandbox_backend == "daytona"


### PR DESCRIPTION
## Why

In terminal-RL, two distinct problems both surfaced as "looks fine, reward 0":

1. **Wall-clock timeouts were mislabeled `env_done`.** The terminus2 driver runs the agent inside the sandbox as `python driver.py | tee log`; with no `pipefail` the kill's exit code is masked, so the harness inferred a clean exit. In a recent GLM-5.2 run **76/178 episodes were cut off at the wall but every one reported `env_done`** — timeouts had to be reconstructed by hand.
2. **Grading-infra failures trained as real task failures.** A verifier timeout / crash / missing reward file was swallowed into `reward=0.0` with `termination_reason` untouched — byte-identical to a task the agent legitimately failed, so `mask_*` could never catch it.

This mirrors [Harbor's](https://github.com/laude-institute/harbor) granular failure taxonomy end-to-end so eval and train can tell these apart — and so a timeout is still graded on partial state (a timeout that already produced correct output still passes).

## Failure taxonomy & classification

`TerminationReason` (`rllm/types.py`). **Reward trustworthy** = is the attached reward a real reflection of the policy. **Eval error** = counts toward `EvalResult.errors` / populates `EvalItem.error` (only infra reasons do; all reasons appear in `termination_breakdown`). **Train batch** = whether the rollout's tokens enter the loss *when `compact_filtering.enable=True`*.

| `TerminationReason` | Set when | New | Reward | Eval: error? | Train batch (filtering ON) |
|---|---|:--:|:--:|:--:|:--:|
| `env_done` | agent declared done / clean exit | | ✅ real | no | ✅ **included** |
| `timeout` | agent hit wall-clock budget (graded on partial state) | | ✅ real | no | ❌ excluded ⚠️ |
| `max_turns_exceeded` | turn cap hit | | ⚠️ truncated | no | ❌ excluded |
| `max_prompt_length_exceeded` | context overflow (`ContextLengthExceededError`) | | ⚠️ truncated | no | ❌ excluded |
| `max_response_length_exceeded` | output overflow (`OutputLengthExceededError`) | | ⚠️ truncated | no | ❌ excluded |
| `unknown` | unclassified fallback | | ❔ unknown | no | ✅ **included** |
| `error` | generic agent/exec failure on a *live* box, retry-exhaustion, `NonZeroAgentExitCodeError` | | ❌ invalid | **yes** | ❌ excluded |
| `agent_setup_timeout` | `agent.setup` exceeded its budget | ✨ | ❌ invalid | **yes** | ❌ excluded |
| `env_start_timeout` | environment start exceeded its budget | ✨ | ❌ invalid | **yes** | ❌ excluded |
| `verifier_timeout` | verifier exec exceeded its budget | ✨ | ❌ invalid | **yes** | ❌ excluded |
| `grading_error` | verifier crash / missing·empty·unparseable reward / tests-dir upload | ✨ | ❌ invalid | **yes** | ❌ excluded |
| `sandbox_error` | **sandbox died mid-run** (`is_alive()` probe after an exec failure) / snapshot gone (`SnapshotNotFound`) / sandbox health·build·OOM (mapped) | ✨ | ❌ invalid | **yes** | ❌ excluded |

> **Shipped default is `compact_filtering.enable: False` → nothing is masked, every reason is included.** The last column is the policy that takes effect once you set `enable: True`. The per-flag defaults (`base.yaml`): infra reasons + truncation reasons `mask: True`; `env_done`/`unknown` `mask: False`.

> ⚠️ **`timeout`** is the one debatable cell. `mask_timeout: True` is a pre-existing default (truncated-rollout logic, grouped with the length/turn caps). But in terminal-RL a timeout is graded on partial container state and *can be a real pass*, so masking all timeouts discards valid positive signal. **Left unchanged here** — call it a separate policy decision once labels are re-measured. Note: this PR is what makes that default actually fire (timeouts were previously dormant under the `env_done` mislabel).

## How it works

**Single source of truth** — `termination_reason_from_error()` (`types.py`) maps Harbor's exception class names → coarse reasons; `trial_helper.map_termination_reason` delegates to it, so the harbor-runtime and in-sandbox CLI paths classify identically.

**Agent timeout label** — the terminus2 driver self-limits `agent.setup`/`agent.run` with `asyncio.wait_for`, raises Harbor's `AgentTimeoutError`/`AgentSetupTimeoutError`, writes an `ExceptionInfo`-shaped outcome sentinel, then exits 0 so partial state survives for grading. `BaseCliHarness.run` trusts that sentinel over the `| tee`-masked exit code, with an elapsed-vs-budget backstop for harnesses that write none (exec gets a grace window so the sentinel write wins the race).

**Grading errors (eval + train)** — `EvalOutput` gains a structured `error`; `ShellScriptEvaluator`/`PythonModuleEvaluator` tag verifier timeout / missing·empty·unparseable reward / tests-dir upload / verifier crash with Harbor-aligned names. `_finish_episode` promotes these to the matching infra reason, **overriding only non-infra outcomes** — grading stays unconditional, so a timeout is still scored.

**Error-rate tracking** — train: `episode/infra_error` + per-reason `episode/termination_reason/*`. Eval: `EvalResult.termination_breakdown` + per-item `EvalItem.termination_reason`/`error` (Harbor class name) persisted to `results.json` and `rllm view`; the `rllm eval` summary panel gains a **"Terminations"** row listing each reason's count (infra reasons highlighted).

## Decisions / known gaps
- `compact_filtering.enable` default **left `False`** (avoid surprising global behavior change); set `enable: true` for the terminal-RL config to activate the per-flag policy above.
- `mask_timeout` default **left `True`** (see ⚠️).
- **Sandbox death mid-run** is now classified `sandbox_error` by probing `sandbox.is_alive()` in the exec-failure handler (distinguishing it from a benign non-zero CLI exit on a live box, which stays `error`). This is a liveness probe, not a typed transport exception — a backend that returns a stale "alive" right after death would fall back to `error`; a fully-typed `SandboxUnreachable` raised by the backends remains a possible follow-up.

## Update 2026-07-01: exec-completion loss (silent NAT drop) — root-caused, fixed, tested

Debugging a terminal-bench-2 eval where **21/31 episodes reported `timeout` at exactly `budget+65s`** (many with `task_complete` confirmed in-trajectory and reward 1.0) uncovered a transport bug that mislabels finished episodes:

- The Daytona SDK's one-shot `process.exec` carries the whole command on a **single HTTP request that stays byte-silent until completion**. NAT middleboxes on the client path silently drop flows idle past ~4min (measured drop threshold: **240s survives, 250s+ lost, 100% reproducible** from a WSL2 host; the identical probe from inside AWS delivers fine). The command finishes in the sandbox, its response is black-holed, and the client blocks in `_read_status` until the SDK read timeout — which the harness then mislabeled as "agent spent its budget" (verified via py-spy stacks, in-sandbox outcome sentinels, `ss` socket idle-times, and a controlled sleep-bisect).

**Fixes (each validated live against real Daytona):**
- `daytona.py`: execs with budgets >180s ride a **session command** (async submit + adaptive 1→15s polls) — no connection ever idles long enough to drop. In-sandbox coreutils `timeout` remains the deterministic killer (exit 124 → `SandboxCommandTimeout`). Validated: 300s command delivered at 303s (0/6 without), real budget-kill still raises at ~244s, short path unchanged.
- `daytona.py`: **TCP keepalive** (60s probes) injected into the SDK HTTP pools, best-effort — keeps L4 flow entries alive for every other call. Validated: a 300s one-shot exec delivers with it, is always lost without.
- `cli_harness.py`: on `SandboxCommandTimeout` the driver's **outcome sentinel is now consulted** (it survives transport loss): clean sentinel → `env_done` + an **`ExecCompletionLost`** audit marker in episode metadata (reward is valid; the transport event stays visible in tracking — fits this PR's taxonomy); typed sentinel → mapped reason; no sentinel → `timeout` as before.

**Tests:** +8 unit (session routing/delivery/timeout/cleanup, `tests/sandbox/test_daytona_backend.py`), +3 harness (timeout×sentinel matrix, `tests/harnesses/test_cli_harness.py`), + a live-gated regression suite (`tests/integration/test_daytona_exec_delivery.py`, `DAYTONA_API_KEY` / `RLLM_LIVE_SLOW=1`) asserting completions are **delivered past the NAT drop line** instead of hanging to the read timeout.

Also: rebased onto latest `terminal-rl` (kept this PR's typed `RewardFileNotFoundError`/`RewardFileEmptyError` over upstream's interim bare `RuntimeError`, updating the upstream test), and fixed a stale `max_concurrent` default assertion that fails on a clean `terminal-rl` checkout.

## Testing
`tests/eval/test_script_module_evaluators.py` and `tests/harnesses/test_cli_harness.py` cover the sentinel/backstop classification and evaluator error tagging. All non-`verl` tests pass locally; the `verl`-dependent suites don't collect in this env (pre-existing, unrelated). Not exercised: a live Modal/terminus2 end-to-end run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)