### PR TITLE
Add GDPval as a native benchmark

### DIFF
--- a/docs/cookbooks/gdpval.mdx
+++ b/docs/cookbooks/gdpval.mdx
@@ -76,15 +76,22 @@ python -m rllm.data.gdpval_builder --out-dir ~/.rllm/datasets/gdpval \
 
 ## Integration seam
 
-The host-side reward function grades **only a deliverable the harness has
-explicitly surfaced** on the episode — via `episode.artifacts['deliverable_path']`
-(a file path the grader extracts) or `['deliverable_text']` (already-extracted
-text). It is **fail-closed**: it never reads the agent's transcript or final
-answer, so the judge grades the artifact, not the process (and can't be gamed by
-an agent that merely *describes* a good deliverable). If nothing is surfaced, the
-task is marked `ungraded` (reason `no_deliverable_surfaced`) rather than scored 0.
-So the solver's harness must copy the produced file out of the sandbox and set
-`deliverable_path`. See `_find_deliverable_text` in `rllm/eval/reward_fns/gdpval.py`.
+The host-side grader scores **only a deliverable surfaced on the episode** —
+`episode.artifacts['deliverable_path']` (a file the grader extracts) or
+`['deliverable_text']`. It is **fail-closed**: it never reads the agent's
+transcript or final answer, so the judge grades the artifact, not the process
+(and can't be gamed by an agent that merely *describes* a good deliverable). If
+nothing is surfaced, the task is `ungraded` (reason `no_deliverable_surfaced`),
+not scored 0.
+
+Surfacing is automatic. Because a host-side grader never sees the sandbox,
+`SandboxTaskHooks` wraps the grader with `_SurfacingEvaluator` (opt-in via the
+task's `surface_deliverable` metadata, set by the builder): right before
+grading — while the sandbox is still alive — it reads the produced deliverable
+out of the workdir and sets `deliverable_path`. It's backend-agnostic (base64
+over `sandbox.exec`), so it works on Docker/Modal/Daytona alike. It picks the
+file matching the task's `expected_deliverables`, else the newest non-input file
+in the workdir. See `surface_deliverable` in `rllm/eval/_resolution.py`.
 
 ## Caveat
 

--- a/docs/cookbooks/gdpval.mdx
+++ b/docs/cookbooks/gdpval.mdx
@@ -90,10 +90,12 @@ task's `surface_deliverable` metadata, set by the builder): right before
 grading — while the sandbox is still alive — it reads the produced deliverable
 out of the workdir and sets `deliverable_path`. It's backend-agnostic (base64
 over `sandbox.exec`), so it works on Docker/Modal/Daytona alike. The task
-instruction tells the agent to save deliverables into an `output/` directory, so
-the surfacer reads that first (unambiguous); it only falls back to the expected
-filename, then the newest non-input file, if the agent ignores that. See
-`surface_deliverable` in `rllm/eval/_resolution.py`.
+instruction tells the agent to save deliverables into an `output/` directory,
+and the surfacer reads **only** that directory — matching the task's expected
+basenames within it when given, else taking all files there. Nothing else in
+the workdir is searched: if the agent didn't write to `output/`, nothing is
+surfaced and grading fails closed. See `surface_deliverable` in
+`rllm/eval/_resolution.py`.
 
 ## Caveat
 

--- a/docs/cookbooks/gdpval.mdx
+++ b/docs/cookbooks/gdpval.mdx
@@ -1,0 +1,80 @@
+---
+title: GDPval
+description: Evaluate an agent on OpenAI's GDPval — 220 gold tasks of economically valuable knowledge work — with a faithful weighted-rubric LLM judge, entirely from the CLI
+---
+
+This cookbook runs an agent against [GDPval](https://openai.com/index/gdpval/) (`openai/gdpval`), OpenAI's benchmark of real, economically valuable knowledge work: 220 open "gold" tasks across 44 occupations in 9 GDP-heavy sectors. Each task is a role-first prompt plus reference files, and the deliverable is a document (xlsx / docx / pptx / pdf). Like `claw_eval`, this is a native rLLM benchmark — no plugin to install: the builder, the dataset entry, and the reward function all ship with rLLM.
+
+Unlike Terminal-Bench (pass/fail pytest verifier), GDPval is graded by an **LLM judge against a per-task rubric**. This benchmark reproduces GDPval's *automated* grading — the reproducible LLM-judge methodology — not the headline human pairwise win-rate.
+
+## Pattern
+
+| Aspect | Value |
+|---|---|
+| Loop shape | Single-turn deliverable production (agent runs in a sandbox, writes a file) |
+| Dataset | `gdpval` — 220 tasks, reference files pulled from the HF Hub |
+| Grading | `gdpval_reward_fn`: for each rubric criterion, an LLM judge decides met / not-met |
+| Reward shape | Weight-normalized: `clip(Σ score[met] / Σ score[positive], 0, 1)` |
+| Metrics | Per-task rubric score in [0, 1], averaged across tasks |
+
+## Grading detail
+
+Each task ships `rubric_json`: a list of weighted criteria such as
+`{"score": 5, "criterion": "The recommended sample size is 220 …"}`. The grader
+(`rllm/eval/reward_fns/gdpval.py`) extracts the deliverable's text
+(openpyxl / python-docx / python-pptx / pdfplumber), asks the judge to rule on
+each criterion independently, and aggregates:
+
+```
+earned         = Σ score[c] for criteria judged satisfied     # penalties (score < 0) subtract
+total_possible = Σ score[c] for criteria with score > 0
+reward         = clip(earned / total_possible, 0, 1)
+```
+
+## Prerequisites
+
+- **Python ≥ 3.12**, with the deliverable-extraction extras: `pip install openpyxl python-docx python-pptx pdfplumber`.
+- **A judge model** — resolved (first hit wins) from `GDPVAL_JUDGE_MODEL` / `GDPVAL_JUDGE_BASE_URL` / `GDPVAL_JUDGE_API_KEY`, then per-task metadata, then your `rllm model setup` provider config.
+- **A configured model provider** for the solver agent (`rllm model setup`).
+
+## Steps
+
+Pull the benchmark (materializes task dirs and downloads reference files):
+
+```bash
+# smoke run: 3 tasks
+python -m rllm.data.gdpval_builder --out-dir ~/.rllm/datasets/gdpval --limit 3 --clean
+# or via the catalog
+rllm dataset pull gdpval
+```
+
+Run the eval:
+
+```bash
+export GDPVAL_JUDGE_MODEL=...           # your judge endpoint
+rllm eval gdpval --agent claude-code --limit 3
+```
+
+Restrict to the occupations that overlap your task-generation pipeline:
+
+```bash
+python -m rllm.data.gdpval_builder --out-dir ~/.rllm/datasets/gdpval \
+  --occupations "Accountants and Auditors" "Financial and Investment Analysts" --clean
+```
+
+## Integration seam
+
+The host-side reward function grades the deliverable **text surfaced on the
+episode**. The solver's harness must expose the produced file via
+`episode.artifacts['deliverable_path']` (a path the grader extracts) or
+`['deliverable_text']` (already-extracted text). If neither is present, the
+grader falls back to the agent's final answer text — fine for text-only
+deliverables, but document deliverables (xlsx/pptx/pdf) require the file to be
+surfaced. See `_find_deliverable_text` in `rllm/eval/reward_fns/gdpval.py`.
+
+## Caveat
+
+GDPval's headline metric is a blind human pairwise win-rate against an expert's
+deliverable, which is not reproducible in an automated harness. The score here
+is the automated rubric grade — useful and comparable across runs, but not the
+same number as the human evaluation.

--- a/docs/cookbooks/gdpval.mdx
+++ b/docs/cookbooks/gdpval.mdx
@@ -76,13 +76,15 @@ python -m rllm.data.gdpval_builder --out-dir ~/.rllm/datasets/gdpval \
 
 ## Integration seam
 
-The host-side reward function grades the deliverable **text surfaced on the
-episode**. The solver's harness must expose the produced file via
-`episode.artifacts['deliverable_path']` (a path the grader extracts) or
-`['deliverable_text']` (already-extracted text). If neither is present, the
-grader falls back to the agent's final answer text — fine for text-only
-deliverables, but document deliverables (xlsx/pptx/pdf) require the file to be
-surfaced. See `_find_deliverable_text` in `rllm/eval/reward_fns/gdpval.py`.
+The host-side reward function grades **only a deliverable the harness has
+explicitly surfaced** on the episode — via `episode.artifacts['deliverable_path']`
+(a file path the grader extracts) or `['deliverable_text']` (already-extracted
+text). It is **fail-closed**: it never reads the agent's transcript or final
+answer, so the judge grades the artifact, not the process (and can't be gamed by
+an agent that merely *describes* a good deliverable). If nothing is surfaced, the
+task is marked `ungraded` (reason `no_deliverable_surfaced`) rather than scored 0.
+So the solver's harness must copy the produced file out of the sandbox and set
+`deliverable_path`. See `_find_deliverable_text` in `rllm/eval/reward_fns/gdpval.py`.
 
 ## Caveat
 

--- a/docs/cookbooks/gdpval.mdx
+++ b/docs/cookbooks/gdpval.mdx
@@ -89,9 +89,11 @@ Surfacing is automatic. Because a host-side grader never sees the sandbox,
 task's `surface_deliverable` metadata, set by the builder): right before
 grading — while the sandbox is still alive — it reads the produced deliverable
 out of the workdir and sets `deliverable_path`. It's backend-agnostic (base64
-over `sandbox.exec`), so it works on Docker/Modal/Daytona alike. It picks the
-file matching the task's `expected_deliverables`, else the newest non-input file
-in the workdir. See `surface_deliverable` in `rllm/eval/_resolution.py`.
+over `sandbox.exec`), so it works on Docker/Modal/Daytona alike. The task
+instruction tells the agent to save deliverables into an `output/` directory, so
+the surfacer reads that first (unambiguous); it only falls back to the expected
+filename, then the newest non-input file, if the agent ignores that. See
+`surface_deliverable` in `rllm/eval/_resolution.py`.
 
 ## Caveat
 

--- a/docs/cookbooks/gdpval.mdx
+++ b/docs/cookbooks/gdpval.mdx
@@ -5,25 +5,37 @@ description: Evaluate an agent on OpenAI's GDPval — 220 gold tasks of economic
 
 This cookbook runs an agent against [GDPval](https://openai.com/index/gdpval/) (`openai/gdpval`), OpenAI's benchmark of real, economically valuable knowledge work: 220 open "gold" tasks across 44 occupations in 9 GDP-heavy sectors. Each task is a role-first prompt plus reference files, and the deliverable is a document (xlsx / docx / pptx / pdf). Like `claw_eval`, this is a native rLLM benchmark — no plugin to install: the builder, the dataset entry, and the reward function all ship with rLLM.
 
-Unlike Terminal-Bench (pass/fail pytest verifier), GDPval is graded by an **LLM judge against a per-task rubric**. This benchmark reproduces GDPval's *automated* grading — the reproducible LLM-judge methodology — not the headline human pairwise win-rate.
+GDPval's grading standard is blind **pairwise human-expert preference** — an expert compares the model's deliverable to the expert's own and picks the better one. Per [OpenAI's current guidance](https://evals.openai.com/gdpval/grading) (the hosted leaderboard/grader is retired), you now run grading yourself, and you may "run an LLM-based judge on the rubrics and deliverables to get a rough estimate of model performance." This benchmark does exactly that.
+
+Two graders ship, and they are complementary:
+
+- **`gdpval`** (headline) — **rubric-informed pairwise** vs. the gold deliverable → GDPval win-rate. This reproduces the benchmark's number.
+- **`gdpval-rubric`** — **absolute weighted-rubric** score in [0, 1]. Dense signal, best used as an RL reward.
 
 ## Pattern
 
 | Aspect | Value |
 |---|---|
 | Loop shape | Single-turn deliverable production (agent runs in a sandbox, writes a file) |
-| Dataset | `gdpval` — 220 tasks, reference files pulled from the HF Hub |
-| Grading | `gdpval_reward_fn`: for each rubric criterion, an LLM judge decides met / not-met |
-| Reward shape | Weight-normalized: `clip(Σ score[met] / Σ score[positive], 0, 1)` |
-| Metrics | Per-task rubric score in [0, 1], averaged across tasks |
+| Dataset | `gdpval` — 220 tasks; reference files **and** gold deliverables pulled from the HF Hub |
+| Grading | `gdpval_pairwise_reward_fn`: judge picks the better of {candidate, expert} deliverable, guided by the rubric |
+| Reward shape | `{0, 0.5, 1}` (loss / tie / win vs. expert), position-swap debiased |
+| Metrics | Win-rate vs. expert, averaged across tasks |
 
 ## Grading detail
 
-Each task ships `rubric_json`: a list of weighted criteria such as
-`{"score": 5, "criterion": "The recommended sample size is 220 …"}`. The grader
-(`rllm/eval/reward_fns/gdpval.py`) extracts the deliverable's text
-(openpyxl / python-docx / python-pptx / pdfplumber), asks the judge to rule on
-each criterion independently, and aggregates:
+**Pairwise (`gdpval`, headline).** The grader extracts the text of both the
+model's deliverable and the expert's gold deliverable
+(openpyxl / python-docx / python-pptx / pdfplumber), gives the judge the task
+prompt, the rubric criteria as guidance, and both deliverables, and asks which
+is the better professional work product. To cancel the judge's position bias it
+runs twice with the deliverables swapped and averages: win = 1, tie = 0.5,
+loss = 0. `is_correct` is a strict win (> 0.5). Averaged over tasks this is the
+GDPval win-rate.
+
+**Rubric (`gdpval-rubric`, RL reward).** Each task ships `rubric_json`: weighted
+criteria such as `{"score": 5, "criterion": "The recommended sample size is 220 …"}`.
+The grader judges each criterion met / not-met and aggregates:
 
 ```
 earned         = Σ score[c] for criteria judged satisfied     # penalties (score < 0) subtract
@@ -74,7 +86,8 @@ surfaced. See `_find_deliverable_text` in `rllm/eval/reward_fns/gdpval.py`.
 
 ## Caveat
 
-GDPval's headline metric is a blind human pairwise win-rate against an expert's
-deliverable, which is not reproducible in an automated harness. The score here
-is the automated rubric grade — useful and comparable across runs, but not the
-same number as the human evaluation.
+The true GDPval standard is *human* expert pairwise preference. The LLM judge
+here is OpenAI's sanctioned self-serve approximation ("a rough estimate"), not a
+human panel — OpenAI's own automated grader agrees with human experts ~66% of
+the time (vs. ~71% human-human). The pairwise number is comparable across runs
+and to the published methodology, but it is an estimate, not the human result.

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -48,7 +48,22 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 REPO_ID = "openai/gdpval"
-VERIFIER_NAME = "gdpval_reward_fn"
+# Default per-task verifiers, matched to the two catalog entries. The stamped
+# [verifier] in task.toml MUST agree with the catalog reward_fn, or eval can
+# grade with a different grader than intended depending on the dispatch path.
+PAIRWISE_VERIFIER = "gdpval_pairwise_reward_fn"
+RUBRIC_VERIFIER = "gdpval_reward_fn"
+
+
+def _verifier_for(name: str, catalog_entry: dict | None) -> str:
+    """The per-task verifier to stamp — the catalog reward_fn when known, else
+    inferred from the dataset name (``*-rubric`` → rubric, else pairwise)."""
+    rf = (catalog_entry or {}).get("reward_fn")
+    if rf:
+        return rf
+    return RUBRIC_VERIFIER if "rubric" in name else PAIRWISE_VERIFIER
+
+
 # Designated output directory (relative to the sandbox workdir) the agent is
 # told to save deliverables into, and the surfacer reads first.
 DELIVERABLE_DIR = "output"
@@ -89,7 +104,7 @@ def _write_instruction(task_dir: Path, row: dict, ref_names: list[str]) -> None:
     (task_dir / "instruction.md").write_text("\n".join(lines), encoding="utf-8")
 
 
-def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], gold_names: list[str], judge_model: str | None) -> None:
+def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], gold_names: list[str], verifier_name: str, judge_model: str | None) -> None:
     prompt = row.get("prompt") or ""
     rubric_json = row.get("rubric_json") or "[]"
     deliverables = _deliverable_basenames(row)
@@ -112,7 +127,7 @@ def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], gold_names
         # (SandboxTaskHooks wraps the evaluator with _SurfacingEvaluator).
         "surface_deliverable = true",
         # Directory (under workdir) the agent is told to write deliverables to;
-        # the surfacer reads it first before falling back to filename heuristics.
+        # the surfacer reads only this directory.
         f'deliverable_dir = "{DELIVERABLE_DIR}"',
     ]
     if judge_model:
@@ -126,7 +141,7 @@ def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], gold_names
         'workdir = "/workspace"',
         "",
         "[verifier]",
-        f'name = "{VERIFIER_NAME}"',
+        f'name = "{verifier_name}"',
         "",
     ]
     (task_dir / "task.toml").write_text("\n".join(lines), encoding="utf-8")
@@ -254,6 +269,8 @@ def build_benchmark(
     reg_rows: list[dict] = []
     n_with_files = 0
     n_with_gold = 0
+    verifier_name = _verifier_for(name, catalog_entry)
+    logger.info("[gdpval] per-task verifier: %s", verifier_name)
     for row in rows:
         task_id = row.get("task_id")
         if not task_id:
@@ -274,7 +291,7 @@ def build_benchmark(
             n_with_gold += 1
 
         _write_instruction(task_dir, row, ref_names)
-        _write_task_toml(task_dir, row, ref_names, gold_names, judge_model)
+        _write_task_toml(task_dir, row, ref_names, gold_names, verifier_name, judge_model)
 
         # Ship the structured rubric alongside the task for transparency/debug.
         tests_dir = task_dir / "tests"

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -1,0 +1,308 @@
+"""Builder for the GDPval sandbox benchmark.
+
+GDPval (``openai/gdpval``) is OpenAI's benchmark of real, economically valuable
+knowledge work across 44 occupations in 9 GDP-heavy sectors. The open ("gold")
+split ships 220 tasks; each row is::
+
+    task_id, sector, occupation, prompt,
+    reference_files[], reference_file_urls[], reference_file_hf_uris[],
+    deliverable_files[], ...,          # the expert's reference deliverable
+    rubric_pretty, rubric_json          # weighted pass/fail grading criteria
+
+This module materializes the split into rLLM's ``type="sandbox"`` task-per-
+directory layout so ``rllm eval gdpval`` can run each task in a sandbox and
+grade the produced deliverable against ``rubric_json`` with the faithful
+weighted-rubric LLM judge (:mod:`rllm.eval.reward_fns.gdpval`).
+
+Used by ``rllm dataset pull gdpval`` (the ``builder`` field in
+``rllm/registry/datasets.json`` → :func:`rllm.cli._pull.pull_dataset`).
+
+On-disk output (``<out_dir>/``)::
+
+    gdpval/
+    ├── dataset.toml                       # [dataset] type="sandbox"
+    ├── <task_id>/
+    │   ├── task.toml                      # prompt/rubric_json in metadata + [verifier]
+    │   ├── instruction.md                 # the role-first prompt + reference-file list
+    │   ├── environment/files/             # reference files (uploaded to /workspace)
+    │   └── tests/rubric.json              # structured rubric (debug/transparency)
+    └── ...
+
+Grading: each task's ``[verifier]`` points at ``gdpval_reward_fn``, a host-side
+LLM-judge that reads the deliverable text surfaced on the episode and scores it
+against the rubric. Surfacing the produced deliverable file to the episode
+(``artifacts['deliverable_path']`` / ``['deliverable_text']``) is the harness
+integration seam — see :func:`rllm.eval.reward_fns.gdpval._find_deliverable_text`.
+
+NOTE: ``openai/gdpval`` reference files are pulled from the HF Hub; the full
+220-task pull downloads all reference documents. Use ``--limit`` for smoke runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REPO_ID = "openai/gdpval"
+VERIFIER_NAME = "gdpval_reward_fn"
+
+
+def _toml_escape(s: str) -> str:
+    """Escape a string for a TOML triple-quoted basic string."""
+    return s.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+
+
+def _deliverable_basenames(row: dict) -> list[str]:
+    """Expected deliverable filenames (basename) from the reference deliverables."""
+    out = []
+    for f in row.get("deliverable_files") or []:
+        name = Path(str(f)).name
+        if name:
+            out.append(name)
+    return out
+
+
+def _write_instruction(task_dir: Path, row: dict, ref_names: list[str]) -> None:
+    prompt = row.get("prompt") or ""
+    lines = [prompt.strip(), ""]
+    if ref_names:
+        lines.append("## Reference files (available in your working directory)")
+        lines += [f"- {n}" for n in ref_names]
+        lines.append("")
+    deliverables = _deliverable_basenames(row)
+    if deliverables:
+        lines.append("## Expected deliverable filename(s)")
+        lines += [f"- {n}" for n in deliverables]
+        lines.append("")
+    (task_dir / "instruction.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], judge_model: str | None) -> None:
+    prompt = row.get("prompt") or ""
+    rubric_json = row.get("rubric_json") or "[]"
+    deliverables = _deliverable_basenames(row)
+
+    # Top-level scalars land directly in Task.metadata (the loader copies the
+    # whole task.toml into metadata), so the reward_fn can read prompt/rubric.
+    # Scalars MUST precede the first [section] in TOML.
+    lines = [
+        f'task_id = "{row.get("task_id", "")}"',
+        f'sector = """{_toml_escape(row.get("sector", ""))}"""',
+        f'occupation = """{_toml_escape(row.get("occupation", ""))}"""',
+        f'prompt = """{_toml_escape(prompt)}"""',
+        f'rubric_json = """{_toml_escape(rubric_json)}"""',
+        f"expected_deliverables = {json.dumps(deliverables)}",
+        f"reference_files = {json.dumps(ref_names)}",
+    ]
+    if judge_model:
+        lines.append(f'judge_model = "{judge_model}"')
+    lines += [
+        "",
+        "[task]",
+        f'name = "{row.get("task_id", "")}"',
+        "",
+        "[environment]",
+        'workdir = "/workspace"',
+        "",
+        "[verifier]",
+        f'name = "{VERIFIER_NAME}"',
+        "",
+    ]
+    (task_dir / "task.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _stage_reference_files(row: dict, files_dir: Path) -> list[str]:
+    """Download the task's reference files into ``files_dir``. Returns basenames.
+
+    Uses ``hf_hub_download`` on the repo-relative paths in ``reference_files``
+    (cached). Failures are logged and skipped so one bad file can't abort the
+    whole build.
+    """
+    from huggingface_hub import hf_hub_download
+
+    names: list[str] = []
+    for rel in row.get("reference_files") or []:
+        rel = str(rel)
+        try:
+            local = hf_hub_download(REPO_ID, rel, repo_type="dataset")
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[gdpval] could not download reference file %s: %s", rel, e)
+            continue
+        dest = files_dir / Path(rel).name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(local, dest)
+        names.append(dest.name)
+    return names
+
+
+def _write_dataset_toml(out: Path, *, name: str, split: str, description: str, default_agent: str) -> None:
+    content = "\n".join(
+        [
+            "[dataset]",
+            f'name = "{name}"',
+            'type = "sandbox"',
+            f'description = "{_toml_escape(description)}"',
+            'default_sandbox = "docker"',
+            f'default_agent = "{default_agent}"',
+            f'split = "{split}"',
+            "",
+        ]
+    )
+    (out / "dataset.toml").write_text(content, encoding="utf-8")
+
+
+def build_benchmark(
+    *,
+    name: str = "gdpval",
+    split: str = "train",
+    out_dir: str | Path,
+    catalog_entry: dict | None = None,
+    limit: int | None = None,
+    occupations: list[str] | None = None,
+    default_agent: str = "claude-code",
+    judge_model: str | None = None,
+    skip_files: bool = False,
+    clean: bool = False,
+    register: bool = True,
+) -> Path:
+    """Materialize the GDPval split into a sandbox benchmark directory.
+
+    Args:
+        name: Dataset/registry name (also dataset.toml ``name``).
+        split: HF split to build (``openai/gdpval`` publishes ``train``).
+        out_dir: Output benchmark directory.
+        catalog_entry: Optional datasets.json entry; ``description`` /
+            ``default_agent`` / ``eval_split`` are read from it when present.
+        limit: Keep only the first N tasks (after the occupation filter).
+        occupations: Optional occupation allowlist (exact match), e.g. to build
+            only the GDPval occupations that overlap the pipeline's coverage.
+        default_agent: ``default_agent`` written into dataset.toml.
+        judge_model: Optional judge model stamped into each task's metadata.
+        skip_files: Skip downloading reference files (fast structural smoke run).
+        clean: Remove ``out_dir`` before building.
+        register: Also register rows in ``DatasetRegistry`` for ``rllm dataset`` parity.
+
+    Returns:
+        Path to the built benchmark directory.
+    """
+    from datasets import load_dataset
+
+    if catalog_entry:
+        split = catalog_entry.get("eval_split") or split
+        default_agent = catalog_entry.get("default_agent") or default_agent
+
+    out = Path(out_dir).expanduser()
+    if clean and out.exists():
+        logger.info("[gdpval] removing existing %s", out)
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    logger.info("[gdpval] loading %s split=%s ...", REPO_ID, split)
+    rows = [dict(r) for r in load_dataset(REPO_ID, split=split)]
+
+    if occupations:
+        keep = {o.strip().lower() for o in occupations}
+        rows = [r for r in rows if str(r.get("occupation", "")).strip().lower() in keep]
+    if limit is not None:
+        rows = rows[:limit]
+    logger.info("[gdpval] selected %d tasks (occupations=%s, limit=%s)", len(rows), occupations and len(occupations), limit)
+
+    reg_rows: list[dict] = []
+    n_with_files = 0
+    for row in rows:
+        task_id = row.get("task_id")
+        if not task_id:
+            continue
+        task_dir = out / task_id
+        if task_dir.exists():
+            shutil.rmtree(task_dir)
+        files_dir = task_dir / "environment" / "files"
+        files_dir.mkdir(parents=True, exist_ok=True)
+
+        ref_names = [] if skip_files else _stage_reference_files(row, files_dir)
+        if ref_names:
+            n_with_files += 1
+
+        _write_instruction(task_dir, row, ref_names)
+        _write_task_toml(task_dir, row, ref_names, judge_model)
+
+        # Ship the structured rubric alongside the task for transparency/debug.
+        tests_dir = task_dir / "tests"
+        tests_dir.mkdir(parents=True, exist_ok=True)
+        (tests_dir / "rubric.json").write_text(row.get("rubric_json") or "[]", encoding="utf-8")
+
+        reg_rows.append(
+            {
+                "task_id": task_id,
+                "id": task_id,
+                "instruction": (row.get("prompt") or "").strip(),
+                "task_path": str(task_dir),
+                "occupation": row.get("occupation", ""),
+                "sector": row.get("sector", ""),
+                "expected_deliverables": _deliverable_basenames(row),
+            }
+        )
+
+    description = (catalog_entry or {}).get("description") or "GDPval (OpenAI): 220 gold tasks of economically valuable knowledge work (sandbox; weighted-rubric LLM-judge graded)."
+    _write_dataset_toml(out, name=name, split=split, description=description, default_agent=default_agent)
+    logger.info("[gdpval] wrote %d task dirs to %s (%d with reference files)", len(reg_rows), out, n_with_files)
+
+    if not reg_rows:
+        raise RuntimeError(f"[gdpval] no tasks materialized from {REPO_ID} split={split}.")
+
+    if register:
+        try:
+            from rllm.data import DatasetRegistry
+
+            DatasetRegistry.register_dataset(
+                name=name,
+                data=reg_rows,
+                split=split,
+                source=REPO_ID,
+                description=description,
+                category=(catalog_entry or {}).get("category", "agentic"),
+            )
+        except Exception:  # registry parity is best-effort; eval uses the sandbox dir
+            logger.warning("[gdpval] could not register rows in DatasetRegistry (non-fatal)", exc_info=True)
+
+    return out
+
+
+def main() -> None:
+    """CLI: ``python -m rllm.data.gdpval_builder --out-dir <dir> [--limit N]``."""
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(description="Materialize GDPval into an rLLM sandbox benchmark directory.")
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--name", default="gdpval")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--occupations", nargs="*", default=None)
+    parser.add_argument("--default-agent", default="claude-code")
+    parser.add_argument("--judge-model", default=None)
+    parser.add_argument("--skip-files", action="store_true")
+    parser.add_argument("--clean", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=os.environ.get("RLLM_LOG_LEVEL", "INFO"))
+    build_benchmark(
+        name=args.name,
+        split=args.split,
+        out_dir=args.out_dir,
+        limit=args.limit,
+        occupations=args.occupations,
+        default_agent=args.default_agent,
+        judge_model=args.judge_model,
+        skip_files=args.skip_files,
+        clean=args.clean,
+        register=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -49,6 +49,9 @@ logger = logging.getLogger(__name__)
 
 REPO_ID = "openai/gdpval"
 VERIFIER_NAME = "gdpval_reward_fn"
+# Designated output directory (relative to the sandbox workdir) the agent is
+# told to save deliverables into, and the surfacer reads first.
+DELIVERABLE_DIR = "output"
 
 
 def _toml_escape(s: str) -> str:
@@ -78,6 +81,11 @@ def _write_instruction(task_dir: Path, row: dict, ref_names: list[str]) -> None:
         lines.append("## Expected deliverable filename(s)")
         lines += [f"- {n}" for n in deliverables]
         lines.append("")
+    # Harness instruction: a designated output directory removes any ambiguity
+    # about which produced file is the deliverable to grade.
+    lines.append("## Where to save your work")
+    lines.append(f"Save your final deliverable file(s) into the `{DELIVERABLE_DIR}/` directory of your working directory. Only put the files you want graded there.")
+    lines.append("")
     (task_dir / "instruction.md").write_text("\n".join(lines), encoding="utf-8")
 
 
@@ -103,6 +111,9 @@ def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], gold_names
         # Opt in to sandbox->host deliverable surfacing before host-side grading
         # (SandboxTaskHooks wraps the evaluator with _SurfacingEvaluator).
         "surface_deliverable = true",
+        # Directory (under workdir) the agent is told to write deliverables to;
+        # the surfacer reads it first before falling back to filename heuristics.
+        f'deliverable_dir = "{DELIVERABLE_DIR}"',
     ]
     if judge_model:
         lines.append(f'judge_model = "{judge_model}"')

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -81,7 +81,7 @@ def _write_instruction(task_dir: Path, row: dict, ref_names: list[str]) -> None:
     (task_dir / "instruction.md").write_text("\n".join(lines), encoding="utf-8")
 
 
-def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], judge_model: str | None) -> None:
+def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], gold_names: list[str], judge_model: str | None) -> None:
     prompt = row.get("prompt") or ""
     rubric_json = row.get("rubric_json") or "[]"
     deliverables = _deliverable_basenames(row)
@@ -97,6 +97,9 @@ def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], judge_mode
         f'rubric_json = """{_toml_escape(rubric_json)}"""',
         f"expected_deliverables = {json.dumps(deliverables)}",
         f"reference_files = {json.dumps(ref_names)}",
+        # Gold (expert) deliverables staged under <task_dir>/reference/ — read by
+        # the pairwise grader (gdpval_pairwise_reward_fn) via _find_reference_text.
+        f"reference_deliverables = {json.dumps(gold_names)}",
     ]
     if judge_model:
         lines.append(f'judge_model = "{judge_model}"')
@@ -133,6 +136,29 @@ def _stage_reference_files(row: dict, files_dir: Path) -> list[str]:
             logger.warning("[gdpval] could not download reference file %s: %s", rel, e)
             continue
         dest = files_dir / Path(rel).name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(local, dest)
+        names.append(dest.name)
+    return names
+
+
+def _stage_gold_deliverables(row: dict, ref_dir: Path) -> list[str]:
+    """Download the task's gold (expert) deliverables into ``ref_dir``.
+
+    These are the reference deliverables the pairwise grader compares against.
+    Uses ``hf_hub_download`` on the repo-relative paths in ``deliverable_files``.
+    """
+    from huggingface_hub import hf_hub_download
+
+    names: list[str] = []
+    for rel in row.get("deliverable_files") or []:
+        rel = str(rel)
+        try:
+            local = hf_hub_download(REPO_ID, rel, repo_type="dataset")
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[gdpval] could not download gold deliverable %s: %s", rel, e)
+            continue
+        dest = ref_dir / Path(rel).name
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(local, dest)
         names.append(dest.name)
@@ -213,6 +239,7 @@ def build_benchmark(
 
     reg_rows: list[dict] = []
     n_with_files = 0
+    n_with_gold = 0
     for row in rows:
         task_id = row.get("task_id")
         if not task_id:
@@ -227,8 +254,13 @@ def build_benchmark(
         if ref_names:
             n_with_files += 1
 
+        # Gold deliverables → <task_dir>/reference/ (used by the pairwise grader).
+        gold_names = [] if skip_files else _stage_gold_deliverables(row, task_dir / "reference")
+        if gold_names:
+            n_with_gold += 1
+
         _write_instruction(task_dir, row, ref_names)
-        _write_task_toml(task_dir, row, ref_names, judge_model)
+        _write_task_toml(task_dir, row, ref_names, gold_names, judge_model)
 
         # Ship the structured rubric alongside the task for transparency/debug.
         tests_dir = task_dir / "tests"
@@ -244,12 +276,13 @@ def build_benchmark(
                 "occupation": row.get("occupation", ""),
                 "sector": row.get("sector", ""),
                 "expected_deliverables": _deliverable_basenames(row),
+                "reference_deliverables": gold_names,
             }
         )
 
     description = (catalog_entry or {}).get("description") or "GDPval (OpenAI): 220 gold tasks of economically valuable knowledge work (sandbox; weighted-rubric LLM-judge graded)."
     _write_dataset_toml(out, name=name, split=split, description=description, default_agent=default_agent)
-    logger.info("[gdpval] wrote %d task dirs to %s (%d with reference files)", len(reg_rows), out, n_with_files)
+    logger.info("[gdpval] wrote %d task dirs to %s (%d with reference files, %d with gold deliverables)", len(reg_rows), out, n_with_files, n_with_gold)
 
     if not reg_rows:
         raise RuntimeError(f"[gdpval] no tasks materialized from {REPO_ID} split={split}.")

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -100,6 +100,9 @@ def _write_task_toml(task_dir: Path, row: dict, ref_names: list[str], gold_names
         # Gold (expert) deliverables staged under <task_dir>/reference/ — read by
         # the pairwise grader (gdpval_pairwise_reward_fn) via _find_reference_text.
         f"reference_deliverables = {json.dumps(gold_names)}",
+        # Opt in to sandbox->host deliverable surfacing before host-side grading
+        # (SandboxTaskHooks wraps the evaluator with _SurfacingEvaluator).
+        "surface_deliverable = true",
     ]
     if judge_model:
         lines.append(f'judge_model = "{judge_model}"')

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -643,15 +643,26 @@ def _safe_exec(sandbox: Sandbox, command: str, timeout: float | None = None, use
 _SURFACE_MAX_BYTES = 25 * 1024 * 1024  # skip files too large to base64 over exec
 
 
-def _locate_deliverable_paths(sandbox: Sandbox, workdir: str, expected: list[str], inputs: set[str]) -> list[str]:
+def _locate_deliverable_paths(sandbox: Sandbox, workdir: str, expected: list[str], inputs: set[str], deliverable_dir: str | None = None) -> list[str]:
     """Find the produced deliverable file(s) inside the sandbox workdir.
 
-    Prefers files matching the task's expected deliverable basenames; otherwise
-    falls back to the newest top-level file that isn't a staged input.
+    Priority: (1) everything in the designated ``deliverable_dir`` the agent was
+    told to write to; (2) files matching the task's expected basenames; (3) the
+    newest top-level file that isn't a staged input. (1) is the reliable path;
+    (2)/(3) are fallbacks for when the agent ignores the output-dir instruction.
     """
     import shlex
 
     wd = shlex.quote(workdir)
+
+    # (1) Designated output directory — unambiguous when the agent complied.
+    if deliverable_dir:
+        out_dir = f"{workdir.rstrip('/')}/{deliverable_dir.strip('/')}"
+        listed = _safe_exec(sandbox, f"find {shlex.quote(out_dir)} -type f 2>/dev/null | head -n 50", timeout=30)
+        in_dir = [ln.strip() for ln in listed.splitlines() if ln.strip()]
+        if in_dir:
+            return list(dict.fromkeys(in_dir))
+
     found: list[str] = []
     for name in expected:
         out = _safe_exec(sandbox, f"find {wd} -type f -name {shlex.quote(name)} 2>/dev/null | head -n 5", timeout=30)
@@ -707,8 +718,9 @@ def surface_deliverable(sandbox: Sandbox, task: Task, episode: Any) -> None:
     workdir = task.metadata.get("workdir") or "/workspace"
     expected = list(task.metadata.get("expected_deliverables") or [])
     inputs = {Path(x).name for x in (task.metadata.get("reference_files") or [])}
+    deliverable_dir = task.metadata.get("deliverable_dir")
 
-    paths = _locate_deliverable_paths(sandbox, workdir, expected, inputs)
+    paths = _locate_deliverable_paths(sandbox, workdir, expected, inputs, deliverable_dir)
     if not paths:
         return
 

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -629,6 +629,127 @@ def _safe_exec(sandbox: Sandbox, command: str, timeout: float | None = None, use
         return ""
 
 
+# --------------------------------------------------------------------------- #
+# Deliverable surfacing: the reverse of _setup_task_environment's upload_dir.
+#
+# Host-side graders (e.g. GDPval's) score a file the agent produced *inside* the
+# sandbox, but they only receive (task, episode) — never the sandbox handle. So
+# before such a grader runs we read the produced deliverable out of the still-
+# alive sandbox and attach it to the episode. Backend-agnostic: uses the common
+# ``exec`` primitive (base64 over stdout), so it works on Docker/Modal/Daytona
+# alike. Opt-in per task via ``metadata['surface_deliverable']``.
+# --------------------------------------------------------------------------- #
+
+_SURFACE_MAX_BYTES = 25 * 1024 * 1024  # skip files too large to base64 over exec
+
+
+def _locate_deliverable_paths(sandbox: Sandbox, workdir: str, expected: list[str], inputs: set[str]) -> list[str]:
+    """Find the produced deliverable file(s) inside the sandbox workdir.
+
+    Prefers files matching the task's expected deliverable basenames; otherwise
+    falls back to the newest top-level file that isn't a staged input.
+    """
+    import shlex
+
+    wd = shlex.quote(workdir)
+    found: list[str] = []
+    for name in expected:
+        out = _safe_exec(sandbox, f"find {wd} -type f -name {shlex.quote(name)} 2>/dev/null | head -n 5", timeout=30)
+        found += [ln.strip() for ln in out.splitlines() if ln.strip()]
+    if found:
+        return list(dict.fromkeys(found))  # dedupe, preserve order
+
+    # Fallback: newest top-level file that wasn't uploaded as an input.
+    listing = _safe_exec(sandbox, f"ls -1t {wd} 2>/dev/null", timeout=30)
+    for name in (ln.strip() for ln in listing.splitlines()):
+        if not name or name in inputs:
+            continue
+        path = f"{workdir.rstrip('/')}/{name}"
+        if _safe_exec(sandbox, f"test -f {shlex.quote(path)} && echo yes", timeout=15).strip() == "yes":
+            return [path]
+    return []
+
+
+def _read_sandbox_file(sandbox: Sandbox, path: str) -> bytes | None:
+    """Read a file's bytes out of the sandbox via base64-over-exec."""
+    import shlex
+
+    q = shlex.quote(path)
+    size = _safe_exec(sandbox, f"wc -c < {q} 2>/dev/null", timeout=15).strip()
+    if size.isdigit() and int(size) > _SURFACE_MAX_BYTES:
+        logger.warning("[surface] deliverable %s is %s bytes (> %d); skipping", path, size, _SURFACE_MAX_BYTES)
+        return None
+    b64 = _safe_exec(sandbox, f"base64 {q} 2>/dev/null", timeout=120)
+    if not b64.strip():
+        return None
+    try:
+        return base64.b64decode("".join(b64.split()))
+    except (ValueError, TypeError):
+        logger.warning("[surface] could not decode base64 for %s", path)
+        return None
+
+
+def surface_deliverable(sandbox: Sandbox, task: Task, episode: Any) -> None:
+    """Pull the agent's produced deliverable out of the sandbox onto the episode.
+
+    Sets ``episode.artifacts['deliverable_path']`` (and ``output_files`` for
+    multi-file deliverables) so a host-side grader can read it. No-op if the
+    flow already surfaced a deliverable, or if nothing was produced (the grader
+    then fails closed — marks the task ungraded rather than scoring it).
+    """
+    import os
+    import tempfile
+
+    arts = episode.artifacts if episode.artifacts is not None else {}
+    if arts.get("deliverable_path") or arts.get("deliverable_text"):
+        return
+
+    workdir = task.metadata.get("workdir") or "/workspace"
+    expected = list(task.metadata.get("expected_deliverables") or [])
+    inputs = {Path(x).name for x in (task.metadata.get("reference_files") or [])}
+
+    paths = _locate_deliverable_paths(sandbox, workdir, expected, inputs)
+    if not paths:
+        return
+
+    host_paths: list[str] = []
+    for p in paths:
+        data = _read_sandbox_file(sandbox, p)
+        if data is None:
+            continue
+        fd, host_path = tempfile.mkstemp(prefix="rllm_deliv_", suffix=Path(p).suffix)
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        host_paths.append(host_path)
+
+    if not host_paths:
+        return
+    episode.artifacts["deliverable_path"] = host_paths[0]
+    if len(host_paths) > 1:
+        episode.artifacts["output_files"] = host_paths
+
+
+class _SurfacingEvaluator:
+    """Wrap an evaluator so the produced deliverable is surfaced before grading.
+
+    Runs at evaluate time — while the sandbox is still alive (teardown is
+    deferred until after the evaluator) — so the closed-over sandbox handle is
+    valid. Surfacing failures are swallowed: the wrapped grader then sees no
+    deliverable and fails closed on its own terms.
+    """
+
+    def __init__(self, inner: Evaluator, sandbox: Sandbox) -> None:
+        self._inner = inner
+        self._sandbox = sandbox
+
+    def evaluate(self, task: Task, episode: Any):
+        try:
+            surface_deliverable(self._sandbox, task, episode)
+        except Exception:
+            logger.warning("[surface] deliverable surfacing failed; grader will fail closed", exc_info=True)
+        return self._inner.evaluate(task, episode)
+
+
 # ---------------------------------------------------------------------------
 # Adapters
 # ---------------------------------------------------------------------------

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -643,42 +643,31 @@ def _safe_exec(sandbox: Sandbox, command: str, timeout: float | None = None, use
 _SURFACE_MAX_BYTES = 25 * 1024 * 1024  # skip files too large to base64 over exec
 
 
-def _locate_deliverable_paths(sandbox: Sandbox, workdir: str, expected: list[str], inputs: set[str], deliverable_dir: str | None = None) -> list[str]:
-    """Find the produced deliverable file(s) inside the sandbox workdir.
+def _locate_deliverable_paths(sandbox: Sandbox, workdir: str, expected: list[str], deliverable_dir: str | None) -> list[str]:
+    """Return the produced deliverable file(s) from the designated output dir.
 
-    Priority: (1) everything in the designated ``deliverable_dir`` the agent was
-    told to write to; (2) files matching the task's expected basenames; (3) the
-    newest top-level file that isn't a staged input. (1) is the reliable path;
-    (2)/(3) are fallbacks for when the agent ignores the output-dir instruction.
+    Reads every file under ``<workdir>/<deliverable_dir>`` — the directory the
+    agent was instructed to save deliverables into. When the task declares
+    expected basenames and any of them are present, restricts to those;
+    otherwise returns all files found. No workdir-wide search or newest-file
+    guessing: if the agent didn't write to the output dir, nothing is surfaced
+    and the grader fails closed.
     """
     import shlex
 
-    wd = shlex.quote(workdir)
-
-    # (1) Designated output directory — unambiguous when the agent complied.
-    if deliverable_dir:
-        out_dir = f"{workdir.rstrip('/')}/{deliverable_dir.strip('/')}"
-        listed = _safe_exec(sandbox, f"find {shlex.quote(out_dir)} -type f 2>/dev/null | head -n 50", timeout=30)
-        in_dir = [ln.strip() for ln in listed.splitlines() if ln.strip()]
-        if in_dir:
-            return list(dict.fromkeys(in_dir))
-
-    found: list[str] = []
-    for name in expected:
-        out = _safe_exec(sandbox, f"find {wd} -type f -name {shlex.quote(name)} 2>/dev/null | head -n 5", timeout=30)
-        found += [ln.strip() for ln in out.splitlines() if ln.strip()]
-    if found:
-        return list(dict.fromkeys(found))  # dedupe, preserve order
-
-    # Fallback: newest top-level file that wasn't uploaded as an input.
-    listing = _safe_exec(sandbox, f"ls -1t {wd} 2>/dev/null", timeout=30)
-    for name in (ln.strip() for ln in listing.splitlines()):
-        if not name or name in inputs:
-            continue
-        path = f"{workdir.rstrip('/')}/{name}"
-        if _safe_exec(sandbox, f"test -f {shlex.quote(path)} && echo yes", timeout=15).strip() == "yes":
-            return [path]
-    return []
+    if not deliverable_dir:
+        return []
+    out_dir = f"{workdir.rstrip('/')}/{deliverable_dir.strip('/')}"
+    listed = _safe_exec(sandbox, f"find {shlex.quote(out_dir)} -type f 2>/dev/null | head -n 100", timeout=30)
+    files = list(dict.fromkeys(ln.strip() for ln in listed.splitlines() if ln.strip()))
+    if not files:
+        return []
+    if expected:
+        exp = set(expected)
+        matched = [f for f in files if Path(f).name in exp]
+        if matched:
+            return matched
+    return files
 
 
 def _read_sandbox_file(sandbox: Sandbox, path: str) -> bytes | None:
@@ -717,10 +706,9 @@ def surface_deliverable(sandbox: Sandbox, task: Task, episode: Any) -> None:
 
     workdir = task.metadata.get("workdir") or "/workspace"
     expected = list(task.metadata.get("expected_deliverables") or [])
-    inputs = {Path(x).name for x in (task.metadata.get("reference_files") or [])}
     deliverable_dir = task.metadata.get("deliverable_dir")
 
-    paths = _locate_deliverable_paths(sandbox, workdir, expected, inputs, deliverable_dir)
+    paths = _locate_deliverable_paths(sandbox, workdir, expected, deliverable_dir)
     if not paths:
         return
 

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -712,13 +712,17 @@ def surface_deliverable(sandbox: Sandbox, task: Task, episode: Any) -> None:
     if not paths:
         return
 
+    # Preserve the agent's original basename: write into a temp *directory* under
+    # the file's real name (not mkstemp, which mangles it). Basename matters — the
+    # rubric grader has criteria like "the deliverable's basename is 'Sample'".
+    tmpdir = tempfile.mkdtemp(prefix="rllm_deliv_")
     host_paths: list[str] = []
     for p in paths:
         data = _read_sandbox_file(sandbox, p)
         if data is None:
             continue
-        fd, host_path = tempfile.mkstemp(prefix="rllm_deliv_", suffix=Path(p).suffix)
-        with os.fdopen(fd, "wb") as fh:
+        host_path = os.path.join(tmpdir, Path(p).name)
+        with open(host_path, "wb") as fh:
             fh.write(data)
         host_paths.append(host_path)
 

--- a/rllm/eval/evaluator_loader.py
+++ b/rllm/eval/evaluator_loader.py
@@ -100,6 +100,7 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
     "llm_judge_reward_fn": "rllm.eval.reward_fns.llm_judge:evaluate",
     "claw_eval_reward_fn": "rllm.eval.reward_fns.claw_eval:evaluate",
     "gdpval_reward_fn": "rllm.eval.reward_fns.gdpval:evaluate",
+    "gdpval_pairwise_reward_fn": "rllm.eval.reward_fns.gdpval:evaluate_pairwise",
     "llm_equality_reward_fn": "rllm.eval.reward_fns.llm_equality:evaluate",
     "translation_reward_fn": "rllm.eval.reward_fns.translation:evaluate",
     "widesearch_reward_fn": "rllm.eval.reward_fns.widesearch:evaluate",

--- a/rllm/eval/evaluator_loader.py
+++ b/rllm/eval/evaluator_loader.py
@@ -99,6 +99,7 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
     "bfcl_reward_fn": "rllm.eval.reward_fns.bfcl:evaluate",
     "llm_judge_reward_fn": "rllm.eval.reward_fns.llm_judge:evaluate",
     "claw_eval_reward_fn": "rllm.eval.reward_fns.claw_eval:evaluate",
+    "gdpval_reward_fn": "rllm.eval.reward_fns.gdpval:evaluate",
     "llm_equality_reward_fn": "rllm.eval.reward_fns.llm_equality:evaluate",
     "translation_reward_fn": "rllm.eval.reward_fns.translation:evaluate",
     "widesearch_reward_fn": "rllm.eval.reward_fns.widesearch:evaluate",

--- a/rllm/eval/reward_fns/_resolver.py
+++ b/rllm/eval/reward_fns/_resolver.py
@@ -33,6 +33,7 @@ _REWARD_FN_TO_SCORE_FN: dict[str, str] = {
     "llm_equality_reward_fn": "rllm.eval.reward_fns.llm_equality",
     "llm_judge_reward_fn": "rllm.eval.reward_fns.llm_judge",
     "gdpval_reward_fn": "rllm.eval.reward_fns.gdpval",
+    "gdpval_pairwise_reward_fn": "rllm.eval.reward_fns.gdpval",
     "translation_reward_fn": "rllm.eval.reward_fns.translation",
     "widesearch_reward_fn": "rllm.eval.reward_fns.widesearch",
 }

--- a/rllm/eval/reward_fns/_resolver.py
+++ b/rllm/eval/reward_fns/_resolver.py
@@ -32,6 +32,7 @@ _REWARD_FN_TO_SCORE_FN: dict[str, str] = {
     "ifeval_reward_fn": "rllm.eval.reward_fns.ifeval",
     "llm_equality_reward_fn": "rllm.eval.reward_fns.llm_equality",
     "llm_judge_reward_fn": "rllm.eval.reward_fns.llm_judge",
+    "gdpval_reward_fn": "rllm.eval.reward_fns.gdpval",
     "translation_reward_fn": "rllm.eval.reward_fns.translation",
     "widesearch_reward_fn": "rllm.eval.reward_fns.widesearch",
 }

--- a/rllm/eval/reward_fns/gdpval.py
+++ b/rllm/eval/reward_fns/gdpval.py
@@ -47,7 +47,6 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from rllm.eval.reward_fns._helpers import extract_answer_text
 from rllm.eval.types import EvalOutput, Signal
 from rllm.types import Episode, Task
 
@@ -255,12 +254,17 @@ def _extract_pdf(p: Path) -> str:
 def _find_deliverable_text(task: Task, episode: Episode) -> tuple[str, str]:
     """Locate the deliverable's text. Returns (text, source_description).
 
+    FAIL-CLOSED: the grader only ever reads a deliverable the harness has
+    explicitly surfaced — never the agent's transcript or final answer. This
+    keeps the judge from grading the *process* instead of the *artifact* (and
+    from being gamed by an agent that describes a good deliverable it never
+    produced). If nothing is surfaced, returns ("", "none") and the caller
+    marks the task ungraded rather than scoring it.
+
     Resolution order:
-      1. ``episode.artifacts['deliverable_text']`` — text surfaced directly.
+      1. ``episode.artifacts['deliverable_text']`` — deliverable text surfaced directly.
       2. ``episode.artifacts['deliverable_path']`` / ``output_files`` — a file
-         path (in the sandbox workdir mount or on the host) to extract.
-      3. Fallback: the agent's final answer text (lets text-only deliverables
-         still be graded, matching the claw_eval fallback philosophy).
+         path (sandbox workdir mount or host) to extract.
     """
     arts = episode.artifacts or {}
     if arts.get("deliverable_text"):
@@ -279,7 +283,7 @@ def _find_deliverable_text(task: Task, episode: Episode) -> tuple[str, str]:
         if text:
             return text, f"file:{Path(c).name}"
 
-    return extract_answer_text(episode) or "", "final_answer_fallback"
+    return "", "none"
 
 
 def _resolve_judge(task: Task) -> tuple[str, str | None, str | None]:
@@ -360,6 +364,14 @@ def evaluate(task: Task, episode: Episode) -> EvalOutput:
         )
 
     deliverable, source = _find_deliverable_text(task, episode)
+    if not deliverable:
+        # Fail-closed: no deliverable was surfaced (never grade the transcript).
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="rubric_score", value=0.0)],
+            metadata={"reason": "no_deliverable_surfaced", "ungraded": True},
+        )
     prompt = task.metadata.get("prompt") or (task.instruction if isinstance(task.instruction, str) else "") or ""
 
     model, base_url, api_key = _resolve_judge(task)
@@ -522,6 +534,14 @@ def evaluate_pairwise(task: Task, episode: Episode) -> EvalOutput:
     deliverable). Mean over tasks = GDPval win-rate.
     """
     candidate, cand_src = _find_deliverable_text(task, episode)
+    if not candidate:
+        # Fail-closed: no candidate deliverable surfaced (never grade the transcript).
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="pairwise_win", value=0.0)],
+            metadata={"reason": "no_deliverable_surfaced", "ungraded": True},
+        )
     reference, ref_src = _find_reference_text(task)
     if not reference:
         # No gold deliverable → pairwise is impossible; don't fabricate a score.

--- a/rllm/eval/reward_fns/gdpval.py
+++ b/rllm/eval/reward_fns/gdpval.py
@@ -1,0 +1,380 @@
+"""GDPval grader: faithful weighted-rubric LLM-as-judge.
+
+GDPval (``openai/gdpval``) is OpenAI's benchmark of real, economically valuable
+knowledge work: each task is a role-first ``prompt`` plus ``reference_files``,
+and the expected output is a document *deliverable* (xlsx / docx / pptx / pdf).
+Each task ships a machine-readable rubric (``rubric_json``): a list of weighted
+pass/fail criteria::
+
+    [{"score": 2, "criterion": "The workbook contains a worksheet named ...", ...},
+     {"score": 5, "criterion": "The recommended sample size is 220 ...", ...},
+     {"score": -2, "criterion": "The deliverable fabricates figures not in ...", ...}]
+
+This module reproduces GDPval's *automated* grading (the reproducible LLM-judge
+methodology, not the headline human pairwise win-rate): an LLM judge decides,
+per criterion, whether the deliverable satisfies it, and the reward is the
+weight-normalized sum of satisfied criteria.
+
+Score aggregation (matches GDPval's rubric semantics):
+    earned         = sum(c.score for c in rubric if judge_says_condition_holds(c))
+    total_possible = sum(c.score for c in rubric if c.score > 0)
+    reward         = clip(earned / total_possible, 0.0, 1.0)
+
+Positive-weight criteria *add* when satisfied; negative-weight (penalty)
+criteria *subtract* when their (undesirable) condition is present. Reward is
+clipped to [0, 1] so penalties cannot drive it below zero.
+
+Two entry points share this logic:
+* :func:`evaluate` — a host-side rLLM reward_fn (``gdpval_reward_fn``) that
+  grades the deliverable text surfaced on the episode. This is the canonical
+  spec; the in-sandbox ``tests/grade.py`` written by :mod:`rllm.data.gdpval_builder`
+  is a self-contained copy of :func:`grade_rubric` for the case where the
+  deliverable file only exists inside the sandbox.
+* :func:`grade_rubric` / :func:`extract_deliverable_text` — reusable helpers.
+
+Judge model resolution (first hit wins), mirroring ``claw_eval``:
+  1. ``GDPVAL_JUDGE_MODEL`` / ``GDPVAL_JUDGE_BASE_URL`` / ``GDPVAL_JUDGE_API_KEY``.
+  2. ``task.metadata`` keys ``judge_model`` / ``judge_base_url`` / ``judge_api_key``.
+  3. The user's rLLM provider config (``~/.rllm/config.json``) via litellm.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rllm.eval.reward_fns._helpers import extract_answer_text
+from rllm.eval.types import EvalOutput, Signal
+from rllm.types import Episode, Task
+
+logger = logging.getLogger(__name__)
+
+# Hint injected into the solver's system prompt (picked up by
+# rllm.eval.reward_fns._resolver.get_verifier_system_prompt).
+SYSTEM_PROMPT = (
+    "Produce the requested deliverable as an actual file (xlsx/docx/pptx/pdf/csv/txt) "
+    "in the working directory, using the exact filename the task specifies. Your work "
+    "is graded by an LLM judge against a detailed rubric applied to that file's contents."
+)
+
+JUDGE_SYSTEM_PROMPT = """\
+You are an impartial grader for GDPval, a benchmark of professional knowledge work.
+You are given ONE rubric criterion and the text contents of the deliverable an AI
+produced. Decide whether the deliverable satisfies the criterion.
+
+Judge ONLY the single criterion given. Be strict and literal: a criterion is met
+only if the deliverable clearly and verifiably satisfies it. If the deliverable is
+missing, empty, or the criterion cannot be verified from its contents, it is NOT met.
+
+Respond with ONLY a JSON object: {"met": 0 or 1, "reasoning": "<one sentence>"}."""
+
+JUDGE_USER_TEMPLATE = """\
+## Task prompt (context)
+{prompt}
+
+## Rubric criterion (weight {score})
+{criterion}
+
+## Deliverable contents
+{deliverable}
+
+Is this single criterion satisfied? Respond with JSON: {{"met": 0 or 1, "reasoning": "..."}}"""
+
+_MAX_DELIVERABLE_CHARS = 60000
+
+
+@dataclass
+class Criterion:
+    score: float
+    text: str
+    rubric_item_id: str = ""
+
+
+@dataclass
+class GradeResult:
+    reward: float
+    earned: float
+    total_possible: float
+    per_criterion: list[dict] = field(default_factory=list)
+    ungraded: bool = False
+    reason: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Rubric parsing + aggregation (pure; unit-testable without a judge)
+# --------------------------------------------------------------------------- #
+
+
+def parse_rubric(rubric_json: str | list) -> list[Criterion]:
+    """Parse ``rubric_json`` (str or already-decoded list) into Criteria."""
+    items = json.loads(rubric_json) if isinstance(rubric_json, str) else rubric_json
+    out: list[Criterion] = []
+    for it in items or []:
+        try:
+            score = float(it["score"])
+            text = str(it["criterion"]).strip()
+        except (KeyError, TypeError, ValueError):
+            continue
+        if not text:
+            continue
+        out.append(Criterion(score=score, text=text, rubric_item_id=str(it.get("rubric_item_id", ""))))
+    return out
+
+
+def aggregate(criteria: list[Criterion], met: list[bool]) -> GradeResult:
+    """Weight-normalized aggregation. ``met[i]`` = judge says criterion i holds."""
+    total_possible = sum(c.score for c in criteria if c.score > 0)
+    earned = sum(c.score for c, m in zip(criteria, met, strict=False) if m)
+    if total_possible <= 0:
+        return GradeResult(reward=0.0, earned=earned, total_possible=total_possible, ungraded=True, reason="no_positive_weight_criteria")
+    reward = max(0.0, min(1.0, earned / total_possible))
+    per = [{"score": c.score, "met": bool(m), "criterion": c.text, "rubric_item_id": c.rubric_item_id} for c, m in zip(criteria, met, strict=False)]
+    return GradeResult(reward=reward, earned=earned, total_possible=total_possible, per_criterion=per)
+
+
+def grade_rubric(criteria: list[Criterion], deliverable_text: str, prompt: str, judge_fn) -> GradeResult:
+    """Judge every criterion via ``judge_fn(criterion_text, score, deliverable, prompt) -> bool``.
+
+    ``judge_fn`` is injected so the aggregation is testable with a stub and the
+    same logic can drive either litellm (host) or the openai client (sandbox).
+    A criterion whose judge call fails is treated as NOT met (conservative).
+    """
+    met: list[bool] = []
+    for c in criteria:
+        try:
+            met.append(bool(judge_fn(c.text, c.score, deliverable_text, prompt)))
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[gdpval] judge failed for criterion %s: %s", c.rubric_item_id or c.text[:40], e)
+            met.append(False)
+    return aggregate(criteria, met)
+
+
+# --------------------------------------------------------------------------- #
+# Deliverable text extraction
+# --------------------------------------------------------------------------- #
+
+
+def extract_deliverable_text(path: str | Path, max_chars: int = _MAX_DELIVERABLE_CHARS) -> str:
+    """Best-effort extraction of a deliverable file's textual content.
+
+    Supports xlsx/xlsm, docx, pptx, pdf, and text-like files. Optional deps
+    (openpyxl / python-docx / python-pptx / pdfplumber) are imported lazily;
+    a missing dep degrades to an empty/annotated string rather than raising.
+    """
+    p = Path(path)
+    if not p.exists() or not p.is_file():
+        return ""
+    ext = p.suffix.lower()
+    try:
+        if ext in (".xlsx", ".xlsm", ".xls"):
+            text = _extract_xlsx(p)
+        elif ext == ".docx":
+            text = _extract_docx(p)
+        elif ext == ".pptx":
+            text = _extract_pptx(p)
+        elif ext == ".pdf":
+            text = _extract_pdf(p)
+        elif ext in (".csv", ".tsv", ".txt", ".md", ".json", ".html", ".xml"):
+            text = p.read_text(encoding="utf-8", errors="replace")
+        else:
+            # Unknown binary: try utf-8, else note the type.
+            try:
+                text = p.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                text = f"[unsupported deliverable type: {ext or 'no extension'}]"
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[gdpval] extraction failed for %s: %s", p.name, e)
+        text = f"[extraction error for {p.name}: {e}]"
+    header = f"# Deliverable file: {p.name}\n"
+    body = text if len(text) <= max_chars else text[:max_chars] + "\n...[truncated]..."
+    return header + body
+
+
+def _extract_xlsx(p: Path) -> str:
+    from openpyxl import load_workbook
+
+    wb = load_workbook(p, read_only=True, data_only=True)
+    parts: list[str] = []
+    for ws in wb.worksheets:
+        parts.append(f"## Sheet: {ws.title}")
+        for row in ws.iter_rows(values_only=True):
+            cells = ["" if v is None else str(v) for v in row]
+            if any(cells):
+                parts.append("\t".join(cells))
+    wb.close()
+    return "\n".join(parts)
+
+
+def _extract_docx(p: Path) -> str:
+    import docx  # python-docx
+
+    d = docx.Document(str(p))
+    parts = [para.text for para in d.paragraphs]
+    for tbl in d.tables:
+        for row in tbl.rows:
+            parts.append("\t".join(cell.text for cell in row.cells))
+    return "\n".join(x for x in parts if x is not None)
+
+
+def _extract_pptx(p: Path) -> str:
+    from pptx import Presentation
+
+    prs = Presentation(str(p))
+    parts: list[str] = []
+    for i, slide in enumerate(prs.slides, 1):
+        parts.append(f"## Slide {i}")
+        for shape in slide.shapes:
+            if shape.has_text_frame:
+                parts.append(shape.text_frame.text)
+            if shape.has_table:
+                for row in shape.table.rows:
+                    parts.append("\t".join(c.text for c in row.cells))
+    return "\n".join(parts)
+
+
+def _extract_pdf(p: Path) -> str:
+    import pdfplumber
+
+    parts: list[str] = []
+    with pdfplumber.open(str(p)) as pdf:
+        for i, page in enumerate(pdf.pages, 1):
+            parts.append(f"## Page {i}")
+            parts.append(page.extract_text() or "")
+    return "\n".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+# Host-side reward_fn entry point
+# --------------------------------------------------------------------------- #
+
+
+def _find_deliverable_text(task: Task, episode: Episode) -> tuple[str, str]:
+    """Locate the deliverable's text. Returns (text, source_description).
+
+    Resolution order:
+      1. ``episode.artifacts['deliverable_text']`` — text surfaced directly.
+      2. ``episode.artifacts['deliverable_path']`` / ``output_files`` — a file
+         path (in the sandbox workdir mount or on the host) to extract.
+      3. Fallback: the agent's final answer text (lets text-only deliverables
+         still be graded, matching the claw_eval fallback philosophy).
+    """
+    arts = episode.artifacts or {}
+    if arts.get("deliverable_text"):
+        return str(arts["deliverable_text"]), "artifacts.deliverable_text"
+
+    candidates: list[str] = []
+    if arts.get("deliverable_path"):
+        candidates.append(str(arts["deliverable_path"]))
+    of = arts.get("output_files")
+    if isinstance(of, list | tuple):
+        candidates.extend(str(x) for x in of)
+    elif isinstance(of, str):
+        candidates.append(of)
+    for c in candidates:
+        text = extract_deliverable_text(c)
+        if text:
+            return text, f"file:{Path(c).name}"
+
+    return extract_answer_text(episode) or "", "final_answer_fallback"
+
+
+def _resolve_judge(task: Task) -> tuple[str, str | None, str | None]:
+    """Return (model, base_url, api_key); mirrors claw_eval's resolution."""
+    env_model = os.environ.get("GDPVAL_JUDGE_MODEL")
+    if env_model:
+        return env_model, os.environ.get("GDPVAL_JUDGE_BASE_URL"), os.environ.get("GDPVAL_JUDGE_API_KEY")
+
+    meta_model = task.metadata.get("judge_model")
+    if meta_model:
+        return meta_model, task.metadata.get("judge_base_url"), task.metadata.get("judge_api_key")
+
+    try:
+        from rllm.eval.config import get_provider_info, load_config
+
+        cfg = load_config()
+        if cfg.provider == "custom":
+            return cfg.model, cfg.base_url or None, cfg.api_key or "EMPTY"
+        info = get_provider_info(cfg.provider)
+        if info and cfg.model:
+            prefix = info.litellm_prefix
+            model = f"{prefix}/{cfg.model}" if prefix and not cfg.model.startswith(prefix + "/") else cfg.model
+            return model, None, cfg.api_key or None
+    except Exception:
+        logger.debug("[gdpval] could not resolve judge from rLLM config", exc_info=True)
+    return "", None, None
+
+
+def _make_litellm_judge(model: str, base_url: str | None, api_key: str | None):
+    import litellm
+
+    def judge_fn(criterion: str, score: float, deliverable: str, prompt: str) -> bool:
+        messages = [
+            {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+            {"role": "user", "content": JUDGE_USER_TEMPLATE.format(prompt=prompt[:4000], score=score, criterion=criterion, deliverable=deliverable)},
+        ]
+        kwargs: dict = {"model": model, "messages": messages, "temperature": 0.0}
+        if base_url:
+            kwargs["base_url"] = base_url
+        if api_key:
+            kwargs["api_key"] = api_key
+        resp = litellm.completion(**kwargs)
+        return _parse_met(resp.choices[0].message.content or "")
+
+    return judge_fn
+
+
+def _parse_met(text: str) -> bool:
+    m = re.search(r"\{.*?\}", text, re.DOTALL)
+    if m:
+        try:
+            return int(json.loads(m.group()).get("met", 0)) == 1
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+    return bool(re.search(r"\b(yes|met|true|1)\b", text, re.IGNORECASE))
+
+
+def evaluate(task: Task, episode: Episode) -> EvalOutput:
+    """Host-side ``gdpval_reward_fn``: weighted-rubric LLM-judge grade."""
+    rubric_raw = task.metadata.get("rubric_json") or task.metadata.get("rubric")
+    criteria = parse_rubric(rubric_raw) if rubric_raw else []
+    if not criteria:
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="rubric_score", value=0.0)],
+            metadata={"reason": "no_rubric", "ungraded": True},
+        )
+
+    deliverable, source = _find_deliverable_text(task, episode)
+    prompt = task.metadata.get("prompt") or (task.instruction if isinstance(task.instruction, str) else "") or ""
+
+    model, base_url, api_key = _resolve_judge(task)
+    if not model:
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="rubric_score", value=0.0)],
+            metadata={"reason": "no_judge_configured", "ungraded": True},
+        )
+
+    result = grade_rubric(criteria, deliverable, prompt, _make_litellm_judge(model, base_url, api_key))
+    n_met = sum(1 for c in result.per_criterion if c["met"])
+    return EvalOutput(
+        reward=float(result.reward),
+        is_correct=result.reward >= 0.5,
+        signals=[Signal(name="rubric_score", value=float(result.reward))],
+        metadata={
+            "judge_model": model,
+            "deliverable_source": source,
+            "earned": result.earned,
+            "total_possible": result.total_possible,
+            "criteria_met": n_met,
+            "criteria_total": len(criteria),
+            "occupation": task.metadata.get("occupation", ""),
+            "sector": task.metadata.get("sector", ""),
+        },
+    )

--- a/rllm/eval/reward_fns/gdpval.py
+++ b/rllm/eval/reward_fns/gdpval.py
@@ -55,9 +55,10 @@ logger = logging.getLogger(__name__)
 # Hint injected into the solver's system prompt (picked up by
 # rllm.eval.reward_fns._resolver.get_verifier_system_prompt).
 SYSTEM_PROMPT = (
-    "Produce the requested deliverable as an actual file (xlsx/docx/pptx/pdf/csv/txt) "
-    "in the working directory, using the exact filename the task specifies. Your work "
-    "is graded by an LLM judge against a detailed rubric applied to that file's contents."
+    "Produce the requested deliverable as an actual file (xlsx/docx/pptx/pdf/csv/txt), "
+    "using the exact filename the task specifies, and save it into the 'output/' directory "
+    "of your working directory. Your work is graded by an LLM judge applied to that file's "
+    "contents, so only the files you place in 'output/' will be evaluated."
 )
 
 JUDGE_SYSTEM_PROMPT = """\

--- a/rllm/eval/reward_fns/gdpval.py
+++ b/rllm/eval/reward_fns/gdpval.py
@@ -337,6 +337,16 @@ def _parse_met(text: str) -> bool:
     return bool(re.search(r"\b(yes|met|true|1)\b", text, re.IGNORECASE))
 
 
+def _rubric_as_guidance(criteria: list[Criterion], limit: int = 40) -> str:
+    """Render the rubric as bullet guidance for the pairwise judge."""
+    if not criteria:
+        return "(no rubric provided; judge on overall professional quality)"
+    lines = [f"- [weight {int(c.score) if c.score == int(c.score) else c.score}] {c.text}" for c in criteria[:limit]]
+    if len(criteria) > limit:
+        lines.append(f"- ...(+{len(criteria) - limit} more criteria)")
+    return "\n".join(lines)
+
+
 def evaluate(task: Task, episode: Episode) -> EvalOutput:
     """Host-side ``gdpval_reward_fn``: weighted-rubric LLM-judge grade."""
     rubric_raw = task.metadata.get("rubric_json") or task.metadata.get("rubric")
@@ -374,6 +384,184 @@ def evaluate(task: Task, episode: Episode) -> EvalOutput:
             "total_possible": result.total_possible,
             "criteria_met": n_met,
             "criteria_total": len(criteria),
+            "occupation": task.metadata.get("occupation", ""),
+            "sector": task.metadata.get("sector", ""),
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Pairwise grader (headline metric) — rubric-informed, vs the gold deliverable
+# --------------------------------------------------------------------------- #
+#
+# This reproduces GDPval's grading standard as closely as a self-hosted judge
+# can: the judge compares the model's deliverable against the expert's gold
+# deliverable and picks the better one, guided by the task's rubric. Per
+# OpenAI's own current guidance (evals.openai.com/gdpval/grading): the standard
+# is pairwise human-expert preference, but you may "run an LLM-based judge on
+# the rubrics and deliverables to get a rough estimate of model performance."
+#
+# Output per task: candidate score in {0, 0.5, 1} (loss / tie / win vs. the
+# expert), averaged over a position-swapped pair of judge calls to cancel the
+# judge's position bias. Averaged across tasks this is the GDPval win-rate.
+
+PAIRWISE_SYSTEM_PROMPT = """\
+You are an experienced professional grading two deliverables produced for the same
+work request — one by an AI, one by a human expert (you are not told which is which).
+Decide which deliverable is the higher-quality professional work product.
+
+Use the provided rubric criteria as your guide, and also weigh professional quality:
+correctness, completeness, structure, and fitness for the stated purpose. Be
+decisive; only call a genuine tie when the two are truly indistinguishable in quality.
+
+Respond with ONLY a JSON object: {"winner": "A" | "B" | "tie", "reasoning": "<one sentence>"}."""
+
+PAIRWISE_USER_TEMPLATE = """\
+## Work request
+{prompt}
+
+## Rubric criteria (guidance)
+{rubric}
+
+## Deliverable A
+{a}
+
+## Deliverable B
+{b}
+
+Which deliverable is the better professional work product? Respond with JSON:
+{{"winner": "A" | "B" | "tie", "reasoning": "..."}}"""
+
+
+def _parse_winner(text: str) -> str | None:
+    """Return 'A', 'B', or 'tie' from a judge response, or None if unparseable."""
+    m = re.search(r"\{.*?\}", text, re.DOTALL)
+    if m:
+        try:
+            w = str(json.loads(m.group()).get("winner", "")).strip().lower()
+            if w in ("a", "b", "tie"):
+                return w
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+    low = text.lower()
+    if "tie" in low:
+        return "tie"
+    if re.search(r"\bwinner\b[^ab]*b\b", low) or re.search(r"\bb\b.*better", low):
+        return "b"
+    if re.search(r"\ba\b", low):
+        return "a"
+    return None
+
+
+def _make_litellm_pairwise_judge(model: str, base_url: str | None, api_key: str | None):
+    import litellm
+
+    def judge(prompt: str, rubric: str, a: str, b: str) -> str | None:
+        messages = [
+            {"role": "system", "content": PAIRWISE_SYSTEM_PROMPT},
+            {"role": "user", "content": PAIRWISE_USER_TEMPLATE.format(prompt=prompt[:4000], rubric=rubric, a=a, b=b)},
+        ]
+        kwargs: dict = {"model": model, "messages": messages, "temperature": 0.0}
+        if base_url:
+            kwargs["base_url"] = base_url
+        if api_key:
+            kwargs["api_key"] = api_key
+        resp = litellm.completion(**kwargs)
+        return _parse_winner(resp.choices[0].message.content or "")
+
+    return judge
+
+
+def score_pairwise(candidate: str, reference: str, prompt: str, rubric: str, judge) -> float | None:
+    """Candidate's win score in {0, 0.5, 1}, position-swap debiased.
+
+    ``judge(prompt, rubric, a, b) -> 'a'|'b'|'tie'|None`` is injected for testing.
+    Runs twice with candidate in each slot; returns the mean of the two per-call
+    candidate scores (win=1, tie=0.5, loss=0). Returns None if both calls fail.
+    """
+
+    def _cand_score(winner: str | None, candidate_is: str) -> float | None:
+        if winner is None:
+            return None
+        if winner == "tie":
+            return 0.5
+        return 1.0 if winner == candidate_is else 0.0
+
+    s1 = _cand_score(judge(prompt, rubric, candidate, reference), "a")  # candidate = A
+    s2 = _cand_score(judge(prompt, rubric, reference, candidate), "b")  # candidate = B
+    scores = [s for s in (s1, s2) if s is not None]
+    if not scores:
+        return None
+    return sum(scores) / len(scores)
+
+
+def _find_reference_text(task: Task) -> tuple[str, str]:
+    """Locate the gold (expert) deliverable's text. Returns (text, source)."""
+    meta = task.metadata or {}
+    if meta.get("reference_deliverable_text"):
+        return str(meta["reference_deliverable_text"]), "metadata.reference_deliverable_text"
+    if meta.get("reference_deliverable_path"):
+        text = extract_deliverable_text(meta["reference_deliverable_path"])
+        if text:
+            return text, "metadata.reference_deliverable_path"
+    # Resolve files staged under <task_dir>/reference/ by the builder.
+    names = meta.get("reference_deliverables") or []
+    if names and task.dataset_dir is not None:
+        base = task.dataset_dir / task.sub_dir if task.sub_dir else task.dataset_dir
+        for name in names:
+            text = extract_deliverable_text(Path(base) / "reference" / name)
+            if text:
+                return text, f"reference/{name}"
+    return "", "none"
+
+
+def evaluate_pairwise(task: Task, episode: Episode) -> EvalOutput:
+    """Headline ``gdpval_pairwise_reward_fn``: rubric-informed pairwise vs. gold.
+
+    reward = candidate win score in {0, 0.5, 1} (loss / tie / win vs. the expert
+    deliverable). Mean over tasks = GDPval win-rate.
+    """
+    candidate, cand_src = _find_deliverable_text(task, episode)
+    reference, ref_src = _find_reference_text(task)
+    if not reference:
+        # No gold deliverable → pairwise is impossible; don't fabricate a score.
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="pairwise_win", value=0.0)],
+            metadata={"reason": "no_reference_deliverable", "ungraded": True},
+        )
+
+    criteria = parse_rubric(task.metadata.get("rubric_json") or task.metadata.get("rubric") or [])
+    rubric = _rubric_as_guidance(criteria)
+    prompt = task.metadata.get("prompt") or (task.instruction if isinstance(task.instruction, str) else "") or ""
+
+    model, base_url, api_key = _resolve_judge(task)
+    if not model:
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="pairwise_win", value=0.0)],
+            metadata={"reason": "no_judge_configured", "ungraded": True},
+        )
+
+    score = score_pairwise(candidate, reference, prompt, rubric, _make_litellm_pairwise_judge(model, base_url, api_key))
+    if score is None:
+        return EvalOutput(
+            reward=0.0,
+            is_correct=False,
+            signals=[Signal(name="pairwise_win", value=0.0)],
+            metadata={"reason": "judge_call_failed", "ungraded": True},
+        )
+
+    return EvalOutput(
+        reward=float(score),
+        is_correct=score > 0.5,  # strict win over the expert; tie (0.5) is not a "win"
+        signals=[Signal(name="pairwise_win", value=float(score))],
+        metadata={
+            "judge_model": model,
+            "candidate_source": cand_src,
+            "reference_source": ref_src,
             "occupation": task.metadata.get("occupation", ""),
             "sector": task.metadata.get("sector", ""),
         },

--- a/rllm/eval/reward_fns/gdpval.py
+++ b/rllm/eval/reward_fns/gdpval.py
@@ -321,7 +321,10 @@ def _make_litellm_judge(model: str, base_url: str | None, api_key: str | None):
             {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
             {"role": "user", "content": JUDGE_USER_TEMPLATE.format(prompt=prompt[:4000], score=score, criterion=criterion, deliverable=deliverable)},
         ]
-        kwargs: dict = {"model": model, "messages": messages, "temperature": 0.0}
+        # drop_params lets litellm silently drop provider-unsupported params:
+        # reasoning models (gpt-5*, o-series) reject temperature=0.0, so it's
+        # dropped for them while non-reasoning judges keep deterministic temp=0.
+        kwargs: dict = {"model": model, "messages": messages, "temperature": 0.0, "drop_params": True}
         if base_url:
             kwargs["base_url"] = base_url
         if api_key:
@@ -474,7 +477,10 @@ def _make_litellm_pairwise_judge(model: str, base_url: str | None, api_key: str 
             {"role": "system", "content": PAIRWISE_SYSTEM_PROMPT},
             {"role": "user", "content": PAIRWISE_USER_TEMPLATE.format(prompt=prompt[:4000], rubric=rubric, a=a, b=b)},
         ]
-        kwargs: dict = {"model": model, "messages": messages, "temperature": 0.0}
+        # drop_params lets litellm silently drop provider-unsupported params:
+        # reasoning models (gpt-5*, o-series) reject temperature=0.0, so it's
+        # dropped for them while non-reasoning judges keep deterministic temp=0.
+        kwargs: dict = {"model": model, "messages": messages, "temperature": 0.0, "drop_params": True}
         if base_url:
             kwargs["base_url"] = base_url
         if api_key:

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -274,6 +274,13 @@ class SandboxTaskHooks:
                 _run_healthcheck(task, sandbox)
 
             evaluator = self.evaluation.resolve(task, sandbox, plan.verifier_kind, plan.verifier_config)
+            # Opt-in: pull the produced deliverable out of the sandbox before a
+            # host-side grader runs (it never sees the sandbox otherwise). Gated
+            # by task metadata so it's a no-op for every other benchmark.
+            if sandbox is not None and task.metadata.get("surface_deliverable"):
+                from rllm.eval._resolution import _SurfacingEvaluator
+
+                evaluator = _SurfacingEvaluator(evaluator, sandbox)
         except BaseException:
             # Nothing has registered a teardown yet — close the sandbox here
             # or it leaks (and the retry path provisions another).

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "datasets": {
+    "gdpval": {
+      "description": "GDPval (OpenAI): 220 gold tasks of economically valuable knowledge work across 44 occupations (sandbox; weighted-rubric LLM-judge graded)",
+      "source": "openai/gdpval",
+      "builder": "rllm.data.gdpval_builder:build_benchmark",
+      "category": "agentic",
+      "splits": [
+        "train"
+      ],
+      "eval_split": "train",
+      "default_agent": "claude-code",
+      "reward_fn": "gdpval_reward_fn"
+    },
     "claw_eval": {
       "description": "Claw-Eval general split: 161 personal-assistant agent tasks (sandbox; LLM-judge graded)",
       "source": "claw-eval/Claw-Eval",

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -2,7 +2,19 @@
   "version": 1,
   "datasets": {
     "gdpval": {
-      "description": "GDPval (OpenAI): 220 gold tasks of economically valuable knowledge work across 44 occupations (sandbox; weighted-rubric LLM-judge graded)",
+      "description": "GDPval (OpenAI): 220 gold tasks of economically valuable knowledge work across 44 occupations (sandbox; rubric-informed pairwise LLM-judge vs. the expert deliverable -> win-rate)",
+      "source": "openai/gdpval",
+      "builder": "rllm.data.gdpval_builder:build_benchmark",
+      "category": "agentic",
+      "splits": [
+        "train"
+      ],
+      "eval_split": "train",
+      "default_agent": "claude-code",
+      "reward_fn": "gdpval_pairwise_reward_fn"
+    },
+    "gdpval-rubric": {
+      "description": "GDPval scored by absolute weighted-rubric LLM-judge (dense [0,1] signal; useful as an RL reward). Same tasks as gdpval.",
       "source": "openai/gdpval",
       "builder": "rllm.data.gdpval_builder:build_benchmark",
       "category": "agentic",

--- a/tests/eval/test_gdpval.py
+++ b/tests/eval/test_gdpval.py
@@ -189,6 +189,23 @@ class TestEvaluate:
         out = g.evaluate(self._task(rubric), Episode(artifacts={"deliverable_text": "d"}))
         assert out.reward == 0.0 and out.metadata.get("reason") == "no_judge_configured"
 
+    def test_no_deliverable_is_ungraded_not_zero(self):
+        # Fail-closed: nothing surfaced -> ungraded, and the judge is never called.
+        rubric = [{"score": 1, "criterion": "c"}]
+        out = g.evaluate(self._task(rubric), Episode(artifacts={}))
+        assert out.reward == 0.0 and out.metadata.get("reason") == "no_deliverable_surfaced"
+        assert out.metadata.get("ungraded") is True
+
+    def test_never_reads_transcript(self, monkeypatch):
+        # Even with a rich transcript on the episode, no deliverable => ungraded.
+        rubric = [{"score": 1, "criterion": "c"}]
+        called = {"n": 0}
+        monkeypatch.setattr(g, "_make_litellm_judge", lambda *a, **k: (lambda *args: called.__setitem__("n", called["n"] + 1) or True))
+        ep = Episode(artifacts={"answer": "I produced a perfect deliverable", "conversation": [{"role": "assistant", "content": "trust me"}]})
+        out = g.evaluate(self._task(rubric), ep)
+        assert out.metadata.get("reason") == "no_deliverable_surfaced"
+        assert called["n"] == 0  # judge never invoked
+
 
 # --------------------------------------------------------------------------- #
 # _parse_met tolerance
@@ -287,3 +304,11 @@ class TestEvaluatePairwise:
         monkeypatch.setattr(g, "_resolve_judge", lambda task: ("", None, None))
         out = g.evaluate_pairwise(self._task(), Episode(artifacts={"deliverable_text": "CAND"}))
         assert out.reward == 0.0 and out.metadata.get("reason") == "no_judge_configured"
+
+    def test_no_candidate_deliverable_is_ungraded(self, monkeypatch):
+        # Fail-closed: no candidate surfaced -> ungraded; judge never called.
+        called = {"n": 0}
+        monkeypatch.setattr(g, "_make_litellm_pairwise_judge", lambda *a, **k: (lambda *args: called.__setitem__("n", called["n"] + 1) or "a"))
+        out = g.evaluate_pairwise(self._task(), Episode(artifacts={"answer": "I made a great file"}))
+        assert out.reward == 0.0 and out.metadata.get("reason") == "no_deliverable_surfaced"
+        assert called["n"] == 0

--- a/tests/eval/test_gdpval.py
+++ b/tests/eval/test_gdpval.py
@@ -1,0 +1,205 @@
+"""Tests for the GDPval weighted-rubric grader.
+
+The grading core (rubric parsing + weighted aggregation) is pure and tested
+without a judge. ``grade_rubric`` takes an injected ``judge_fn`` so the
+per-criterion LLM call is stubbed. ``evaluate`` is tested end-to-end by
+monkeypatching the litellm judge factory.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rllm.eval.reward_fns import gdpval as g
+from rllm.eval.reward_fns.gdpval import Criterion, aggregate, parse_rubric
+from rllm.types import Episode
+
+# --------------------------------------------------------------------------- #
+# Rubric parsing
+# --------------------------------------------------------------------------- #
+
+
+class TestParseRubric:
+    def test_parses_json_string(self):
+        raw = json.dumps(
+            [
+                {"score": 2, "criterion": "Has a summary section", "rubric_item_id": "a"},
+                {"score": 5, "criterion": "Recommended value is 220", "rubric_item_id": "b"},
+            ]
+        )
+        crits = parse_rubric(raw)
+        assert [c.score for c in crits] == [2.0, 5.0]
+        assert crits[0].text == "Has a summary section"
+        assert crits[1].rubric_item_id == "b"
+
+    def test_accepts_decoded_list(self):
+        crits = parse_rubric([{"score": 1, "criterion": "x"}])
+        assert len(crits) == 1 and crits[0].score == 1.0
+
+    def test_skips_malformed_items(self):
+        crits = parse_rubric(
+            [
+                {"score": 1, "criterion": "ok"},
+                {"score": "notnum", "criterion": "bad"},
+                {"criterion": "no score"},
+                {"score": 2, "criterion": "   "},  # blank text
+            ]
+        )
+        assert len(crits) == 1 and crits[0].text == "ok"
+
+
+# --------------------------------------------------------------------------- #
+# Weighted aggregation
+# --------------------------------------------------------------------------- #
+
+
+class TestAggregate:
+    def _crits(self):
+        return [Criterion(2, "a"), Criterion(3, "b"), Criterion(5, "c")]
+
+    def test_all_met_is_full_score(self):
+        r = aggregate(self._crits(), [True, True, True])
+        assert r.reward == 1.0
+        assert r.earned == 10 and r.total_possible == 10
+
+    def test_none_met_is_zero(self):
+        r = aggregate(self._crits(), [False, False, False])
+        assert r.reward == 0.0 and r.earned == 0
+
+    def test_partial_is_weight_normalized(self):
+        # met a(2) and c(5) of possible 10 -> 0.7
+        r = aggregate(self._crits(), [True, False, True])
+        assert r.reward == 0.7
+        assert r.earned == 7 and r.total_possible == 10
+
+    def test_negative_penalty_subtracts_and_clips_at_zero(self):
+        crits = [Criterion(4, "good"), Criterion(-10, "fabricates data")]
+        # good met (+4), penalty condition also present (-10) -> earned -6, clip 0
+        r = aggregate(crits, [True, True])
+        assert r.earned == -6 and r.total_possible == 4
+        assert r.reward == 0.0
+
+    def test_negative_penalty_not_triggered(self):
+        crits = [Criterion(4, "good"), Criterion(-10, "fabricates data")]
+        r = aggregate(crits, [True, False])
+        assert r.earned == 4 and r.reward == 1.0
+
+    def test_no_positive_weight_is_ungraded(self):
+        r = aggregate([Criterion(-2, "penalty only")], [False])
+        assert r.ungraded is True and r.reward == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# grade_rubric with injected judge
+# --------------------------------------------------------------------------- #
+
+
+class TestGradeRubric:
+    def test_injected_judge_drives_score(self):
+        crits = [Criterion(1, "mentions revenue"), Criterion(1, "mentions risk"), Criterion(2, "concludes GO")]
+
+        def judge(text, score, deliverable, prompt):
+            return text.split()[-1].lower() in deliverable.lower()
+
+        deliverable = "The memo covers revenue and recommends GO."
+        r = g.grade_rubric(crits, deliverable, "prompt", judge)
+        # "revenue" yes(1), "risk" no(0), "GO" yes(2) -> 3/4
+        assert r.reward == 0.75
+        assert [c["met"] for c in r.per_criterion] == [True, False, True]
+
+    def test_judge_exception_counts_as_not_met(self):
+        crits = [Criterion(1, "a"), Criterion(1, "b")]
+
+        def judge(text, score, deliverable, prompt):
+            if text == "a":
+                raise RuntimeError("judge down")
+            return True
+
+        r = g.grade_rubric(crits, "x", "p", judge)
+        assert r.reward == 0.5  # only "b" counted
+
+
+# --------------------------------------------------------------------------- #
+# Deliverable text extraction
+# --------------------------------------------------------------------------- #
+
+
+class TestExtraction:
+    def test_missing_file_returns_empty(self):
+        assert g.extract_deliverable_text("/no/such/file.xlsx") == ""
+
+    def test_text_file_roundtrip(self, tmp_path):
+        p = tmp_path / "out.md"
+        p.write_text("# Report\nrevenue is up", encoding="utf-8")
+        text = g.extract_deliverable_text(p)
+        assert "out.md" in text and "revenue is up" in text
+
+    def test_csv_extracted(self, tmp_path):
+        p = tmp_path / "data.csv"
+        p.write_text("a,b\n1,2\n", encoding="utf-8")
+        assert "1,2" in g.extract_deliverable_text(p)
+
+
+# --------------------------------------------------------------------------- #
+# evaluate() end-to-end (judge factory monkeypatched)
+# --------------------------------------------------------------------------- #
+
+
+class TestEvaluate:
+    def _task(self, rubric):
+        from pathlib import Path
+
+        from rllm.types import Task
+
+        return Task(
+            id="t1",
+            instruction="do the thing",
+            metadata={"prompt": "do the thing", "rubric_json": json.dumps(rubric), "judge_model": "stub/model"},
+            dataset_dir=Path("/"),
+        )
+
+    def test_no_rubric_is_ungraded(self):
+        from pathlib import Path
+
+        from rllm.types import Task
+
+        task = Task(id="t", instruction="x", metadata={}, dataset_dir=Path("/"))
+        out = g.evaluate(task, Episode(artifacts={"deliverable_text": "anything"}))
+        assert out.reward == 0.0 and out.metadata.get("ungraded") is True
+
+    def test_full_pass_with_stub_judge(self, monkeypatch):
+        rubric = [{"score": 2, "criterion": "c1"}, {"score": 3, "criterion": "c2"}]
+        monkeypatch.setattr(g, "_make_litellm_judge", lambda *a, **k: (lambda *args: True))
+        task = self._task(rubric)
+        ep = Episode(artifacts={"deliverable_text": "a great deliverable"})
+        out = g.evaluate(task, ep)
+        assert out.reward == 1.0 and out.is_correct is True
+        assert out.metadata["criteria_met"] == 2 and out.metadata["criteria_total"] == 2
+
+    def test_partial_with_stub_judge(self, monkeypatch):
+        rubric = [{"score": 1, "criterion": "yes"}, {"score": 1, "criterion": "no"}]
+        monkeypatch.setattr(g, "_make_litellm_judge", lambda *a, **k: (lambda text, *args: text == "yes"))
+        out = g.evaluate(self._task(rubric), Episode(artifacts={"deliverable_text": "d"}))
+        assert out.reward == 0.5 and out.is_correct is True
+
+    def test_no_judge_configured_is_ungraded(self, monkeypatch):
+        # Force resolution to find no judge model.
+        monkeypatch.setattr(g, "_resolve_judge", lambda task: ("", None, None))
+        rubric = [{"score": 1, "criterion": "c"}]
+        out = g.evaluate(self._task(rubric), Episode(artifacts={"deliverable_text": "d"}))
+        assert out.reward == 0.0 and out.metadata.get("reason") == "no_judge_configured"
+
+
+# --------------------------------------------------------------------------- #
+# _parse_met tolerance
+# --------------------------------------------------------------------------- #
+
+
+class TestParseMet:
+    def test_json_forms(self):
+        assert g._parse_met('{"met": 1, "reasoning": "ok"}') is True
+        assert g._parse_met('{"met": 0}') is False
+
+    def test_prose_fallback(self):
+        assert g._parse_met("Yes, this is met.") is True
+        assert g._parse_met("No.") is False

--- a/tests/eval/test_gdpval.py
+++ b/tests/eval/test_gdpval.py
@@ -203,3 +203,87 @@ class TestParseMet:
     def test_prose_fallback(self):
         assert g._parse_met("Yes, this is met.") is True
         assert g._parse_met("No.") is False
+
+
+# --------------------------------------------------------------------------- #
+# Pairwise grader
+# --------------------------------------------------------------------------- #
+
+
+class TestParseWinner:
+    def test_json(self):
+        assert g._parse_winner('{"winner": "A", "reasoning": "x"}') == "a"
+        assert g._parse_winner('{"winner": "B"}') == "b"
+        assert g._parse_winner('{"winner": "tie"}') == "tie"
+
+    def test_unparseable(self):
+        assert g._parse_winner("no verdict here 12345") is None
+
+
+class TestScorePairwise:
+    def test_consistent_win_both_positions(self):
+        # judge always prefers the candidate regardless of slot
+        def judge(prompt, rubric, a, b):
+            return "a" if a == "CAND" else "b"
+
+        # call1: a=CAND -> 'a' -> win(1); call2: a=REF,b=CAND -> 'b' -> win(1)
+        assert g.score_pairwise("CAND", "REF", "p", "r", judge) == 1.0
+
+    def test_consistent_loss(self):
+        def judge(prompt, rubric, a, b):
+            return "a" if a == "REF" else "b"  # always prefers REF
+
+        assert g.score_pairwise("CAND", "REF", "p", "r", judge) == 0.0
+
+    def test_tie(self):
+        assert g.score_pairwise("C", "R", "p", "r", lambda *a: "tie") == 0.5
+
+    def test_position_bias_averages_to_tie(self):
+        # judge always picks slot A regardless of content -> pure position bias
+        def judge(prompt, rubric, a, b):
+            return "a"
+
+        # call1 (cand=A) -> win(1); call2 (cand=B) -> 'a'=REF -> loss(0); mean 0.5
+        assert g.score_pairwise("C", "R", "p", "r", judge) == 0.5
+
+    def test_both_calls_fail_returns_none(self):
+        assert g.score_pairwise("C", "R", "p", "r", lambda *a: None) is None
+
+
+class TestEvaluatePairwise:
+    def _task(self, *, rubric=None, ref_text="EXPERT DELIVERABLE"):
+        from pathlib import Path
+
+        from rllm.types import Task
+
+        meta = {"prompt": "do the thing", "judge_model": "stub/model", "reference_deliverable_text": ref_text}
+        if rubric is not None:
+            meta["rubric_json"] = json.dumps(rubric)
+        return Task(id="t1", instruction="do the thing", metadata=meta, dataset_dir=Path("/"))
+
+    def test_no_reference_is_ungraded(self):
+        from pathlib import Path
+
+        from rllm.types import Task
+
+        task = Task(id="t", instruction="x", metadata={"prompt": "p", "judge_model": "m"}, dataset_dir=Path("/"))
+        out = g.evaluate_pairwise(task, Episode(artifacts={"deliverable_text": "cand"}))
+        assert out.reward == 0.0 and out.metadata.get("reason") == "no_reference_deliverable"
+
+    def test_win_with_stub_judge(self, monkeypatch):
+        # stub the pairwise judge factory to always prefer the candidate
+        monkeypatch.setattr(g, "_make_litellm_pairwise_judge", lambda *a, **k: (lambda prompt, rubric, x, y: "a" if x == "CAND" else "b"))
+        task = self._task(rubric=[{"score": 2, "criterion": "c1"}])
+        out = g.evaluate_pairwise(task, Episode(artifacts={"deliverable_text": "CAND"}))
+        assert out.reward == 1.0 and out.is_correct is True
+        assert out.metadata["reference_source"] == "metadata.reference_deliverable_text"
+
+    def test_tie_is_not_a_win(self, monkeypatch):
+        monkeypatch.setattr(g, "_make_litellm_pairwise_judge", lambda *a, **k: (lambda *args: "tie"))
+        out = g.evaluate_pairwise(self._task(), Episode(artifacts={"deliverable_text": "CAND"}))
+        assert out.reward == 0.5 and out.is_correct is False
+
+    def test_no_judge_is_ungraded(self, monkeypatch):
+        monkeypatch.setattr(g, "_resolve_judge", lambda task: ("", None, None))
+        out = g.evaluate_pairwise(self._task(), Episode(artifacts={"deliverable_text": "CAND"}))
+        assert out.reward == 0.0 and out.metadata.get("reason") == "no_judge_configured"

--- a/tests/eval/test_gdpval.py
+++ b/tests/eval/test_gdpval.py
@@ -212,6 +212,92 @@ class TestEvaluate:
 # --------------------------------------------------------------------------- #
 
 
+class TestDeliverableSurfacing:
+    """The sandbox->host surfacing step (rllm.eval._resolution)."""
+
+    class FakeSandbox:
+        """Minimal sandbox emulating the exec commands the surfacer issues."""
+
+        def __init__(self, files):
+            self.files = files  # {sandbox_path: bytes}
+
+        def exec(self, command, timeout=None, user=None):
+            import base64 as _b64
+
+            if "base64 " in command:
+                for p, d in self.files.items():
+                    if p in command:
+                        return _b64.b64encode(d).decode()
+                return ""
+            if "wc -c" in command:
+                for p, d in self.files.items():
+                    if p in command:
+                        return str(len(d))
+                return ""
+            if command.startswith("test -f"):
+                return "yes" if any(p in command for p in self.files) else ""
+            if command.strip().startswith("find"):
+                import re as _re
+
+                m = _re.search(r"-name\s+(\S+)", command)
+                from pathlib import Path as _P
+
+                name = m.group(1).strip("'\"") if m else None
+                return "\n".join(p for p in self.files if _P(p).name == name)
+            if "ls -1t" in command:
+                from pathlib import Path as _P
+
+                return "\n".join(_P(p).name for p in self.files)
+            return ""
+
+    def _task(self, expected, inputs=None):
+        from pathlib import Path
+
+        from rllm.types import Task
+
+        return Task(id="t", instruction="x", metadata={"workdir": "/workspace", "expected_deliverables": expected, "reference_files": inputs or []}, dataset_dir=Path("/"))
+
+    def test_surfaces_expected_file(self):
+        from rllm.eval._resolution import surface_deliverable
+
+        sb = self.FakeSandbox({"/workspace/out.xlsx": b"BINARYBYTES\x00\x01"})
+        ep = Episode(artifacts={})
+        surface_deliverable(sb, self._task(["out.xlsx"]), ep)
+        p = ep.artifacts.get("deliverable_path")
+        assert p and open(p, "rb").read() == b"BINARYBYTES\x00\x01"
+
+    def test_no_produced_file_leaves_unsurfaced(self):
+        from rllm.eval._resolution import surface_deliverable
+
+        sb = self.FakeSandbox({"/workspace/input.csv": b"a,b"})  # only the staged input exists
+        ep = Episode(artifacts={})
+        surface_deliverable(sb, self._task(["out.xlsx"], inputs=["input.csv"]), ep)
+        assert "deliverable_path" not in ep.artifacts  # fail-closed downstream
+
+    def test_does_not_clobber_already_surfaced(self):
+        from rllm.eval._resolution import surface_deliverable
+
+        sb = self.FakeSandbox({"/workspace/out.xlsx": b"x"})
+        ep = Episode(artifacts={"deliverable_text": "already here"})
+        surface_deliverable(sb, self._task(["out.xlsx"]), ep)
+        assert "deliverable_path" not in ep.artifacts
+
+    def test_wrapper_surfaces_then_delegates(self):
+        from rllm.eval._resolution import _SurfacingEvaluator
+
+        sb = self.FakeSandbox({"/workspace/out.txt": b"hello"})
+        seen = {}
+
+        class Inner:
+            def evaluate(self, task, episode):
+                seen["path"] = episode.artifacts.get("deliverable_path")
+                return "RESULT"
+
+        out = _SurfacingEvaluator(Inner(), sb).evaluate(self._task(["out.txt"]), Episode(artifacts={}))
+        assert out == "RESULT"
+        assert seen["path"] and open(seen["path"]).read() == "hello"
+
+
 class TestParseMet:
     def test_json_forms(self):
         assert g._parse_met('{"met": 1, "reasoning": "ok"}') is True

--- a/tests/eval/test_gdpval.py
+++ b/tests/eval/test_gdpval.py
@@ -213,90 +213,80 @@ class TestEvaluate:
 
 
 class TestDeliverableSurfacing:
-    """The sandbox->host surfacing step (rllm.eval._resolution)."""
+    """The sandbox->host surfacing step (rllm.eval._resolution).
+
+    Behavior: read files from <workdir>/<deliverable_dir> only; match expected
+    basenames within it when given; nothing else is searched.
+    """
 
     class FakeSandbox:
-        """Minimal sandbox emulating the exec commands the surfacer issues."""
+        """Minimal sandbox emulating the exec commands the surfacer issues:
+        ``find <dir> -type f``, ``wc -c < <path>``, ``base64 <path>``."""
 
         def __init__(self, files):
             self.files = files  # {sandbox_path: bytes}
 
         def exec(self, command, timeout=None, user=None):
             import base64 as _b64
+            import re as _re
 
             if "base64 " in command:
-                for p, d in self.files.items():
-                    if p in command:
-                        return _b64.b64encode(d).decode()
-                return ""
+                return next((_b64.b64encode(d).decode() for p, d in self.files.items() if p in command), "")
             if "wc -c" in command:
-                for p, d in self.files.items():
-                    if p in command:
-                        return str(len(d))
-                return ""
-            if command.startswith("test -f"):
-                return "yes" if any(p in command for p in self.files) else ""
+                return next((str(len(d)) for p, d in self.files.items() if p in command), "")
             if command.strip().startswith("find"):
-                import re as _re
-                from pathlib import Path as _P
-
-                if "-name" in command:
-                    m = _re.search(r"-name\s+(\S+)", command)
-                    name = m.group(1).strip("'\"") if m else None
-                    return "\n".join(p for p in self.files if _P(p).name == name)
-                # `find <dir> -type f` (no -name): list files under that dir.
                 m = _re.search(r"find\s+('([^']*)'|\"([^\"]*)\"|(\S+))", command)
-                raw = m.group(1) if m else ""
-                d = raw.strip("'\"").rstrip("/")
+                d = (m.group(1) if m else "").strip("'\"").rstrip("/")
                 return "\n".join(p for p in self.files if p.startswith(d + "/"))
-            if "ls -1t" in command:
-                from pathlib import Path as _P
-
-                return "\n".join(_P(p).name for p in self.files)
             return ""
 
-    def _task(self, expected, inputs=None, deliverable_dir=None):
+    def _task(self, expected, deliverable_dir="output"):
         from pathlib import Path
 
         from rllm.types import Task
 
-        meta = {"workdir": "/workspace", "expected_deliverables": expected, "reference_files": inputs or []}
-        if deliverable_dir:
-            meta["deliverable_dir"] = deliverable_dir
+        meta = {"workdir": "/workspace", "expected_deliverables": expected, "deliverable_dir": deliverable_dir}
         return Task(id="t", instruction="x", metadata=meta, dataset_dir=Path("/"))
 
-    def test_output_dir_takes_priority_over_heuristics(self):
+    def test_reads_output_dir(self):
         from rllm.eval._resolution import surface_deliverable
 
-        # A stray newest file sits in the workdir root, but the real deliverable
-        # is in output/ — the designated dir must win.
+        # A stray file in the workdir root is ignored; only output/ is read.
         sb = self.FakeSandbox({"/workspace/scratch.txt": b"junk", "/workspace/output/report.docx": b"REAL"})
         ep = Episode(artifacts={})
-        surface_deliverable(sb, self._task([], deliverable_dir="output"), ep)
+        surface_deliverable(sb, self._task([]), ep)
         p = ep.artifacts.get("deliverable_path")
         assert p and open(p, "rb").read() == b"REAL"
 
-    def test_surfaces_expected_file(self):
+    def test_matches_expected_names_within_output(self):
         from rllm.eval._resolution import surface_deliverable
 
-        sb = self.FakeSandbox({"/workspace/out.xlsx": b"BINARYBYTES\x00\x01"})
+        sb = self.FakeSandbox({"/workspace/output/report.docx": b"WANT", "/workspace/output/notes.txt": b"scratch"})
+        ep = Episode(artifacts={})
+        surface_deliverable(sb, self._task(["report.docx"]), ep)
+        assert open(ep.artifacts["deliverable_path"], "rb").read() == b"WANT"
+        assert "output_files" not in ep.artifacts  # only the matched file
+
+    def test_returns_all_when_no_expected_match(self):
+        from rllm.eval._resolution import surface_deliverable
+
+        sb = self.FakeSandbox({"/workspace/output/a.txt": b"A"})
+        ep = Episode(artifacts={})
+        surface_deliverable(sb, self._task(["nomatch.docx"]), ep)  # expected present but absent in output/
+        assert open(ep.artifacts["deliverable_path"], "rb").read() == b"A"
+
+    def test_empty_output_dir_leaves_unsurfaced(self):
+        from rllm.eval._resolution import surface_deliverable
+
+        sb = self.FakeSandbox({"/workspace/input.csv": b"a,b"})  # nothing in output/
         ep = Episode(artifacts={})
         surface_deliverable(sb, self._task(["out.xlsx"]), ep)
-        p = ep.artifacts.get("deliverable_path")
-        assert p and open(p, "rb").read() == b"BINARYBYTES\x00\x01"
-
-    def test_no_produced_file_leaves_unsurfaced(self):
-        from rllm.eval._resolution import surface_deliverable
-
-        sb = self.FakeSandbox({"/workspace/input.csv": b"a,b"})  # only the staged input exists
-        ep = Episode(artifacts={})
-        surface_deliverable(sb, self._task(["out.xlsx"], inputs=["input.csv"]), ep)
         assert "deliverable_path" not in ep.artifacts  # fail-closed downstream
 
     def test_does_not_clobber_already_surfaced(self):
         from rllm.eval._resolution import surface_deliverable
 
-        sb = self.FakeSandbox({"/workspace/out.xlsx": b"x"})
+        sb = self.FakeSandbox({"/workspace/output/out.xlsx": b"x"})
         ep = Episode(artifacts={"deliverable_text": "already here"})
         surface_deliverable(sb, self._task(["out.xlsx"]), ep)
         assert "deliverable_path" not in ep.artifacts
@@ -304,7 +294,7 @@ class TestDeliverableSurfacing:
     def test_wrapper_surfaces_then_delegates(self):
         from rllm.eval._resolution import _SurfacingEvaluator
 
-        sb = self.FakeSandbox({"/workspace/out.txt": b"hello"})
+        sb = self.FakeSandbox({"/workspace/output/out.txt": b"hello"})
         seen = {}
 
         class Inner:

--- a/tests/eval/test_gdpval.py
+++ b/tests/eval/test_gdpval.py
@@ -249,6 +249,8 @@ class TestDeliverableSurfacing:
         return Task(id="t", instruction="x", metadata=meta, dataset_dir=Path("/"))
 
     def test_reads_output_dir(self):
+        from pathlib import Path
+
         from rllm.eval._resolution import surface_deliverable
 
         # A stray file in the workdir root is ignored; only output/ is read.
@@ -257,6 +259,8 @@ class TestDeliverableSurfacing:
         surface_deliverable(sb, self._task([]), ep)
         p = ep.artifacts.get("deliverable_path")
         assert p and open(p, "rb").read() == b"REAL"
+        # The agent's original basename must be preserved (rubric checks basename).
+        assert Path(p).name == "report.docx"
 
     def test_matches_expected_names_within_output(self):
         from rllm.eval._resolution import surface_deliverable

--- a/tests/eval/test_gdpval.py
+++ b/tests/eval/test_gdpval.py
@@ -238,24 +238,43 @@ class TestDeliverableSurfacing:
                 return "yes" if any(p in command for p in self.files) else ""
             if command.strip().startswith("find"):
                 import re as _re
-
-                m = _re.search(r"-name\s+(\S+)", command)
                 from pathlib import Path as _P
 
-                name = m.group(1).strip("'\"") if m else None
-                return "\n".join(p for p in self.files if _P(p).name == name)
+                if "-name" in command:
+                    m = _re.search(r"-name\s+(\S+)", command)
+                    name = m.group(1).strip("'\"") if m else None
+                    return "\n".join(p for p in self.files if _P(p).name == name)
+                # `find <dir> -type f` (no -name): list files under that dir.
+                m = _re.search(r"find\s+('([^']*)'|\"([^\"]*)\"|(\S+))", command)
+                raw = m.group(1) if m else ""
+                d = raw.strip("'\"").rstrip("/")
+                return "\n".join(p for p in self.files if p.startswith(d + "/"))
             if "ls -1t" in command:
                 from pathlib import Path as _P
 
                 return "\n".join(_P(p).name for p in self.files)
             return ""
 
-    def _task(self, expected, inputs=None):
+    def _task(self, expected, inputs=None, deliverable_dir=None):
         from pathlib import Path
 
         from rllm.types import Task
 
-        return Task(id="t", instruction="x", metadata={"workdir": "/workspace", "expected_deliverables": expected, "reference_files": inputs or []}, dataset_dir=Path("/"))
+        meta = {"workdir": "/workspace", "expected_deliverables": expected, "reference_files": inputs or []}
+        if deliverable_dir:
+            meta["deliverable_dir"] = deliverable_dir
+        return Task(id="t", instruction="x", metadata=meta, dataset_dir=Path("/"))
+
+    def test_output_dir_takes_priority_over_heuristics(self):
+        from rllm.eval._resolution import surface_deliverable
+
+        # A stray newest file sits in the workdir root, but the real deliverable
+        # is in output/ — the designated dir must win.
+        sb = self.FakeSandbox({"/workspace/scratch.txt": b"junk", "/workspace/output/report.docx": b"REAL"})
+        ep = Episode(artifacts={})
+        surface_deliverable(sb, self._task([], deliverable_dir="output"), ep)
+        p = ep.artifacts.get("deliverable_path")
+        assert p and open(p, "rb").read() == b"REAL"
 
     def test_surfaces_expected_file(self):
         from rllm.eval._resolution import surface_deliverable


### PR DESCRIPTION
## Summary

Adds **GDPval** (OpenAI's benchmark of economically valuable knowledge work — 220 open "gold" tasks across 44 occupations) as a native rLLM sandbox benchmark, following the `claw_eval` host-side LLM-judge pattern.

## What's included

- **Builder** (`rllm/data/gdpval_builder.py`) — pulls `openai/gdpval`, stages reference files + gold deliverables from the HF Hub, materializes each task into rLLM's sandbox task-per-directory format. Two catalog entries share it:
  - **`gdpval`** — headline metric: rubric-informed **pairwise** LLM-judge vs. the expert deliverable → win-rate (reproduces GDPval's grading standard).
  - **`gdpval-rubric`** — absolute weighted-rubric score in `[0,1]` (dense signal, e.g. as an RL reward).
- **Graders** (`rllm/eval/reward_fns/gdpval.py`) — host-side LLM judges. Pairwise uses position-swap debiasing vs. the gold; rubric judges each criterion and weight-normalizes (`clip(Σ score[met] / Σ score[positive], 0, 1)`, penalties subtract). Deliverable text extraction for xlsx/docx/pptx/pdf/csv/txt. `drop_params=True` so reasoning judges that reject `temperature=0` still work.
- **Fail-closed grading** — the judge grades only an explicitly-surfaced deliverable, never the transcript/final answer. No deliverable → `ungraded`, judge not called.
- **Deliverable surfacing** (`rllm/eval/_resolution.py` + a gated hook in `rllm/hooks.py`) — host-side graders can't see the sandbox filesystem, so this reads the produced file out of the (still-alive) sandbox via base64-over-`exec` (backend-agnostic: Docker/Modal/Daytona) and attaches it to the episode. Opt-in via task metadata (`surface_deliverable`); no-op for other benchmarks. The agent is instructed to write to `output/`, and the surfacer reads only that directory, preserving the original basename.

## Grading fidelity

GDPval's true standard is blind human pairwise preference; OpenAI's current guidance sanctions running a self-hosted LLM judge over the rubrics + deliverables for an estimate. The pairwise grader is that automated estimate — comparable across runs, not the human number.

## Tests

40 unit tests (rubric parsing/aggregation incl. penalties, pairwise position-swap, fail-closed paths, text extraction, sandbox→host surfacing). Validated end-to-end live: `mini-swe-agent` + `gpt-4o` in a Docker sandbox → deliverable written to `output/` → surfaced to host → pairwise judge returned a real win/loss verdict.

## Usage

```bash
rllm eval gdpval --agent <agent> --model <model>     # pairwise win-rate
GDPVAL_JUDGE_MODEL=<model> rllm eval gdpval ...       # set an independent judge
```
