### PR TITLE
Keep slow non-streaming LLM calls alive through tunnel timers; eval honors the tunnel daemon

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -87,6 +87,9 @@ class ReverseProxy:
         local_handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
         cumulative_token_mode: bool = False,
         renderer: Any = None,
+        heartbeat_initial_delay_s: float = 50.0,
+        heartbeat_interval_s: float = 25.0,
+        heartbeat_budget_s: float = 3600.0,
     ) -> None:
         self.router = router
         self.store = store
@@ -96,6 +99,16 @@ class ReverseProxy:
         self.local_handler = local_handler
         self.cumulative_token_mode = cumulative_token_mode
         self.renderer = renderer
+        # Whitespace heartbeat for slow non-streaming completions: middleboxes
+        # on the response path (Cloudflare quick tunnel: 120s; ngrok: ~300s;
+        # NAT flow tables) silently kill responses that stay byte-silent while
+        # the model generates. After ``initial_delay`` with no upstream result,
+        # the response is committed as chunked and a single space (legal JSON
+        # leading whitespace, invisible to every JSON parser) is emitted every
+        # ``interval`` until the real body is ready. ``interval <= 0`` disables.
+        self.heartbeat_initial_delay_s = heartbeat_initial_delay_s
+        self.heartbeat_interval_s = heartbeat_interval_s
+        self.heartbeat_budget_s = heartbeat_budget_s
         self.weight_version: int | None = None
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
@@ -230,6 +243,68 @@ class ReverseProxy:
         session_id: str | None,
         originally_requested_logprobs: bool = False,
     ) -> Response:
+        """Proxy a non-streaming request, keeping the response connection warm.
+
+        The upstream call runs as a task; if it finishes within
+        ``heartbeat_initial_delay_s`` the plain JSON response goes out with its
+        true status code (fast successes AND fast upstream errors are
+        untouched). Past that, the response is committed as chunked 200 and a
+        space is emitted every ``heartbeat_interval_s`` so no middlebox on the
+        path (tunnel edge read timers, NAT flow tables) sees a byte-silent
+        connection while the model generates. Leading spaces are insignificant
+        JSON whitespace — parsed output is byte-identical for every client.
+        """
+        result_task = asyncio.ensure_future(self._non_streaming_result(request, raw_body, request_body, session_id, originally_requested_logprobs))
+        if self.heartbeat_interval_s <= 0:
+            content, status_code = await result_task
+            return Response(content=content, status_code=status_code, media_type="application/json")
+
+        try:
+            content, status_code = await asyncio.wait_for(asyncio.shield(result_task), timeout=self.heartbeat_initial_delay_s)
+            return Response(content=content, status_code=status_code, media_type="application/json")
+        except TimeoutError:
+            pass  # slow generation — switch to the heartbeat stream
+        except asyncio.TimeoutError:  # noqa: UP041 — pre-3.11 alias, kept for safety
+            pass
+
+        async def _heartbeat_stream():
+            deadline = time.monotonic() + self.heartbeat_budget_s
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    result_task.cancel()
+                    logger.error("Heartbeat budget (%.0fs) exhausted waiting for upstream; failing the request", self.heartbeat_budget_s)
+                    yield json.dumps(
+                        {"error": {"message": f"gateway heartbeat budget of {self.heartbeat_budget_s:.0f}s exhausted waiting for upstream", "type": "gateway_upstream_timeout", "code": 504}}
+                    ).encode()
+                    return
+                try:
+                    content, status_code = await asyncio.wait_for(asyncio.shield(result_task), timeout=min(self.heartbeat_interval_s, remaining))
+                except (TimeoutError, asyncio.TimeoutError):
+                    yield b" "  # legal JSON leading whitespace; resets every idle timer on the path
+                    continue
+                except Exception as e:  # noqa: BLE001 — surface upstream failure as a parseable error body
+                    logger.warning("Upstream failed after heartbeat commit (status already 200): %s", e)
+                    yield json.dumps({"error": {"message": f"gateway upstream failure: {e}", "type": "gateway_upstream_error", "code": 502}}).encode()
+                    return
+                if status_code != 200:
+                    # Status line is already committed as 200; the upstream error
+                    # body still goes through — clients see a JSON error object
+                    # instead of a typed status, and the log keeps the truth.
+                    logger.warning("Upstream returned %d after heartbeat commit; forwarding error body under 200", status_code)
+                yield content
+                return
+
+        return StreamingResponse(_heartbeat_stream(), status_code=200, media_type="application/json")
+
+    async def _non_streaming_result(
+        self,
+        request: Request,
+        raw_body: bytes,
+        request_body: dict[str, Any],
+        session_id: str | None,
+        originally_requested_logprobs: bool = False,
+    ) -> tuple[bytes, int]:
         t0 = time.perf_counter()
 
         if self.local_handler is not None:
@@ -291,11 +366,7 @@ class ReverseProxy:
             if needs_strip_logprobs:
                 sanitized = _strip_logprobs(sanitized)
 
-        return Response(
-            content=json.dumps(sanitized),
-            status_code=status_code,
-            media_type="application/json",
-        )
+        return json.dumps(sanitized).encode(), status_code
 
     # ------------------------------------------------------------------
     # Cumulative token mode

--- a/rllm-model-gateway/tests/unit/test_heartbeat.py
+++ b/rllm-model-gateway/tests/unit/test_heartbeat.py
@@ -1,0 +1,179 @@
+"""Whitespace heartbeat for slow non-streaming completions.
+
+Middleboxes on the response path (Cloudflare quick tunnel: 120s read timer;
+ngrok: ~300s / ERR_NGROK_3004; NAT flow tables) silently kill responses that
+stay byte-silent while the model generates. ``_handle_non_streaming`` commits
+a chunked 200 after ``heartbeat_initial_delay_s`` and emits a single space —
+insignificant JSON leading whitespace — every ``heartbeat_interval_s`` until
+the upstream body is ready.
+
+Invariants pinned here:
+* the parsed response is byte-for-byte identical to the upstream payload
+  (spaces are stripped by every JSON parser);
+* fast responses — successes AND errors — bypass the heartbeat entirely and
+  keep their true status codes;
+* an upstream failure after the 200 is committed still surfaces as a
+  parseable OpenAI-style error object (never a silent hang);
+* a genuinely hung upstream is bounded by ``heartbeat_budget_s``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from rllm_model_gateway.proxy import ReverseProxy
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+
+
+class _State:
+    weight_version = 0
+    session_id = "sess-hb"
+    originally_requested_logprobs = True
+
+
+class _URL:
+    path = "/v1/chat/completions"
+    query = ""
+
+
+class _Request:
+    state = _State()
+    url = _URL()
+    method = "POST"
+    headers: dict[str, str] = {"content-type": "application/json"}
+
+    async def body(self) -> bytes:
+        return json.dumps({"messages": [{"role": "user", "content": "hi"}]}).encode()
+
+
+_COMPLETION = {
+    "id": "chatcmpl-hb",
+    "object": "chat.completion",
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop"}],
+    "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+}
+
+
+def _make_proxy(local_handler, *, delay=0.2, interval=0.1, budget=60.0):
+    return ReverseProxy(
+        router=None,
+        store=MemoryTraceStore(),
+        sync_traces=True,
+        local_handler=local_handler,
+        heartbeat_initial_delay_s=delay,
+        heartbeat_interval_s=interval,
+        heartbeat_budget_s=budget,
+    )
+
+
+async def _drain(response) -> bytes:
+    """Collect a (Streaming)Response's full body bytes."""
+    if hasattr(response, "body_iterator"):
+        chunks = [chunk async for chunk in response.body_iterator]
+        return b"".join(c if isinstance(c, bytes) else c.encode() for c in chunks)
+    return bytes(response.body)
+
+
+async def _handle_and_drain(proxy):
+    response = await proxy.handle(_Request())
+    return response, await _drain(response)
+
+
+def test_slow_response_heartbeats_and_parses_identically():
+    """The regression case: generation slower than every middlebox timer.
+
+    Bytes must flow before the body is ready, and the parsed payload must be
+    exactly what the upstream produced.
+    """
+
+    async def slow_handler(body):
+        await asyncio.sleep(1.0)  # >> delay + several intervals
+        return dict(_COMPLETION)
+
+    proxy = _make_proxy(slow_handler)
+    response, raw = asyncio.run(_handle_and_drain(proxy))
+
+    assert response.status_code == 200
+    assert raw.startswith(b" "), "no heartbeat bytes were emitted before the body"
+    assert raw.lstrip(b" ").startswith(b"{"), "payload must follow the whitespace"
+    assert json.loads(raw) == _COMPLETION, "parsed response must be identical to the upstream payload"
+
+
+def test_fast_response_is_untouched():
+    """Fast generations never enter heartbeat mode: plain body, no padding."""
+
+    async def fast_handler(body):
+        return dict(_COMPLETION)
+
+    proxy = _make_proxy(fast_handler, delay=5.0)
+    response, raw = asyncio.run(_handle_and_drain(proxy))
+
+    assert response.status_code == 200
+    assert not raw.startswith(b" ")
+    assert json.loads(raw) == _COMPLETION
+
+
+def test_fast_upstream_error_keeps_true_status():
+    """An upstream that fails quickly keeps its real status code — the
+    heartbeat must not blur errors it never needed to paper over."""
+
+    class _Resp:
+        status_code = 429
+        content = json.dumps({"error": {"message": "rate limited"}}).encode()
+
+    proxy = _make_proxy(None, delay=5.0)
+
+    async def fake_send(**kwargs):
+        return _Resp()
+
+    proxy._send_with_retry = fake_send
+    proxy.router = type("R", (), {"route": lambda self, sid: type("W", (), {"api_url": "http://up", "url": "http://up"})(), "release": lambda self, url: None})()
+
+    response, raw = asyncio.run(_handle_and_drain(proxy))
+    assert response.status_code == 429
+    assert json.loads(raw)["error"]["message"] == "rate limited"
+
+
+def test_upstream_failure_after_commit_surfaces_as_error_object():
+    """Failure vs hang, case 1: the upstream *fails* mid-heartbeat. The client
+    gets a parseable OpenAI-style error object immediately — not a hang, not
+    a truncated stream."""
+
+    async def dying_handler(body):
+        await asyncio.sleep(0.6)
+        raise RuntimeError("upstream exploded")
+
+    proxy = _make_proxy(dying_handler)
+    _, raw = asyncio.run(_handle_and_drain(proxy))
+
+    payload = json.loads(raw)
+    assert payload["error"]["type"] == "gateway_upstream_error"
+    assert "upstream exploded" in payload["error"]["message"]
+
+
+def test_hung_upstream_is_bounded_by_budget():
+    """Failure vs hang, case 2: the upstream never answers. The heartbeat does
+    not keep the client waiting forever — the budget converts the hang into a
+    typed timeout error object."""
+
+    async def hung_handler(body):
+        await asyncio.sleep(3600)
+
+    proxy = _make_proxy(hung_handler, budget=0.8)
+    _, raw = asyncio.run(_handle_and_drain(proxy))
+
+    payload = json.loads(raw)
+    assert payload["error"]["type"] == "gateway_upstream_timeout"
+    assert payload["error"]["code"] == 504
+
+
+def test_heartbeat_disabled_restores_plain_behavior():
+    async def slow_handler(body):
+        await asyncio.sleep(0.3)
+        return dict(_COMPLETION)
+
+    proxy = _make_proxy(slow_handler, interval=0)  # disabled
+    _, raw = asyncio.run(_handle_and_drain(proxy))
+    assert not raw.startswith(b" ")
+    assert json.loads(raw) == _COMPLETION

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -95,8 +95,42 @@ async def run_dataset(
     owned_gateway = gateway is None
     if owned_gateway:
         # Auto-tunnel for off-host sandboxes (same predicate AgentTrainer uses).
-        gateway_tunnel = None if is_local_sandbox_backend(sandbox_backend) else "cloudflared"
-        gateway = EvalGatewayManager(upstream_url=base_url, model=model, tunnel=gateway_tunnel)
+        # Resolve like training does: $RLLM_GATEWAY_TUNNEL → a running
+        # `rllm tunnel up` daemon → cloudflared quick-tunnel fallback. Quick
+        # tunnels enforce a 120s origin read timeout, which kills slow
+        # non-streaming LLM calls (CF 524) — a configured ngrok tunnel avoids
+        # that, so eval must honor it, not just training.
+        gateway_tunnel: str | None = None
+        gateway_port: int | None = None
+        if not is_local_sandbox_backend(sandbox_backend):
+            from rllm.gateway.tunnel import resolve_auto_tunnel
+
+            gateway_tunnel, tunnel_warning = resolve_auto_tunnel()
+            if tunnel_warning:
+                logger.warning(tunnel_warning)
+            if gateway_tunnel.startswith(("http://", "https://")):
+                # A tunnel URL means an already-running forwarder; the gateway
+                # must bind wherever it forwards (a free-port pick would leave
+                # the tunnel pointing at nothing). The daemon's recorded
+                # ``upstream`` is authoritative; a URL supplied some other way
+                # (env var) falls back to the setup config's port.
+                from urllib.parse import urlparse
+
+                from rllm.gateway.tunnel import live_tunnel
+
+                state = live_tunnel() or {}
+                upstream = state.get("upstream") if state.get("url") == gateway_tunnel else None
+                gateway_port = urlparse(upstream).port if upstream else None
+                if gateway_port is None:
+                    from rllm.eval.config import load_tunnel_config
+
+                    gateway_port = int(load_tunnel_config().get("port") or 9090)
+                    logger.warning(
+                        "Tunnel URL %s has no matching daemon state; binding the gateway to port %d from the tunnel config — it must match the port that URL forwards to.",
+                        gateway_tunnel,
+                        gateway_port,
+                    )
+        gateway = EvalGatewayManager(upstream_url=base_url, model=model, tunnel=gateway_tunnel, port=gateway_port)
         gateway.start()
 
     hooks = SandboxTaskHooks(evaluation=FixedEvaluation(evaluator) if evaluator is not None else None, sandbox_backend=sandbox_backend, use_snapshot=use_snapshot)

--- a/rllm/gateway/tunnel.py
+++ b/rllm/gateway/tunnel.py
@@ -524,15 +524,27 @@ def clear_tunnel_state() -> None:
         pass
 
 
-def live_tunnel_url() -> str | None:
-    """URL of a currently-running daemon tunnel, or ``None`` (clearing stale state)."""
+def live_tunnel() -> dict | None:
+    """State of a currently-running daemon tunnel, or ``None`` (clearing stale state).
+
+    The dict is the state file as written by ``rllm tunnel up``: ``backend``,
+    ``url`` (public), ``pid``, ``upstream`` (the local ``http://127.0.0.1:<port>``
+    the daemon forwards to — the authoritative answer to "which port must the
+    gateway bind"), ``log_path``.
+    """
     state = read_tunnel_state()
     if not state:
         return None
     if pid_alive(state.get("pid")) and state.get("url"):
-        return state["url"]
+        return state
     clear_tunnel_state()
     return None
+
+
+def live_tunnel_url() -> str | None:
+    """URL of a currently-running daemon tunnel, or ``None`` (clearing stale state)."""
+    state = live_tunnel()
+    return state["url"] if state else None
 
 
 def resolve_auto_tunnel() -> tuple[str, str | None]:


### PR DESCRIPTION
## Why

On terminal-bench-2 with a slow model (deepseek-v4-pro, `reasoning_effort=max` — p50 63s / p90 134s / max 502s per LLM call), **28/267 episodes (10.5%) died with `litellm.Timeout`**, burning 31.7h of eval slot time, plus ~46 more episodes taxed by retry cycles. Root cause (bisected against live infra): the eval gateway is fronted by a **Cloudflare quick tunnel, whose edge kills any response that stays byte-silent for 120s** (`Error 524: origin_response_timeout` in every dead episode's error body). Terminus-2's LLM calls are non-streaming, so time-to-first-byte = full generation time — any call slower than 120s can never be delivered. ngrok raises the ceiling to ~300s (`ERR_NGROK_3004`, measured deterministically at 300.8-301.2s across three probes) but does not remove it, and v4-pro's tail exceeds that too.

Two changes, independently useful:

## 1. Gateway whitespace heartbeat (`rllm-model-gateway`)

`ReverseProxy._handle_non_streaming` now runs the upstream call as a task:

- Result within `heartbeat_initial_delay_s` (**50s**) → plain response, true status code. Fast successes **and typed errors** (auth/429/4xx) are byte-identical to today.
- Slower → the response commits as chunked 200 and a **single space** — insignificant JSON leading whitespace, invisible to every parser — is emitted every `heartbeat_interval_s` (**25s**). No middlebox on the path (tunnel edge timers, NAT flow tables) ever sees an idle response. The upstream JSON then passes through unchanged: parsed output is identical.
- Failure vs hang stays distinguishable: upstream failure after commit → immediate OpenAI-style `{"error": {"type": "gateway_upstream_error"}}`; a hung upstream is bounded by `heartbeat_budget_s` (1h) → `gateway_upstream_timeout` (504). The heartbeat proves the *path* is alive; it never fakes progress.
- `heartbeat_interval_s <= 0` disables. Streaming requests are untouched (they already flow bytes).

**Validated A/B through a real quick tunnel** with a 150s upstream sleep: heartbeat off → **524 at 125.7s** (exact reproduction of the production failure); heartbeat on → **200 at 150.7s**, 5 leading spaces, parsed body identical to the upstream payload.

## 2. Eval honors the tunnel daemon (`rllm/eval/runner.py`, `rllm/gateway/tunnel.py`)

`rllm eval` hardcoded `"cloudflared"` — a fresh quick tunnel per run — so `rllm tunnel setup`/`up` (ngrok, reserved domain) only ever applied to training. Eval now resolves identically to training: `$RLLM_GATEWAY_TUNNEL` → running `rllm tunnel up` daemon → quick-tunnel fallback with a warning naming the fix. When the resolved tunnel is a daemon URL, the gateway binds **the port the daemon actually forwards to**, read from the daemon state file's `upstream` via a new `live_tunnel()` helper (not from config, so it follows the daemon across port/backend changes; a bare env URL with no daemon state falls back to the configured port with a warning).

## Testing

- `rllm-model-gateway/tests/unit/test_heartbeat.py`: 6 tests pinning the invariants — identical parsed payload, untouched fast path, true status for fast errors, typed error object after commit, budget-bounded hang, kill-switch.
- Tunnel resolution: all three paths unit-verified (daemon URL + arbitrary-port binding, configured-but-down warning fallback, env override); stale daemon state self-clears.
- Full gateway unit suite: 236 passed. `tests/eval` + `tests/sandbox` + `tests/harnesses`: 616 passed.
- Note: the gateway suite requires `pytest-asyncio` (declared in `rllm-model-gateway/pyproject.toml` dev deps but easy to miss in a parent-repo venv — 39 tests fail without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)