### PR TITLE
fix(agentcore-math): fix agentcore math training script

### DIFF
--- a/examples/agentcore_math/train_agentcore_math_verl.sh
+++ b/examples/agentcore_math/train_agentcore_math_verl.sh
@@ -33,9 +33,9 @@ python -m examples.agentcore_math.train_agentcore_math_verl \
     data.max_response_length=2048 \
     +model.name=$MODEL_PATH \
     actor_rollout_ref.model.path=$MODEL_PATH \
-    +actor_rollout_ref.model.lora.rank=16 \
-    +actor_rollout_ref.model.lora.alpha=16 \
-    +actor_rollout_ref.model.lora.merge=true \
+    actor_rollout_ref.model.lora.rank=16 \
+    actor_rollout_ref.model.lora.alpha=16 \
+    actor_rollout_ref.model.lora.merge=true \
     actor_rollout_ref.hybrid_engine=True \
     actor_rollout_ref.actor.optim.lr=2e-5 \
     actor_rollout_ref.actor.ppo_mini_batch_size=64 \


### PR DESCRIPTION
## Summary

Fix the training script of a math agent using AgentCore Runtime. The original script produces the following error: 
```
Could not append to config. An item is already at 'actor_rollout_ref.model.lora.rank'.                                               
  Either remove + prefix: 'actor_rollout_ref.model.lora.rank=16'                                                                       
  Or add a second + to add or override 'actor_rollout_ref.model.lora.rank': '++actor_rollout_ref.model.lora.rank=16' 
```
The fix is to add `+`.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

<!-- High-level bullets only. Prefer behavior/subsystem changes over exhaustive file lists. -->

- 
- 
- 

## Validation

<!-- Replace with the checks you actually ran. If nothing was run, say why. -->

- [ ] `pre-commit run --all-files`
- [ ] Targeted tests: `pytest ...`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- 

## Breaking changes / migration notes

<!-- Required for API, config, trainer/backend, or behavior changes. Otherwise write "None". -->

- None

## Docs / examples

- [ ] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- Optional. Use for UI changes, docs rendering changes, or notable CLI/training output. -->
