### PR TITLE
fix(hooks): initialize warm_queue on FixedEvaluatorHooks so agent_flow validation doesn't crash

### DIFF
--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -304,6 +304,7 @@ class FixedEvaluatorHooks:
         from rllm.eval._resolution import _adapt_legacy_evaluator
 
         self.evaluator = _adapt_legacy_evaluator(evaluator)
+        self.warm_queue = None
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:  # noqa: ARG002
         from rllm.engine.agentflow_engine import TaskContext


### PR DESCRIPTION
## Summary

`FixedEvaluatorHooks` never initialized `warm_queue`, but the unified trainer's periodic validation runs inside `_detached_warm_queue`, which reads `hooks.warm_queue` unconditionally (`unified_trainer.py:60`, entered at `:444`).

On the no-sandbox `AgentFlowEngine` path the only engine that wraps a bare `evaluator` in `FixedEvaluatorHooks` this raised `AttributeError: 'FixedEvaluatorHooks' object has no attribute 'warm_queue'` at the first periodic validation, killing on-policy runs. This adds `self.warm_queue = None` so `FixedEvaluatorHooks` honors the same contract as `SandboxTaskHooks`.

## Type of change

- [ ] Feature
- [X] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- `FixedEvaluatorHooks.__init__` now sets `self.warm_queue = None`, matching the `SandboxTaskHooks` contract that the trainer's warm-queue helpers rely on.
- No behavior change for sandbox runs; fixes a crash on the no-sandbox `agent_flow` + host-evaluator validation path.

Example to reproduce the bug based on the countdown example:

```python
from openai import AsyncOpenAI

import rllm
from rllm.eval.types import EvalOutput
from rllm.rewards.countdown_reward import countdown_reward_fn
from rllm.types import AgentConfig, Episode, Step, Task, Trajectory


@rllm.rollout(name="countdown")
async def countdown_flow(task: Task, config: AgentConfig) -> Episode:
    question = str((task.metadata or {}).get("question") or task.instruction or "")
    client = AsyncOpenAI(base_url=config.base_url, api_key="EMPTY")
    messages = [{"role": "user", "content": question}]
    try:
        resp = await client.chat.completions.create(model=config.model, messages=messages, timeout=300)
        content = resp.choices[0].message.content or ""
    except Exception:
        content = ""
    messages.append({"role": "assistant", "content": content})
    step = Step(chat_completions=list(messages), model_response=content, action=content, thought=content)
    return Episode(trajectories=[Trajectory(name="countdown", steps=[step])], artifacts={"answer": content})


@rllm.evaluator
def countdown_evaluator(task: Task | dict, episode: Episode) -> EvalOutput:
    meta = task.metadata if isinstance(task, Task) else task
    out = countdown_reward_fn(meta, str(episode.artifacts.get("answer", "")))
    return EvalOutput(reward=float(out.reward), is_correct=bool(out.is_correct))

# The actual trigger — swap the trainer call in examples/countdown/unified_trainer/train_countdown_unified_verl.py:

# from rllm.rewards.countdown_reward import countdown_reward_fn
# from rllm.workflows.simple_workflow import SimpleWorkflow
from examples.countdown.countdown_flow import countdown_evaluator, countdown_flow

     trainer = AgentTrainer(
#        workflow_class=SimpleWorkflow,
#        workflow_args={
#            "reward_function": countdown_reward_fn,
#        },
         agent_flow=countdown_flow,      # -> AgentFlowEngine -> FixedEvaluatorHooks
         evaluator=countdown_evaluator,
         config=config,
         train_dataset=train_dataset,
         val_dataset=test_dataset,
         backend="verl",
     )
```




## Validation

- [ ] `pre-commit run --all-files`
- [X] Targeted tests: `pytest ...`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `ruff` + `ruff-format` pass on the changed files (ran scoped via `pre-commit run --files`, not `--all-files`).
- `pytest tests/unified_trainer/test_warm_queue_wiring.py` → 4 passed (directly covers the warm-queue path).
- Broader relevant set — `tests/engine/test_agentflow_engine.py`, `tests/engine/test_remote_runtime.py`, `tests/eval/test_env_join.py` — passes (35 passed total).

## Breaking changes / migration notes

- None

## Docs / examples

- [X] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed