### PR TITLE
feat(async): continuous rollout dispatch (capacity-based)

### DIFF
--- a/rllm/trainer/sync_coordinator.py
+++ b/rllm/trainer/sync_coordinator.py
@@ -1,4 +1,4 @@
-"""SyncCoordinator: manages rollout quotas and parameter sync timing for fully-async training."""
+"""SyncCoordinator: manages rollout capacity and parameter sync timing for fully-async training."""
 
 from __future__ import annotations
 
@@ -12,39 +12,54 @@ class SyncCoordinatorConfig:
     group_size: int  # episodes per group (rollout.n)
     staleness_threshold: float
     trigger_parameter_sync_step: int
+    max_concurrent_rollouts: int  # rollout tasks kept in flight (== workflow.n_parallel_tasks)
 
     @property
-    def max_rollout_quota(self) -> int:
-        """Max dispatches per sync window (Verl/AReaL formulation)."""
+    def max_in_flight_groups(self) -> int:
+        """Staleness cap: groups dispatched-but-not-consumed may not exceed this.
+
+        Keeps generation at most (1 + staleness_threshold) mini-batches ahead of
+        training. Equivalent to the version-scaled ceiling
+        ``(staleness + version + 1) * mini_batch``, just expressed in the
+        consumption frame; the two match because the version advances one
+        mini-batch per optimizer step.
+        """
         return int((1 + self.staleness_threshold) * self.trigger_parameter_sync_step * self.mini_batch_size)
 
 
 class SyncCoordinator:
     """Coordinates rollout scheduling and parameter sync between generation and training loops.
 
-    Uses a per-sync-window dispatch counter (matching Verl/AReaL). The counter
-    resets only on weight sync, not on consume. This guarantees zero staleness
-    when staleness_threshold=0.
+    Dispatch is governed by a continuously-evaluated capacity::
+
+        capacity > 0  iff  in_flight_groups < max_in_flight_groups        (staleness)
+                      and  running_rollouts  < max_concurrent_rollouts    (concurrency)
+
+    Both terms are re-checked (and generation is woken) whenever a group is
+    consumed/filtered or a rollout task completes -- so freed budget is refilled
+    immediately rather than in a burst at weight sync. This keeps the rollout
+    workers saturated across a step instead of front-loading the sync window and
+    idling until the next sync.
     """
 
     def __init__(self, config: SyncCoordinatorConfig):
         self.config = config
 
         self._weight_version: int = 0
-        self._quota_used: int = 0  # groups counting toward current sync window quota (includes carryover)
-        self._in_flight: int = 0  # groups dispatched but not yet consumed/filtered
+        self._in_flight: int = 0  # groups dispatched but not yet consumed/filtered (staleness budget)
         self._steps_since_sync: int = 0
         self._total_syncs: int = 0
 
-        # Throttle — blocks generation when dispatched_since_sync >= max_rollout_quota
-        self._throttle_event: asyncio.Event = asyncio.Event()
-        self._throttle_event.set()
+        # Capacity gate — set whenever staleness or concurrency budget frees up.
+        # Generation waits on it and re-checks has_capacity() (level-triggered).
+        self._capacity_event: asyncio.Event = asyncio.Event()
+        self._capacity_event.set()
 
         # Generation pause — blocks generation during validation or weight sync
         self._generation_paused: asyncio.Event = asyncio.Event()
         self._generation_paused.set()
 
-        # Tracks in-flight async rollout tasks for drain/wait logic
+        # Tracks in-flight async rollout tasks for drain/wait logic + concurrency term
         self._in_flight_tasks: set[asyncio.Task] = set()
         self._task_errors: list[BaseException] = []
         self._task_error_event: asyncio.Event = asyncio.Event()
@@ -53,34 +68,46 @@ class SyncCoordinator:
     def weight_version(self) -> int:
         return self._weight_version
 
-    # --- Throttle ---
+    # --- Capacity (continuous dispatch control) ---
 
-    def on_group_dispatched(self) -> None:
-        """Generation loop dispatched one prompt (n rollouts)."""
-        self._quota_used += 1
-        self._in_flight += 1
-        if self._quota_used >= self.config.max_rollout_quota:
-            self._throttle_event.clear()
+    def _signal_capacity(self) -> None:
+        """Wake the generation loop to re-evaluate capacity."""
+        self._capacity_event.set()
 
-    def on_group_consumed(self) -> None:
-        """Training loop consumed one group from the buffer."""
-        self._in_flight = max(0, self._in_flight - 1)
+    def has_capacity(self) -> bool:
+        """Whether the generation loop may dispatch another group right now.
 
-    def on_group_filtered(self) -> None:
-        """Accumulator filtered out a group. Releases in-flight and quota."""
-        self._in_flight = max(0, self._in_flight - 1)
-        self._quota_used = max(0, self._quota_used - 1)
-        if self._quota_used < self.config.max_rollout_quota:
-            self._throttle_event.set()
+        min(concurrency_capacity, staleness_capacity) > 0.
+        """
+        staleness_ok = self._in_flight < self.config.max_in_flight_groups
+        concurrency_ok = len(self._in_flight_tasks) < self.config.max_concurrent_rollouts
+        return staleness_ok and concurrency_ok
 
-    async def wait_for_throttle(self) -> None:
-        """Generation loop blocks here when dispatch window is full."""
-        await self._throttle_event.wait()
+    async def wait_for_capacity(self) -> None:
+        """Block until there is capacity to dispatch another group.
+
+        Level-triggered: signallers may set the event when only one of the two
+        constraints frees, so we loop and re-check has_capacity().
+        """
+        while not self.has_capacity():
+            self._capacity_event.clear()
+            await self._capacity_event.wait()
+            self.raise_if_task_failed()
         self.raise_if_task_failed()
 
-    def has_quota(self) -> bool:
-        """Whether the generation loop can dispatch another group."""
-        return self._quota_used < self.config.max_rollout_quota
+    def on_group_dispatched(self) -> None:
+        """Generation loop dispatched one group (group_size rollouts)."""
+        self._in_flight += 1
+
+    def on_group_consumed(self) -> None:
+        """Training loop consumed one group from the buffer. Frees staleness budget."""
+        self._in_flight = max(0, self._in_flight - 1)
+        self._signal_capacity()
+
+    def on_group_filtered(self) -> None:
+        """Accumulator filtered out a group. Frees staleness budget."""
+        self._in_flight = max(0, self._in_flight - 1)
+        self._signal_capacity()
 
     # --- Weight sync ---
 
@@ -94,11 +121,6 @@ class SyncCoordinator:
         self._weight_version += 1
         self._steps_since_sync = 0
         self._total_syncs += 1
-        # Reset dispatch window. In-flight items span the sync boundary —
-        # they were dispatched with old weights and count toward the new window.
-        self._quota_used = self._in_flight
-        if self._quota_used < self.config.max_rollout_quota:
-            self._throttle_event.set()
 
     # --- Generation pause (for validation / weight sync if partial_rollout is False) ---
 
@@ -120,6 +142,8 @@ class SyncCoordinator:
 
         def _on_done(done_task: asyncio.Task) -> None:
             self._in_flight_tasks.discard(done_task)
+            # A completed rollout frees a concurrency slot — refill immediately.
+            self._signal_capacity()
             if done_task.cancelled():
                 return
             exc = done_task.exception()
@@ -133,7 +157,7 @@ class SyncCoordinator:
         if not any(existing is exc for existing in self._task_errors):
             self._task_errors.append(exc)
         self._task_error_event.set()
-        self._throttle_event.set()
+        self._capacity_event.set()
         self._generation_paused.set()
 
     def raise_if_task_failed(self) -> None:
@@ -163,10 +187,10 @@ class SyncCoordinator:
     def stats(self) -> dict:
         return {
             "async/weight_version": self._weight_version,
-            "async/dispatched_since_sync": self._quota_used - self._in_flight,
-            "async/quota_used": self._quota_used,
             "async/in_flight_groups": self._in_flight,
+            "async/running_rollouts": len(self._in_flight_tasks),
+            "async/max_in_flight_groups": self.config.max_in_flight_groups,
+            "async/max_concurrent_rollouts": self.config.max_concurrent_rollouts,
             "async/steps_since_sync": self._steps_since_sync,
-            "async/max_rollout_quota": self.config.max_rollout_quota,
             "async/total_syncs": self._total_syncs,
         }

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -561,6 +561,7 @@ class UnifiedTrainer:
             group_size=self.rllm_config.rollout.n,
             staleness_threshold=self.async_config.staleness_threshold,
             trigger_parameter_sync_step=self.async_config.trigger_parameter_sync_step,
+            max_concurrent_rollouts=self.agent_workflow_engine.n_parallel_tasks,
         )
         coordinator = SyncCoordinator(coord_config)
         aggregator = MetricsAggregator()
@@ -633,8 +634,7 @@ class UnifiedTrainer:
                     task = batch[0]
 
                     await coordinator.wait_for_generation_allowed()
-                    if not coordinator.has_quota():
-                        await coordinator.wait_for_throttle()
+                    await coordinator.wait_for_capacity()
                     coordinator.on_group_dispatched()
 
                     task_id = str(uuid.uuid4())

--- a/tests/trainer/test_sync_coordinator.py
+++ b/tests/trainer/test_sync_coordinator.py
@@ -1,0 +1,134 @@
+"""Unit tests for SyncCoordinator's continuous dispatch capacity."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rllm.trainer.sync_coordinator import SyncCoordinator, SyncCoordinatorConfig
+
+
+def _make(staleness=3.0, mini_batch=8, group_size=16, sync_step=1, max_concurrent=256):
+    return SyncCoordinator(
+        SyncCoordinatorConfig(
+            mini_batch_size=mini_batch,
+            group_size=group_size,
+            staleness_threshold=staleness,
+            trigger_parameter_sync_step=sync_step,
+            max_concurrent_rollouts=max_concurrent,
+        )
+    )
+
+
+def test_max_in_flight_groups_formula():
+    # (1 + staleness) * trigger * mini_batch
+    assert _make(staleness=3.0, mini_batch=8, sync_step=1).config.max_in_flight_groups == 32
+    assert _make(staleness=0.0, mini_batch=8, sync_step=1).config.max_in_flight_groups == 8
+    assert _make(staleness=1.0, mini_batch=16, sync_step=2).config.max_in_flight_groups == 64
+
+
+def test_staleness_cap_blocks_dispatch():
+    c = _make(staleness=3.0, mini_batch=8)  # cap = 32 groups
+    for _ in range(32):
+        assert c.has_capacity()
+        c.on_group_dispatched()
+    assert not c.has_capacity()  # staleness budget exhausted
+
+
+def test_concurrency_cap_blocks_dispatch():
+    # tiny concurrency budget so it binds before staleness
+    c = _make(staleness=3.0, mini_batch=8, max_concurrent=2)
+    # fill concurrency with 2 fake running tasks
+    loop = asyncio.new_event_loop()
+    try:
+
+        async def _noop():
+            await asyncio.sleep(3600)
+
+        tasks = [loop.create_task(_noop()) for _ in range(2)]
+        for t in tasks:
+            c.track_task(t)
+        assert not c.has_capacity()  # 2 running >= max_concurrent=2
+        for t in tasks:
+            t.cancel()
+        loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
+    finally:
+        loop.close()
+    # done-callbacks fired -> concurrency freed
+    assert len(c._in_flight_tasks) == 0
+    assert c.has_capacity()
+
+
+def test_consume_reopens_capacity_without_sync():
+    """The core less-bursty fix: consuming a group frees staleness budget and
+    wakes generation immediately, with no weight sync in between."""
+
+    async def scenario():
+        c = _make(staleness=3.0, mini_batch=8)  # cap = 32
+        for _ in range(32):
+            c.on_group_dispatched()
+        assert not c.has_capacity()
+
+        # Generation parks on capacity.
+        waiter = asyncio.create_task(c.wait_for_capacity())
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        # A single consume (no on_sync_complete!) must release the waiter.
+        c.on_group_consumed()
+        await asyncio.wait_for(waiter, timeout=1.0)
+        assert c.has_capacity()
+
+    asyncio.run(scenario())
+
+
+def test_task_completion_reopens_concurrency():
+    async def scenario():
+        c = _make(staleness=3.0, mini_batch=8, max_concurrent=1)
+
+        async def _job(evt: asyncio.Event):
+            await evt.wait()
+
+        gate = asyncio.Event()
+        t = asyncio.create_task(_job(gate))
+        c.track_task(t)
+        await asyncio.sleep(0)
+        assert not c.has_capacity()  # concurrency full (1/1)
+
+        waiter = asyncio.create_task(c.wait_for_capacity())
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        gate.set()  # let the job finish -> done-callback signals capacity
+        await asyncio.wait_for(waiter, timeout=1.0)
+        assert c.has_capacity()
+
+    asyncio.run(scenario())
+
+
+def test_sync_only_bumps_version():
+    c = _make()
+    c.on_group_dispatched()
+    in_flight_before = c._in_flight
+    c.on_training_step_complete()
+    assert c.should_sync()
+    c.on_sync_complete()
+    assert c.weight_version == 1
+    assert c._steps_since_sync == 0
+    # sync must NOT touch the staleness budget (continuous model)
+    assert c._in_flight == in_flight_before
+
+
+def test_stats_shape():
+    c = _make()
+    c.on_group_dispatched()
+    s = c.stats()
+    assert s["async/in_flight_groups"] == 1
+    assert s["async/max_in_flight_groups"] == 32
+    assert s["async/max_concurrent_rollouts"] == 256
+    assert s["async/running_rollouts"] == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

In fully-async training, `SyncCoordinator` used a **per-sync-window dispatch quota** that was refilled *only* in `on_sync_complete`. `on_group_consumed` decremented `_in_flight` but never re-opened the throttle. So within a step, generation front-loaded the whole `(1+staleness)·mini_batch` window and then **idled until the next weight sync** released another `mini_batch`.

Combined with the rollout engine completing tasks faster than the once-per-step refill, `running_rollouts` decayed between syncs — the rollout workers were left under-saturated for much of each step.

## Change

Replace the sync-gated quota with a **continuously-evaluated capacity**:

```
dispatch allowed  iff  in_flight_groups < (1+staleness)·mini_batch   (staleness)
                  and  running_rollouts  < n_parallel_tasks          (concurrency)
```

- Budget frees — and generation is woken — on **every consume, every filter, and every rollout-task completion** (`_signal_capacity`), not only at weight sync. Freed slots refill immediately instead of bursting after sync.
- `on_sync_complete` now only bumps the weight version (no window reset).
- Concurrency cap sourced from `engine.n_parallel_tasks`, so it always matches the real rollout semaphore.

The staleness bound is unchanged in magnitude — `(1+staleness)·mini_batch` groups ahead of consumption. Equivalent to the version-scaled ceiling `(staleness + version + 1)·mini_batch`, just expressed in the consumption frame (the two match because the version advances one mini-batch per optimizer step).

## What this does / doesn't do

- **Does**: removes the within-step idle gaps; `async/running_rollouts` now stays near `n_parallel_tasks` across a step.
- **Doesn't**: raise the throughput *ceiling*. Average generation rate is still pinned to the consumption rate by the staleness bound (that's what the bound means). The real levers remain `n_parallel_tasks` (currently often half the sample budget) and straggler-gated group completion.

## Metrics

Replaces `async/quota_used` / `async/dispatched_since_sync` with `async/running_rollouts`, `async/max_in_flight_groups`, `async/max_concurrent_rollouts`. Watch `async/staleness_max` (should stay ≤ ~`staleness+1`).

## Tests

`tests/trainer/test_sync_coordinator.py` — 7 tests, all pass. Key ones pin the behavior change: `test_consume_reopens_capacity_without_sync` (a single consume, no sync, releases parked generation) and `test_task_completion_reopens_concurrency`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)