### PR TITLE
Return custom metrics in remote agent flow

### DIFF
--- a/rllm/engine/remote_agent_flow_engine.py
+++ b/rllm/engine/remote_agent_flow_engine.py
@@ -196,11 +196,7 @@ def _build_episode(
     metrics["steps_collected"] = len(traces)
 
     remote_metrics = (result.raw_result or {}).get("metrics") or {}
-    scalar_remote = {
-        k: int(v) if isinstance(v, bool) else v
-        for k, v in remote_metrics.items()
-        if isinstance(v, (bool, int, float))
-    }
+    scalar_remote = {k: int(v) if isinstance(v, bool) else v for k, v in remote_metrics.items() if isinstance(v, (bool | int | float))}
     metrics = {**scalar_remote, **metrics}
 
     is_correct = bool(result.reward and result.reward >= 1.0)

--- a/rllm/engine/remote_agent_flow_engine.py
+++ b/rllm/engine/remote_agent_flow_engine.py
@@ -195,6 +195,14 @@ def _build_episode(
     metrics["empty"] = int(len(traces) == 0)
     metrics["steps_collected"] = len(traces)
 
+    remote_metrics = (result.raw_result or {}).get("metrics") or {}
+    scalar_remote = {
+        k: int(v) if isinstance(v, bool) else v
+        for k, v in remote_metrics.items()
+        if isinstance(v, (bool, int, float))
+    }
+    metrics = {**scalar_remote, **metrics}
+
     is_correct = bool(result.reward and result.reward >= 1.0)
 
     return Episode(


### PR DESCRIPTION
## Summary

`RemoteAgentFlowEngine._build_episode` now merges scalar metrics returned by the remote `@rollout_entrypoint` (in `raw_result['metrics']`) into the episode metrics dict, so custom signals reach `val/<source>/<metric>`. Only `bool`/`int`/`float` values are carried (`bool` normalized to `int`); local computed metrics win on key collision. Previously the remote backend read only `rewards` into `result.reward`, so these custom signals were dropped and never surfaced in validation or the training UI.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Merge scalar entries from the remote `raw_result['metrics']` into the computed episode metrics so they reach `val/<source>/<metric>`.
- Carry only numeric scalars (`bool`/`int`/`float`), normalizing `bool → int`; non-numeric fields are skipped since episode metrics are averaged downstream.
- Local computed metrics take precedence on key collision (`{**scalar_remote, **metrics}`), so remote keys can't clobber `empty` / `steps_collected` / step stats.


## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest tests/engine/test_remote_runtime.py tests/integration/test_remote_engine.py`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Ran the remote-path suites that exercise `RemoteAgentFlowEngine` / `_build_episode` — both passed:
  - `uv run pytest tests/engine/test_remote_runtime.py -v` 
  - `uv run pytest tests/integration/test_remote_engine.py -v` 
- A training run was ran that logged custom metrics and they appeared in the rLLM UI
## Breaking changes / migration notes

- None. Purely additive: adds keys to the metrics dict; no sge for existing callers, and a no-op when the remote returnsno `metrics`.

## Docs / examples

- [x] Not needed

## Related issues / PRs

- Fixes #
- Related to #
- Stacked on / depends on #

## Screenshots / logs

<!-- n/a -->     