### PR TITLE
Multi-worker gateway: session-sharding front + N worker processes (num_workers>1)

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/front.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/front.py
@@ -1,0 +1,191 @@
+"""Thin session-sharding reverse proxy ("front") for multi-worker gateways.
+
+Runs in front of N backend gateway workers (each an ordinary
+``num_workers=1`` gateway) and routes by ``session_id``:
+
+- ``/sessions/{sid}/...`` (chat, traces, get, delete) → the worker that owns
+  ``{sid}`` (deterministic ``ConsistentHashPolicy`` over the fixed worker set).
+  The **original path is forwarded unchanged**, so the worker's own middleware
+  keys its per-session state — the whole reason the front is a pass-through and
+  not the gateway app in proxy mode.
+- ``POST /sessions`` (create): ``{sid}`` is in the body → route to its owner.
+- global ops (``POST /admin/weight_version|flush|reload``,
+  ``POST /sessions/batch_delete``) → fan out to all workers.
+- ``/health`` → ok.
+
+Responses are **streamed** through (preserves SSE + the whitespace heartbeat).
+The front never parses chat bodies or touches session state — the workers do
+all of that. It is deliberately thin so one core routes for many workers; run
+several via SO_REUSEPORT if it ever saturates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
+import httpx
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+from rllm_model_gateway import fastjson
+from rllm_model_gateway.models import WorkerInfo
+from rllm_model_gateway.session_router import ConsistentHashPolicy
+
+logger = logging.getLogger(__name__)
+
+# Global ops that must reach every worker (workers hold their own shard of state
+# / build their own traces), not a single session's owner.
+_GLOBAL_POST_PATHS = frozenset({"/admin/weight_version", "/admin/flush", "/admin/reload", "/sessions/batch_delete"})
+
+_DROP_REQ_HEADERS = frozenset({"host", "content-length", "connection", "keep-alive", "transfer-encoding", "te", "trailer", "upgrade"})
+_DROP_RESP_HEADERS = frozenset({"content-length", "connection", "keep-alive", "transfer-encoding", "te", "trailer", "upgrade"})
+
+
+def _extract_session_id(path: str) -> str | None:
+    """Extract ``{sid}`` from ``/sessions/{sid}/v1/...``, ``/sessions/{sid}/traces``,
+    or ``/sessions/{sid}``. ``{sid}`` may be multi-segment (e.g. ``harbor/task:0``)."""
+    prefix = "/sessions/"
+    if not path.startswith(prefix):
+        return None
+    rest = path[len(prefix) :]
+    for suffix in ("/v1", "/traces"):
+        i = rest.find(suffix + "/")
+        if i != -1:
+            return rest[:i]
+        if rest.endswith(suffix):
+            return rest[: -len(suffix)]
+    return rest or None
+
+
+class Front:
+    def __init__(self, worker_urls: list[str]) -> None:
+        if not worker_urls:
+            raise ValueError("front requires at least one --worker URL")
+        self.workers = [WorkerInfo(worker_id=str(i), url=u) for i, u in enumerate(worker_urls)]
+        self.policy = ConsistentHashPolicy()
+        self.policy.on_worker_change(self.workers)
+        self._client: httpx.AsyncClient | None = None
+
+    async def start(self) -> None:
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout=None),  # workers own the timeouts / heartbeat
+            follow_redirects=True,
+            limits=httpx.Limits(max_connections=1000, max_keepalive_connections=200),
+        )
+
+    async def stop(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    def _owner(self, session_id: str) -> WorkerInfo:
+        return self.policy.select_worker(self.workers, session_id, {})
+
+    def _req_headers(self, request: Request) -> dict[str, str]:
+        return {k: v for k, v in request.headers.items() if k.lower() not in _DROP_REQ_HEADERS}
+
+    def _resp_headers(self, resp: httpx.Response) -> dict[str, str]:
+        return {k: v for k, v in resp.headers.items() if k.lower() not in _DROP_RESP_HEADERS}
+
+    async def handle(self, request: Request) -> Response:
+        path = request.url.path
+        method = request.method
+        if path == "/health":
+            return JSONResponse({"status": "ok", "workers": len(self.workers)})
+
+        body = await request.body()
+
+        if method == "POST" and path in _GLOBAL_POST_PATHS:
+            return await self._fan_out(method, path, request, body)
+
+        if method == "POST" and path == "/sessions":  # create: sid in body
+            sid = None
+            try:
+                sid = fastjson.loads(body).get("session_id")
+            except Exception:  # noqa: BLE001
+                pass
+            target = self._owner(sid) if sid else self.workers[0]
+            return await self._forward(target, request, body, stream=False)
+
+        sid = _extract_session_id(path)
+        if sid is not None:
+            # Stream so SSE + the worker's whitespace heartbeat pass through.
+            return await self._forward(self._owner(sid), request, body, stream=True)
+
+        # Unrecognized (e.g. GET /sessions list, /traces/{id}) — best-effort to worker 0.
+        return await self._forward(self.workers[0], request, body, stream=False)
+
+    async def _forward(self, worker: WorkerInfo, request: Request, body: bytes, *, stream: bool) -> Response:
+        assert self._client is not None
+        url = f"{worker.url}{request.url.path}"
+        if request.url.query:
+            url = f"{url}?{request.url.query}"
+        headers = self._req_headers(request)
+
+        if not stream:
+            resp = await self._client.request(request.method, url, headers=headers, content=body or None)
+            return Response(content=resp.content, status_code=resp.status_code, headers=self._resp_headers(resp))
+
+        req = self._client.build_request(request.method, url, headers=headers, content=body or None)
+        resp = await self._client.send(req, stream=True)
+
+        async def _body_iter():
+            try:
+                async for chunk in resp.aiter_raw():
+                    yield chunk
+            finally:
+                await resp.aclose()
+
+        return StreamingResponse(_body_iter(), status_code=resp.status_code, headers=self._resp_headers(resp))
+
+    async def _fan_out(self, method: str, path: str, request: Request, body: bytes) -> Response:
+        assert self._client is not None
+        headers = self._req_headers(request)
+
+        async def _one(w: WorkerInfo):
+            try:
+                return await self._client.request(method, f"{w.url}{path}", headers=headers, content=body or None)
+            except Exception as e:  # noqa: BLE001
+                return e
+
+        results = await asyncio.gather(*[_one(w) for w in self.workers])
+        merged: dict = {"workers": len(self.workers), "ok": 0, "errors": 0, "deleted": 0}
+        weight_version = None
+        for r in results:
+            if isinstance(r, Exception):
+                merged["errors"] += 1
+                logger.warning("front fan-out to a worker failed for %s: %s", path, r)
+                continue
+            merged["ok"] += 1
+            try:
+                j = r.json()
+                if isinstance(j.get("deleted"), int):
+                    merged["deleted"] += j["deleted"]
+                if "weight_version" in j:
+                    weight_version = j["weight_version"]
+            except Exception:  # noqa: BLE001
+                pass
+        if weight_version is not None:
+            merged["weight_version"] = weight_version
+        return JSONResponse(merged)
+
+
+def create_front_app(worker_urls: list[str]) -> Starlette:
+    front = Front(worker_urls)
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette):
+        await front.start()
+        logger.info("Gateway front started over %d workers: %s", len(front.workers), [w.url for w in front.workers])
+        yield
+        await front.stop()
+
+    async def _catch_all(request: Request) -> Response:
+        return await front.handle(request)
+
+    routes = [Route("/{path:path}", _catch_all, methods=["GET", "POST", "PUT", "DELETE", "PATCH"])]
+    return Starlette(routes=routes, lifespan=lifespan)

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -379,9 +379,7 @@ class ReverseProxy:
         connection while the model generates. Leading spaces are insignificant
         JSON whitespace — parsed output is byte-identical for every client.
         """
-        return await self._respond_with_heartbeat(
-            self._non_streaming_result(request, raw_body, request_body, session_id, originally_requested_logprobs)
-        )
+        return await self._respond_with_heartbeat(self._non_streaming_result(request, raw_body, request_body, session_id, originally_requested_logprobs))
 
     async def _respond_with_heartbeat(self, result_coro: Awaitable[tuple[bytes, int]]) -> Response:
         """Await *result_coro* (returns ``(content_bytes, status_code)``); keep
@@ -576,9 +574,7 @@ class ReverseProxy:
         being idle-cut and re-sent as a duplicate.
         """
         return await self._respond_with_heartbeat(
-            self._cumulative_non_streaming_result(
-                request, request_body, completions_body, session_id, acc, token_ids, originally_requested_logprobs, replay=replay
-            )
+            self._cumulative_non_streaming_result(request, request_body, completions_body, session_id, acc, token_ids, originally_requested_logprobs, replay=replay)
         )
 
     async def _cumulative_non_streaming_result(

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -119,9 +119,13 @@ class ReverseProxy:
         heartbeat_interval_s: float = 25.0,
         heartbeat_budget_s: float = 3600.0,
         capture_raw_payloads: bool = False,
+        worker_label: str = "",
     ) -> None:
         self.router = router
         self.store = store
+        # Distinguishes this process's logs when several gateway workers run
+        # behind a front (num_workers>1); empty for the single-process case.
+        self.worker_label = f"[{worker_label}] " if worker_label else ""
         self.strip_vllm = strip_vllm
         self.sync_traces = sync_traces
         self.max_retries = max_retries
@@ -209,7 +213,8 @@ class ReverseProxy:
                 p50 = ordered[len(ordered) // 2]
                 p99 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.99))]
                 logger.info(
-                    "gateway loop health: lag_ms p50=%.0f p99=%.0f max=%.0f | thread_cpu=%.0f%% | inflight cur=%d max=%d | window=%.0fs",
+                    "%sgateway loop health: lag_ms p50=%.0f p99=%.0f max=%.0f | thread_cpu=%.0f%% | inflight cur=%d max=%d | window=%.0fs",
+                    self.worker_label,
                     p50,
                     p99,
                     ordered[-1],
@@ -327,7 +332,8 @@ class ReverseProxy:
                     # fresh sample (not a cached one) is returned, so a retry that
                     # depends on resampling still makes progress.
                     logger.info(
-                        "TokenAccumulator duplicate session=%s turn=%d age_s=%s inflight=%d loop_lag_ms=%.0f: regenerating in place, no reset",
+                        "%sTokenAccumulator duplicate session=%s turn=%d age_s=%s inflight=%d loop_lag_ms=%.0f: regenerating in place, no reset",
+                        self.worker_label,
                         session_id,
                         acc.turn_count,
                         plan.diagnostics.get("age_s", "?"),

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -559,15 +559,26 @@ def main() -> None:
         default=None,
         help="Path to a JSON file passed to --handler-factory.",
     )
+    parser.add_argument(
+        "--front",
+        action="store_true",
+        default=False,
+        help="Run as a thin session-sharding reverse proxy over the --worker gateways "
+        "(the front for rllm.gateway.num_workers>1). Routes by session_id; no local engine.",
+    )
 
     args = parser.parse_args()
     config = _load_config(args)
 
     logging.basicConfig(level=getattr(logging, config.log_level.upper(), logging.INFO))
 
-    local_handler = _load_handler_factory(args.handler_factory, args.handler_config) if args.handler_factory else None
+    if args.front:
+        from rllm_model_gateway.front import create_front_app
 
-    app = create_app(config, local_handler=local_handler)
+        app = create_front_app(getattr(args, "worker", None) or [])
+    else:
+        local_handler = _load_handler_factory(args.handler_factory, args.handler_config) if args.handler_factory else None
+        app = create_app(config, local_handler=local_handler)
 
     import uvicorn
 

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -193,6 +193,7 @@ def create_app(
         local_handler=local_handler,
         cumulative_token_mode=config.cumulative_token_mode,
         renderer=renderer,
+        worker_label=str(config.port) if config.port else "",
     )
     sessions = SessionManager(store)
 

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -573,6 +573,13 @@ def main() -> None:
 
     logging.basicConfig(level=getattr(logging, config.log_level.upper(), logging.INFO))
 
+    # httpx emits one INFO line per request; at high concurrency (especially the
+    # front's per-request forwards to workers, and workers' calls to Fireworks)
+    # that floods. Silence it unless debugging — our own INFO logs are separate.
+    if config.log_level.lower() != "debug":
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
+
     if args.front:
         from rllm_model_gateway.front import create_front_app
 

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -564,8 +564,7 @@ def main() -> None:
         "--front",
         action="store_true",
         default=False,
-        help="Run as a thin session-sharding reverse proxy over the --worker gateways "
-        "(the front for rllm.gateway.num_workers>1). Routes by session_id; no local engine.",
+        help="Run as a thin session-sharding reverse proxy over the --worker gateways (the front for rllm.gateway.num_workers>1). Routes by session_id; no local engine.",
     )
 
     args = parser.parse_args()

--- a/rllm-model-gateway/src/rllm_model_gateway/session_router.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/session_router.py
@@ -6,6 +6,7 @@ Reference implementations:
 """
 
 import asyncio
+import hashlib
 import logging
 from collections import OrderedDict
 from typing import Protocol
@@ -99,6 +100,40 @@ class StickyLeastLoadedPolicy:
 
     def on_worker_change(self, workers: list[WorkerInfo]) -> None:
         self._cache.clear()
+
+
+class ConsistentHashPolicy:
+    """Deterministic ``session_id`` -> worker mapping for multi-worker sharding.
+
+    Each gateway worker holds a shard of per-session state (TokenAccumulator,
+    traces, sampling params), so a session's chat turns AND its trace/session
+    control ops must always land on the *same* worker. We therefore hash the
+    session id (stable ``sha256``, not the salted builtin ``hash``) over the
+    **fixed registered worker set** in a stable order — health churn does not
+    change the mapping (a dead worker's sessions fail cleanly rather than
+    silently remapping to another worker that lacks their state).
+
+    Sessionless requests fall back to least-loaded over the (healthy) pool.
+    """
+
+    def __init__(self) -> None:
+        self._ordered: list[WorkerInfo] = []
+
+    def on_worker_change(self, workers: list[WorkerInfo]) -> None:
+        # Stable order so hash % N is deterministic; url is unique + stable.
+        self._ordered = sorted(workers, key=lambda w: w.url)
+
+    def select_worker(
+        self,
+        workers: list[WorkerInfo],
+        session_id: str | None,
+        active_counts: dict[str, int],
+    ) -> WorkerInfo:
+        if not session_id:
+            return min(workers, key=lambda w: active_counts.get(w.url, 0))
+        pool = self._ordered or sorted(workers, key=lambda w: w.url)
+        digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+        return pool[int(digest, 16) % len(pool)]
 
 
 # ------------------------------------------------------------------

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -29,8 +29,8 @@ For Tinker backends, an in-process handler is injected into the gateway
 from __future__ import annotations
 
 import logging
-import re
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -429,10 +429,7 @@ class GatewayManager:
 
         spec = getattr(rollout_engine, "handler_factory_spec", None)
         if spec is None:
-            raise RuntimeError(
-                f"{type(rollout_engine).__name__} does not support a separate-process gateway "
-                "(no handler_factory_spec); set rllm.gateway.num_workers=0."
-            )
+            raise RuntimeError(f"{type(rollout_engine).__name__} does not support a separate-process gateway (no handler_factory_spec); set rllm.gateway.num_workers=0.")
         factory_path, cfg = spec()
         fd, cfg_path = tempfile.mkstemp(prefix="rllm_gw_handler_", suffix=".json")
         with os.fdopen(fd, "w") as f:

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -179,6 +179,7 @@ class GatewayManager:
         self.mode = mode
 
         self._process: subprocess.Popen | None = None
+        self._processes: list[subprocess.Popen] = []  # workers + front for num_workers>1
         self._handler_config_path: str | None = None  # temp file for --handler-config (cleaned up in stop)
         self._thread: threading.Thread | None = None
         self._server: Any = None  # uvicorn.Server when using thread mode
@@ -272,13 +273,17 @@ class GatewayManager:
             self._client.close()
             self._client = None
 
-        if self._process is not None:
-            self._process.terminate()
+        # Terminate the single process (verl / num_workers=1) and any multi-worker
+        # processes (front is last in the list; terminate it first so it stops
+        # routing before the workers go away).
+        for proc in ([self._process] if self._process is not None else []) + list(reversed(self._processes)):
+            proc.terminate()
             try:
-                self._process.wait(timeout=5)
+                proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                self._process.kill()
-            self._process = None
+                proc.kill()
+        self._process = None
+        self._processes = []
 
         if self._handler_config_path is not None:
             try:
@@ -359,22 +364,69 @@ class GatewayManager:
 
     # -- Internal ------------------------------------------------------------
 
-    def _start_gateway_subprocess(self, rollout_engine: RolloutEngine) -> None:
-        """Run the gateway in its own process with a rebuilt in-process handler.
+    def _gateway_cmd(
+        self,
+        port: int,
+        *,
+        handler_factory: str | None = None,
+        handler_config_path: str | None = None,
+        front: bool = False,
+        worker_urls: list[str] | None = None,
+    ) -> list[str]:
+        """Build a ``python -m rllm_model_gateway`` command for one process."""
+        cmd = [sys.executable, "-m", "rllm_model_gateway", "--host", "0.0.0.0", "--port", str(port), "--store", self.store]
+        if self.db_path:
+            cmd += ["--db-path", self.db_path]
+        if front:
+            cmd.append("--front")
+            for u in worker_urls or []:
+                cmd += ["--worker", u]
+            return cmd
+        if self.model:
+            cmd += ["--model", self.model]
+        if self.cumulative_token_mode:
+            cmd.append("--cumulative-token-mode")
+            if self.renderer_family != "auto":
+                cmd += ["--renderer-family", self.renderer_family]
+        if handler_factory:
+            cmd += ["--handler-factory", handler_factory]
+            if handler_config_path:
+                cmd += ["--handler-config", handler_config_path]
+        return cmd
 
-        The live engine can't cross a process boundary, so the subprocess rebuilds
-        an equivalent one from ``engine.handler_factory_spec()`` (see
-        ``rllm.gateway.worker_handlers``). N=1 only for now (single process, no
-        session sharding); >1 needs the session-sticky front router.
+    def _poll_health(self, port: int, proc: subprocess.Popen, timeout: float) -> None:
+        """Poll ``http://127.0.0.1:{port}/health`` until healthy, ``proc`` dies, or timeout."""
+        from rllm_model_gateway.client import GatewayClient
+
+        client = GatewayClient(f"http://127.0.0.1:{port}")
+        try:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                try:
+                    client.health()
+                    logger.info("Gateway healthy on port %d", port)
+                    return
+                except Exception as e:
+                    if proc.poll() is not None:
+                        raise RuntimeError(f"Gateway process on port {port} exited unexpectedly (rc={proc.returncode})") from e
+                    time.sleep(_HEALTH_POLL_INTERVAL)
+            proc.terminate()
+            raise TimeoutError(f"Gateway on port {port} did not become healthy within {timeout}s")
+        finally:
+            client.close()
+
+    def _start_gateway_subprocess(self, rollout_engine: RolloutEngine) -> None:
+        """Run the gateway in its own process(es) with a rebuilt in-process handler.
+
+        The live engine can't cross a process boundary, so each worker subprocess
+        rebuilds an equivalent one from ``engine.handler_factory_spec()`` (see
+        ``rllm.gateway.worker_handlers``). ``num_workers==1`` runs one gateway on
+        ``self.port``; ``>1`` runs N workers on ``port+1..port+N`` behind a thin
+        session-sharding front on ``self.port`` (the tunnel target).
         """
         import json
         import tempfile
 
-        if self.num_workers > 1:
-            raise NotImplementedError(
-                "rllm.gateway.num_workers > 1 requires the session-sticky front router (not yet implemented). "
-                "Use num_workers=1 for a single separate gateway process, or 0 for the in-trainer thread."
-            )
         spec = getattr(rollout_engine, "handler_factory_spec", None)
         if spec is None:
             raise RuntimeError(
@@ -386,61 +438,39 @@ class GatewayManager:
         with os.fdopen(fd, "w") as f:
             json.dump(cfg, f)
         self._handler_config_path = cfg_path
-        # Building the engine (tokenizer load ×2 + renderer resolve) takes longer
-        # than a proxy-only start, so allow more startup headroom.
-        self._start_process(handler_factory=factory_path, handler_config_path=cfg_path, poll_timeout=max(_HEALTH_POLL_TIMEOUT, 180.0))
+        # Building the engine (tokenizer load + renderer resolve) takes longer than
+        # a proxy-only start, so allow more startup headroom per worker.
+        worker_timeout = max(_HEALTH_POLL_TIMEOUT, 180.0)
 
-    def _start_process(self, handler_factory: str | None = None, handler_config_path: str | None = None, poll_timeout: float | None = None) -> None:
-        """Launch gateway as a subprocess and poll until healthy.
+        if self.num_workers == 1:
+            cmd = self._gateway_cmd(self.port, handler_factory=factory_path, handler_config_path=cfg_path)
+            logger.info("Starting gateway subprocess: %s", " ".join(cmd))
+            self._process = subprocess.Popen(cmd)
+            self._poll_health(self.port, self._process, worker_timeout)
+            return
 
-        With ``handler_factory``/``handler_config_path`` the subprocess builds an
-        in-process ``local_handler`` (backend engine) from that recipe; without
-        them it runs as a pure HTTP proxy to registered workers (verl path)."""
-        cmd = [
-            sys.executable,
-            "-m",
-            "rllm_model_gateway",
-            "--host",
-            "0.0.0.0",
-            "--port",
-            str(self.port),
-        ]
-        cmd.extend(["--store", self.store])
-        if self.db_path:
-            cmd.extend(["--db-path", self.db_path])
-        if self.model:
-            cmd.extend(["--model", self.model])
-        if self.cumulative_token_mode:
-            cmd.append("--cumulative-token-mode")
-            if self.renderer_family != "auto":
-                cmd.extend(["--renderer-family", self.renderer_family])
-        if handler_factory:
-            cmd.extend(["--handler-factory", handler_factory])
-            if handler_config_path:
-                cmd.extend(["--handler-config", handler_config_path])
+        # num_workers > 1: N workers on port+1..port+N behind a front on self.port.
+        worker_ports = [self.port + 1 + i for i in range(self.num_workers)]
+        for port in worker_ports:
+            cmd = self._gateway_cmd(port, handler_factory=factory_path, handler_config_path=cfg_path)
+            logger.info("Starting gateway worker subprocess: %s", " ".join(cmd))
+            proc = subprocess.Popen(cmd)
+            self._processes.append(proc)
+            self._poll_health(port, proc, worker_timeout)
+        worker_urls = [f"http://127.0.0.1:{p}" for p in worker_ports]
+        front_cmd = self._gateway_cmd(self.port, front=True, worker_urls=worker_urls)
+        logger.info("Starting gateway front subprocess: %s", " ".join(front_cmd))
+        front = subprocess.Popen(front_cmd)
+        self._processes.append(front)
+        self._poll_health(self.port, front, _HEALTH_POLL_TIMEOUT)
+        logger.info("Gateway running with %d workers behind front on port %d", self.num_workers, self.port)
 
+    def _start_process(self) -> None:
+        """Launch the gateway as a subprocess (verl HTTP-proxy path) and poll until healthy."""
+        cmd = self._gateway_cmd(self.port)
         logger.info("Starting gateway subprocess: %s", " ".join(cmd))
-        # Inherit parent's stdout/stderr so gateway logs are visible for debugging.
-        # subprocess.PIPE causes problems as without an active reader, the OS pipe
-        # buffer (~64KB on Linux) fills up under high-throughput logging, causing the
-        # gateway process to block on write and eventually hang.
         self._process = subprocess.Popen(cmd)
-
-        # Poll health endpoint
-        timeout = poll_timeout if poll_timeout is not None else _HEALTH_POLL_TIMEOUT
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            try:
-                self.client.health()
-                logger.info("Gateway process healthy at %s", self.gateway_url)
-                return
-            except Exception as e:
-                if self._process.poll() is not None:
-                    raise RuntimeError(f"Gateway process exited unexpectedly (rc={self._process.returncode})") from e
-                time.sleep(_HEALTH_POLL_INTERVAL)
-
-        self._process.terminate()
-        raise TimeoutError(f"Gateway did not become healthy within {timeout}s")
+        self._poll_health(self.port, self._process, _HEALTH_POLL_TIMEOUT)
 
     def _start_thread(self, local_handler: Any = None) -> None:
         """Start gateway in a background thread using create_app + uvicorn."""

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -166,8 +166,10 @@ gateway:
   host: null          # Auto-detects routable IP; set explicitly to override
   num_workers: 0      # 0 = gateway runs in a trainer thread (shares the trainer's GIL).
                       # 1 = run it in its own process (own event loop/GIL; recommended when the
-                      # gateway is CPU-bound and contends with the trainer). >1 (multiple gateway
-                      # processes with session-sticky routing) is not yet implemented.
+                      # gateway is CPU-bound and contends with the trainer).
+                      # >1 = N gateway worker processes (ports port+1..port+N) behind a thin
+                      # session-sharding front on `port`, to spread the gateway's per-request CPU
+                      # across cores. Use when one gateway process still saturates its core.
   tunnel: null        # Reach the gateway from remote sandboxes. When null and a run uses remote
                       # sandboxes, it auto-resolves: $RLLM_GATEWAY_TUNNEL -> a running `rllm tunnel up`
                       # daemon -> a free Cloudflare quick tunnel (shared/rate-limited; warns). Or set


### PR DESCRIPTION
## Summary
Follow-up to #727 (separate-process gateway). Adds **`rllm.gateway.num_workers > 1`**: run N gateway **worker** processes behind a thin **session-sharding front**, to spread the gateway's per-request CPU across cores when a single gateway process saturates its one core.

`num_workers`: `0` = in-trainer thread (default, unchanged), `1` = one separate gateway process (from #727), `>1` = N workers + front (this PR).

## Design
```
agents ─tunnel─► FRONT (port P) ──route by session_id──► worker i (port P+1+i)
trainer ───────► FRONT (port P) ── same router ─────────►  (control ops)
```
- **Workers** = N × the ordinary `num_workers=1` gateway (each with its own rebuilt `FireworksEngine` via the handler-factory, cumulative ON), one per port `P+1..P+N`. **Unchanged worker code.**
- **Front** (`front.py`) = a thin reverse proxy on the tunnel port. Routes `/sessions/{sid}/…` to the owning worker via a deterministic `ConsistentHashPolicy` (stable sha256 over the fixed worker set), **forwarding the original path** so each worker's own middleware keys its per-session state; responses are **streamed** so SSE + the heartbeat pass through. Global ops (`weight_version`/`flush`/`batch_delete`) fan out to all workers.
- Trainer↔gateway control plane is **unchanged** — it hits the front (`port`), which routes/fans-out, so `set_weight_version` / `aget_traces` / `adelete_session` need no changes.

## Why the front is a thin pass-through (not the gateway app in proxy mode)
The gateway's `SessionRoutingMiddleware` strips `/sessions/{sid}/v1/…` → `/v1/…`. If the front did that, the worker would never see `{sid}` in the path → its per-session `TokenAccumulator` couldn't key → cumulative-token mode breaks. So the front forwards the original path and the workers do all the gateway logic.

## Changes
- `ConsistentHashPolicy` (`session_router.py`) — deterministic session→worker mapping over the fixed set (chat *and* trace/control ops always hit the owner; health churn doesn't remap).
- `front.py` — the thin session-sharding reverse proxy (route-to-owner + fan-out + `/health`), streaming.
- `server.py` — `--front` entrypoint; silence httpx per-request INFO logs (the front's per-request forwards flooded stdout).
- `manager.py` — spawn N workers + front, health-poll all, teardown all; `num_workers` config.
- Per-worker log labels (`[<port>] gateway loop health / duplicate …`).

## Validation
- `ConsistentHashPolicy`: determinism + balanced distribution (unit).
- Front over 2 dummy workers: sticky routing (same sid→same worker across repeats), traces→owner, `weight_version` fan-out reaching both, delete→owner.
- Manager-driven smoke (2 workers + front): requests shard across both worker pids, sticky, fan-out, spawn + teardown.
- 236 gateway unit tests pass.

## Needs a live run to validate
- `build_fireworks_handler` constructing N real engines attached to the same deployment; cumulative-token correctness under real sharding.

## Follow-ups (not in this PR)
- Front loop-health monitor (the front has none; add if it saturates, or run multiple fronts via `SO_REUSEPORT`).
- Renderer/tokenizer parity self-check per worker.
- Explicit worker-death handling/logging (fixed-set hashing already fails a dead worker's sessions cleanly).

Note: the async-training throughput dynamics I've been investigating separately (concurrency gated by straggler group-completion + the staleness quota) are **orthogonal** to this PR — multi-worker gateway helps only when the *gateway* is the bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
