### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ This installs dependencies for running `rllm` CLI with the `tinker` backend (sin
 
 ```bash
 # Distributed multi-GPU training (verl + vLLM/SGLang)
+
+[![Listed on TakoAPI](https://takoapi.com/api/badge/rllm-org-rllm)](https://takoapi.com/agents/rllm-org-rllm)
+
 uv pip install "rllm[verl] @ git+https://github.com/rllm-org/rllm.git"
 
 # Fireworks training platform


### PR DESCRIPTION
Hi! 👋 **rllm** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/rllm-org-rllm

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building rllm! 🙏