### PR TITLE
fix: include SFT backend configs in package-data (#712)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ where   = ["."]
 include = ["rllm", "rllm.*"]
 
 [tool.setuptools.package-data]
-rllm = ["trainer/config/**/*.yaml", "registry/*.json"]
+rllm = ["trainer/**/config/**/*.yaml", "registry/*.json"]
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]


### PR DESCRIPTION
## Summary

Fixes #712.

Running `rllm sft` from a non-editable install crashes immediately:

```
FileNotFoundError: [Errno 2] No such file or directory:
'.../site-packages/rllm/trainer/sft/config/tinker.yaml'
```

The `tool.setuptools.package-data` glob `trainer/config/**/*.yaml` only matches YAML files under `trainer/config/`. The SFT backend configs live at `trainer/sft/config/*.yaml` (`tinker.yaml`, `fireworks.yaml`), so they were never bundled into built wheels — only editable installs (which read from source) worked.

## Change

Broaden the glob to `trainer/**/config/**/*.yaml` so config YAMLs under any `trainer` subdirectory are packaged.

```diff
-rllm = ["trainer/config/**/*.yaml", "registry/*.json"]
+rllm = ["trainer/**/config/**/*.yaml", "registry/*.json"]
```

## Verification

Built the wheel (`uv build --wheel`) and inspected its contents:

- ✅ `rllm/trainer/sft/config/tinker.yaml` and `rllm/trainer/sft/config/fireworks.yaml` are now included.
- ✅ All existing `rllm/trainer/config/*.yaml` files remain present (no regression).