### PR TITLE
fix(sandbox): size Modal/Daytona lifetime from agent+verifier timeouts; add RLLM_HARNESS_VERIFIER_TIMEOUT_S cap

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -93,6 +93,21 @@ def _read_verifier_config(task: Task) -> dict:
     return {}
 
 
+def _effective_verifier_timeout(task: Task) -> float | None:
+    """Per-task verifier timeout (s), with RLLM_HARNESS_VERIFIER_TIMEOUT_S as a hard cap
+    (mirrors RLLM_HARNESS_RUN_TIMEOUT_S for the agent). Returns None only when the task
+    declares no verifier_timeout and no cap is set (callers apply their own default)."""
+    from rllm.env import env_int
+
+    declared = task.metadata.get("verifier_timeout")
+    cap = env_int("RLLM_HARNESS_VERIFIER_TIMEOUT_S", 0)
+    if declared is None:
+        return float(cap) if cap > 0 else None
+    if cap > 0:
+        return min(float(declared), float(cap))
+    return float(declared)
+
+
 def _resolve_evaluator(
     task: Task,
     sandbox: Sandbox | None,
@@ -107,7 +122,7 @@ def _resolve_evaluator(
             sandbox=sandbox,
             script_path=verifier_config.get("script", "tests/test.sh"),
             verifier_user=task.metadata.get("verifier_user"),
-            verifier_timeout=float(task.metadata.get("verifier_timeout", 600.0)),
+            verifier_timeout=(_effective_verifier_timeout(task) or 600.0),
             reward_file_override=verifier_config.get("reward_file"),
         )
 
@@ -385,7 +400,7 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
     # Sandbox must outlast the full rollout (agent + verifier + teardown). When the task
     # declares a verifier_timeout, budget exactly that plus 300s teardown/scheduling slack;
     # otherwise a flat 600s cushion. Raised to the operator override (RLLM_SANDBOX_TIMEOUT_S).
-    verifier_t = task.metadata.get("verifier_timeout")
+    verifier_t = _effective_verifier_timeout(task)
     if verifier_t is not None:
         lifetime_s = int(agent_t + float(verifier_t) + 300)
     else:

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -369,11 +369,28 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
         disk_mb = min(int(disk_mb), disk_cap)
 
     # Per-task lifetime floor (seconds), shared across backends: agent + verifier
-    # + install + teardown/scheduling slack, raised to the operator override.
-    agent_t = float(task.metadata.get("agent_timeout") or env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 3600))
-    verifier_t = float(task.metadata.get("verifier_timeout") or 600.0)
-    install_t = float(env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 600))
-    lifetime_s = max(int(agent_t + verifier_t + install_t + 600), sandbox_timeout_override_s())
+    # + install + teardown/scheduling slack, raised to the operator override. The
+    # sandbox lifetime tracks the *effective* agent timeout: RLLM_HARNESS_RUN_TIMEOUT_S,
+    # when set, is a hard CAP on a task's own agent_timeout (matching
+    # cli_harness._effective_timeout) — otherwise a task's large baked-in agent_timeout
+    # (e.g. SWE-bench Verified) keeps the sandbox alive far past the operator cap.
+    _run_cap = env_int("RLLM_HARNESS_RUN_TIMEOUT_S", 0)
+    _per_task = task.metadata.get("agent_timeout")
+    if _per_task is None:
+        agent_t = float(_run_cap or 3600)
+    elif _run_cap > 0:
+        agent_t = min(float(_per_task), float(_run_cap))
+    else:
+        agent_t = float(_per_task)
+    # Sandbox must outlast the full rollout (agent + verifier + teardown). When the task
+    # declares a verifier_timeout, budget exactly that plus 300s teardown/scheduling slack;
+    # otherwise a flat 600s cushion. Raised to the operator override (RLLM_SANDBOX_TIMEOUT_S).
+    verifier_t = task.metadata.get("verifier_timeout")
+    if verifier_t is not None:
+        lifetime_s = int(agent_t + float(verifier_t) + 300)
+    else:
+        lifetime_s = int(agent_t + 600)
+    lifetime_s = max(lifetime_s, sandbox_timeout_override_s())
 
     kw: dict = {}
     if backend == "modal":


### PR DESCRIPTION
## Summary

Two related sandbox/harness **timeout** fixes, split out from the DPPO custom-loss PR (#713) since they're general infra. Both touch only `rllm/eval/_resolution.py`.

Symptom that motivated them: SWE-bench Verified rollouts appeared to "run forever" / got reaped mid-verify. Those tasks declare `[agent] timeout_sec = 3000` and `[verifier] timeout_sec = 3000` (confirmed across the val set), and the sandbox lifetime wasn't sized to match the enforced agent+verifier budget, while an operator's `RLLM_HARNESS_RUN_TIMEOUT_S` cap was being bypassed.

## Commits

**1. `fix(sandbox)`: size Modal/Daytona lifetime from the effective agent + verifier timeout**
- The sandbox lifetime derived its agent term from `task.metadata["agent_timeout"] or RLLM_HARNESS_RUN_TIMEOUT_S`, so a task's large baked-in `agent_timeout` (e.g. SWE-bench's 3000) **bypassed the operator cap**. Now `RLLM_HARNESS_RUN_TIMEOUT_S` is a hard cap on the per-task value (matching `cli_harness._effective_timeout`).
- Reworked the lifetime formula to reliably cover the enforced verifier:
  - verifier declared → `agent + verifier_timeout + 300`
  - verifier absent → `agent + 600`
  - still floored to `RLLM_SANDBOX_TIMEOUT_S`.
- So the sandbox is always slightly longer than `agent + verifier`, with no config needed. Example (cap 1800, verifier 3000): lifetime `1800 + 3000 + 300 = 5100s` (was oversized/mismatched).

**2. `feat(sandbox)`: `RLLM_HARNESS_VERIFIER_TIMEOUT_S` — operator cap on the verifier timeout**
- Symmetric to `RLLM_HARNESS_RUN_TIMEOUT_S` (agent). Caps the per-task `verifier_timeout` as a hard ceiling, applied via a shared `_effective_verifier_timeout(task) = min(declared, cap)` to **both** the enforced verifier (`ShellScriptEvaluator` — the verifier is killed at it → `VERIFIER_TIMEOUT`) **and** the sandbox-lifetime sizing.
- Unset = use the task's declared value. Lets an operator shrink an over-declared verifier (SWE-bench's 3000) for fast iteration without editing task.toml. E.g. `RLLM_HARNESS_VERIFIER_TIMEOUT_S=300` → verifier bounded at 300, sandbox `1800 + 300 + 300 = 2400s`.

## Testing
- Cap/sizing logic verified numerically for the SWE-bench Verified case (agent 3000→cap 1800; verifier 3000→cap 300).
- `_effective_verifier_timeout` runtime-invoked (guards against the undefined-name class of bug): declared 3000 + cap 300 → 300; no cap → 3000; none declared → None.

## Notes for reviewers
- **Base is `terminal-rl`** (where these were developed, alongside #713). They're general fixes — happy to retarget to `main` if preferred.
- Cold-**install** time isn't separately budgeted in the lifetime (fine for the snapshot/warm path where install ≈ 0; bump `RLLM_SANDBOX_TIMEOUT_S` for cold-install-heavy runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
