### PR TITLE
Bound gateway memory in async training + tune gateway GC

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import gc
 import logging
 import os
 import uuid
@@ -586,6 +587,14 @@ def main() -> None:
     else:
         local_handler = _load_handler_factory(args.handler_factory, args.handler_config) if args.handler_factory else None
         app = create_app(config, local_handler=local_handler)
+
+    # Standalone gateway process only (main() never runs for the in-trainer
+    # thread-mode gateway, so this can't perturb the trainer's GC). Freeze the
+    # static tokenizer/renderer/sampler out of GC's scan set and make gen-2 sweeps
+    # rare, so cyclic GC on the event-loop thread stops stalling request handling.
+    gc.collect()
+    gc.freeze()
+    gc.set_threshold(50_000, 500, 500)
 
     import uvicorn
 

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -641,8 +641,20 @@ class UnifiedTrainer:
                     for rollout_idx in range(group_size):
 
                         async def _run_rollout(t=task, tid=task_id, ridx=rollout_idx):
-                            _, _, _, episode = await self.agent_workflow_engine.process_task_with_retry(task=t, task_id=tid, rollout_idx=ridx, result_idx=0)
-                            await buffer.add_episode(tid, episode)
+                            uid = f"{tid}:{ridx}"
+                            try:
+                                _, _, _, episode = await self.agent_workflow_engine.process_task_with_retry(task=t, task_id=tid, rollout_idx=ridx, result_idx=0)
+                                await buffer.add_episode(tid, episode)
+                            finally:
+                                # Release the gateway session (traces are already in `episode`).
+                                # This async loop never calls engine.run(), whose end-of-step
+                                # batch_delete would otherwise do this -- without it the gateway's
+                                # in-memory trace store grows unbounded for the whole run.
+                                if self._gateway is not None:
+                                    try:
+                                        await self._gateway.adelete_session(uid)
+                                    except Exception:
+                                        logger.warning("gateway session cleanup failed for %s", uid)
 
                         t = asyncio.create_task(_run_rollout())
                         coordinator.track_task(t)


### PR DESCRIPTION
## Problem

The gateway's event-loop thread saturates (`thread_cpu≈100%`, `lag_ms p99≈41s`, `/health` timing out) and it **worsens over the first 10–20 steps** of async training. Measured on a live run: each gateway worker held **~50 GB** of private heap and **~2,500 sessions / ~89K traces** in its in-memory store, climbing monotonically.

Root cause is a session leak specific to the async path:

- The async continuous-dispatch loop (`unified_trainer._generation_loop`) drives rollouts via `engine.process_task_with_retry()`, which only deletes a session **on retry**.
- It never calls `AgentFlowEngine.run()`, whose end-of-step `batch_delete` is the only place successful rollouts' sessions get released.
- So every completed rollout's session + traces (fat cumulative token-id lists) linger in the gateway's in-memory store for the entire run → unbounded heap → CPython's cyclic GC walks that ever-growing object graph **on the event-loop thread**, stalling request handling. That's why CPU tracks the growing store rather than the (steady-state) request rate.

## Fix

**1. `rllm/trainer/unified_trainer.py` — release the session in the async loop.**
`_run_rollout` now wraps its body in `try/finally` and calls `self._gateway.adelete_session(uid)` once the episode is buffered. Traces are already fetched into the episode by the time `process_task_with_retry` returns (`_run_single` → `aget_traces`), so this is safe. Bounds the store to the in-flight set (~512/worker) instead of growing for the whole run. Guarded so it's a no-op for gateway-less engines; the `finally` also frees the session on permanent failure.

**2. `rllm-model-gateway/.../server.py` — tune GC in the standalone gateway process.**
`gc.collect(); gc.freeze(); gc.set_threshold(50_000, 500, 500)` in `main()`, before `uvicorn.run`. `freeze()` moves the static tokenizer/renderer/sampler out of GC's scan set; the raised threshold makes gen-2 sweeps rare (per-request dicts/lists are still reclaimed by refcounting). Placed in `main()` specifically so it only affects the separate-process gateway — it never runs for the in-trainer thread-mode gateway, so it can't perturb the trainer's own GC.

Together these cap the per-worker heap and stop the GC-driven loop stalls; #1 fixes the leak, #2 removes residual gen-2 pauses over the bounded working set.

## Verification

- Both files compile; import resolves to the edited gateway `server.py` (`gc.freeze in main(): True`).
- Gateway unit suite: **84 passed** (`test_server`, `test_session_router`, `test_middleware`) — no app-construction/import regression.
- Confirmed the delete targets the correct session (`uid = f"{tid}:{ridx}"`) and that traces are consumed into the episode before deletion.

After deploying, expect per-worker `RssAnon` and session count (`GET :909x/sessions`) to plateau at the in-flight window instead of climbing, and loop-health `lag_ms`/`thread_cpu` to drop.

## Note / follow-up

Cancelled rollouts (staleness cancellation) usually still hit the in-`finally` delete, but a force-cancel during shutdown could skip it — a small number of cancelled-rollout sessions may linger. Not material to the leak (dominated by completed rollouts); a periodic sweep or a delete in the coordinator's cancel path would make it airtight. Larger follow-ups discussed but not included here: storing per-turn *delta* prompts instead of full cumulative ones (removes the O(turns²) per-trace growth) and `int32`/bytes token packing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)