### PR TITLE
feat(gateway): add use_sglang mode in model gateway that translates upstream agent's /chat/completions requests to sglang server or sgl-router endpoint's /generate requests, required for RL training with sglang (e.g. slime)

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -126,3 +126,16 @@ class GatewayConfig(BaseModel):
     # renderers family for the cumulative-mode bridge. Check supported model families
     # in MODEL_RENDERER_MAP of https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
     renderer_family: str = "auto"
+    # use_sglang: route generation through SGLang's native /generate API instead
+    # of the OpenAI /v1/{chat/,}completions endpoints. /generate returns token ids
+    # + logprobs in meta_info natively (no server-side schema patch needed) and
+    # accepts pre-tokenized input_ids through sgl-router — so it is the correct
+    # transport for capturing token ids on any SGLang server or sgl-router endpoint.
+    use_sglang: bool = False
+    # SGLang function-call parser name (e.g. "qwen", "llama3", "deepseekv3") used
+    # to parse tool calls out of /generate output text in use_sglang mode.
+    # Required for tool-using agents in use_sglang mode.
+    sglang_tool_call_parser: str | None = None
+    # SGLang reasoning parser name (e.g. "qwen3", "deepseek-r1") to split
+    # <think>…</think> reasoning from output text.
+    sglang_reasoning_parser: str | None = None

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import time
+import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -15,6 +16,7 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
 
+from rllm_model_gateway import sglang_helper
 from rllm_model_gateway.data_process import (
     build_trace_record,
     build_trace_record_from_chunks,
@@ -86,7 +88,12 @@ class ReverseProxy:
         max_retries: int = 2,
         local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
         cumulative_token_mode: bool = False,
+        use_sglang: bool = False,
         renderer: Any = None,
+        tokenizer: Any = None,
+        model: str | None = None,
+        sglang_tool_call_parser: str | None = None,
+        sglang_reasoning_parser: str | None = None,
     ) -> None:
         self.router = router
         self.store = store
@@ -95,7 +102,26 @@ class ReverseProxy:
         self.max_retries = max_retries
         self.local_handler = local_handler
         self.cumulative_token_mode = cumulative_token_mode
+        self.use_sglang = use_sglang
         self.renderer = renderer
+        self.tokenizer = tokenizer
+        self.model = model
+        self.sglang_tool_call_parser = sglang_tool_call_parser
+        self.sglang_reasoning_parser = sglang_reasoning_parser
+        # Lazily-built SGLang FunctionCallParser (depends on the request's tools).
+        self._fc_parser_cache: dict[str, Any] = {}
+        # Probe whether the tokenizer auto-prepends special tokens (e.g. BOS) on
+        # encode(). SGLang's chat path splits apply_chat_template into render +
+        # encode and passes add_special_tokens=False when this is True, so the
+        # chat template's own role/special tokens aren't doubled (e.g. double BOS
+        # on Llama/Kimi-style tokenizers). We mirror that to tokenize a message
+        # list byte-identically to SGLang's /v1/chat/completions. Probed once.
+        self._tokenizer_auto_adds_specials = True
+        if self.tokenizer is not None:
+            try:
+                self._tokenizer_auto_adds_specials = len(self.tokenizer.encode("")) > 0
+            except Exception:
+                self._tokenizer_auto_adds_specials = True
         self.weight_version: int | None = None
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
@@ -147,6 +173,15 @@ class ReverseProxy:
 
         is_stream = request_body.get("stream", False)
 
+        # use_sglang: route every chat turn through SGLang's native /generate API.
+        # The gateway renders the prompt to token ids itself (full render on turn 0
+        # or after a prefix break; cross-turn bridge otherwise), so /generate
+        # returns token ids + logprobs in meta_info natively — no sglang patches for
+        # RL, and it works through sgl-router (which rejects token-id prompts on
+        # /v1/completions).
+        if self.use_sglang and session_id and request.url.path.endswith("/chat/completions"):
+            return await self._handle_sglang_generate(request, request_body, session_id, is_stream, originally_requested_logprobs)
+
         # Cumulative token mode interception: if enabled and past first turn,
         # rewrite to /v1/completions with pre-tokenized prompt to avoid drift.
         if self.cumulative_token_mode and session_id and request.url.path.endswith("/chat/completions"):
@@ -182,6 +217,257 @@ class ReverseProxy:
         if is_stream:
             return await self._handle_streaming(request, body, request_body, session_id, originally_requested_logprobs)
         return await self._handle_non_streaming(request, body, request_body, session_id, originally_requested_logprobs)
+
+    # ------------------------------------------------------------------
+    # SGLang native /generate path (use_sglang)
+    # ------------------------------------------------------------------
+
+    def _render_sglang_prompt(self, session_id: str, request_body: dict[str, Any]) -> list[int]:
+        """Render this chat turn's prompt to token ids for SGLang /generate.
+
+        The renderer is used for the cross-turn BRIDGE ONLY. The bridge is a
+        narrow interception — it applies just on turn>0 cumulative turns whose
+        history cumulatively extends the tracked prefix, where it extends
+        ``prev_prompt + prev_completion`` with only the new (non-assistant)
+        messages, keeping sampled tokens verbatim so adjacent turns share a
+        byte-exact prefix (mergeable). EVERYTHING ELSE — non-cumulative mode,
+        cumulative turn 0, a prefix break, or a declined bridge — falls through to
+        the common path: tokenize the full message list client-side with the
+        model's HF chat template (authoritative; mirrors slime's _render_token_ids
+        and works through sgl-router, which exposes no messages→token-ids endpoint).
+        """
+        messages = request_body.get("messages", []) or []
+        tools = request_body.get("tools")
+
+        # Cumulative bridge: the only path that uses the renderer.
+        if self.cumulative_token_mode:
+            acc = self._get_accumulator(session_id)
+            if acc.should_rewrite() and acc.is_cumulative(messages):
+                new_messages = extract_new_messages(messages, acc.message_count)
+                if new_messages:
+                    # Flatten block content before the renderer (it expects str).
+                    token_ids = acc.build_next_prompt([sglang_helper.flatten_message_content(m) for m in new_messages], tools=tools)
+                    if token_ids is not None:
+                        return token_ids
+            # Bridge did not apply (turn 0, divergent/declined): reset prefix
+            # bookkeeping and fall through to the common full-render path.
+            acc.reset()
+
+        # Common path (non-cumulative always; cumulative turn-0/reset): full render
+        # via the model's HF chat template (delegated to sglang_helper, which
+        # mirrors SGLang's ServingChat._apply_jinja_template exactly).
+        return sglang_helper.apply_chat_template(
+            messages,
+            tools,
+            tokenizer=self.tokenizer,
+            auto_adds_specials=self._tokenizer_auto_adds_specials,
+        )
+
+    def _parse_completion(self, completion_ids: list[int], tools: Any) -> dict[str, Any]:
+        """Parse /generate completion ids into ``{content, reasoning, tool_calls}``
+        with SGLang's parsers (thin wrapper over sglang_helper.parse_completion,
+        binding this proxy's tokenizer / parser names / parser cache)."""
+        return sglang_helper.parse_completion(
+            completion_ids,
+            tools,
+            tokenizer=self.tokenizer,
+            tool_call_parser=self.sglang_tool_call_parser,
+            reasoning_parser=self.sglang_reasoning_parser,
+            fc_cache=self._fc_parser_cache,
+        )
+
+    async def _handle_sglang_generate(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        session_id: str,
+        is_stream: bool,
+        originally_requested_logprobs: bool = False,
+    ) -> Response:
+        """Run one chat turn via SGLang's native /generate (token-in, token-out).
+
+        Renders the prompt to token ids, posts to <worker>/generate with
+        return_logprob=True, captures token ids + logprobs from meta_info into a
+        TraceRecord, updates the accumulator, and returns an OpenAI-chat-shaped
+        response to the agent (so the client sees a normal chat completion).
+        """
+        t0 = time.perf_counter()
+
+        # Tokenize the prompt client-side (model chat template / cumulative bridge).
+        prompt_ids = self._render_sglang_prompt(session_id, request_body)
+
+        worker = self.router.route(session_id)
+        headers = self._forward_headers(request)
+        # Keep a session sticky to one engine (radix/prefix-cache affinity).
+        headers["X-SMG-Routing-Key"] = session_id
+
+        gen_body: dict[str, Any] = {
+            "rid": uuid.uuid4().hex,
+            "input_ids": prompt_ids,
+            "sampling_params": sglang_helper.sglang_sampling_params(request_body),
+            "return_logprob": True,
+            "stream": bool(is_stream),
+        }
+        # /generate lives at the worker root, not under the OpenAI /v1 prefix.
+        url = f"{worker.url.rstrip('/')}/generate"
+        raw_body = json.dumps(gen_body).encode()
+
+        assert self._http is not None
+        if is_stream:
+            # The streaming generator owns the worker release (after [DONE]); do
+            # not release here or we'd double-decrement the active count.
+            return await self._sglang_generate_streaming(request, request_body, session_id, prompt_ids, url, headers, raw_body, t0)
+        try:
+            resp = await self._http.post(url, content=raw_body, headers=headers)
+        finally:
+            self.router.release(worker.url)
+
+        content = resp.content
+        status_code = resp.status_code
+        if status_code >= 400:
+            logger.warning("sglang /generate %s: %.300s", status_code, content[:300])
+            return Response(content=content, status_code=status_code, media_type="application/json")
+
+        try:
+            gen = json.loads(content)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            gen = {}
+        if isinstance(gen, list):  # n>1 returns a list; we use n=1
+            gen = gen[0] if gen else {}
+
+        prompt_ids_out, completion_ids, logprobs, text, finish_reason = sglang_helper.parse_sglang_generate(gen, prompt_ids)
+        latency_ms = (time.perf_counter() - t0) * 1000
+
+        # Update accumulator bookkeeping so the next turn can bridge — only needed
+        # in cumulative mode (non-cumulative full-renders every turn statelessly).
+        if self.cumulative_token_mode:
+            acc = self._get_accumulator(session_id)
+            acc.ingest_turn(prompt_ids_out, completion_ids)
+            acc.update_prefix(request_body.get("messages", []))
+
+        trace = sglang_helper.build_generate_trace(
+            session_id,
+            request_body,
+            prompt_ids_out,
+            completion_ids,
+            logprobs,
+            text,
+            finish_reason,
+            latency_ms,
+            weight_version=request.state.weight_version,
+        )
+        await self._persist(trace)
+
+        # Parse the completion token ids back into structured tool_calls so the
+        # agent (which reads message.tool_calls, not raw text) can act on them —
+        # /generate returns only raw text, so we parse with SGLang's own parser
+        # (same as /v1/chat/completions).
+        parsed = self._parse_completion(completion_ids, request_body.get("tools"))
+        chat = sglang_helper.generate_to_chat_response(request_body, text, finish_reason, len(prompt_ids_out), len(completion_ids), parsed=parsed)
+        return Response(content=json.dumps(chat), status_code=200, media_type="application/json")
+
+    async def _sglang_generate_streaming(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        session_id: str,
+        prompt_ids: list[int],
+        url: str,
+        headers: dict[str, str],
+        raw_body: bytes,
+        t0: float,
+    ) -> StreamingResponse:
+        """Stream SGLang /generate, translate to OpenAI chat SSE, capture trace.
+
+        SGLang /generate has no token-level tool-call parsing, so we cannot stream
+        raw text deltas as ``content`` (a ``<tool_call>`` would reach the agent as
+        text, not structured tool_calls). Following slime's adapter, we realise the
+        whole turn server-side (consume the full SGLang stream), parse it, then emit
+        the OpenAI chat SSE as single role/content/tool_calls/finish chunks.
+        """
+        worker_url_for_release = url.rsplit("/generate", 1)[0]
+        completion_id = f"chatcmpl-{uuid.uuid4().hex}"
+        created = int(time.time())
+        model = request_body.get("model", "")
+
+        def _chunk(delta: dict[str, Any], finish: str | None = None) -> bytes:
+            payload = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+            }
+            return f"data: {json.dumps(payload)}\n\n".encode()
+
+        async def event_generator():
+            last: dict[str, Any] = {}
+            assert self._http is not None
+            try:
+                async with self._http.stream("POST", url, content=raw_body, headers=headers) as resp:
+                    if resp.status_code >= 400:
+                        body = await resp.aread()
+                        logger.warning("sglang /generate stream %s: %.300s", resp.status_code, body[:300])
+                        yield b"data: [DONE]\n\n"
+                        return
+                    # Consume the full (cumulative) stream; keep the last payload.
+                    async for line in resp.aiter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        data_str = line[6:].strip()
+                        if data_str == "[DONE]":
+                            break
+                        try:
+                            last = json.loads(data_str)
+                        except json.JSONDecodeError:
+                            continue
+            finally:
+                self.router.release(worker_url_for_release)
+
+            # Realise + parse the whole turn, then emit slime-style SSE.
+            p_ids, c_ids, lps, text, finish = sglang_helper.parse_sglang_generate(last, prompt_ids)
+            parsed = self._parse_completion(c_ids, request_body.get("tools"))
+            tool_calls = sglang_helper.to_openai_tool_calls(parsed.get("tool_calls") or [])
+            content = parsed.get("content")
+            reasoning = parsed.get("reasoning")
+
+            # Emit content + tool_calls + reasoning losslessly (mirrors SGLang
+            # native): the leftover text is always sent, never dropped because a
+            # tool call is present, so the agent can replay the full message next
+            # turn and we re-tokenize it identically.
+            wire_finish = finish or "stop"
+            yield _chunk({"role": "assistant"})
+            if reasoning:
+                yield _chunk({"reasoning_content": reasoning})
+            body_text = content if content is not None else text
+            if body_text:
+                yield _chunk({"content": body_text})
+            if tool_calls:
+                yield _chunk({"tool_calls": [{**tc, "index": i} for i, tc in enumerate(tool_calls)]})
+                wire_finish = "tool_calls"
+            yield _chunk({}, finish=wire_finish)
+            yield b"data: [DONE]\n\n"
+
+            if self.cumulative_token_mode:
+                acc = self._get_accumulator(session_id)
+                acc.ingest_turn(p_ids, c_ids)
+                acc.update_prefix(request_body.get("messages", []))
+            trace = sglang_helper.build_generate_trace(
+                session_id,
+                request_body,
+                p_ids,
+                c_ids,
+                lps,
+                text,
+                finish,
+                (time.perf_counter() - t0) * 1000,
+                weight_version=request.state.weight_version,
+            )
+            task = asyncio.create_task(self._safe_store(trace.trace_id, trace.session_id, trace.model_dump()))
+            self._pending_traces.add(task)
+            task.add_done_callback(self._pending_traces.discard)
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
 
     # ------------------------------------------------------------------
     # Non-streaming

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -154,16 +154,26 @@ def create_app(
     # served model path (``config.model``), which we assume is a complete,
     # unmodified HuggingFace checkpoint.
     renderer = None
-    if config.cumulative_token_mode:
+    tokenizer = None
+    # use_sglang needs the model tokenizer (to decode /generate completion token
+    # ids for tool-call parsing). cumulative_token_mode additionally needs the
+    # renderer (the cross-turn bridge that keeps prior sampled tokens verbatim).
+    # Non-cumulative use_sglang does NOT need the renderer: input tokenization is
+    # done server-side via /tokenize and output parsing via SGLang's parser.
+    if config.cumulative_token_mode or config.use_sglang:
         if not config.model:
-            raise ValueError("cumulative_token_mode=True requires 'model' to be set in GatewayConfig (path to the served HuggingFace checkpoint).")
+            raise ValueError("cumulative_token_mode/use_sglang require 'model' to be set in GatewayConfig (path to the served HuggingFace checkpoint).")
         try:
-            from renderers import create_renderer
             from transformers import AutoTokenizer
         except ImportError as err:
-            raise ImportError("cumulative_token_mode requires the 'renderers' and 'transformers' packages. Install them with: pip install renderers transformers") from err
-
+            raise ImportError("cumulative_token_mode/use_sglang require the 'transformers' package. Install it with: pip install transformers") from err
         tokenizer = AutoTokenizer.from_pretrained(config.model)
+
+    if config.cumulative_token_mode:
+        try:
+            from renderers import create_renderer
+        except ImportError as err:
+            raise ImportError("cumulative_token_mode requires the 'renderers' package. Install it with: pip install renderers") from err
 
         # renderer_family="auto" lets renderers resolve the family by matching the
         # tokenizer's name_or_path against its MODEL_RENDERER_MAP. This succeeds
@@ -175,10 +185,12 @@ def create_app(
         #   https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py
         renderer = create_renderer(tokenizer, renderer=config.renderer_family)
         logger.info(
-            "Built %s (family=%r) from %s for cumulative token mode",
+            "Built %s (family=%r) from %s for cumulative_token_mode=%s use_sglang=%s",
             type(renderer).__name__,
             config.renderer_family,
             config.model,
+            config.cumulative_token_mode,
+            config.use_sglang,
         )
         if type(renderer).__name__ == "DefaultRenderer":
             raise ValueError(
@@ -201,7 +213,12 @@ def create_app(
         sync_traces=config.sync_traces,
         local_handler=local_handler,
         cumulative_token_mode=config.cumulative_token_mode,
+        use_sglang=config.use_sglang,
         renderer=renderer,
+        tokenizer=tokenizer,
+        model=config.model,
+        sglang_tool_call_parser=config.sglang_tool_call_parser,
+        sglang_reasoning_parser=config.sglang_reasoning_parser,
     )
     sessions = SessionManager(store)
 
@@ -501,8 +518,14 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["model"] = args.model
     if getattr(args, "cumulative_token_mode", False):
         data["cumulative_token_mode"] = True
+    if getattr(args, "use_sglang", False):
+        data["use_sglang"] = True
     if getattr(args, "renderer_family", None) is not None:
         data["renderer_family"] = args.renderer_family
+    if getattr(args, "sglang_tool_call_parser", None) is not None:
+        data["sglang_tool_call_parser"] = args.sglang_tool_call_parser
+    if getattr(args, "sglang_reasoning_parser", None) is not None:
+        data["sglang_reasoning_parser"] = args.sglang_reasoning_parser
 
     # Workers from CLI --worker flags (WorkerConfig validator auto-splits URLs)
     worker_urls = getattr(args, "worker", None) or []
@@ -542,6 +565,30 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Enable cumulative token mode for drift-free multi-turn RL training. Loads the tokenizer from --model (the served HuggingFace checkpoint).",
+    )
+    parser.add_argument(
+        "--use-sglang",
+        action="store_true",
+        default=False,
+        help="Route generation through SGLang's native /generate API (token ids + "
+        "logprobs in meta_info, works through sgl-router) instead of the OpenAI "
+        "/v1/{chat/,}completions endpoints. Requires --model and a renderer; the "
+        "gateway renders each turn's prompt to token ids itself. Required for RL "
+        "with SGLang server or sgl-router as inference endpoint.",
+    )
+    parser.add_argument(
+        "--sglang-tool-call-parser",
+        type=str,
+        default=None,
+        help="SGLang function-call parser name (e.g. 'qwen', 'llama3', 'deepseekv3') used "
+        "in use_sglang mode to parse tool calls from /generate output text, required for"
+        "tool-using agents in use_sglang mode.",
+    )
+    parser.add_argument(
+        "--sglang-reasoning-parser",
+        type=str,
+        default=None,
+        help="SGLang reasoning parser name (e.g. 'qwen3', 'deepseek-r1') to split <think>...</think> reasoning from output text in use_sglang mode. Optional.",
     )
     parser.add_argument(
         "--renderer-family",

--- a/rllm-model-gateway/src/rllm_model_gateway/sglang_helper.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/sglang_helper.py
@@ -1,0 +1,386 @@
+"""SGLang helpers for the gateway's ``use_sglang`` mode.
+
+In ``use_sglang`` mode the gateway routes every chat turn through SGLang's
+native ``/generate`` API (token-in ``input_ids``, token-out via
+``meta_info.output_token_logprobs``), tokenizing prompts client-side with the
+model's HF chat template and parsing completions with SGLang's own
+FunctionCallParser / ReasoningParser — so a rollout turn is byte-identical to
+the agent-harness + SGLang-server deployment path.
+
+This module holds the stateless / parser-construction pieces of that path. The
+I/O orchestration (routing, HTTP, trace persistence, accumulator updates) stays
+on ``ReverseProxy`` (see proxy.py: ``_handle_sglang_generate`` /
+``_sglang_generate_streaming`` / ``_render_sglang_prompt``), which calls these.
+
+SGLang is an OPTIONAL dependency: ``rllm-model-gateway`` does not require it
+(vLLM users never install it). Every ``sglang`` import here is therefore
+function-local — this module imports cleanly without sglang installed, and the
+``sglang`` packages load only when ``use_sglang`` mode actually runs a parser.
+Do not hoist these imports to module scope.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Any
+
+from rllm_model_gateway.models import TraceRecord
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Content flattening (chat-template prep)
+# ---------------------------------------------------------------------------
+
+
+def flatten_block_content(content: Any) -> str:
+    """Flatten OpenAI/Anthropic block-format content to a plain string.
+
+    A turn's content may arrive as a list of blocks, e.g.
+    ``[{"type": "text", "text": "..."}]`` (OpenAI) or ``{"text": ...}`` /
+    ``{"content": ...}`` (Anthropic/tool-result shapes). The renderers package
+    expects string content and silently drops list content, so we join the text
+    parts. A plain string passes through unchanged.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+    parts: list[str] = []
+    for b in content:
+        if isinstance(b, str):
+            parts.append(b)
+        elif isinstance(b, dict):
+            if b.get("type") in {"text", "input_text", "output_text"} or "text" in b:
+                parts.append(str(b.get("text") or ""))
+            elif "content" in b:
+                parts.append(flatten_block_content(b.get("content")))
+    return "\n".join(p for p in parts if p)
+
+
+def flatten_message_content(message: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of *message* with block-format content flattened to
+    a string (other fields — role, tool_calls, tool_call_id — untouched)."""
+    if not isinstance(message, dict) or isinstance(message.get("content"), str):
+        return message
+    out = dict(message)
+    out["content"] = flatten_block_content(message.get("content"))
+    return out
+
+
+def prepare_template_message(message: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one message for chat-template rendering, matching SGLang:
+    flatten block content, coerce None content to "", and parse JSON-string
+    tool-call arguments to dicts."""
+    msg = flatten_message_content(message)
+    if not isinstance(msg, dict):
+        return msg
+    if msg.get("content") is None:
+        msg = {**msg, "content": ""}
+    tool_calls = msg.get("tool_calls")
+    if msg.get("role") == "assistant" and isinstance(tool_calls, list):
+        new_calls = []
+        changed = False
+        for call in tool_calls:
+            fn = isinstance(call, dict) and call.get("function")
+            args = fn and fn.get("arguments")
+            if isinstance(args, str):
+                try:
+                    parsed_args = json.loads(args)
+                except (json.JSONDecodeError, TypeError):
+                    new_calls.append(call)
+                    continue
+                new_calls.append({**call, "function": {**fn, "arguments": parsed_args}})
+                changed = True
+            else:
+                new_calls.append(call)
+        if changed:
+            msg = {**msg, "tool_calls": new_calls}
+    return msg
+
+
+def apply_chat_template(
+    messages: list[dict[str, Any]],
+    tools: Any,
+    *,
+    tokenizer: Any,
+    auto_adds_specials: bool,
+) -> list[int]:
+    """Tokenize the full message list to token ids EXACTLY as SGLang's
+    /v1/chat/completions would, so a rollout turn is byte-identical to the
+    agent-harness + SGLang-server deployment path it will be used in.
+
+    Client-side (the gateway holds the tokenizer): authoritative for the served
+    model and reachable in the sgl-router topology, which exposes no
+    messages→token-ids endpoint (its /v1/tokenize is text-only).
+
+    Mirrors SGLang's ``ServingChat._apply_jinja_template`` step for step:
+      1. flatten OpenAI block-format content (``[{"type":"text",...}]``) to a
+         string — the HF template silently drops list content otherwise (image/
+         non-text blocks become a text placeholder; multimodal is out of scope);
+      2. coerce ``content: None`` -> ``""`` (template-safe);
+      3. parse assistant ``tool_calls[].function.arguments`` from a JSON string
+         to a dict — tool-use chat templates expect a mapping, and a raw JSON
+         string would render double-escaped on some models (Transformers docs);
+      4. render with ``tokenize=False`` then ``encode`` with
+         ``add_special_tokens=False`` when the tokenizer auto-adds specials, so
+         the template's own role/special tokens are not doubled (e.g. BOS).
+
+    ``auto_adds_specials`` is the proxy's one-time probe of whether
+    ``tokenizer.encode("")`` returns any tokens (see ReverseProxy.__init__).
+    """
+    prepared = [prepare_template_message(m) for m in messages]
+    rendered = tokenizer.apply_chat_template(
+        prepared,
+        tools=tools or None,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    encode_kwargs = {"add_special_tokens": False} if auto_adds_specials else {}
+    return list(tokenizer.encode(rendered, **encode_kwargs))
+
+
+# ---------------------------------------------------------------------------
+# SGLang parsers (tool calls + reasoning) — sglang imported lazily
+# ---------------------------------------------------------------------------
+
+
+def get_fc_parser(tools: Any, tool_call_parser: str | None, cache: dict[str, Any]) -> Any:
+    """Build (and cache) an SGLang FunctionCallParser for the request's tools.
+
+    Cached (in the caller-owned ``cache`` dict) by the tool-name set so repeated
+    turns reuse the detector. Returns None if no parser is configured or tools
+    are absent. ``sglang`` is imported here, lazily, so the module loads without
+    it installed.
+    """
+    if not tool_call_parser or not tools:
+        return None
+    try:
+        from sglang.srt.entrypoints.openai.protocol import Function, Tool
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+    except ImportError:
+        logger.warning("sglang FunctionCallParser unavailable; tool calls returned as text", exc_info=True)
+        return None
+    key = ",".join(sorted((t.get("function") or {}).get("name", "") for t in tools))
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    try:
+        sg_tools = [Tool(type="function", function=Function(**t["function"])) for t in tools]
+        parser = FunctionCallParser(tools=sg_tools, tool_call_parser=tool_call_parser)
+    except Exception:
+        logger.warning("Failed to build FunctionCallParser(%r)", tool_call_parser, exc_info=True)
+        return None
+    cache[key] = parser
+    return parser
+
+
+def parse_completion(
+    completion_ids: list[int],
+    tools: Any,
+    *,
+    tokenizer: Any,
+    tool_call_parser: str | None,
+    reasoning_parser: str | None,
+    fc_cache: dict[str, Any],
+) -> dict[str, Any]:
+    """Parse /generate completion token ids into ``{content, reasoning,
+    tool_calls}`` using SGLang's own parsers (same as /v1/chat/completions and
+    slime's agent parsing).
+
+    Steps (mirrors slime.agent.parsing.parse_model_output):
+      1. decode token ids -> text (the gateway's tokenizer),
+      2. optional reasoning split via SGLang ReasoningParser,
+      3. tool-call extraction via SGLang FunctionCallParser -> remaining text +
+         ToolCallItem(name, parameters: JSON-str).
+
+    Best-effort: any failure degrades to plain-text content (the agent still
+    gets the text; only structured tool_calls are lost). ``sglang`` is imported
+    lazily inside this function.
+    """
+    result: dict[str, Any] = {"content": "", "reasoning": None, "tool_calls": []}
+    if not completion_ids or tokenizer is None:
+        return result
+    try:
+        text = tokenizer.decode(list(completion_ids), skip_special_tokens=False)
+    except Exception:
+        logger.warning("tokenizer.decode failed; returning empty reply", exc_info=True)
+        return result
+
+    # 1. reasoning split
+    if reasoning_parser:
+        try:
+            from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+            r, b = ReasoningParser(model_type=reasoning_parser, stream_reasoning=False).parse_non_stream(text)
+            result["reasoning"], text = (r or None), (b or "")
+        except Exception:
+            logger.warning("ReasoningParser failed; keeping raw text", exc_info=True)
+
+    # 2. tool-call extraction
+    parser = get_fc_parser(tools, tool_call_parser, fc_cache)
+    if parser is not None:
+        try:
+            if parser.has_tool_call(text):
+                text, calls = parser.parse_non_stream(text)
+                result["tool_calls"] = [{"name": c.name or "tool", "arguments": c.parameters or "{}"} for c in calls]
+        except Exception:
+            logger.warning("FunctionCallParser failed; returning text-only reply", exc_info=True)
+
+    result["content"] = (text or "").strip()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# /generate request + response shaping
+# ---------------------------------------------------------------------------
+
+
+def sglang_sampling_params(request_body: dict[str, Any]) -> dict[str, Any]:
+    """Translate the OpenAI chat body's sampling fields to SGLang's schema."""
+    sp: dict[str, Any] = {
+        "skip_special_tokens": False,
+        "no_stop_trim": True,
+    }
+    # max tokens: accept the common OpenAI spellings
+    for key in ("max_completion_tokens", "max_tokens", "max_new_tokens"):
+        if request_body.get(key) is not None:
+            sp["max_new_tokens"] = int(request_body[key])
+            break
+    for src, dst in (("temperature", "temperature"), ("top_p", "top_p"), ("top_k", "top_k")):
+        if request_body.get(src) is not None:
+            sp[dst] = request_body[src]
+    if request_body.get("stop"):
+        sp["stop"] = request_body["stop"]
+    return sp
+
+
+def parse_sglang_generate(
+    gen: dict[str, Any],
+    prompt_ids: list[int],
+) -> tuple[list[int], list[int], list[float], str, str | None]:
+    """Extract (prompt_ids, completion_ids, logprobs, text, finish_reason) from
+    an SGLang /generate response dict.
+
+    ``meta_info.output_token_logprobs`` is a list of ``[logprob, token_id, ...]``
+    (the canonical token-id+logprob source — see slime's call_sglang_generate).
+    SGLang does not echo the prompt ids, so we keep the ones we sent.
+    """
+    meta = gen.get("meta_info") or {}
+    otl = meta.get("output_token_logprobs") or []
+    completion_ids = [int(x[1]) for x in otl]
+    logprobs = [float(x[0]) for x in otl]
+    text = gen.get("text", "") or ""
+    finish = (meta.get("finish_reason") or {}).get("type") if isinstance(meta.get("finish_reason"), dict) else None
+    # Prefer engine-provided prompt ids if present, else the ids we sent.
+    prompt_out = meta.get("prompt_token_ids") or list(prompt_ids)
+    return list(prompt_out), completion_ids, logprobs, text, finish
+
+
+def build_generate_trace(
+    session_id: str,
+    request_body: dict[str, Any],
+    prompt_ids: list[int],
+    completion_ids: list[int],
+    logprobs: list[float],
+    text: str,
+    finish_reason: str | None,
+    latency_ms: float,
+    *,
+    weight_version: int | None = None,
+) -> TraceRecord:
+    """Build a TraceRecord from native /generate token ids + logprobs."""
+    return TraceRecord(
+        trace_id=uuid.uuid4().hex,
+        session_id=session_id,
+        model=request_body.get("model", ""),
+        messages=request_body.get("messages", []) or [],
+        prompt_token_ids=list(prompt_ids),
+        response_message={"role": "assistant", "content": text},
+        completion_token_ids=list(completion_ids),
+        logprobs=list(logprobs) if logprobs else None,
+        finish_reason=finish_reason,
+        latency_ms=latency_ms,
+        token_counts={"prompt": len(prompt_ids), "completion": len(completion_ids)},
+        weight_version=weight_version,
+    )
+
+
+def to_openai_tool_calls(parsed_tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert parsed tool calls -> OpenAI wire tool_calls.
+
+    Input shape (from parse_completion / SGLang FunctionCallParser):
+    ``{"name": str, "arguments": <JSON string>}``. OpenAI clients (incl. Strands)
+    expect a unique ``id``, ``type": "function"``, ``function.name``, and
+    ``function.arguments`` as a JSON-encoded **string** — so arguments pass
+    through verbatim when already a string, else are JSON-encoded.
+    """
+    out: list[dict[str, Any]] = []
+    for tc in parsed_tool_calls:
+        name = tc.get("name", "") or ""
+        args = tc.get("arguments", "{}")
+        args_str = args if isinstance(args, str) else json.dumps(args, ensure_ascii=False)
+        out.append(
+            {
+                "id": f"call_{uuid.uuid4().hex[:24]}",
+                "type": "function",
+                "function": {"name": name, "arguments": args_str},
+            }
+        )
+    return out
+
+
+def generate_to_chat_response(
+    request_body: dict[str, Any],
+    text: str,
+    finish_reason: str | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+    *,
+    parsed: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Render an OpenAI chat.completion response so the agent sees a normal reply.
+
+    Mirrors SGLang's native /v1/chat/completions exactly (serving_chat.py builds
+    ``ChatMessage(content=text if text else "", tool_calls=..., reasoning_content=...)``):
+    the parser's leftover ``normal_text`` is ALWAYS surfaced as ``content`` — never
+    dropped — and ``tool_calls`` / ``reasoning_content`` are added alongside it when
+    present. ``parsed`` (``{content, reasoning, tool_calls}``) already holds the
+    post-parse fields from parse_completion; ``content`` is the text remaining after
+    reasoning + tool-call extraction. Emitting all three lossless lets the agent send
+    the same message list back next turn, which we then re-tokenize identically to
+    how SGLang's chat API would. The gateway adds no discards of its own.
+    """
+    message: dict[str, Any] = {"role": "assistant"}
+    wire_finish = finish_reason or "stop"
+
+    parsed = parsed or {}
+    tool_calls = parsed.get("tool_calls")
+    content = parsed.get("content")
+    reasoning = parsed.get("reasoning")
+
+    # content is always present (empty string if the whole turn was tool call /
+    # reasoning), matching SGLang native; tool_calls are added, not substituted.
+    message["content"] = content if content is not None else (text or "")
+    if tool_calls:
+        message["tool_calls"] = to_openai_tool_calls(tool_calls)
+        wire_finish = "tool_calls"
+    if reasoning:
+        message["reasoning_content"] = reasoning
+
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": request_body.get("model", ""),
+        "choices": [{"index": 0, "message": message, "finish_reason": wire_finish}],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }

--- a/rllm-model-gateway/tests/helpers/mock_sglang.py
+++ b/rllm-model-gateway/tests/helpers/mock_sglang.py
@@ -1,0 +1,108 @@
+"""Mock SGLang server for use_sglang-mode tests.
+
+SGLang's native generation API is ``POST /generate``: token-in (``input_ids``),
+token-out via ``meta_info.output_token_logprobs`` — a list of
+``[logprob, token_id, ...]`` rows (the canonical token-id + logprob source the
+gateway's use_sglang path reads).
+"""
+
+import json
+import socket
+import threading
+import time
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+# Canned completion: 3 output tokens [10, 11, 12] with logprobs.
+_OUTPUT_TOKEN_LOGPROBS = [[-0.5, 10, None], [-0.3, 11, None], [-0.1, 12, None]]
+_OUTPUT_TEXT = "Hello from mock!"
+
+
+def _generate_payload(input_ids: list[int]) -> dict[str, Any]:
+    return {
+        "text": _OUTPUT_TEXT,
+        "meta_info": {
+            "output_token_logprobs": _OUTPUT_TOKEN_LOGPROBS,
+            "finish_reason": {"type": "stop"},
+            "prompt_tokens": len(input_ids),
+            "completion_tokens": len(_OUTPUT_TOKEN_LOGPROBS),
+        },
+    }
+
+
+def build_mock_sglang_app() -> FastAPI:
+    """Create a minimal mock SGLang server exposing /health and /generate."""
+    app = FastAPI()
+    app.state.request_log: list[dict[str, Any]] = []
+    app.state._log_lock = threading.Lock()
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/generate")
+    async def generate(request: Request):
+        body = await request.json()
+        with app.state._log_lock:
+            app.state.request_log.append(body)
+        payload = _generate_payload(body.get("input_ids", []) or [])
+        if body.get("stream"):
+
+            def gen_stream():
+                # SGLang streams cumulative payloads; one chunk + [DONE] suffices.
+                yield f"data: {json.dumps(payload)}\n\n"
+                yield "data: [DONE]\n\n"
+
+            return StreamingResponse(gen_stream(), media_type="text/event-stream")
+        return JSONResponse(content=payload)
+
+    return app
+
+
+def _reserve_local_port(host: str) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return sock.getsockname()[1]
+
+
+class MockSGLangServer:
+    """Run a mock SGLang server in a background thread."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 0) -> None:
+        self.host = host
+        self.port = port
+        self.app = build_mock_sglang_app()
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def request_log(self) -> list[dict[str, Any]]:
+        return self.app.state.request_log
+
+    def start(self) -> None:
+        if self.port == 0:
+            self.port = _reserve_local_port(self.host)
+        config = uvicorn.Config(self.app, host=self.host, port=self.port, log_level="error")
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self._thread.start()
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if self._server.started:
+                return
+            time.sleep(0.05)
+        raise RuntimeError("Mock SGLang server failed to start")
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)

--- a/rllm-model-gateway/tests/unit/conftest.py
+++ b/rllm-model-gateway/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from tests.helpers.mock_sglang import MockSGLangServer
 from tests.helpers.mock_vllm import MockVLLMServer
 
 
@@ -9,6 +10,15 @@ from tests.helpers.mock_vllm import MockVLLMServer
 def mock_vllm():
     """Start a mock vLLM server and yield it."""
     server = MockVLLMServer(port=0)
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture
+def mock_sglang():
+    """Start a mock SGLang server (native /generate) and yield it."""
+    server = MockSGLangServer(port=0)
     server.start()
     yield server
     server.stop()

--- a/rllm-model-gateway/tests/unit/test_sglang.py
+++ b/rllm-model-gateway/tests/unit/test_sglang.py
@@ -1,0 +1,250 @@
+"""Tests for use_sglang mode.
+
+When use_sglang=True the gateway routes every /v1/chat/completions turn to
+SGLang's native /generate API (token-in input_ids, token-out via
+meta_info.output_token_logprobs), instead of the OpenAI /chat/completions
+endpoints. This captures token ids + logprobs natively (no server patch) and
+works through sgl-router.
+
+Two prompt-construction modes are exercised:
+  * cumulative_token_mode=True  -> turn N>1 bridges (prefix-extends) prior tokens
+  * cumulative_token_mode=False -> every turn full-renders the message list
+
+The renderer is mocked so no real tokenizer/model is loaded.
+"""
+
+import json
+
+import openai
+import pytest
+from rllm_model_gateway import GatewayClient, GatewayConfig, create_app
+
+from tests.helpers.gateway_server import GatewayServer
+from tests.helpers.mock_sglang import MockSGLangServer
+
+# The mock SGLang /generate returns canned completion ids [10, 11, 12]. The
+# gateway decodes them via self.tokenizer, then parses tool calls with SGLang's
+# real Qwen FunctionCallParser. So the fake tokenizer decodes those ids to a
+# real Qwen tool-call string, which the real parser turns into structured calls.
+_QWEN_TOOL_TEXT = '<tool_call>\n{"name": "calculator", "arguments": {"expression": "1+1"}}\n</tool_call>'
+
+# Tool schema the agent advertises; SGLang's FunctionCallParser only fires when
+# the request carries tools (matching real agent requests).
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Evaluate a math expression",
+            "parameters": {"type": "object", "properties": {"expression": {"type": "string"}}},
+        },
+    }
+]
+
+
+class _MockRendered:
+    """Stand-in for renderers.RenderedTokens (only .token_ids is consumed)."""
+
+    def __init__(self, token_ids):
+        self.token_ids = token_ids
+
+
+class _FakeTokenizer:
+    """Minimal stand-in for an HF tokenizer.
+
+    Mirrors the SGLang render+encode split the gateway now uses:
+    - apply_chat_template(tokenize=False): concatenates message content into a
+      string whose length reflects the flattened text of all messages (so the
+      block-content test can assert a non-empty, content-dependent prompt).
+    - encode: returns ids whose COUNT equals the rendered string length, so the
+      bridge/length assertions stay deterministic.
+    - encode(""): empty -> _tokenizer_auto_adds_specials probes to False.
+    - decode: maps the canned completion ids [10,11,12] -> a Qwen tool-call string
+      so the real SGLang FunctionCallParser can extract the call.
+    """
+
+    def apply_chat_template(self, messages, *, tools=None, tokenize=False, add_generation_prompt=True):
+        text = "".join(m.get("content") or "" for m in messages if isinstance(m.get("content"), str))
+        rendered = text or "x"  # never empty, mirrors a real template's wrappers
+        if tokenize:
+            return list(range(1, len(rendered) + 1))
+        return rendered
+
+    def encode(self, text, add_special_tokens=True):
+        return list(range(1, len(text) + 1))
+
+    def decode(self, ids, skip_special_tokens=False):
+        return _QWEN_TOOL_TEXT if list(ids) == [10, 11, 12] else "plain text reply"
+
+
+class _MockRenderer:
+    """Mimics the renderer bridge used only by the cumulative path.
+
+    bridge_to_next_turn: prev_prompt + prev_completion + a fixed extension,
+    prefix-extending by contract. (Full-render tokenization is done client-side
+    via the tokenizer's apply_chat_template; tool parsing via SGLang's
+    FunctionCallParser — neither uses the renderer.)
+    """
+
+    def bridge_to_next_turn(self, prev_prompt_ids, prev_completion_ids, new_messages, *, tools=None):
+        if not new_messages or any(m.get("role") == "assistant" for m in new_messages):
+            return None
+        bridge = [200, 201]
+        return _MockRendered(list(prev_prompt_ids) + list(prev_completion_ids) + bridge)
+
+
+def _make_gateway(mock_sglang: MockSGLangServer, *, cumulative: bool) -> GatewayServer:
+    """Gateway with use_sglang enabled, a fake tokenizer + real SGLang Qwen tool
+    parser injected (create_app is called bare to avoid loading a real model).
+    The worker is the mock SGLang base URL (no /v1 — /generate lives at root).
+    """
+    config = GatewayConfig(
+        store_worker="memory",
+        workers=[{"url": mock_sglang.url, "worker_id": "w0", "api_path": "/"}],
+        health_check_interval=999,
+        sync_traces=True,
+    )
+    app = create_app(config)
+    p = app.state.proxy
+    p.use_sglang = True
+    p.cumulative_token_mode = cumulative
+    p.renderer = _MockRenderer()
+    p.tokenizer = _FakeTokenizer()
+    # Re-probe specials now that a tokenizer is injected (create_app ran with none).
+    p._tokenizer_auto_adds_specials = len(p.tokenizer.encode("")) > 0
+    p.sglang_tool_call_parser = "qwen"  # use SGLang's real Qwen detector
+
+    server = GatewayServer(app, port=0)
+    server.start()
+    return server
+
+
+@pytest.fixture
+def sglang_gateway_cumulative(mock_sglang):
+    server = _make_gateway(mock_sglang, cumulative=True)
+    yield server, mock_sglang
+    server.stop()
+
+
+@pytest.fixture
+def sglang_gateway_noncumulative(mock_sglang):
+    server = _make_gateway(mock_sglang, cumulative=False)
+    yield server, mock_sglang
+    server.stop()
+
+
+def _generate_reqs(mock_sglang) -> list:
+    """/generate request bodies (those carrying input_ids)."""
+    return [r for r in mock_sglang.request_log if "input_ids" in r]
+
+
+class TestUseSglang:
+    def test_noncumulative_tokenizes_clientside_then_generates(self, sglang_gateway_noncumulative):
+        """Non-cumulative: the prompt is tokenized client-side (HF chat template),
+        then /generate is called with the resulting input_ids — only /generate hits
+        the server (no messages→tokens server endpoint exists behind sgl-router)."""
+        server, mock_sglang = sglang_gateway_noncumulative
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-tok/v1", api_key="dummy")
+        oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "Hello there"}])
+
+        gen = _generate_reqs(mock_sglang)
+        assert len(gen) == 1
+        # /generate used client-tokenized ids, return_logprob on, no chat fields
+        assert isinstance(gen[0]["input_ids"], list) and len(gen[0]["input_ids"]) > 0
+        assert gen[0].get("return_logprob") is True
+        assert "messages" not in gen[0] and "prompt" not in gen[0]
+
+    def test_noncumulative_block_content_is_tokenized_nonempty(self, sglang_gateway_noncumulative):
+        """Regression: OpenAI block-format content must not produce an empty prompt.
+
+        The fake tokenizer's apply_chat_template derives id count from flattened
+        message text length, so block content that was dropped (not flattened)
+        would yield a near-empty prompt."""
+        server, mock_sglang = sglang_gateway_noncumulative
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-block/v1", api_key="dummy")
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[{"role": "user", "content": [{"type": "text", "text": "A long question here"}]}],
+        )
+        gen = _generate_reqs(mock_sglang)
+        assert len(gen) == 1
+        # text "A long question here" (20 chars) -> 20 ids; certainly not empty/tiny
+        assert len(gen[0]["input_ids"]) >= len("A long question here")
+
+    def test_noncumulative_no_accumulator(self, sglang_gateway_noncumulative):
+        """Non-cumulative must not create a per-session accumulator."""
+        server, mock_sglang = sglang_gateway_noncumulative
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-noacc/v1", api_key="dummy")
+        oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "Hi"}])
+        assert "sg-noacc" not in server.app.state.proxy._accumulators
+
+    def test_tool_calls_parsed_to_structured(self, sglang_gateway_noncumulative):
+        """The renderer-parsed completion is surfaced as structured tool_calls."""
+        server, _ = sglang_gateway_noncumulative
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-tool/v1", api_key="dummy")
+        resp = oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "calc"}], tools=_TOOLS)
+        choice = resp.choices[0]
+        assert choice.finish_reason == "tool_calls"
+        assert choice.message.tool_calls
+        tc = choice.message.tool_calls[0]
+        assert tc.function.name == "calculator"
+        assert tc.id and tc.type == "function"
+        # arguments is a JSON string (OpenAI/Strands contract)
+        assert json.loads(tc.function.arguments) == {"expression": "1+1"}
+        # No-discard contract: content is always present alongside tool_calls
+        # (never None), mirroring SGLang native. Here the whole turn was the tool
+        # call, so leftover text is the empty string — not a dropped field.
+        assert choice.message.content == ""
+
+    def test_trace_captures_native_token_ids_and_logprobs(self, sglang_gateway_noncumulative):
+        """The trace has non-empty prompt+completion token ids and aligned logprobs."""
+        server, _ = sglang_gateway_noncumulative
+        client = GatewayClient(server.url)
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-trace/v1", api_key="dummy")
+        oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "Hello"}])
+
+        traces = client.get_session_traces("sg-trace")
+        assert len(traces) == 1
+        t = traces[0]
+        assert len(t.prompt_token_ids) > 0
+        assert t.completion_token_ids == [10, 11, 12]
+        assert t.logprobs == [-0.5, -0.3, -0.1]
+        client.close()
+
+    def test_cumulative_turn0_tokenizes_turn2_bridges(self, sglang_gateway_cumulative):
+        """cumulative=True: turn 0 tokenizes client-side (full chat template, NOT
+        the renderer — like the vLLM path); only turn 2+ uses the renderer bridge
+        to prefix-extend."""
+        server, mock_sglang = sglang_gateway_cumulative
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-cum/v1", api_key="dummy")
+
+        # Turn 0 — "Hello" (5 chars) -> fake apply_chat_template returns [1,2,3,4,5].
+        oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "Hello"}])
+        # Turn 1 — bridge off turn-0 (prompt [1..5] + completion [10,11,12]).
+        oai.chat.completions.create(
+            model="mock-model",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello from mock!"},
+                {"role": "user", "content": "More"},
+            ],
+        )
+        gen = _generate_reqs(mock_sglang)
+        assert len(gen) == 2
+        # turn-0 generate used the client-tokenized ids; turn-1 used the bridge:
+        # turn-0 prompt [1,2,3,4,5] + completion [10,11,12] + bridge [200,201].
+        assert gen[1]["input_ids"] == [1, 2, 3, 4, 5, 10, 11, 12, 200, 201]
+
+    def test_streaming_routes_to_generate(self, sglang_gateway_noncumulative):
+        """Streaming chat also goes via client tokenize + /generate and emits the
+        parsed tool call as chat-format SSE."""
+        server, mock_sglang = sglang_gateway_noncumulative
+        oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-stream/v1", api_key="dummy")
+        stream = oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "Hello"}], tools=_TOOLS, stream=True)
+        tool_call_seen = False
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.tool_calls:
+                tool_call_seen = True
+        gen = _generate_reqs(mock_sglang)
+        assert len(gen) == 1 and gen[0].get("stream") is True
+        assert tool_call_seen

--- a/rllm-model-gateway/tests/unit/test_sglang.py
+++ b/rllm-model-gateway/tests/unit/test_sglang.py
@@ -180,6 +180,9 @@ class TestUseSglang:
 
     def test_tool_calls_parsed_to_structured(self, sglang_gateway_noncumulative):
         """The renderer-parsed completion is surfaced as structured tool_calls."""
+        # Needs SGLang's real FunctionCallParser to turn <tool_call> text into a
+        # structured call; sglang is an optional dep, so skip where it's absent.
+        pytest.importorskip("sglang")
         server, _ = sglang_gateway_noncumulative
         oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-tool/v1", api_key="dummy")
         resp = oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "calc"}], tools=_TOOLS)
@@ -238,6 +241,9 @@ class TestUseSglang:
     def test_streaming_routes_to_generate(self, sglang_gateway_noncumulative):
         """Streaming chat also goes via client tokenize + /generate and emits the
         parsed tool call as chat-format SSE."""
+        # Asserts a structured tool_call in the SSE, which needs SGLang's real
+        # FunctionCallParser; sglang is optional, so skip where it's absent.
+        pytest.importorskip("sglang")
         server, mock_sglang = sglang_gateway_noncumulative
         oai = openai.OpenAI(base_url=f"{server.url}/sessions/sg-stream/v1", api_key="dummy")
         stream = oai.chat.completions.create(model="mock-model", messages=[{"role": "user", "content": "Hello"}], tools=_TOOLS, stream=True)


### PR DESCRIPTION
## What this adds

A new **`use_sglang`** mode for `rllm-model-gateway` that routes every agent
`/v1/chat/completions` turn through **SGLang's native `/generate` API**
(token-in `input_ids`, token-out via `meta_info.output_token_logprobs`) instead
of the OpenAI `/v1/{chat,}/completions` endpoints.

**Why:** RL training needs the exact prompt/completion **token ids + logprobs**
of every turn. SGLang's OpenAI-compatible endpoints don't expose token ids, and
`sgl-router` rejects token-id prompts on `/v1/completions`. The only path that
yields token ids **and** works behind `sgl-router` is the native `/generate`
endpoint. `use_sglang` makes the gateway:

1. **Tokenize each turn's prompt client-side** with the model's HF chat
   template — byte-identical to how SGLang's own `/v1/chat/completions`
   tokenizes (flattens block content, parses tool-call args to dicts, render +
   encode split to avoid double-BOS). A rollout turn therefore matches the
   agent-harness + SGLang-server **deployment** path exactly.
2. **POST `input_ids` to `<worker>/generate`** with `return_logprob=True`,
   capturing token ids + logprobs natively — **no SGLang server patches**, and
   it works through `sgl-router`.
3. **Parse the completion** back into structured
   `{content, tool_calls, reasoning_content}` using SGLang's own
   `FunctionCallParser` / `ReasoningParser`, then return a normal OpenAI chat
   response so the agent is unchanged. Content is surfaced **losslessly** (never
   dropped when a tool call is present), so the agent can replay the full
   message list next turn and it re-tokenizes identically.

Composes with the existing **`cumulative_token_mode`**: turn-0 (or after a
prefix break) full-renders via the chat template; subsequent turns use the
renderer bridge to prefix-extend, keeping sampled tokens verbatim for drift-free
multi-turn merging.

`sglang` remains an **optional dependency** — all `sglang` imports are
function-local, so vLLM-only users are unaffected.

## Code changes

| File | Change |
|------|--------|
| `sglang_helper.py` *(new)* | All stateless SGLang logic as free functions: chat-template prep (`flatten_*`, `prepare_template_message`, `apply_chat_template`), parsers (`get_fc_parser`, `parse_completion` — lazy `sglang` imports here), and `/generate` request/response shaping (`sglang_sampling_params`, `parse_sglang_generate`, `build_generate_trace`, `to_openai_tool_calls`, `generate_to_chat_response`). |
| `proxy.py` | Adds the `use_sglang` interception in `handle()` plus the orchestration skeleton — `_render_sglang_prompt`, `_handle_sglang_generate`, `_sglang_generate_streaming` — which own routing / HTTP / trace-persistence / accumulator state and delegate all SGLang specifics to `sglang_helper`. New `__init__` fields: `use_sglang`, `tokenizer`, `sglang_tool_call_parser`, `sglang_reasoning_parser`, plus a one-time `tokenizer.encode("")` probe for special-token handling. |
| `server.py` | New CLI flags (`--use-sglang`, `--sglang-tool-call-parser`, `--sglang-reasoning-parser`); builds the tokenizer when `use_sglang` / `cumulative_token_mode` is set and wires the new fields into `ReverseProxy`. |
| `models.py` | `GatewayConfig` gains `use_sglang`, `sglang_tool_call_parser`, `sglang_reasoning_parser`. |
| `tests/` | New `tests/unit/test_sglang.py` (client-side tokenization, block-content regression, structured tool-call parsing, native token + logprob trace capture, cumulative prefix-extension vs non-cumulative, streaming) and `tests/helpers/mock_sglang.py` (mock `/generate` server). |

## Usage

Launch the gateway in `use_sglang` mode pointed at an SGLang server (or
`sgl-router` in front of several), then register the worker and point any
OpenAI-compatible agent at a gateway session — no agent code changes.

```bash
python -m rllm_model_gateway \
  --port 9090 \
  --use-sglang \
  --model Qwen/Qwen3-4B-Instruct-2507 \
  --sglang-tool-call-parser qwen
# add  --cumulative-token-mode --renderer-family qwen3   for drift-free multi-turn merging
# add  --sglang-reasoning-parser qwen3                    for <think>…</think> models
```

Each turn's `TraceRecord` then carries the native `prompt_token_ids`,
`completion_token_ids`, and aligned `logprobs` — ready to feed a training engine
(e.g. slime GRPO).
