### PR TITLE
perf(async): eval-priority rollout scheduling on the shared pool

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -38,6 +38,7 @@ from rllm.gateway.manager import container_reachable_url
 from rllm.types import INFRA_ERROR_REASONS, AgentConfig, Episode, Step, Task, TerminationReason, Trajectory, flow_accepts_env, run_agent_flow, termination_reason_from_error
 from rllm.utils import colorful_print
 from rllm.utils.group_summary import format_group_finished
+from rllm.utils.priority_semaphore import EVAL_PRIORITY, TRAIN_PRIORITY, PrioritySemaphore
 
 if TYPE_CHECKING:
     from rllm_model_gateway.models import TraceRecord
@@ -415,7 +416,9 @@ class AgentFlowEngine:
 
         self.n_parallel_tasks = n_parallel_tasks
         self.executor = ThreadPoolExecutor(max_workers=n_parallel_tasks)
-        self._semaphore = asyncio.Semaphore(n_parallel_tasks)
+        # Priority-aware so eval rollouts (is_validation=True) preempt training
+        # rollouts for slots on this shared pool. See process_task_with_retry.
+        self._semaphore = PrioritySemaphore(n_parallel_tasks)
 
         # Raise the file descriptor limit to avoid "Too many open files" when
         # running many parallel agent flows with individual HTTP clients.
@@ -439,7 +442,7 @@ class AgentFlowEngine:
         the internal state can't be read.
         """
         try:
-            return max(0, self.n_parallel_tasks - self._semaphore._value)  # type: ignore[attr-defined]
+            return max(0, self.n_parallel_tasks - self._semaphore.available)
         except Exception:
             return -1
 
@@ -447,8 +450,7 @@ class AgentFlowEngine:
     def pending(self) -> int:
         """Best-effort count of rollout tasks queued waiting for a slot."""
         try:
-            waiters = self._semaphore._waiters  # type: ignore[attr-defined]
-            return len(waiters) if waiters else 0
+            return self._semaphore.waiting
         except Exception:
             return -1
 
@@ -593,7 +595,8 @@ class AgentFlowEngine:
         task_for_episode = task.metadata if isinstance(task, Task) else task
         task_obj = task if isinstance(task, Task) else task_from_row(task, task_id)
 
-        async with self._semaphore:
+        priority = EVAL_PRIORITY if is_validation else TRAIN_PRIORITY
+        async with self._semaphore.slot(priority):
             for retry_attempt in range(1, self.retry_limit + 1):
                 uid = f"{task_id}:{rollout_idx}"
                 if retry_attempt > 1:

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -841,9 +841,13 @@ class UnifiedTrainer:
                 trajectory_groups=trainer_state.trajectory_groups,
             )
 
-            # Periodic validation
+            # Periodic validation. Eval rollouts run on the shared rollout pool
+            # and preempt training rollouts for slots (PrioritySemaphore), so no
+            # dispatch pause / drain barrier is needed -- eval saturates the pool
+            # and training fills the leftover. Weights stay frozen for the duration
+            # because this await blocks the training loop, so no weight sync runs.
             if self.rllm_config.trainer.test_freq > 0 and trainer_state.global_step % self.rllm_config.trainer.test_freq == 0:
-                await self._validate_async_with_pause(trainer_state, coordinator)
+                await self._validate_async(trainer_state)
 
             trainer_state.global_step += 1
 
@@ -865,15 +869,6 @@ class UnifiedTrainer:
         coordinator.on_sync_complete()
 
         if not self.async_config.partial_rollout:
-            coordinator.resume_generation()
-
-    async def _validate_async_with_pause(self, trainer_state: TrainerState, coordinator: SyncCoordinator) -> dict:
-        """Validation with dispatch-level pause. Waits for workflows to drain, then runs validation."""
-        coordinator.pause_generation()
-        await coordinator.wait_for_drain()
-        try:
-            return await self._validate_async(trainer_state)
-        finally:
             coordinator.resume_generation()
 
     async def _validate_async(self, trainer_state: TrainerState) -> dict:

--- a/rllm/utils/priority_semaphore.py
+++ b/rllm/utils/priority_semaphore.py
@@ -1,0 +1,100 @@
+"""A priority-aware asyncio semaphore.
+
+Behaves like :class:`asyncio.Semaphore`, except that when a permit is released
+and multiple coroutines are waiting, the one with the highest ``priority`` is
+served first (FIFO within a priority). This lets eval rollouts preempt training
+rollouts for slots on a *shared* concurrency pool: eval acquires at
+``EVAL_PRIORITY`` and always wins contention, while training (``TRAIN_PRIORITY``)
+naturally fills whatever capacity eval leaves free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from contextlib import asynccontextmanager
+
+# Higher value == served first.
+TRAIN_PRIORITY = 0
+EVAL_PRIORITY = 1
+
+
+class PrioritySemaphore:
+    """An asyncio counting semaphore that grants waiters in priority order."""
+
+    def __init__(self, value: int = 1):
+        if value < 0:
+            raise ValueError("PrioritySemaphore initial value must be >= 0")
+        self._value = value
+        # priority -> FIFO queue of waiter futures. Kept sparse (empty buckets
+        # are dropped) so `waiting` and `_wake_up_next` stay cheap.
+        self._waiters: dict[int, deque[asyncio.Future]] = {}
+
+    @property
+    def available(self) -> int:
+        """Free permits not currently held."""
+        return max(0, self._value)
+
+    @property
+    def waiting(self) -> int:
+        """Number of coroutines queued waiting for a permit."""
+        return sum(len(q) for q in self._waiters.values())
+
+    def locked(self) -> bool:
+        return self._value == 0
+
+    async def acquire(self, priority: int = TRAIN_PRIORITY) -> bool:
+        """Acquire a permit, blocking until one is free.
+
+        When contending for a freed permit, higher ``priority`` waiters are
+        served before lower ones; ties break FIFO.
+        """
+        if self._value > 0:
+            self._value -= 1
+            return True
+
+        fut = asyncio.get_running_loop().create_future()
+        q = self._waiters.setdefault(priority, deque())
+        q.append(fut)
+        try:
+            try:
+                await fut
+            finally:
+                # Woken (result set) or cancelled: drop ourselves from the queue.
+                if fut in q:
+                    q.remove(fut)
+                if not q:
+                    self._waiters.pop(priority, None)
+        except asyncio.CancelledError:
+            if not fut.cancelled():
+                # release() granted us a permit (decrementing the counter on our
+                # behalf) but we were cancelled before resuming. Return the permit
+                # to the pool, then hand it to the next waiter instead of losing it.
+                self._value += 1
+                self._wake_up_next()
+            raise
+        return True
+
+    def release(self) -> None:
+        """Return a permit, waking the highest-priority waiter if any."""
+        self._value += 1
+        self._wake_up_next()
+
+    def _wake_up_next(self) -> None:
+        # Highest priority first; FIFO within a priority. On grant, decrement
+        # the counter on the waiter's behalf so it holds the permit on resume.
+        for priority in sorted(self._waiters, reverse=True):
+            for fut in self._waiters[priority]:
+                if not fut.done():
+                    self._value -= 1
+                    fut.set_result(True)
+                    return
+
+    @asynccontextmanager
+    async def slot(self, priority: int = TRAIN_PRIORITY):
+        """``async with sem.slot(priority): ...`` — acquire then release."""
+        await self.acquire(priority)
+        try:
+            yield
+        finally:
+            self.release()

--- a/tests/engine/test_priority_semaphore.py
+++ b/tests/engine/test_priority_semaphore.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import pytest
+
+from rllm.utils.priority_semaphore import EVAL_PRIORITY, TRAIN_PRIORITY, PrioritySemaphore
+
+
+def test_fast_path_and_counts():
+    async def _run():
+        sem = PrioritySemaphore(2)
+        assert sem.available == 2 and not sem.locked()
+        await sem.acquire()
+        await sem.acquire()
+        assert sem.available == 0 and sem.locked()
+        assert sem.waiting == 0
+        sem.release()
+        assert sem.available == 1 and not sem.locked()
+
+    asyncio.run(_run())
+
+
+def test_higher_priority_served_first():
+    """A queued eval (high) waiter preempts already-queued train (low) waiters;
+    ties within a priority stay FIFO."""
+
+    async def _run():
+        sem = PrioritySemaphore(1)
+        order = []
+        await sem.acquire(TRAIN_PRIORITY)  # hold the only permit
+
+        async def worker(name, prio):
+            await sem.acquire(prio)
+            order.append(name)
+            await asyncio.sleep(0)
+            sem.release()
+
+        workers = [
+            asyncio.create_task(worker("train-A", TRAIN_PRIORITY)),
+            asyncio.create_task(worker("train-B", TRAIN_PRIORITY)),
+            asyncio.create_task(worker("eval-1", EVAL_PRIORITY)),
+            asyncio.create_task(worker("train-C", TRAIN_PRIORITY)),
+        ]
+        await asyncio.sleep(0.05)  # let all four enqueue
+        assert sem.waiting == 4
+        sem.release()  # release the held permit -> cascade through the queue
+        await asyncio.gather(*workers)
+        return order
+
+    order = asyncio.run(_run())
+    assert order[0] == "eval-1", order
+    assert order[1:] == ["train-A", "train-B", "train-C"], order
+
+
+def test_slot_ctx_releases_on_exception():
+    async def _run():
+        sem = PrioritySemaphore(1)
+        with pytest.raises(ValueError):
+            async with sem.slot(EVAL_PRIORITY):
+                assert sem.available == 0
+                raise ValueError("boom")
+        assert sem.available == 1
+
+    asyncio.run(_run())
+
+
+def test_cancel_after_grant_hands_off_permit():
+    """A waiter cancelled after being granted must pass its permit to the next
+    waiter, not leak it (counter must not go negative or lose a slot)."""
+
+    async def _run():
+        sem = PrioritySemaphore(1)
+        await sem.acquire()  # hold permit
+        granted = []
+
+        async def waiter(name):
+            await sem.acquire(TRAIN_PRIORITY)
+            granted.append(name)
+            sem.release()
+
+        t1 = asyncio.create_task(waiter("w1"))
+        t2 = asyncio.create_task(waiter("w2"))
+        await asyncio.sleep(0.02)
+        sem.release()  # grants to w1 (sets its future result)
+        t1.cancel()  # cancel w1 after grant, before it resumes
+        await asyncio.sleep(0.05)
+        await asyncio.gather(t1, t2, return_exceptions=True)
+        return granted, sem.available
+
+    granted, available = asyncio.run(_run())
+    assert granted == ["w2"], granted
+    assert available == 1, available
+
+
+def test_rejects_negative_initial_value():
+    with pytest.raises(ValueError):
+        PrioritySemaphore(-1)


### PR DESCRIPTION
## Problem

In fully-async training, periodic validation currently **stops the world**:
`_validate_async_with_pause` calls `coordinator.pause_generation()` then
`await coordinator.wait_for_drain()` — it waits for **all** in-flight training
rollouts to finish before any eval rollout starts. With long-horizon SWE tasks,
that drain can leave the rollout pool idle for many minutes every `test_freq`
steps.

## Change

Run eval on the **same shared rollout pool** and let eval rollouts **preempt**
training rollouts for concurrency slots — no separate pool, no drain barrier.

- **`PrioritySemaphore`** (`rllm/utils/priority_semaphore.py`): an asyncio
  counting semaphore that hands a freed permit to the **highest-priority**
  waiter (FIFO within a priority). Exposes `available` / `waiting` for the
  existing `inflight` / `pending` diagnostics, plus a `slot(priority)` async
  context manager. Handles the cancel-after-grant case (returns the permit to
  the pool before re-granting) the same way `asyncio.Semaphore` does.
- **`AgentFlowEngine`** uses it in place of `asyncio.Semaphore`.
  `process_task_with_retry` acquires at `EVAL_PRIORITY` when `is_validation`
  else `TRAIN_PRIORITY` (the flag already threads down to this call).
- **`unified_trainer`**: the fully-async validation path calls `_validate_async`
  directly; the `pause_generation` + `wait_for_drain` + `resume_generation`
  wrapper is removed.

## Behavior

- Eval rollouts win contention: as in-flight training rollouts release slots,
  freed slots go to eval first, so eval **saturates the pool** as fast as
  training naturally drains (no waiting for a full drain first).
- Once every eval task holds a slot, remaining slots go to training — training
  fills whatever eval leaves free, exactly as requested.
- `eval tasks ≥ pool` → eval takes the whole pool, training only resumes in the
  eval tail. `eval tasks < pool` → training keeps the leftover capacity busy.

## Consistency

Eval still runs on frozen weights: `await self._validate_async(...)` blocks the
training loop, and weight sync (`_perform_weight_sync`) only runs from that same
loop, so no sync happens for the eval duration. No explicit weight pinning
needed. The generation loop keeps producing training groups during eval; the
coordinator's staleness/concurrency caps bound the pile-up (blocked training
tasks still count toward `max_concurrent_rollouts`).

## Scope

- Gateway / agent-flow fully-async path only (where `AgentFlowEngine._semaphore`
  governs rollout concurrency). Sync training paths already call
  `_validate_async` directly and are unaffected.
- Coordinator `pause_generation` / `wait_for_drain` / `resume_generation` remain
  in use by weight sync and the generation loop's end-of-run drain.

## Tests

`tests/engine/test_priority_semaphore.py` — priority ordering, FIFO within a
priority, context-manager release on exception, and cancel-after-grant permit
hand-off. Existing `tests/engine/test_agentflow_engine.py` still passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)