### PR TITLE
feat(sandbox): env-var caps for per-task sandbox resources

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -322,6 +322,24 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
     OOM-kills compile-heavy graders (e.g. ``go test ./...``). Modal takes memory
     in MB; Daytona takes memory/disk in GB. Docker/local ignore the values.
 
+    Those per-task values are baked into ``task.toml`` at dataset-build time, so
+    an over-provisioned default can only be shrunk by rebuilding the dataset.
+    Three provider-agnostic *caps* let an operator clamp every sandbox down at
+    runtime instead — each lowers the task's declared value (``min``) when set
+    (>0); a task already at or below the cap is untouched, and a task that
+    declares nothing is left at the backend default (a cap only lowers — it never
+    raises a task above what it declared, nor introduces a value where there is
+    none):
+
+    * ``RLLM_SANDBOX_MAX_CPUS`` (float) — max physical cores.
+    * ``RLLM_SANDBOX_MAX_MEMORY_MB`` (int) — max memory in MB.
+    * ``RLLM_SANDBOX_MAX_STORAGE_MB`` (int) — max disk in MB (Daytona only; Modal
+      never receives ``storage`` and bills scratch disk as part of compute).
+
+    Modal Sandboxes bill on reserved CPU+memory per second, so capping cuts the
+    per-rollout bill proportionally (e.g. ``RLLM_SANDBOX_MAX_CPUS=2`` halves the
+    CPU term of a 4-core task).
+
     The sandbox lifetime is sized to this task's own budget so the box always
     outlives the agent + verifier it hosts (both run inside it). A flat default
     could be shorter than agent+verifier and reap the box mid-rollout ("Sandbox
@@ -331,10 +349,24 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
     (Modal's hard ``timeout`` in seconds; Daytona's idle ``auto_stop_interval``
     in minutes).
     """
-    from rllm.env import env_int, sandbox_timeout_override_s
+    from rllm.env import env_float, env_int, sandbox_timeout_override_s
 
     env = task.metadata.get("environment", {}) or {}
     cpus, mem_mb, disk_mb = env.get("cpus"), env.get("memory_mb"), env.get("storage_mb")
+
+    # Operator caps clamp the baked-in task.toml values down (see docstring):
+    # shrink an over-provisioned sandbox at runtime without rebuilding. A cap
+    # only lowers — never raises a task above its declared value, nor sets one
+    # where the task declares none (a min against a missing value would be wrong).
+    cpu_cap = env_float("RLLM_SANDBOX_MAX_CPUS", 0.0)
+    mem_cap = env_int("RLLM_SANDBOX_MAX_MEMORY_MB", 0)
+    disk_cap = env_int("RLLM_SANDBOX_MAX_STORAGE_MB", 0)
+    if cpu_cap > 0 and cpus:
+        cpus = min(float(cpus), cpu_cap)
+    if mem_cap > 0 and mem_mb:
+        mem_mb = min(int(mem_mb), mem_cap)
+    if disk_cap > 0 and disk_mb:
+        disk_mb = min(int(disk_mb), disk_cap)
 
     # Per-task lifetime floor (seconds), shared across backends: agent + verifier
     # + install + teardown/scheduling slack, raised to the operator override.
@@ -352,7 +384,7 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
         kw["timeout"] = lifetime_s  # Modal's hard lifetime, in seconds
     elif backend == "daytona":
         if cpus:
-            kw["cpu"] = int(cpus)
+            kw["cpu"] = max(1, int(cpus))  # Daytona cores are ints; a fractional Modal-style cap floors to 1
         if mem_mb:
             kw["memory"] = max(1, round(mem_mb / 1024))
         if disk_mb:


### PR DESCRIPTION
## What

Adds three provider-agnostic **caps** that clamp a task's sandbox resources at runtime, read in `_sandbox_resource_kwargs`:

| Env var | Effect |
|---|---|
| `RLLM_SANDBOX_MAX_CPUS` | max physical cores (float) |
| `RLLM_SANDBOX_MAX_MEMORY_MB` | max memory in MB |
| `RLLM_SANDBOX_MAX_STORAGE_MB` | max disk in MB (Daytona only) |

## Why

Per-task `[environment]` `cpus`/`memory_mb`/`storage_mb` are baked into `task.toml` at dataset-build time, so an over-provisioned default can only be shrunk by **rebuilding the whole dataset**. Example: `tmax-15k` bakes **4 CPU / 8 GiB** — 4× the CPU of a typical Terminal-Bench 2.0 task (84/89 run at 1 CPU / 4 GiB), matching only the 2 heaviest tasks in the entire eval suite.

Modal **Sandboxes** bill on *reserved* CPU+memory per second ([$0.00003942/core/s + $0.00000672/GiB/s](https://modal.com/pricing)), so an oversized shape directly inflates the per-rollout bill — and a full tmax run is ~128K rollouts. These caps let an operator cut cost without a rebuild:

```bash
RLLM_SANDBOX_MAX_CPUS=1 RLLM_SANDBOX_MAX_MEMORY_MB=4096 <train/eval command>
```

## Semantics

Each cap **only lowers** (`min`) the task's declared value when set (>0):
- task above the cap → clamped down;
- task at/below the cap → untouched;
- task declaring nothing → left at the backend default (a cap never raises or introduces a value).

Provider-agnostic (applies to Modal + Daytona; Docker/local ignore resources). `storage_mb` is a Daytona-only knob — Modal never receives `storage` and folds scratch disk into compute, so it has no Modal cost. Daytona `cpu` floors to 1 for a fractional (Modal-style) cap.

## Test

- `ruff check` clean.
- Verified: task `4 CPU/8 GiB` + cap `2/4096` → `2/4096`; task `1/2048` (below cap) → untouched; task declaring nothing → stays backend default; fractional cap `0.5` → Daytona `cpu=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)