### PR TITLE
Gateway concurrency: separate-process mode, per-request CPU cuts & loop-health monitoring

### DIFF
--- a/rllm-model-gateway/pyproject.toml
+++ b/rllm-model-gateway/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "PyYAML>=6.0",
     "renderers>=0.1.7",
     "transformers>=4.50.0",
+    "orjson>=3.9.0",
 ]
 
 [project.optional-dependencies]

--- a/rllm-model-gateway/src/rllm_model_gateway/data_process.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/data_process.py
@@ -187,8 +187,17 @@ def build_trace_record(
     *,
     metadata: dict[str, Any] | None = None,
     weight_version: int | None = None,
+    capture_raw: bool = False,
 ) -> TraceRecord:
-    """Assemble a ``TraceRecord`` from raw request/response dicts."""
+    """Assemble a ``TraceRecord`` from raw request/response dicts.
+
+    ``capture_raw`` retains the full ``raw_request``/``raw_response`` on the
+    record. Defaults to False: training reads only the token-id / logprob /
+    message fields (see ``rllm.engine.trace_converter``), and keeping the raw
+    dicts (a ≤120K-token prompt + its full response) balloons ``model_dump``
+    serialization on the gateway's event loop — the dominant per-request CPU
+    cost at high concurrency. Enable only for debugging.
+    """
     choices = response_body.get("choices") or []
     first_choice = choices[0] if choices else {}
 
@@ -219,8 +228,8 @@ def build_trace_record(
         token_counts=token_counts,
         timestamp=time.time(),
         metadata=metadata or {},
-        raw_request=request_body,
-        raw_response=response_body,
+        raw_request=request_body if capture_raw else None,
+        raw_response=response_body if capture_raw else None,
     )
 
 
@@ -232,6 +241,7 @@ def build_trace_record_from_chunks(
     *,
     metadata: dict[str, Any] | None = None,
     weight_version: int | None = None,
+    capture_raw: bool = False,
 ) -> TraceRecord:
     """Assemble a ``TraceRecord`` from accumulated streaming SSE chunks.
 
@@ -305,6 +315,6 @@ def build_trace_record_from_chunks(
         token_counts=token_counts,
         timestamp=time.time(),
         metadata=metadata or {},
-        raw_request=request_body,
+        raw_request=request_body if capture_raw else None,
         raw_response=None,  # Too large for streaming; individual chunks not stored
     )

--- a/rllm-model-gateway/src/rllm_model_gateway/fastjson.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/fastjson.py
@@ -1,0 +1,53 @@
+"""Fast JSON encode/decode via orjson, with a stdlib fallback.
+
+orjson is ~2-5x faster than the stdlib ``json`` module, and at high request
+concurrency JSON (de)serialization is the gateway event loop's dominant
+per-request CPU cost (see the loop-health monitor). All helpers return/accept
+``bytes`` (orjson-native); callers that need ``str`` decode explicitly.
+
+``dumps``/``dumps_sorted`` fall back to the stdlib on any type orjson can't
+serialize natively (with ``default=str``), so swapping in this module never
+changes *which* payloads serialize successfully — only how fast.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+
+try:
+    import orjson
+
+    _OPT_SORT = orjson.OPT_SORT_KEYS
+
+    def dumps(obj: Any) -> bytes:
+        """Serialize *obj* to UTF-8 JSON bytes."""
+        try:
+            return orjson.dumps(obj)
+        except TypeError:
+            return _json.dumps(obj, ensure_ascii=False, default=str).encode("utf-8")
+
+    def dumps_sorted(obj: Any) -> bytes:
+        """Serialize *obj* with sorted keys (stable) to UTF-8 JSON bytes."""
+        try:
+            return orjson.dumps(obj, option=_OPT_SORT)
+        except TypeError:
+            return _json.dumps(obj, sort_keys=True, ensure_ascii=False, default=str).encode("utf-8")
+
+    def loads(data: bytes | str) -> Any:
+        return orjson.loads(data)
+
+    HAVE_ORJSON = True
+
+except ImportError:  # pragma: no cover - orjson is a declared dep; fallback for safety
+
+    def dumps(obj: Any) -> bytes:
+        return _json.dumps(obj, ensure_ascii=False).encode("utf-8")
+
+    def dumps_sorted(obj: Any) -> bytes:
+        return _json.dumps(obj, sort_keys=True, ensure_ascii=False).encode("utf-8")
+
+    def loads(data: bytes | str) -> Any:
+        return _json.loads(data)
+
+    HAVE_ORJSON = False

--- a/rllm-model-gateway/src/rllm_model_gateway/middleware.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/middleware.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from rllm_model_gateway import fastjson
+
 logger = logging.getLogger(__name__)
 
 # ``.+?`` (non-greedy) so multi-segment session IDs work — e.g.
@@ -92,15 +94,15 @@ class SessionRoutingMiddleware:
         raw = b"".join(body_parts)
         if raw:
             try:
-                payload = json.loads(raw)
+                payload = fastjson.loads(raw)
                 if isinstance(payload, dict):
                     # Record whether the client originally requested logprobs
                     # so the proxy can strip them from the response if not.
                     state = scope["state"]
                     state["originally_requested_logprobs"] = "logprobs" in payload and payload["logprobs"]
                     self._mutate(payload, session_id)
-                    raw = json.dumps(payload).encode("utf-8")
-            except (json.JSONDecodeError, UnicodeDecodeError):
+                    raw = fastjson.dumps(payload)
+            except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
                 pass  # non-JSON body — forward as-is
 
         # Build a receive that replays the (possibly mutated) body once,

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -16,6 +16,7 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
 
+from rllm_model_gateway import fastjson
 from rllm_model_gateway.data_process import (
     build_trace_record,
     build_trace_record_from_chunks,
@@ -236,8 +237,8 @@ class ReverseProxy:
         body = await request.body()
 
         try:
-            request_body = json.loads(body) if body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
+            request_body = fastjson.loads(body) if body else {}
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
             request_body = {}
 
         is_stream = request_body.get("stream", False)
@@ -476,7 +477,7 @@ class ReverseProxy:
             if needs_strip_logprobs:
                 sanitized = _strip_logprobs(sanitized)
 
-        return json.dumps(sanitized).encode(), status_code
+        return fastjson.dumps(sanitized), status_code
 
     # ------------------------------------------------------------------
     # Cumulative token mode
@@ -627,7 +628,7 @@ class ReverseProxy:
             if not originally_requested_logprobs:
                 sanitized = _strip_logprobs(sanitized)
 
-        return json.dumps(sanitized).encode(), status_code
+        return fastjson.dumps(sanitized), status_code
 
     async def _handle_cumulative_streaming(
         self,

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -67,6 +67,32 @@ def _strip_logprobs(response: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _build_trace_data(
+    session_id: str,
+    request_body: dict[str, Any],
+    response_body: dict[str, Any],
+    latency_ms: float,
+    weight_version: int | None,
+    capture_raw: bool,
+) -> tuple[str, str, dict[str, Any]]:
+    """Build a TraceRecord and serialize it to a dict.
+
+    Runs in a worker thread (see ``ReverseProxy._persist_trace``) so the token-id
+    list copies + ``model_dump`` stay off the event-loop thread. Reads
+    ``request_body``/``response_body`` without mutating them, so it's safe to run
+    concurrently with the response path.
+    """
+    trace = build_trace_record(
+        session_id,
+        request_body,
+        response_body,
+        latency_ms,
+        weight_version=weight_version,
+        capture_raw=capture_raw,
+    )
+    return trace.trace_id, trace.session_id, trace.model_dump()
+
+
 class ReverseProxy:
     """Forward requests to inference workers, capture traces.
 
@@ -453,8 +479,7 @@ class ReverseProxy:
 
         # Persist trace
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
-            await self._persist(trace)
+            await self._persist_trace(session_id, request_body, response_body, latency_ms, request.state.weight_version)
 
             # Ingest first turn into accumulator for cumulative token mode
             if self.cumulative_token_mode and request.url.path.endswith("/chat/completions"):
@@ -618,8 +643,7 @@ class ReverseProxy:
         response_body["object"] = "chat.completion"
 
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
-            await self._persist(trace)
+            await self._persist_trace(session_id, request_body, response_body, latency_ms, request.state.weight_version)
 
         sanitized = response_body
         if isinstance(response_body, dict) and response_body:
@@ -1159,6 +1183,49 @@ class ReverseProxy:
             await self.store.store_trace(trace_id, session_id, data)
         except Exception:
             logger.exception("Failed to persist trace %s", trace_id)
+
+    async def _persist_trace(
+        self,
+        session_id: str,
+        request_body: dict[str, Any],
+        response_body: dict[str, Any],
+        latency_ms: float,
+        weight_version: int | None,
+    ) -> None:
+        """Build + store a trace off the event-loop thread and off the response
+        critical path.
+
+        ``build_trace_record`` + ``model_dump`` copy the ≤120K/16K token-id lists
+        and were previously done inline on the loop before returning the response.
+        Here they run in the executor (``_build_trace_data``); only the async store
+        write touches the loop, and the response no longer waits for any of it.
+        ``sync_traces`` still forces synchronous completion for callers that need it.
+        """
+        loop = asyncio.get_running_loop()
+        capture_raw = self.capture_raw_payloads
+
+        async def _run() -> None:
+            try:
+                trace_id, sess, data = await loop.run_in_executor(
+                    None,
+                    _build_trace_data,
+                    session_id,
+                    request_body,
+                    response_body,
+                    latency_ms,
+                    weight_version,
+                    capture_raw,
+                )
+                await self._safe_store(trace_id, sess, data)
+            except Exception:
+                logger.exception("Failed to persist trace (session=%s)", session_id)
+
+        if self.sync_traces:
+            await _run()
+        else:
+            task = asyncio.create_task(_run())
+            self._pending_traces.add(task)
+            task.add_done_callback(self._pending_traces.discard)
 
     @staticmethod
     def _build_url(worker_url: str, path: str, query: str, *, gateway_prefix: str = "/v1") -> str:

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -5,6 +5,7 @@ Reference: miles ``MilesRouter._do_proxy()``
 """
 
 import asyncio
+import functools
 import json
 import logging
 import time
@@ -90,6 +91,7 @@ class ReverseProxy:
         heartbeat_initial_delay_s: float = 50.0,
         heartbeat_interval_s: float = 25.0,
         heartbeat_budget_s: float = 3600.0,
+        capture_raw_payloads: bool = False,
     ) -> None:
         self.router = router
         self.store = store
@@ -99,6 +101,11 @@ class ReverseProxy:
         self.local_handler = local_handler
         self.cumulative_token_mode = cumulative_token_mode
         self.renderer = renderer
+        # Retain full raw request/response on each trace. Off by default: training
+        # reads only token-id/logprob/message fields, and serializing the raw
+        # dicts (≤120K-token prompt + full response) is the dominant per-request
+        # CPU cost on the event loop at high concurrency. Enable for debugging.
+        self.capture_raw_payloads = capture_raw_payloads
         # Whitespace heartbeat for slow non-streaming completions: middleboxes
         # on the response path (Cloudflare quick tunnel: 120s; ngrok: ~300s;
         # NAT flow tables) silently kill responses that stay byte-silent while
@@ -173,7 +180,15 @@ class ReverseProxy:
                 # the *why* is recoverable from the gateway log.
                 plan = acc.plan_turn(messages)
                 if plan.action == "extend":
-                    token_ids = acc.build_next_prompt(plan.new_messages, tools=request_body.get("tools"))
+                    # bridge_to_next_turn renders the new messages and concatenates
+                    # ≤120K prior token ids — CPU-bound, so keep it off the single
+                    # event loop (the tokenizer half releases the GIL) so the loop
+                    # stays free to service other concurrent requests.
+                    loop = asyncio.get_running_loop()
+                    token_ids = await loop.run_in_executor(
+                        None,
+                        functools.partial(acc.build_next_prompt, plan.new_messages, tools=request_body.get("tools")),
+                    )
                     if token_ids is not None:
                         logger.debug(
                             "TokenAccumulator extend session=%s turn=%d +%d new msgs",
@@ -342,7 +357,7 @@ class ReverseProxy:
 
         # Persist trace
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version)
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
             await self._persist(trace)
 
             # Ingest first turn into accumulator for cumulative token mode
@@ -480,7 +495,7 @@ class ReverseProxy:
         response_body["object"] = "chat.completion"
 
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version)
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
             await self._persist(trace)
 
         sanitized = response_body
@@ -627,7 +642,7 @@ class ReverseProxy:
                 # Ingest accumulated token data
                 if chunks:
                     latency_ms = (time.perf_counter() - t0) * 1000
-                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version)
+                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
                     prompt_ids = trace.prompt_token_ids or token_ids
                     completion_ids = trace.completion_token_ids
 
@@ -686,7 +701,7 @@ class ReverseProxy:
             chat_body["object"] = "chat.completion"
             if chat_body.get("choices"):
                 chat_body["choices"][0]["message"] = {"role": "assistant", "content": content}
-            trace = build_trace_record(session_id, request_body, chat_body, latency_ms, weight_version=request.state.weight_version)
+            trace = build_trace_record(session_id, request_body, chat_body, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
             await self._persist(trace)
 
         chat_id = response_body.get("id", "chatcmpl-local")
@@ -851,7 +866,7 @@ class ReverseProxy:
                 # finally block may run during GeneratorExit, where await
                 # on real async I/O (e.g. aiosqlite) is not reliable.
                 if session_id and chunks:
-                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version)
+                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
                     task = asyncio.create_task(
                         self._safe_store(
                             trace.trace_id,
@@ -893,7 +908,7 @@ class ReverseProxy:
 
         # Persist trace from the full response
         if session_id and response_body:
-            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=weight_version)
+            trace = build_trace_record(session_id, request_body, response_body, latency_ms, weight_version=weight_version, capture_raw=self.capture_raw_payloads)
             await self._persist(trace)
 
         needs_strip_vllm = self.strip_vllm

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -269,7 +269,24 @@ class ReverseProxy:
         connection while the model generates. Leading spaces are insignificant
         JSON whitespace — parsed output is byte-identical for every client.
         """
-        result_task = asyncio.ensure_future(self._non_streaming_result(request, raw_body, request_body, session_id, originally_requested_logprobs))
+        return await self._respond_with_heartbeat(
+            self._non_streaming_result(request, raw_body, request_body, session_id, originally_requested_logprobs)
+        )
+
+    async def _respond_with_heartbeat(self, result_coro: Awaitable[tuple[bytes, int]]) -> Response:
+        """Await *result_coro* (returns ``(content_bytes, status_code)``); keep
+        the client connection warm if it's slow.
+
+        If the coroutine finishes within ``heartbeat_initial_delay_s`` the plain
+        JSON response goes out with its true status code. Past that, the response
+        is committed as chunked 200 and a space is emitted every
+        ``heartbeat_interval_s`` so no middlebox on the path (tunnel edge read
+        timers, NAT flow tables) sees a byte-silent connection while the model
+        generates. Leading spaces are insignificant JSON whitespace — parsed
+        output is byte-identical for every client. Shared by the turn-0 chat path
+        and the cumulative (turn 1+) path so long generations survive on both.
+        """
+        result_task = asyncio.ensure_future(result_coro)
         if self.heartbeat_interval_s <= 0:
             content, status_code = await result_task
             return Response(content=content, status_code=status_code, media_type="application/json")
@@ -444,9 +461,36 @@ class ReverseProxy:
     ) -> Response:
         """Non-streaming cumulative turn: send pre-tokenized prompt, return JSON.
 
-        Routes to the in-process ``local_handler`` (e.g. Tinker) when present,
-        otherwise POSTs ``/v1/completions`` to a vLLM worker. Both return a
-        completions-style body carrying ``prompt_token_ids`` + ``token_ids``.
+        Wrapped in the shared whitespace heartbeat so a slow turn-1+ generation
+        keeps its (otherwise byte-silent) client connection alive instead of
+        being idle-cut and re-sent as a duplicate.
+        """
+        return await self._respond_with_heartbeat(
+            self._cumulative_non_streaming_result(
+                request, request_body, completions_body, session_id, acc, token_ids, originally_requested_logprobs, replay=replay
+            )
+        )
+
+    async def _cumulative_non_streaming_result(
+        self,
+        request: Request,
+        request_body: dict[str, Any],
+        completions_body: dict[str, Any],
+        session_id: str,
+        acc: TokenAccumulator,
+        token_ids: list[int],
+        originally_requested_logprobs: bool = False,
+        *,
+        replay: bool = False,
+    ) -> tuple[bytes, int]:
+        """Produce the cumulative-turn response bytes + status code.
+
+        Routes to the in-process ``local_handler`` (Tinker/Fireworks) when
+        present, otherwise POSTs ``/v1/completions`` to a vLLM worker. Both
+        return a completions-style body carrying ``prompt_token_ids`` +
+        ``token_ids``. Runs as the heartbeat-wrapped result task, so its
+        accumulator side effects (``ingest_turn`` / ``update_prefix``) complete
+        exactly once even if the client connection drops mid-flight.
         """
         t0 = time.perf_counter()
 
@@ -505,11 +549,7 @@ class ReverseProxy:
             if not originally_requested_logprobs:
                 sanitized = _strip_logprobs(sanitized)
 
-        return Response(
-            content=json.dumps(sanitized),
-            status_code=status_code,
-            media_type="application/json",
-        )
+        return json.dumps(sanitized).encode(), status_code
 
     async def _handle_cumulative_streaming(
         self,

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -120,6 +120,13 @@ class ReverseProxy:
         self._http: httpx.AsyncClient | None = None
         self._pending_traces: set[asyncio.Task[None]] = set()
         self._accumulators: dict[str, TokenAccumulator] = {}
+        # Loop-health instrumentation (diagnostic only; see _loop_health_monitor).
+        # _inflight counts concurrent in-flight generations; _recent_lag_ms is the
+        # latest event-loop lag sample, stamped onto duplicate logs for correlation.
+        self._inflight: int = 0
+        self._inflight_max: int = 0
+        self._recent_lag_ms: float = 0.0
+        self._monitor_task: asyncio.Task[None] | None = None
 
     def _get_accumulator(self, session_id: str) -> TokenAccumulator:
         """Return the TokenAccumulator for *session_id*, creating if needed."""
@@ -127,14 +134,82 @@ class ReverseProxy:
             self._accumulators[session_id] = TokenAccumulator(self.renderer, session_id=session_id)
         return self._accumulators[session_id]
 
+    def _track_inflight(self, task: asyncio.Future) -> None:
+        """Count *task* (an in-flight generation) toward the in-flight gauge until
+        it completes. Called by ``_respond_with_heartbeat`` around the result task
+        so the gauge reflects concurrent generation load regardless of whether the
+        response is buffered or heartbeat-streamed."""
+        self._inflight += 1
+        if self._inflight > self._inflight_max:
+            self._inflight_max = self._inflight
+
+        def _done(_: asyncio.Future) -> None:
+            self._inflight -= 1
+
+        task.add_done_callback(_done)
+
+    async def _loop_health_monitor(self, sample_s: float = 0.5, report_s: float = 20.0) -> None:
+        """Log event-loop health so the single-loop gateway's headroom is
+        observable under load. Diagnostic only — no behavioural effect.
+
+        ``lag`` is how much longer than ``sample_s`` a bare sleep actually took —
+        i.e. how long the loop couldn't run this callback, whether from on-loop
+        CPU or from GIL starvation by the trainer thread. ``thread_cpu`` is the
+        loop thread's own CPU utilisation over the window, which disambiguates
+        the two: high lag + high thread_cpu = self-CPU bound (offload / do less);
+        high lag + low thread_cpu = the loop thread is starved (a separate gateway
+        process would help). ``inflight`` is concurrent generations.
+        """
+        lags: list[float] = []
+        window_start = time.monotonic()
+        last_cpu = time.thread_time()
+        next_report = window_start + report_s
+        while True:
+            t0 = time.monotonic()
+            try:
+                await asyncio.sleep(sample_s)
+            except asyncio.CancelledError:
+                return
+            lag_ms = max(0.0, (time.monotonic() - t0 - sample_s) * 1000.0)
+            self._recent_lag_ms = lag_ms
+            lags.append(lag_ms)
+            now = time.monotonic()
+            if now >= next_report and lags:
+                window = now - window_start
+                cpu = time.thread_time()
+                util = 100.0 * (cpu - last_cpu) / window if window > 0 else 0.0
+                ordered = sorted(lags)
+                p50 = ordered[len(ordered) // 2]
+                p99 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.99))]
+                logger.info(
+                    "gateway loop health: lag_ms p50=%.0f p99=%.0f max=%.0f | thread_cpu=%.0f%% | inflight cur=%d max=%d | window=%.0fs",
+                    p50,
+                    p99,
+                    ordered[-1],
+                    util,
+                    self._inflight,
+                    self._inflight_max,
+                    window,
+                )
+                lags.clear()
+                self._inflight_max = self._inflight
+                last_cpu = cpu
+                window_start = now
+                next_report = now + report_s
+
     async def start(self) -> None:
         self._http = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout=None),  # no timeout — LLM calls can be long
             limits=httpx.Limits(max_connections=500, max_keepalive_connections=100),
             follow_redirects=True,
         )
+        if self._monitor_task is None:
+            self._monitor_task = asyncio.ensure_future(self._loop_health_monitor())
 
     async def stop(self) -> None:
+        if self._monitor_task is not None:
+            self._monitor_task.cancel()
+            self._monitor_task = None
         # Drain pending trace writes before closing
         if self._pending_traces:
             logger.info("Draining %d pending trace writes...", len(self._pending_traces))
@@ -225,10 +300,12 @@ class ReverseProxy:
                     # fresh sample (not a cached one) is returned, so a retry that
                     # depends on resampling still makes progress.
                     logger.info(
-                        "TokenAccumulator duplicate session=%s turn=%d age_s=%s: regenerating in place, no reset",
+                        "TokenAccumulator duplicate session=%s turn=%d age_s=%s inflight=%d loop_lag_ms=%.0f: regenerating in place, no reset",
                         session_id,
                         acc.turn_count,
                         plan.diagnostics.get("age_s", "?"),
+                        self._inflight,
+                        self._recent_lag_ms,
                     )
                     return await self._handle_cumulative_turn(
                         request,
@@ -287,6 +364,7 @@ class ReverseProxy:
         and the cumulative (turn 1+) path so long generations survive on both.
         """
         result_task = asyncio.ensure_future(result_coro)
+        self._track_inflight(result_task)
         if self.heartbeat_interval_s <= 0:
             content, status_code = await result_task
             return Response(content=content, status_code=status_code, media_type="application/json")

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -571,7 +571,12 @@ def main() -> None:
 
     import uvicorn
 
-    uvicorn.run(app, host=config.host, port=config.port, log_level=config.log_level.lower())
+    # Per-request access logs flood at hundreds of concurrent requests; disable
+    # them unless log_level=debug (thread-mode gateway runs uvicorn at 'warning',
+    # which suppresses these too). Our own INFO logs (loop-health, duplicates)
+    # are unaffected — they're on the rllm_model_gateway logger, not uvicorn's.
+    access_log = config.log_level.lower() == "debug"
+    uvicorn.run(app, host=config.host, port=config.port, log_level=config.log_level.lower(), access_log=access_log)
 
 
 def _load_handler_factory(spec: str, config_path: str | None):

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -545,16 +545,52 @@ def main() -> None:
         "https://github.com/PrimeIntellect-ai/renderers/blob/main/renderers/base.py",
     )
 
+    parser.add_argument(
+        "--handler-factory",
+        type=str,
+        default=None,
+        help="Import path 'module:function' that maps the --handler-config dict to an in-process "
+        "local_handler (used to run a backend's sampler engine inside this gateway process). "
+        "Backend-agnostic: the gateway imports and calls whatever it is given.",
+    )
+    parser.add_argument(
+        "--handler-config",
+        type=str,
+        default=None,
+        help="Path to a JSON file passed to --handler-factory.",
+    )
+
     args = parser.parse_args()
     config = _load_config(args)
 
     logging.basicConfig(level=getattr(logging, config.log_level.upper(), logging.INFO))
 
-    app = create_app(config)
+    local_handler = _load_handler_factory(args.handler_factory, args.handler_config) if args.handler_factory else None
+
+    app = create_app(config, local_handler=local_handler)
 
     import uvicorn
 
     uvicorn.run(app, host=config.host, port=config.port, log_level=config.log_level.lower())
+
+
+def _load_handler_factory(spec: str, config_path: str | None):
+    """Import a ``module:function`` factory and call it with the JSON config to
+    build an in-process ``local_handler``. Keeps the gateway package backend-
+    agnostic — it loads whatever factory it is told (e.g. rLLM's Fireworks one)."""
+    import importlib
+    import json as _json
+
+    mod_path, sep, fn_name = spec.partition(":")
+    if not sep or not fn_name:
+        raise ValueError(f"--handler-factory must be 'module:function', got {spec!r}")
+    factory = getattr(importlib.import_module(mod_path), fn_name)
+    cfg: dict = {}
+    if config_path:
+        with open(config_path) as f:
+            cfg = _json.load(f)
+    logging.getLogger(__name__).info("Building local_handler via factory %s", spec)
+    return factory(cfg)
 
 
 if __name__ == "__main__":

--- a/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/token_accumulator.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from rllm_model_gateway.fastjson import dumps_sorted
+
 logger = logging.getLogger(__name__)
 
 
@@ -102,9 +104,13 @@ class TurnPlan:
 
 
 def _message_fingerprint(message: dict[str, Any]) -> str:
-    """Stable SHA-256 of a single message (detects any role/content change)."""
-    raw = json.dumps(message, sort_keys=True, ensure_ascii=False)
-    return hashlib.sha256(raw.encode()).hexdigest()
+    """Stable SHA-256 of a single message (detects any role/content change).
+
+    Uses orjson (sorted keys) → hashes the bytes directly; the exact encoding
+    only needs to be stable within a run, and every fingerprint goes through
+    this one function, so snapshot and incoming fps stay comparable.
+    """
+    return hashlib.sha256(dumps_sorted(message)).hexdigest()
 
 
 def _per_message_fingerprints(messages: list[dict[str, Any]]) -> list[str]:

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -395,6 +395,7 @@ class AgentFlowEngine:
         self.train_sampling_params = train_sampling_params
         self.val_sampling_params = val_sampling_params
 
+        self.n_parallel_tasks = n_parallel_tasks
         self.executor = ThreadPoolExecutor(max_workers=n_parallel_tasks)
         self._semaphore = asyncio.Semaphore(n_parallel_tasks)
 
@@ -411,6 +412,27 @@ class AgentFlowEngine:
         self.current_step = step
         self.current_mode = mode
         self.current_epoch = epoch
+
+    @property
+    def inflight(self) -> int:
+        """Best-effort count of rollout tasks currently holding a concurrency slot.
+
+        Diagnostic only (reads the semaphore's remaining permits). Returns -1 if
+        the internal state can't be read.
+        """
+        try:
+            return max(0, self.n_parallel_tasks - self._semaphore._value)  # type: ignore[attr-defined]
+        except Exception:
+            return -1
+
+    @property
+    def pending(self) -> int:
+        """Best-effort count of rollout tasks queued waiting for a slot."""
+        try:
+            waiters = self._semaphore._waiters  # type: ignore[attr-defined]
+            return len(waiters) if waiters else 0
+        except Exception:
+            return -1
 
     async def execute_tasks(
         self,

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import dataclasses
+import functools
 import logging
 import time
 from typing import Any
@@ -254,11 +255,22 @@ class FireworksEngine(TinkerEngine):
         accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.accumulate_reasoning)
         reasoning_effort = kwargs.pop("reasoning_effort", self.reasoning_effort)
 
-        token_input = self._render_prompt_token_input(
-            messages,
-            tools=tools,
-            reasoning_effort=reasoning_effort,
-            accumulate_reasoning=accumulate_reasoning,
+        # Rendering a ≤120K-token prompt is CPU-bound and (via the HF fast
+        # tokenizer) releases the GIL, so run it in a worker thread instead of on
+        # the gateway's single event loop — otherwise every turn-0 request blocks
+        # the loop from flushing responses / firing heartbeats for all other
+        # in-flight requests, which at high concurrency shows up as client
+        # timeouts + TokenAccumulator "duplicate" churn.
+        loop = asyncio.get_running_loop()
+        token_input = await loop.run_in_executor(
+            None,
+            functools.partial(
+                self._render_prompt_token_input,
+                messages,
+                tools=tools,
+                reasoning_effort=reasoning_effort,
+                accumulate_reasoning=accumulate_reasoning,
+            ),
         )
 
         if application_id is not None:

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -341,6 +341,41 @@ class FireworksEngine(TinkerEngine):
         self.sample_timeout = sample_timeout
         self.router_replay = router_replay
         self.sampling_client = sampler
+        # Retained so a separate-process gateway can rebuild an equivalent engine
+        # (see handler_factory_spec / rllm.gateway.worker_handlers).
+        self.renderer_family = renderer_family
+
+    def handler_factory_spec(self) -> tuple[str, dict[str, Any]]:
+        """Recipe for rebuilding this engine as a gateway ``local_handler`` in a
+        separate process (Path 1 / rllm.gateway.manager multi-process mode).
+
+        Returns ``(import_path, config)`` where ``import_path`` is a
+        ``"module:function"`` that maps ``config`` -> a ``local_handler``. The
+        config carries only serializable, non-secret values — the subprocess
+        attaches to the *same* Fireworks deployment via the sampler's
+        ``base_url``/``model`` (no re-provisioning); the API key comes from the
+        inherited ``FIREWORKS_API_KEY`` env, not this config.
+        """
+        sampler = self.sampling_client
+        return (
+            "rllm.gateway.worker_handlers:build_fireworks_handler",
+            {
+                "inference_url": getattr(sampler, "base_url", None),
+                "model": getattr(sampler, "model", None),
+                "tokenizer_model": getattr(self.tokenizer, "name_or_path", None),
+                "max_prompt_length": self.max_prompt_length,
+                "max_response_length": self.max_response_length,
+                # __init__ stored (input - 1); pass +1 so a rebuild lands identically.
+                "max_model_length": self.max_model_length + 1,
+                "sampling_params": {"train": self.train_sampling_params, "val": self.val_sampling_params},
+                "reasoning_effort": self.reasoning_effort,
+                "accumulate_reasoning": self.accumulate_reasoning,
+                "router_replay": self.router_replay,
+                "sample_timeout": self.sample_timeout,
+                "renderer_family": self.renderer_family,
+                "bypass_render_with_parser": self.bypass_render_with_parser,
+            },
+        )
 
     # ------------------------------------------------------------------
     # Token-in / token-out override

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -152,6 +152,53 @@ def _install_httpx_orjson_patch() -> None:
 _install_httpx_orjson_patch()
 
 
+def _install_sdk_response_parse_patch() -> None:
+    """Parse the SDK's streaming completion chunks with orjson.
+
+    ``DeploymentSampler.async_completions_stream`` parses every SSE chunk with
+    stdlib ``json.loads(sse.data)`` on the event-loop thread; across many
+    concurrent streams that per-chunk parse is a continuous on-loop cost. Swap
+    the SDK ``sampling`` module's ``json`` reference for a shim whose ``loads`` is
+    orjson and which delegates every other attribute (``dumps``,
+    ``JSONDecodeError``, …) to stdlib json — so nothing else in the module
+    changes behaviour. ``orjson.JSONDecodeError`` subclasses ``ValueError``, so
+    the SDK's ``except (ValueError, TypeError)`` still catches malformed chunks.
+
+    Best-effort and idempotent: skips silently if the SDK/orjson layout differs.
+    """
+    try:
+        import json as _stdlib_json
+
+        import orjson
+        from fireworks.training.sdk import sampling as _sdk
+    except Exception:  # noqa: BLE001 - layout unknown → skip
+        return
+
+    if getattr(_sdk, "_rllm_orjson_json_shim", False):
+        return
+
+    class _OrjsonJson:
+        loads = staticmethod(orjson.loads)  # the hot path
+
+        def __getattr__(self, name):  # noqa: ANN001 - delegate everything else
+            return getattr(_stdlib_json, name)
+
+    shim = _OrjsonJson()
+    try:
+        assert shim.loads('{"a":1}') == {"a": 1}
+        assert shim.dumps({"a": 1}) == '{"a": 1}'  # delegates to stdlib → str
+    except Exception as e:  # noqa: BLE001
+        logger.warning("SDK response-parse orjson patch skipped (%s); using stdlib json", e)
+        return
+
+    _sdk.json = shim
+    _sdk._rllm_orjson_json_shim = True  # type: ignore[attr-defined]
+    logger.info("Installed orjson patch for Fireworks SDK streaming response parse")
+
+
+_install_sdk_response_parse_patch()
+
+
 class _EmptyCompletionIdsError(RuntimeError):
     pass
 

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -100,6 +100,58 @@ def _install_inference_header_patch() -> None:
 _install_inference_header_patch()
 
 
+def _install_httpx_orjson_patch() -> None:
+    """Serialize httpx ``json=`` request bodies with orjson instead of stdlib json.
+
+    ``DeploymentSampler`` POSTs the full (≤120K-token) prompt via
+    ``client.post(json=payload)``; httpx serializes it with stdlib ``json`` on the
+    calling thread — the gateway's single event loop — which at high concurrency is
+    the dominant per-request on-loop CPU cost. orjson is ~3x faster and matches
+    httpx's wire semantics (compact, UTF-8, rejects NaN).
+
+    Best-effort and guarded: httpx internals (``encode_json`` returning
+    ``(headers, ByteStream)``) are version-specific, so we probe the shape against
+    the real function before installing and skip (keeping stdlib) on any mismatch —
+    a future httpx upgrade can degrade the speedup but never break sampling.
+    """
+    try:
+        import httpx._content as _hc
+        from httpx._content import ByteStream
+        import orjson
+    except Exception:  # noqa: BLE001 - httpx/orjson layout unknown → skip patch
+        return
+
+    orig = getattr(_hc, "encode_json", None)
+    if orig is None or getattr(orig, "_rllm_orjson_patch", False):
+        return
+
+    def _encode_json(json):  # noqa: ANN001 - matches httpx signature
+        try:
+            body = orjson.dumps(json)
+        except TypeError:
+            return orig(json)  # exotic types orjson can't handle → stdlib
+        headers = {"Content-Length": str(len(body)), "Content-Type": "application/json"}
+        return headers, ByteStream(body)
+
+    # Verify our output matches the real httpx contract (types + headers) on a
+    # tiny probe before swapping; otherwise leave stdlib in place.
+    try:
+        ref_headers, ref_stream = orig({"_rllm_probe": 1})
+        new_headers, new_stream = _encode_json({"_rllm_probe": 1})
+        if type(new_stream) is not type(ref_stream) or set(new_headers) != set(ref_headers):
+            raise ValueError("httpx encode_json shape mismatch")
+    except Exception as e:  # noqa: BLE001
+        logger.warning("httpx orjson patch skipped (%s); using stdlib json for httpx bodies", e)
+        return
+
+    _encode_json._rllm_orjson_patch = True  # type: ignore[attr-defined]
+    _hc.encode_json = _encode_json
+    logger.info("Installed httpx orjson encode_json patch (faster large-prompt serialization off the gateway loop's critical path)")
+
+
+_install_httpx_orjson_patch()
+
+
 class _EmptyCompletionIdsError(RuntimeError):
     pass
 

--- a/rllm/engine/rollout/fireworks_engine.py
+++ b/rllm/engine/rollout/fireworks_engine.py
@@ -21,6 +21,7 @@ import asyncio
 import contextvars
 import dataclasses
 import logging
+import time
 from typing import Any
 
 import httpx
@@ -42,6 +43,18 @@ from rllm.types import TerminationEvent, TerminationReason
 logger = logging.getLogger(__name__)
 
 _MAX_SAMPLE_ATTEMPTS = 5
+# The gateway wires FireworksEngine as an in-process handler, so these retries
+# run *inside* the agent's HTTP call and hold that (byte-silent, no-heartbeat on
+# the cumulative path) connection open the whole time. Retrying long enough to
+# ride out a transient reset / weight-sync reload is good; holding past the
+# client/tunnel tolerance is not — the client re-sends, surfacing as
+# TokenAccumulator "duplicate" churn + wasted regeneration. So cap the total
+# retry wall-clock: ride out the common case, then fail fast so a persistent
+# outage surfaces instead of stalling the connection.
+_RETRY_BUDGET_S = 90.0
+# Per-retry backoff cap: the old 10/20/30/40s schedule alone could sleep ~100s,
+# well past the budget. Cap it so backoff can't dominate the budget.
+_RETRY_BACKOFF_CAP_S = 15.0
 _TRANSIENT_ERROR_MARKERS = (
     "502",
     "503",
@@ -397,6 +410,7 @@ class FireworksEngine(TinkerEngine):
         request to the trajectory's pinned replica. Returns
         (response_dict, server_metrics_dict)."""
 
+        start = time.monotonic()
         for attempt in range(_MAX_SAMPLE_ATTEMPTS):
             try:
                 token = _per_request_headers.set(session_headers) if session_headers else None
@@ -425,22 +439,31 @@ class FireworksEngine(TinkerEngine):
                 # markers below miss them; classify by type instead.
                 is_network_error = isinstance(exc, httpx.TimeoutException | httpx.TransportError)
                 transient = isinstance(exc, _EmptyCompletionIdsError) or is_network_error or any(marker in err or marker in exc_name for marker in _TRANSIENT_ERROR_MARKERS)
-                if transient and attempt < _MAX_SAMPLE_ATTEMPTS - 1:
-                    wait = 10 * (attempt + 1)
+                elapsed = time.monotonic() - start
+                wait = min(10 * (attempt + 1), _RETRY_BACKOFF_CAP_S)
+                # Retry only while there's budget left to both back off and make
+                # another attempt worthwhile — else fail fast so the held client
+                # connection is released instead of stalled past its tolerance.
+                budget_left = elapsed + wait < _RETRY_BUDGET_S
+                if transient and attempt < _MAX_SAMPLE_ATTEMPTS - 1 and budget_left:
                     logger.debug(
-                        "Attempt %d/%d failed (%s: %s), retrying in %ds...",
+                        "Attempt %d/%d failed (%s: %s) after %.1fs, retrying in %ds...",
                         attempt + 1,
                         _MAX_SAMPLE_ATTEMPTS,
                         exc_name,
                         exc,
+                        elapsed,
                         wait,
                     )
                     await asyncio.sleep(wait)
                     continue
                 resp_text = getattr(getattr(exc, "response", None), "text", None)
+                give_up = "retry budget exhausted" if (transient and not budget_left) else "permanent"
                 logger.error(
-                    "Sampling failed permanently after %d attempts (%s): %s\n%s",
+                    "Sampling failed (%s) after %d attempts / %.1fs (%s): %s\n%s",
+                    give_up,
                     attempt + 1,
+                    elapsed,
                     exc_name,
                     exc,
                     resp_text or "",

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import re
+import os
 import socket
 import subprocess
 import sys
@@ -169,9 +170,16 @@ class GatewayManager:
         self.cumulative_token_mode: bool = gw_cfg.get("cumulative_token_mode", False)
         self.renderer_family: str = gw_cfg.get("renderer_family", "auto")
 
+        # 0 = gateway runs in a trainer thread (default). >=1 = run it in its own
+        # process(es), so its event loop no longer shares the trainer's GIL. 1 =
+        # a single separate gateway process (no session-sharding); >1 needs the
+        # session-sticky front router (not yet implemented).
+        self.num_workers: int = int(gw_cfg.get("num_workers", 0))
+
         self.mode = mode
 
         self._process: subprocess.Popen | None = None
+        self._handler_config_path: str | None = None  # temp file for --handler-config (cleaned up in stop)
         self._thread: threading.Thread | None = None
         self._server: Any = None  # uvicorn.Server when using thread mode
         self._local_handler: Any = None  # in-process handler for tinker
@@ -212,11 +220,16 @@ class GatewayManager:
         engine_cls = type(rollout_engine).__name__
 
         if engine_cls in ("TinkerEngine", "FireworksEngine"):
-            # In-process handler — no HTTP backend, no worker registration
-            from rllm.gateway.tinker_adapter import create_tinker_handler
+            if self.num_workers >= 1:
+                # Run the gateway (with its own rebuilt engine) in a separate
+                # process so its event loop no longer shares the trainer's GIL.
+                self._start_gateway_subprocess(rollout_engine)
+            else:
+                # In-process handler — no HTTP backend, no worker registration.
+                from rllm.gateway.tinker_adapter import create_tinker_handler
 
-            self._local_handler = create_tinker_handler(rollout_engine)
-            self._start_thread(local_handler=self._local_handler)
+                self._local_handler = create_tinker_handler(rollout_engine)
+                self._start_thread(local_handler=self._local_handler)
         elif engine_cls == "VerlEngine":
             if self.mode == "process":
                 self._start_process()
@@ -266,6 +279,13 @@ class GatewayManager:
             except subprocess.TimeoutExpired:
                 self._process.kill()
             self._process = None
+
+        if self._handler_config_path is not None:
+            try:
+                os.unlink(self._handler_config_path)
+            except OSError:
+                pass
+            self._handler_config_path = None
 
         if self._server is not None:
             self._server.should_exit = True
@@ -339,8 +359,43 @@ class GatewayManager:
 
     # -- Internal ------------------------------------------------------------
 
-    def _start_process(self) -> None:
-        """Launch gateway as a subprocess and poll until healthy."""
+    def _start_gateway_subprocess(self, rollout_engine: RolloutEngine) -> None:
+        """Run the gateway in its own process with a rebuilt in-process handler.
+
+        The live engine can't cross a process boundary, so the subprocess rebuilds
+        an equivalent one from ``engine.handler_factory_spec()`` (see
+        ``rllm.gateway.worker_handlers``). N=1 only for now (single process, no
+        session sharding); >1 needs the session-sticky front router.
+        """
+        import json
+        import tempfile
+
+        if self.num_workers > 1:
+            raise NotImplementedError(
+                "rllm.gateway.num_workers > 1 requires the session-sticky front router (not yet implemented). "
+                "Use num_workers=1 for a single separate gateway process, or 0 for the in-trainer thread."
+            )
+        spec = getattr(rollout_engine, "handler_factory_spec", None)
+        if spec is None:
+            raise RuntimeError(
+                f"{type(rollout_engine).__name__} does not support a separate-process gateway "
+                "(no handler_factory_spec); set rllm.gateway.num_workers=0."
+            )
+        factory_path, cfg = spec()
+        fd, cfg_path = tempfile.mkstemp(prefix="rllm_gw_handler_", suffix=".json")
+        with os.fdopen(fd, "w") as f:
+            json.dump(cfg, f)
+        self._handler_config_path = cfg_path
+        # Building the engine (tokenizer load ×2 + renderer resolve) takes longer
+        # than a proxy-only start, so allow more startup headroom.
+        self._start_process(handler_factory=factory_path, handler_config_path=cfg_path, poll_timeout=max(_HEALTH_POLL_TIMEOUT, 180.0))
+
+    def _start_process(self, handler_factory: str | None = None, handler_config_path: str | None = None, poll_timeout: float | None = None) -> None:
+        """Launch gateway as a subprocess and poll until healthy.
+
+        With ``handler_factory``/``handler_config_path`` the subprocess builds an
+        in-process ``local_handler`` (backend engine) from that recipe; without
+        them it runs as a pure HTTP proxy to registered workers (verl path)."""
         cmd = [
             sys.executable,
             "-m",
@@ -359,6 +414,10 @@ class GatewayManager:
             cmd.append("--cumulative-token-mode")
             if self.renderer_family != "auto":
                 cmd.extend(["--renderer-family", self.renderer_family])
+        if handler_factory:
+            cmd.extend(["--handler-factory", handler_factory])
+            if handler_config_path:
+                cmd.extend(["--handler-config", handler_config_path])
 
         logger.info("Starting gateway subprocess: %s", " ".join(cmd))
         # Inherit parent's stdout/stderr so gateway logs are visible for debugging.
@@ -368,7 +427,8 @@ class GatewayManager:
         self._process = subprocess.Popen(cmd)
 
         # Poll health endpoint
-        deadline = time.monotonic() + _HEALTH_POLL_TIMEOUT
+        timeout = poll_timeout if poll_timeout is not None else _HEALTH_POLL_TIMEOUT
+        deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
                 self.client.health()
@@ -380,7 +440,7 @@ class GatewayManager:
                 time.sleep(_HEALTH_POLL_INTERVAL)
 
         self._process.terminate()
-        raise TimeoutError(f"Gateway did not become healthy within {_HEALTH_POLL_TIMEOUT}s")
+        raise TimeoutError(f"Gateway did not become healthy within {timeout}s")
 
     def _start_thread(self, local_handler: Any = None) -> None:
         """Start gateway in a background thread using create_app + uvicorn."""

--- a/rllm/gateway/worker_handlers.py
+++ b/rllm/gateway/worker_handlers.py
@@ -1,0 +1,72 @@
+"""Handler factories for running the model gateway in a separate process.
+
+The gateway's in-process ``local_handler`` (a rollout engine) can't cross a
+process boundary, so a separate-process gateway rebuilds an equivalent one from
+a serializable spec. ``GatewayManager`` obtains the spec via
+``engine.handler_factory_spec()`` -> ``(import_path, config)`` and spawns
+``python -m rllm_model_gateway --handler-factory <import_path>
+--handler-config <config.json>``; the gateway process then imports the factory
+named here and calls it with the config to build its ``local_handler``.
+
+Each backend supplies its own factory (Fireworks below; Tinker would add one
+that recreates a ``SamplingClient`` from a ``sampler_path``). The generic
+multi-process machinery in the gateway package stays backend-agnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def build_fireworks_handler(config: dict[str, Any]) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+    """Rebuild a Fireworks ``local_handler`` from ``FireworksEngine.handler_factory_spec``.
+
+    Attaches to the *same* deployment as the trainer (via ``inference_url`` +
+    ``model``) — this is just a fresh HTTP client, not a re-provision. The API
+    key is read from ``FIREWORKS_API_KEY`` (inherited env), never serialized.
+    """
+    from fireworks.training.sdk import DeploymentSampler
+    from transformers import AutoTokenizer
+
+    from rllm.engine.rollout.fireworks_engine import FireworksEngine
+    from rllm.gateway.tinker_adapter import create_tinker_handler
+
+    api_key = os.environ.get("FIREWORKS_API_KEY")
+    if not api_key:
+        raise RuntimeError("FIREWORKS_API_KEY not set in the gateway process env; cannot build the Fireworks sampler.")
+
+    tokenizer_model = config["tokenizer_model"]
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
+
+    sampler = DeploymentSampler(
+        inference_url=config["inference_url"],
+        model=config["model"],
+        api_key=api_key,
+        tokenizer=tokenizer,
+    )
+
+    engine = FireworksEngine(
+        tokenizer=tokenizer,
+        sampler=sampler,
+        max_prompt_length=config["max_prompt_length"],
+        max_response_length=config["max_response_length"],
+        max_model_length=config["max_model_length"],
+        sampling_params=config.get("sampling_params"),
+        reasoning_effort=config.get("reasoning_effort", "medium"),
+        accumulate_reasoning=config.get("accumulate_reasoning", False),
+        router_replay=config.get("router_replay", False),
+        sample_timeout=config.get("sample_timeout", 600),
+        renderer_family=config.get("renderer_family", "auto"),
+        bypass_render_with_parser=config.get("bypass_render_with_parser", False),
+    )
+    logger.info(
+        "Built Fireworks gateway handler (deployment=%s, tokenizer=%s, renderer_family=%s)",
+        config.get("model"),
+        tokenizer_model,
+        config.get("renderer_family"),
+    )
+    return create_tinker_handler(engine)

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -164,6 +164,10 @@ remote_runtime:
 gateway:
   port: 9090
   host: null          # Auto-detects routable IP; set explicitly to override
+  num_workers: 0      # 0 = gateway runs in a trainer thread (shares the trainer's GIL).
+                      # 1 = run it in its own process (own event loop/GIL; recommended when the
+                      # gateway is CPU-bound and contends with the trainer). >1 (multiple gateway
+                      # processes with session-sticky routing) is not yet implemented.
   tunnel: null        # Reach the gateway from remote sandboxes. When null and a run uses remote
                       # sandboxes, it auto-resolves: $RLLM_GATEWAY_TUNNEL -> a running `rllm tunnel up`
                       # daemon -> a free Cloudflare quick tunnel (shared/rate-limited; warns). Or set

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -584,6 +584,22 @@ class UnifiedTrainer:
         pbar = tqdm(total=total_tasks, desc="Tasks", unit="task")
         buffer._pbar = pbar
 
+        # Trainer event-loop health monitor (diagnostic). Mirrors the gateway's:
+        # high lag + high thread_cpu => the trainer loop is self-CPU bound (e.g.
+        # on-loop enrich / batch prep); high lag + low thread_cpu => starved.
+        # inflight/pending come from the agent-flow engine's concurrency slots.
+        from rllm.utils.loop_health import run_loop_health_monitor
+
+        def _trainer_gauges() -> str:
+            eng = self.agent_workflow_engine
+            parts = []
+            for name in ("inflight", "pending"):
+                v = getattr(eng, name, None)
+                if isinstance(v, int) and v >= 0:
+                    parts.append(f"{name}={v}")
+            return " ".join(parts)
+
+        monitor_task = asyncio.create_task(run_loop_health_monitor("trainer", gauges=_trainer_gauges))
         try:
             gen_task = asyncio.create_task(self._generation_loop(trainer_state, buffer, coordinator))
             await self._training_loop(trainer_state, buffer, coordinator, aggregator)
@@ -594,6 +610,7 @@ class UnifiedTrainer:
                 except asyncio.CancelledError:
                     pass
         finally:
+            monitor_task.cancel()
             pbar.close()
 
     async def _generation_loop(

--- a/rllm/utils/loop_health.py
+++ b/rllm/utils/loop_health.py
@@ -1,0 +1,82 @@
+"""Event-loop health monitor.
+
+Mirrors the model gateway's ``_loop_health_monitor`` so the *trainer's* single
+event loop is observable too. It periodically logs:
+
+- ``lag_ms`` — how much longer than the sample interval a bare ``sleep`` took,
+  i.e. how long the loop couldn't run a scheduled callback (backlog / blocking).
+- ``thread_cpu`` — this thread's own CPU utilisation over the window, which
+  disambiguates *why*: high lag + high thread_cpu = self-CPU bound (do less /
+  offload); high lag + low thread_cpu = the thread is starved (GIL contention).
+- optional caller-supplied gauges (e.g. in-flight rollouts).
+
+Diagnostic only — no behavioural effect. Run it as a background task on the loop
+you want to observe and cancel it on shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+# This is a purpose-built diagnostic; keep it visible even when the surrounding
+# rllm.* hierarchy is raised to WARNING. Only affects this logger.
+logger.setLevel(logging.INFO)
+
+
+async def run_loop_health_monitor(
+    label: str,
+    *,
+    sample_s: float = 0.5,
+    report_s: float = 20.0,
+    gauges: Callable[[], str] | None = None,
+) -> None:
+    """Log ``label`` loop health every ``report_s`` until cancelled.
+
+    ``gauges``, if given, returns a short string appended to each log line
+    (e.g. ``"inflight=193 pending=42"``); exceptions from it are ignored.
+    """
+    lags: list[float] = []
+    window_start = time.monotonic()
+    last_cpu = time.thread_time()
+    next_report = window_start + report_s
+    while True:
+        t0 = time.monotonic()
+        try:
+            await asyncio.sleep(sample_s)
+        except asyncio.CancelledError:
+            return
+        lags.append(max(0.0, (time.monotonic() - t0 - sample_s) * 1000.0))
+        now = time.monotonic()
+        if now >= next_report and lags:
+            window = now - window_start
+            cpu = time.thread_time()
+            util = 100.0 * (cpu - last_cpu) / window if window > 0 else 0.0
+            ordered = sorted(lags)
+            p50 = ordered[len(ordered) // 2]
+            p99 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.99))]
+            extra = ""
+            if gauges is not None:
+                try:
+                    g = gauges()
+                    if g:
+                        extra = " | " + g
+                except Exception:  # noqa: BLE001 - a gauge must never break the monitor
+                    pass
+            logger.info(
+                "%s loop health: lag_ms p50=%.0f p99=%.0f max=%.0f | thread_cpu=%.0f%% | window=%.0fs%s",
+                label,
+                p50,
+                p99,
+                ordered[-1],
+                util,
+                window,
+                extra,
+            )
+            lags.clear()
+            last_cpu = cpu
+            window_start = now
+            next_report = now + report_s


### PR DESCRIPTION
## Summary
During `terminal-rl` training the gateway was flooded with `TokenAccumulator duplicate … regenerating in place` logs and ~47% of rollouts hit `TIMEOUT`. Root cause: the model gateway's single asyncio event loop (a thread inside the trainer process) was CPU-saturated under high concurrency (~200–378 in-flight requests), so it couldn't flush responses / fire heartbeats in time → connections were idle-cut → the agent's retry stack re-sent identical requests. This PR diagnoses it, cuts the per-request CPU, and makes the gateway runnable in its own process.

## What's here (grouped)

**Diagnosis / observability**
- Gateway `loop health` monitor: logs event-loop lag (p50/p99/max), the loop thread's CPU%, and in-flight generations every ~20s; stamps `inflight`/`loop_lag_ms` onto duplicate lines. The CPU% disambiguates *self-CPU-bound* vs *GIL-starved*.
- Trainer `loop health` monitor (same technique) + `AgentFlowEngine` `inflight`/`pending` gauges, so the trainer loop is observable too.

**Per-request CPU reductions** (the loop was self-CPU bound at ~98% of one core)
- orjson on all hot JSON paths — our request parse / response serialize, the httpx request body (incl. the ≤120K-token prompt, via a guarded `encode_json` patch), and the Fireworks SDK's streaming response parse — each with a stdlib fallback.
- Offload tokenizer render/bridge and trace `build`+`model_dump` off the event-loop thread (executor / background task), and stop capturing unused raw request/response payloads on traces.

**Reliability**
- Whitespace heartbeat extended to the cumulative (turn-1+) path (was turn-0 only) so long byte-silent calls aren't idle-cut.
- Bounded the Fireworks sampling-retry hold time so a stalled retry can't hold a client connection past its tolerance.

**Scaling: separate-process gateway (opt-in)**
- `rllm.gateway.num_workers` (default `0` = in-trainer thread, unchanged). `1` = run the gateway in its own process (own event loop / GIL) so it no longer contends with the trainer. Backend-agnostic handler-factory: the gateway package launches `--handler-factory module:func --handler-config x.json`; rLLM supplies `FireworksEngine.handler_factory_spec()` + `rllm.gateway.worker_handlers.build_fireworks_handler` (rebuilds a `DeploymentSampler` attached to the *same* deployment; API key from env, never serialized). `>1` (multiple workers + session-sticky front) is scoped as a follow-up.

## Config
- `rllm.gateway.num_workers: 0|1` (default `0`).
- New dependency: `orjson`.

## Impact (measured / observed)
- Per-op: 120K-token prompt serialize ~4ms→sub-ms; 16K-token response serialize ~20ms→1.8ms; SDK per-chunk parse ~3×; trace build+dump ~5.7ms moved off the loop + critical path.
- End-to-end (`num_workers=1`, all changes): gateway `loop health` went from **p99 lag ~7s / thread_cpu 98% (shared)** to **p99 ~626ms / 90% (dedicated)** at ~200 in-flight; the duplicate flood dropped accordingly.

## Validation
- 236 gateway unit tests pass.
- Separate-process plumbing validated end-to-end with a dummy handler factory; the Fireworks spec↔factory key contract is checked. The live `build_fireworks_handler` (real `DeploymentSampler` attach) is exercised by a training run.

## Follow-ups (not in this PR)
- `num_workers>1`: session-sticky front router + a `ConsistentHashPolicy`, weight-version broadcast to all workers, and routing session-keyed ops (traces / delete / sampling-params) to the owning worker.
- Offload `enrich_episode_with_traces` if the trainer loop monitor shows it saturating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
