### PR TITLE
terminal-rl: disable Terminus-2 context compaction in training

### DIFF
--- a/cookbooks/terminal-rl/train.py
+++ b/cookbooks/terminal-rl/train.py
@@ -65,6 +65,12 @@ TB_VAL_MAX = int(os.environ.get("TB_VAL_MAX", "0"))
 _terminus_max_turns = os.environ.get("TERMINUS_MAX_TURNS")
 TERMINUS_MAX_TURNS = int(_terminus_max_turns) if _terminus_max_turns and int(_terminus_max_turns) > 0 else None
 
+# Terminus-2 context compaction (summarization). Harbor enables it by default;
+# summarization subagents compress history when the context fills, which
+# fragments the trajectory the gateway captures. The train_*.sh scripts set
+# TERMINUS_ENABLE_SUMMARIZE=0 to disable it. Unset = Harbor's default (on).
+TERMINUS_ENABLE_SUMMARIZE = os.environ.get("TERMINUS_ENABLE_SUMMARIZE", "1").strip().lower() not in ("0", "false", "no", "off")
+
 
 @hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
 def main(config: DictConfig) -> None:
@@ -83,7 +89,10 @@ def main(config: DictConfig) -> None:
     # explicit evaluator/hooks) makes AgentTrainer auto-wire SandboxTaskHooks
     # for the sandbox lifecycle + per-task verifier, and route rollouts through
     # AgentFlowEngine — rLLM's own runtime, not the remote Harbor runtime.
-    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND, max_turns=TERMINUS_MAX_TURNS)
+    # enable_summarize controls Terminus-2 context compaction; the train_*.sh
+    # scripts set TERMINUS_ENABLE_SUMMARIZE=0 to turn it off so summarization
+    # subagents don't fragment the captured trajectory during training.
+    agent_flow = Terminus2Harness(sandbox_backend=SANDBOX_BACKEND, max_turns=TERMINUS_MAX_TURNS, enable_summarize=TERMINUS_ENABLE_SUMMARIZE)
 
     trainer = AgentTrainer(
         backend=config.rllm.get("backend", "tinker"),

--- a/cookbooks/terminal-rl/train_fireworks.sh
+++ b/cookbooks/terminal-rl/train_fireworks.sh
@@ -49,6 +49,9 @@ set -euo pipefail
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
 # Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
 export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
+# Disable Terminus-2 context compaction (summarization) so it doesn't fragment
+# the captured trajectory during training. Set to 1 to re-enable.
+export TERMINUS_ENABLE_SUMMARIZE="${TERMINUS_ENABLE_SUMMARIZE:-0}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_tinker.sh
+++ b/cookbooks/terminal-rl/train_tinker.sh
@@ -30,6 +30,9 @@ set -euo pipefail
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
 # Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
 export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
+# Disable Terminus-2 context compaction (summarization) so it doesn't fragment
+# the captured trajectory during training. Set to 1 to re-enable.
+export TERMINUS_ENABLE_SUMMARIZE="${TERMINUS_ENABLE_SUMMARIZE:-0}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/cookbooks/terminal-rl/train_verl.sh
+++ b/cookbooks/terminal-rl/train_verl.sh
@@ -25,6 +25,9 @@ unset ROCR_VISIBLE_DEVICES 2>/dev/null || true
 export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
 # Per-rollout turn cap for terminus2 (read by train.py). Empty = uncapped.
 export TERMINUS_MAX_TURNS="${TERMINUS_MAX_TURNS:-100}"
+# Disable Terminus-2 context compaction (summarization) so it doesn't fragment
+# the captured trajectory during training. Set to 1 to re-enable.
+export TERMINUS_ENABLE_SUMMARIZE="${TERMINUS_ENABLE_SUMMARIZE:-0}"
 export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-1800}"
 # Modal sandbox LIFETIME (not idle time). Must exceed the agent run timeout
 # above plus setup/verify, or sandboxes get reaped mid-rollout — surfacing as

--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -110,6 +110,13 @@ class Terminus2Harness(BaseCliHarness):
     # Asciinema recording needs an extra dep and a writable trial dir; off by
     # default since rLLM scores from the verifier, not the cast.
     record_terminal_session: bool = False
+    # Context summarization ("compaction"). Harbor's Terminus-2 enables this by
+    # default: it spawns summarization subagents to compress history when the
+    # context fills, which fragments the trajectory the gateway captures. Set
+    # ``enable_summarize=False`` (e.g. via the harness constructor) to turn both
+    # proactive and context-limit summarization off — the agent then simply hits
+    # its context limit instead of compacting.
+    enable_summarize: bool = True
 
     def install_script(self) -> str:
         return _install_script(self.harbor_version, self.terminus_python)
@@ -137,6 +144,7 @@ class Terminus2Harness(BaseCliHarness):
             "RLLM_TERMINUS_PARSER": self.parser_name,
             "RLLM_TERMINUS_TEMPERATURE": str(self.temperature),
             "RLLM_TERMINUS_RECORD": "1" if self.record_terminal_session else "0",
+            "RLLM_TERMINUS_ENABLE_SUMMARIZE": "1" if self.enable_summarize else "0",
             "RLLM_TERMINUS_INSTRUCTION_FILE": _INSTRUCTION_PATH,
             "RLLM_TERMINUS_LOGS_DIR": _LOGS_DIR,
             "RLLM_TERMINUS_OUTCOME_FILE": _OUTCOME_PATH,
@@ -334,6 +342,9 @@ async def _main():
     max_turns = int(_max_turns) if _max_turns else None
     temperature = float(os.environ.get("RLLM_TERMINUS_TEMPERATURE", "1.0"))
     record = os.environ.get("RLLM_TERMINUS_RECORD", "0") == "1"
+    # Compaction toggle: unset defaults to Harbor's own default (on). "0" turns
+    # off both proactive and context-limit summarization.
+    enable_summarize = os.environ.get("RLLM_TERMINUS_ENABLE_SUMMARIZE", "1") == "1"
     logs_dir = Path(os.environ.get("RLLM_TERMINUS_LOGS_DIR", "/tmp/terminus2/logs"))
     logs_dir.mkdir(parents=True, exist_ok=True)
 
@@ -350,6 +361,7 @@ async def _main():
         max_turns=max_turns,
         temperature=temperature,
         record_terminal_session=record,
+        enable_summarize=enable_summarize,
         model_info=model_info,
         suppress_max_turns_warning=True,
     )


### PR DESCRIPTION
## What

Disables Terminus-2's context **compaction** (summarization) in the terminal-rl training cookbook.

Harbor's Terminus-2 enables summarization by default — when the context fills, it spawns summarization subagents that compress history. During RL training that **fragments the trajectory the gateway captures**, so we turn it off.

## Changes

- **`rllm/harnesses/terminus2.py`** — plumb a new `enable_summarize` knob (default `True`, so other cookbooks are unaffected):
  - class attribute `enable_summarize: bool = True`
  - `build_env()` emits `RLLM_TERMINUS_ENABLE_SUMMARIZE`
  - the in-sandbox driver reads it and passes `enable_summarize=` into `Terminus2(...)`
  - `False` disables **both** proactive and context-limit summarization (the agent then hits its context limit instead of compacting).
- **`cookbooks/terminal-rl/train.py`** — reads `TERMINUS_ENABLE_SUMMARIZE` (default on when run standalone) → `enable_summarize` kwarg.
- **`train_fireworks.sh` / `train_tinker.sh` / `train_verl.sh`** — `export TERMINUS_ENABLE_SUMMARIZE="${TERMINUS_ENABLE_SUMMARIZE:-0}"` (disabled by default, still overridable).

## Verification

- kwarg propagates; class default stays `True`.
- `build_env()` emits `RLLM_TERMINUS_ENABLE_SUMMARIZE=0`; in-sandbox driver script parses and forwards the flag.
- `bash -n` clean on the scripts; env parse maps `0/false/no/off` → off, unset/`1` → on.
- All 4 `cookbooks/terminal-rl/test.py` smoke tests pass.

Base is `terminal-rl` (the cookbook only exists on that branch); stacked on top of #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)