### PR TITLE
feat(sandbox,eval): healthcheck + real-Dockerfile build for harbor-format tasks

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -232,9 +232,83 @@ def _replay_dockerfile(task: Task, sandbox: Sandbox, backend: str) -> None:
         _safe_exec(sandbox, cmd, timeout=900)
 
 
+def _task_dockerfile(task: Task) -> Path | None:
+    """Locate a task's ``environment/Dockerfile`` (task dir first, then dataset dir)."""
+    for base in (task.task_dir, task.dataset_dir):
+        df = base / "environment" / "Dockerfile"
+        if df.exists():
+            return df
+    return None
+
+
+# Remote backends that build images themselves and so can build the *real* Dockerfile
+# (COPY/ENV/WORKDIR/RUN) instead of pulling FROM + replaying RUN. ``docker`` is excluded
+# because it already builds via ``docker build``; ``local`` cannot build. ``modal`` is a
+# tracked follow-up (it accepts a ``modal.Image`` and already keepalive-overrides the
+# entrypoint, but the from_dockerfile path there is untested — see _dockerfile_image).
+_FROM_DOCKERFILE_BACKENDS = ("daytona",)
+
+
+def _builds_from_dockerfile(task: Task, backend: str) -> Path | None:
+    """Return the Dockerfile to build directly on a remote backend, else ``None``.
+
+    For remote backends that build images themselves, building the real Dockerfile keeps
+    ``COPY``/``ENV``/``WORKDIR`` (which ``_replay_dockerfile`` silently drops) — required by
+    COPY-then-RUN tasks like honeycomb's AWS/LocalStack tasks (``COPY start_localstack.sh``
+    + ``ready.d``). Only when the task is Dockerfile-based (``replay_dockerfile`` true);
+    prebuilt-image tasks (``replay_dockerfile = false``) boot their image as-is.
+    """
+    if backend not in _FROM_DOCKERFILE_BACKENDS or not _should_replay_dockerfile(task):
+        return None
+    return _task_dockerfile(task)
+
+
+def _dockerfile_image(backend: str, dockerfile: Path):
+    """Backend-native build spec for the real Dockerfile (COPY context = its directory)."""
+    if backend == "daytona":
+        from daytona import Image  # daytona.Image.from_dockerfile bundles the Dockerfile dir as context
+
+        return Image.from_dockerfile(str(dockerfile))
+    raise ValueError(f"from_dockerfile build unsupported for backend {backend!r}")
+
+
+def _dockerfile_context_fingerprint(dockerfile: Path) -> str:
+    """Stable hash of a Dockerfile's build context (its directory) for snapshot identity.
+
+    Tasks built via ``Image.from_dockerfile`` must key on the *whole* context, not just
+    ``FROM``+``RUN``: two tasks that share a base image and RUN block but differ in COPYed
+    data (e.g. AWS tasks with different ``ready.d`` seeds) would otherwise collide on one
+    snapshot / warm-queue sandbox. Hashes the Dockerfile text plus every file under its
+    directory (relative path + bytes).
+    """
+    import hashlib
+
+    ctx = dockerfile.parent
+    h = hashlib.sha256()
+    for p in sorted(ctx.rglob("*")):
+        if p.is_file():
+            h.update(str(p.relative_to(ctx)).encode("utf-8") + b"\0")
+            try:
+                h.update(p.read_bytes())
+            except OSError:
+                pass
+    return h.hexdigest()[:16]
+
+
 def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox:
-    """Cold-path sandbox creation: base image + RUN replay (today's behavior)."""
+    """Cold-path sandbox creation.
+
+    When a Dockerfile-based task runs on a remote backend that builds images itself
+    (``_builds_from_dockerfile``), build the *real* Dockerfile (full COPY/ENV/WORKDIR/RUN
+    fidelity — the same primitive harbor's own environment uses) so nothing needs replaying.
+    Otherwise create from the base/prebuilt image and replay the Dockerfile's RUN steps
+    (``_replay_dockerfile``; a no-op for docker, which already built the image, and for
+    prebuilt-image tasks that set ``replay_dockerfile = false``).
+    """
     backend = _resolve_backend(task, sandbox_backend)
+    dockerfile = _builds_from_dockerfile(task, backend)
+    if dockerfile is not None:
+        return _create_base_sandbox(task, backend, image=_dockerfile_image(backend, dockerfile))
     sandbox = _create_base_sandbox(task, backend)
     _replay_dockerfile(task, sandbox, backend)
     return sandbox
@@ -374,6 +448,52 @@ def _build_docker_image(context_dir: Path, task_id: str) -> str:
     if result.returncode != 0:
         raise RuntimeError(f"Docker build failed for {task_id}:\n{result.stderr[:1000]}")
     return tag
+
+
+def _run_healthcheck(task: Task, sandbox: Sandbox) -> None:
+    """Boot a task's declared service and wait for readiness before the agent.
+
+    Harbor-format tasks may declare ``[environment.healthcheck]`` (command +
+    interval/timeout/retries/start-period) that boots an in-image service and
+    blocks until it is ready — e.g. honeycomb's AWS/LocalStack tasks run
+    ``bash /usr/local/bin/start_localstack.sh`` to start LocalStack and seed
+    ``ready.d``. rLLM boots the container with ``sleep infinity`` and never runs
+    the image CMD/entrypoint, so without this the service never starts and the
+    agent (and verifier) hit a dead endpoint. Mirrors harbor's ``run_healthcheck``
+    (run after environment setup, before the agent).
+
+    No-op when the task declares no healthcheck — so non-service eval *and*
+    training tasks are unaffected. Raises on exhaustion so an unbootable service
+    surfaces as an explicit infra error rather than a silent reward 0.0.
+    """
+    import time
+
+    hc = (task.metadata.get("environment", {}) or {}).get("healthcheck")
+    if not isinstance(hc, dict):
+        return
+    command = hc.get("command")
+    if not command:
+        return
+
+    timeout_s = float(hc.get("timeout_sec") or 300.0)
+    interval_s = float(hc.get("interval_sec") or 5.0)
+    retries = int(hc.get("retries") if hc.get("retries") is not None else 3)
+    start_period_s = float(hc.get("start_period_sec") or 0.0)
+
+    if start_period_s > 0:
+        time.sleep(start_period_s)
+
+    last_err: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            sandbox.exec(command, timeout=timeout_s)
+            logger.info("Healthcheck passed (attempt %d/%d): %s", attempt + 1, retries + 1, command)
+            return
+        except Exception as e:  # non-zero exit / timeout → service not ready yet
+            last_err = e
+            if attempt < retries:
+                time.sleep(interval_s)
+    raise RuntimeError(f"Healthcheck failed after {retries + 1} attempt(s) for command {command!r}: {last_err}")
 
 
 def _setup_task_environment(task: Task, sandbox: Sandbox) -> None:

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -130,8 +130,12 @@ def _read_reward_from_sandbox(sandbox: Sandbox, paths: list[str], user: str | No
             logger.debug("Could not read reward from %s: %s", path, e)
             continue
 
-    logger.warning("No reward file found at any of: %s", paths)
-    return EvalOutput(reward=0.0, is_correct=False, metadata={"error": "no reward file found"})
+    # A missing reward file means the verifier produced no verdict — a verifier/infra
+    # failure, NOT a legitimate score of 0 (a correctly-failing verifier writes reward 0).
+    # Raise so it surfaces as an explicit error (the engine maps it to a task error),
+    # distinguishable from an agent that genuinely scored 0. Mirrors harbor's
+    # RewardFileNotFoundError.
+    raise RuntimeError(f"no reward file found at any of: {paths}")
 
 
 def _parse_reward_json(raw: str) -> EvalOutput:

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -244,7 +244,7 @@ class SandboxTaskHooks:
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:
         from rllm.engine.agentflow_engine import TaskContext
-        from rllm.eval._resolution import _resolve_backend, _setup_task_environment
+        from rllm.eval._resolution import _resolve_backend, _run_healthcheck, _setup_task_environment
 
         plan = resolve_rollout_plan(task, agent_flow, self.evaluation)
 
@@ -266,6 +266,12 @@ class SandboxTaskHooks:
                         sandbox.exec(install, timeout=getattr(agent_flow, "install_timeout", env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600)), user="root")
                     except Exception as e:
                         raise RuntimeError(f"Failed to install {getattr(agent_flow, 'name', type(agent_flow).__name__)} in sandbox: {e}") from e
+
+                # Boot any declared service ([environment.healthcheck], e.g. LocalStack)
+                # and wait for readiness before the agent runs — rLLM boots the container
+                # with `sleep infinity`, so the image CMD never starts it. No-op when no
+                # healthcheck is declared (every non-service eval/training task).
+                _run_healthcheck(task, sandbox)
 
             evaluator = self.evaluation.resolve(task, sandbox, plan.verifier_kind, plan.verifier_config)
         except BaseException:

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -539,6 +539,7 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
 
     from rllm.eval._resolution import (
         _as_single_run_line,
+        _builds_from_dockerfile,
         _dockerfile_run_commands,
         _resolve_image,
         _sandbox_resource_kwargs,
@@ -556,12 +557,19 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
     except DaytonaNotFoundError:
         pass
 
-    img = Image.base(_resolve_image(task, "daytona"))
-    # Honor [environment].replay_dockerfile: fully-built task images opt out so
-    # their RUN steps aren't double-applied on top of the prebuilt image.
-    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
-    if install_script:
-        run_commands.append(_as_single_run_line(install_script))
+    dockerfile = _builds_from_dockerfile(task, "daytona")
+    if dockerfile is not None:
+        # Build the real Dockerfile (COPY/ENV/WORKDIR/RUN) so a snapshotted task is
+        # identical to a cold-built one; only the install script layers on top.
+        img = Image.from_dockerfile(str(dockerfile))
+        run_commands = [_as_single_run_line(install_script)] if install_script else []
+    else:
+        img = Image.base(_resolve_image(task, "daytona"))
+        # Honor [environment].replay_dockerfile: fully-built task images opt out so
+        # their RUN steps aren't double-applied on top of the prebuilt image.
+        run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
+        if install_script:
+            run_commands.append(_as_single_run_line(install_script))
     if run_commands:
         img = img.run_commands(*run_commands)
 

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -69,9 +69,24 @@ def env_key(backend: str, base_image: str, run_commands: list[str], install_scri
 
 
 def env_key_for(task: Task, backend: str, install_script: str = "") -> str:
-    """Fingerprint a task's environment via the shared image/RUN resolution."""
-    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _should_replay_dockerfile
+    """Fingerprint a task's environment via the shared image/RUN resolution.
 
+    Tasks built from the real Dockerfile (``_builds_from_dockerfile``) key on the whole
+    build context — COPYed data included — so tasks sharing a base image + RUN block but
+    differing in COPY (e.g. AWS tasks with different ``ready.d`` seeds) don't collide on one
+    snapshot / warm-queue sandbox. Others key on ``(base image, RUN block)`` as before.
+    """
+    from rllm.eval._resolution import (
+        _builds_from_dockerfile,
+        _dockerfile_context_fingerprint,
+        _dockerfile_run_commands,
+        _resolve_image,
+        _should_replay_dockerfile,
+    )
+
+    dockerfile = _builds_from_dockerfile(task, backend)
+    if dockerfile is not None:
+        return env_key(backend, f"dockerfile:{_dockerfile_context_fingerprint(dockerfile)}", [], install_script)
     run_commands = _dockerfile_run_commands(task) if _should_replay_dockerfile(task) else []
     return env_key(backend, _resolve_image(task, backend), run_commands, install_script)
 

--- a/tests/eval/test_aws_healthcheck_dockerfile.py
+++ b/tests/eval/test_aws_healthcheck_dockerfile.py
@@ -1,0 +1,98 @@
+"""Offline tests for the harbor-format additions: the readiness healthcheck step, the
+``from_dockerfile`` build selection on remote backends, and COPY-aware snapshot identity.
+
+All hermetic — no docker/daytona/network. Fixtures build a task dir with an
+``environment/Dockerfile`` (+ optional context files) and a fake sandbox that records execs.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from rllm.eval._resolution import _builds_from_dockerfile, _run_healthcheck, _task_dockerfile
+from rllm.sandbox.snapshot import env_key_for
+from rllm.types import Task
+
+
+class _Sb:
+    """Records exec() calls; optionally fails to simulate an unready service."""
+
+    def __init__(self, fail: bool = False):
+        self.calls: list[str] = []
+        self.fail = fail
+
+    def exec(self, command: str, timeout=None, user=None) -> str:
+        self.calls.append(command)
+        if self.fail:
+            raise RuntimeError("not ready")
+        return ""
+
+
+def _task(tmp: Path, *, dockerfile: str | None = "FROM x\n", files: dict | None = None, backend: str = "daytona", replay=None, healthcheck=None) -> Task:
+    env = tmp / "environment"
+    env.mkdir(parents=True, exist_ok=True)
+    if dockerfile is not None:
+        (env / "Dockerfile").write_text(dockerfile)
+    for rel, content in (files or {}).items():
+        p = env / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    environment: dict = {}
+    if replay is not None:
+        environment["replay_dockerfile"] = replay
+    if healthcheck is not None:
+        environment["healthcheck"] = healthcheck
+    return Task(id="t", instruction="", metadata={"environment": environment, "sandbox_backend": backend}, dataset_dir=tmp)
+
+
+# ── healthcheck step ──────────────────────────────────────────────────────────
+
+
+def test_healthcheck_noop_without_declaration(tmp_path):
+    sb = _Sb()
+    _run_healthcheck(_task(tmp_path), sb)  # no [environment.healthcheck]
+    assert sb.calls == []  # strict no-op — protects non-service eval/training tasks
+
+
+def test_healthcheck_runs_command(tmp_path):
+    sb = _Sb()
+    task = _task(tmp_path, healthcheck={"command": "bash /usr/local/bin/start_localstack.sh", "timeout_sec": 30})
+    _run_healthcheck(task, sb)
+    assert sb.calls == ["bash /usr/local/bin/start_localstack.sh"]
+
+
+def test_healthcheck_raises_after_retries(tmp_path):
+    sb = _Sb(fail=True)
+    task = _task(tmp_path, healthcheck={"command": "false", "retries": 2, "interval_sec": 0, "timeout_sec": 1})
+    with pytest.raises(RuntimeError, match="Healthcheck failed"):
+        _run_healthcheck(task, sb)
+    assert len(sb.calls) == 3  # retries=2 → 3 attempts
+
+
+# ── from_dockerfile build selection ────────────────────────────────────────────
+
+
+def test_builds_from_dockerfile_gating(tmp_path):
+    # daytona + Dockerfile + replay(default True) → build the real Dockerfile
+    t = _task(tmp_path / "a", backend="daytona")
+    assert _builds_from_dockerfile(t, "daytona") == _task_dockerfile(t)
+    # docker builds itself → never the from_dockerfile path here
+    assert _builds_from_dockerfile(t, "docker") is None
+    # prebuilt-image task (replay_dockerfile = false) boots as-is, no rebuild
+    assert _builds_from_dockerfile(_task(tmp_path / "b", replay=False), "daytona") is None
+    # no Dockerfile on disk → nothing to build
+    assert _builds_from_dockerfile(_task(tmp_path / "c", dockerfile=None), "daytona") is None
+
+
+# ── COPY-aware snapshot identity ───────────────────────────────────────────────
+
+
+def test_env_key_distinguishes_copy_context(tmp_path):
+    df = "FROM localstack/localstack:4.4.0\nCOPY init/ready.d/ /etc/localstack/init/ready.d/\n"
+    a = _task(tmp_path / "a", dockerfile=df, files={"init/ready.d/seed.py": "TABLE_A"})
+    b = _task(tmp_path / "b", dockerfile=df, files={"init/ready.d/seed.py": "TABLE_B"})
+    a2 = _task(tmp_path / "a2", dockerfile=df, files={"init/ready.d/seed.py": "TABLE_A"})
+    # Same FROM+RUN block, different COPYed seed data → distinct snapshot/warm-queue keys.
+    assert env_key_for(a, "daytona") != env_key_for(b, "daytona")
+    # Identical context → identical key (GRPO copies / re-runs share one snapshot).
+    assert env_key_for(a, "daytona") == env_key_for(a2, "daytona")

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -133,16 +133,16 @@ class TestShellScriptEvaluator:
         out = ev.evaluate(task, _episode())
         assert out.reward == 1.0
 
-    def test_no_reward_file_returns_zero(self, tmp_path):
+    def test_no_reward_file_raises(self, tmp_path):
         bench = _bench(tmp_path)
         sb = _FakeSandbox(files={})  # nothing written
         ev = ShellScriptEvaluator(sandbox=sb)
         task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
 
-        out = ev.evaluate(task, _episode())
-        assert out.reward == 0.0
-        assert out.is_correct is False
-        assert "no reward file" in out.metadata.get("error", "")
+        # A missing reward file means the verifier produced no verdict — a verifier/infra
+        # failure, distinct from a legitimate score of 0 — so it surfaces as an error.
+        with pytest.raises(RuntimeError, match="no reward file"):
+            ev.evaluate(task, _episode())
 
     def test_missing_tests_dir_short_circuits(self, tmp_path):
         bench = tmp_path / "bench-no-tests"


### PR DESCRIPTION
## Problem

Harbor-format tasks that declare an `[environment.healthcheck]` (boot an in-image service) and `COPY` files into the image don't run correctly on rLLM's native sandbox path — e.g. honeycomb's AWS/LocalStack tasks (`COPY start_localstack.sh` + `ready.d` seeds; healthcheck boots LocalStack in-process):

1. **No healthcheck handling** — `grep -rn healthcheck rllm/` is empty; the sandbox boots with `sleep infinity` and never runs the image CMD, so the service never starts → agent + verifier hit a dead endpoint → reward 0.0.
2. **COPY dropped on Daytona/non-docker** — the cold path pulls the Dockerfile's `FROM` base and replays only `RUN` lines (`_dockerfile_run_commands`), silently dropping `COPY`/`ENV`/`WORKDIR`. Only the local `docker` backend builds the real image.

## Changes

- **Healthcheck step** (`_resolution._run_healthcheck` + `hooks.SandboxTaskHooks.setup`): execs `task.metadata['environment']['healthcheck'].command` on a bounded `start_period/interval/retries` loop after env materialization and before the agent, mirroring harbor's `run_healthcheck`; raises on exhaustion. **Strict no-op when no healthcheck is declared** — every non-service eval *and* training task is unaffected.
- **Real Dockerfile build on Daytona** (`_resolution._builds_from_dockerfile` / `_dockerfile_image`): for Dockerfile-based tasks (`replay_dockerfile` true), build via `daytona.Image.from_dockerfile` (full COPY/ENV/WORKDIR/RUN fidelity — the primitive harbor's own Daytona env uses) in both the cold path and `build_daytona_snapshot`, instead of base + RUN-replay. `docker` already builds; `modal` is a tracked follow-up (`_FROM_DOCKERFILE_BACKENDS`).
- **COPY-aware snapshot identity** (`snapshot.env_key_for`): tasks built from the real Dockerfile key on the whole build-context fingerprint, so two tasks sharing `FROM`+`RUN` but differing in COPYed data (e.g. different `ready.d` seeds) don't collide on one snapshot / warm-queue sandbox.
- **Explicit missing-reward error** (`script_evaluator`): a missing reward file now raises (was a silent reward 0.0), so a broken verifier is distinguishable from an agent that genuinely scored 0 — matching harbor's `RewardFileNotFoundError`.

## Verification

- New hermetic tests (`tests/eval/test_aws_healthcheck_dockerfile.py`): healthcheck no-op/run/raise, `from_dockerfile` gating, COPY-context `env_key` sensitivity. Existing `tests/eval` + `tests/sandbox` green (the lone pre-existing `test_sandboxed_flow::…max_concurrent` failure is unrelated/env-dependent — `max_concurrent` default is 64, test asserts 4).
- **E2E on remote Daytona** with the built-in `terminus2` harness + regular `AgentFlowEngine` on a honeycomb AWS/LocalStack task: the real image builds (COPY intact), the healthcheck boots LocalStack and seeds `ready.d`, the verifier runs (`6/7` tests pass — the one miss is the agent's GSI result, not infra), reward read from `/logs/verifier/reward.txt`.

## Notes
- No new dependencies. Healthcheck is presence-gated (training rollouts of non-service tasks unaffected); the `from_dockerfile` path is gated to Dockerfile-based tasks on Daytona.
- `modal` Dockerfile-based COPY fidelity is deferred (untestable in this environment) — gated behind `_FROM_DOCKERFILE_BACKENDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
