### PR TITLE
feat(loss): add IcePop discrepancy-mask loss (arXiv:2510.18855)

### DIFF
--- a/docs/training/custom-loss.mdx
+++ b/docs/training/custom-loss.mdx
@@ -51,6 +51,7 @@ Ported from verl 0.8 and verified against its kernels. Select any of these with 
 | `dppo_tv` / `dppo_kl` | **DPPO** ([arXiv:2602.04879](https://arxiv.org/abs/2602.04879)) — replaces ratio-clipping with a per-token divergence mask (total-variation / KL). Uses the untruncated ratio (`C=∞`) per the paper §5.4. |
 | `cispo` | **CISPO** ([arXiv:2506.13585](https://arxiv.org/abs/2506.13585)) — clips the importance-sampling weight (stop-grad) but keeps every token's gradient |
 | `gspo` | **GSPO** ([arXiv:2507.18071](https://arxiv.org/abs/2507.18071)) — sequence-level importance ratio via `seq_reduce`; pins `seq-mean-token-mean` |
+| `icepop` | **IcePop** ([arXiv:2510.18855](https://arxiv.org/abs/2510.18855)) — double-sided train/inference discrepancy mask: zeros a token's gradient when `exp(logp_curr − logp_rollout)` leaves `[icepop_alpha, icepop_beta]` (default `0.5`/`5.0`). Reports `icepop/ratio_{mean,min,max}` + `mask_frac`. |
 | `reinforce` | Clip-free REINFORCE-style policy gradient (verl `gpg`) |
 | `echo` | **ECHO** ([arXiv:2605.24517](https://arxiv.org/abs/2605.24517)) — PPO term plus an observation-token cross-entropy term, composed in one body |
 
@@ -115,29 +116,32 @@ def gspo(ctx): ...
 
 ## Writing a custom loss
 
-A loss is any function `(ctx) -> (scalar, metrics)`. Below is a complete, working example: **IcePop** ([arXiv:2510.18855](https://arxiv.org/abs/2510.18855)), which zeros a token's gradient when its importance ratio leaves a band `[alpha, beta]` — a double-sided divergence mask (masking out-of-range tokens rather than clipping them).
+A loss is any function `(ctx) -> (scalar, metrics)`. The example below is **IcePop** ([arXiv:2510.18855](https://arxiv.org/abs/2510.18855)) — it zeros a token's gradient when its train/inference ratio `exp(logp_curr − logp_rollout)` leaves a band `[alpha, beta]` (masking out-of-range tokens rather than clipping them). rLLM already ships this as the built-in `icepop` (see the table above); it's reproduced here under a different name as a template you can adapt.
 
 ```python
 # my_losses.py
 import rllm
 import torch
 
-@rllm.register_loss("icepop")
-def icepop(ctx: rllm.LossContext):
-    """Mask tokens whose importance ratio exp(logp_curr - logp_old) leaves [alpha, beta]."""
+@rllm.register_loss("my_icepop")
+def my_icepop(ctx: rllm.LossContext):
+    """Mask tokens whose train/inference ratio exp(logp_curr - logp_rollout) leaves [alpha, beta]."""
+    if ctx.logp_rollout is None:
+        raise ValueError("my_icepop needs rollout log-probs, but ctx.logp_rollout is None")
     alpha = float(ctx.params.get("alpha", 0.5))
     beta = float(ctx.params.get("beta", 5.0))
-    ratio = torch.exp(ctx.logp_curr - ctx.logp_old).detach()      # detached weight, no grad
+    ratio = torch.exp(ctx.logp_curr.detach() - ctx.logp_rollout)   # detached weight, no grad
     keep = ((ratio >= alpha) & (ratio <= beta)).to(ctx.logp_curr.dtype)
-    pg = -ctx.advantages * ratio * ctx.logp_curr * keep           # grad flows via logp_curr
+    pg = -ctx.advantages * ratio * ctx.logp_curr * keep            # grad flows via logp_curr
     am = ctx.action_mask
     mask_frac = ((1.0 - keep) * am).sum() / am.sum().clamp(min=1.0)
-    return ctx.aggregate(pg, am), {"icepop/mask_frac": mask_frac.item()}
+    return ctx.aggregate(pg, am), {"my_icepop/mask_frac": mask_frac.item()}
 ```
 
-Two conventions worth internalizing:
+Three conventions worth internalizing:
 
 - **`logp_curr` is the only differentiable term.** Anything used as a *weight* (the ratio, a mask) should be `.detach()`ed so gradient flows only through the score `logp_curr`.
+- **Use `logp_rollout` for the true sampling distribution** and guard on `None` rather than falling back to `logp_old` (which is the *proximal*, not the inference log-prob). It's always populated on the managed backends.
 - **Never reduce by hand.** Return `ctx.aggregate(per_token, mask)` so your loss inherits the configured aggregation and correct global normalization.
 
 ### Selecting and registering it

--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -65,10 +65,13 @@ class LossContext:
             "seq-mean-token-mean"); None uses the backend/config default.
         logp_ref: reference-policy log-probs for a KL term, or None.
         logp_rollout: raw inference/sampling log-probs from the rollout (the behavior policy the
-            tokens were drawn from), or None if unavailable. Distinct from ``logp_old`` only when
-            a proximal old-policy was recomputed (non-bypass); under bypass_mode they coincide.
-            Use this when a loss must reference the true sampling distribution independently of
-            the ratio denominator (e.g. train/inference-mismatch corrections like TIS/IcePop).
+            tokens were drawn from). Always populated on the managed (tinker/fireworks) path;
+            on verl it is None unless rollout log-probs were captured into the batch. Distinct
+            from ``logp_old`` only when a proximal old-policy was recomputed (non-bypass); under
+            bypass_mode they coincide. Use this when a loss must reference the true sampling
+            distribution independently of the ratio denominator (train/inference-mismatch
+            corrections like TIS/IcePop) — a loss that requires it should guard on None rather
+            than fall back to ``logp_old`` (which is the proximal, not the inference log-prob).
         params: loss hyperparameters (``delta``/``eps_clip``, ``env_loss_coef``, ...).
         backend: "verl" | "tinker" | "fireworks".
     """
@@ -364,6 +367,49 @@ def dppo_kl(ctx: LossContext):
     am = ctx.action_mask
     mask_frac = ((1.0 - keep) * am).sum() / am.sum().clamp(min=1.0)
     return ctx.aggregate(pg, am), {"dppo_kl/mask_frac": mask_frac.item()}
+
+
+@register_loss("icepop")
+def icepop(ctx: LossContext):
+    """IcePop (arXiv:2510.18855, Ring-1T): double-sided train/inference discrepancy mask.
+
+    Zero a token's gradient when its importance ratio ``d = exp(logp_curr - logp_rollout)``
+    (current training policy vs the recorded inference/behavior policy) leaves ``[alpha, beta]``;
+    inside the band, weight the score by ``d`` (paper's ``M(k)=k·1[alpha<=k<=beta]``). Masks
+    out-of-range tokens rather than clipping them (unlike TIS/CISPO), and is non-directional
+    (unlike DPPO's advantage-conditioned divergence mask).
+
+    Uses ``logp_rollout`` (the true sampling distribution, correct per-token even across weight
+    versions in a partial rollout) rather than ``logp_old``, so no proximal forward is needed —
+    ``logp_curr`` is the training forward computed for the gradient anyway. Defaults alpha=0.5,
+    beta=5.0 (paper's default range).
+    """
+    import torch
+
+    if ctx.logp_rollout is None:
+        raise ValueError(
+            "icepop needs rollout (inference) log-probs, but ctx.logp_rollout is None. The managed "
+            "backends (tinker/fireworks) always provide them; on verl, enable rollout log-prob "
+            "capture so rollout_log_probs is in the batch."
+        )
+    alpha = float(ctx.params.get("icepop_alpha", 0.5))
+    beta = float(ctx.params.get("icepop_beta", 5.0))
+    d = torch.exp(ctx.logp_curr.detach() - ctx.logp_rollout)  # detached weight; grad flows via logp_curr
+    keep = ((d >= alpha) & (d <= beta)).to(ctx.logp_curr.dtype)
+    pg = -ctx.advantages * d * ctx.logp_curr * keep
+    am = ctx.action_mask
+    mask_frac = ((1.0 - keep) * am).sum() / am.sum().clamp(min=1.0)
+    # Ratio diagnostics over trainable tokens. On the managed per-datum path the loss runs once
+    # per sequence, so min/max are per-sequence and the adapter averages them across the batch
+    # (mean is a good batch-mean proxy); on verl the whole (B,T) batch is one call → true stats.
+    active = am > 0
+    d_active = d[active] if active.any() else d.new_ones(1)
+    return ctx.aggregate(pg, am), {
+        "icepop/mask_frac": mask_frac.item(),
+        "icepop/ratio_mean": d_active.mean().item(),
+        "icepop/ratio_min": d_active.min().item(),
+        "icepop/ratio_max": d_active.max().item(),
+    }
 
 
 @register_loss("cispo")

--- a/tests/unified_trainer/test_custom_loss.py
+++ b/tests/unified_trainer/test_custom_loss.py
@@ -17,6 +17,7 @@ from rllm.trainer.algorithms.loss import (  # noqa: E402
     dppo_tv,
     echo,
     get_loss,
+    icepop,
     is_custom_loss,
     ppo_clip,
     register_loss,
@@ -220,6 +221,52 @@ def test_gspo_gradient_flows_per_token():
     ctx = LossContext(logp_curr=logp_curr, logp_old=logp_old, advantages=adv, action_mask=mask, obs_mask=torch.zeros(1, 3), aggregate=_agg_sum, params={"eps_clip": 0.2})
     gspo(ctx)[0].backward()
     assert logp_curr.grad is not None and (logp_curr.grad != 0).all()  # every token in the sequence gets a gradient
+
+
+# --------------------------------------------------------------------------- IcePop discrepancy mask
+def test_icepop_masks_out_of_band_and_reports_ratio():
+    """d = exp(logp_curr - logp_rollout) per token = [0.3, 1.0, 10.0]; band [0.5, 5.0] keeps only
+    the middle. Masked tokens get no gradient; ratio min/max/mean reflect the raw batch ratios."""
+    import math
+
+    logp_curr = torch.tensor([-0.5, -0.5, -0.5], requires_grad=True)
+    # rollout = logp_curr - ln(d) so exp(logp_curr - rollout) hits the target ratios exactly.
+    rollout = torch.tensor([-0.5 - math.log(0.3), -0.5 - math.log(1.0), -0.5 - math.log(10.0)])
+    ctx = LossContext(
+        logp_curr=logp_curr,
+        logp_old=rollout,
+        logp_rollout=rollout,
+        advantages=torch.tensor([1.0, 1.0, 1.0]),
+        action_mask=torch.ones(3),
+        obs_mask=torch.zeros(3),
+        aggregate=_agg_sum,
+        params={"icepop_alpha": 0.5, "icepop_beta": 5.0},
+    )
+    loss, m = icepop(ctx)
+    loss.backward()
+
+    assert m["icepop/mask_frac"] == pytest.approx(2 / 3)  # tokens 0 (d<α) and 2 (d>β) masked
+    assert m["icepop/ratio_min"] == pytest.approx(0.3, abs=1e-4)
+    assert m["icepop/ratio_max"] == pytest.approx(10.0, abs=1e-4)
+    assert m["icepop/ratio_mean"] == pytest.approx((0.3 + 1.0 + 10.0) / 3, abs=1e-4)
+    assert logp_curr.grad[0].item() == 0.0 and logp_curr.grad[2].item() == 0.0  # out-of-band → no grad
+    assert logp_curr.grad[1].item() != 0.0  # in-band token trains
+
+
+def test_icepop_requires_logp_rollout():
+    """No silent fall back to logp_old (the proximal): a missing rollout log-prob is a loud error."""
+    ctx = LossContext(
+        logp_curr=torch.tensor([-0.5]),
+        logp_old=torch.tensor([-0.5]),
+        logp_rollout=None,
+        advantages=torch.tensor([1.0]),
+        action_mask=torch.ones(1),
+        obs_mask=torch.zeros(1),
+        aggregate=_agg_sum,
+        params={},
+    )
+    with pytest.raises(ValueError, match="rollout"):
+        icepop(ctx)
 
 
 # --------------------------------------------------------------------------- ECHO as one loss function


### PR DESCRIPTION
## Summary

Adds **IcePop** ([arXiv:2510.18855](https://arxiv.org/abs/2510.18855), Ring-1T) as a built-in policy loss (`algorithm.loss_fn: icepop`), on top of the unified custom-loss abstraction. IcePop is a double-sided **train/inference discrepancy mask**: it zeros a token's gradient when its importance ratio leaves a band, instead of clipping it.

```yaml
algorithm:
  loss_fn: icepop
  loss_params: {icepop_alpha: 0.5, icepop_beta: 5.0}   # paper defaults
```

Per token, with `d = exp(logp_curr − logp_rollout)`:
- **`d ∈ [alpha, beta]`** → keep the token, weight the score by `d` (the paper's `M(k)=k·1[α≤k≤β]`).
- **`d < alpha` or `d > beta`** → zero the gradient (mask, don't clip).

## Design: why `logp_curr` vs `logp_rollout`, and no proximal forward

The interesting part is what plays the "train" and "inference" sides of the discrepancy ratio. IcePop's paper quantity is `π_train(θ_old) / π_infer(θ_old)`. We compute `exp(logp_curr − logp_rollout)`:

- **`logp_rollout`** = the recorded inference/sampling log-probs. These are captured **per-token as generated**, so they're correct even when a trajectory spans multiple weight versions in a **partial rollout**.
- **`logp_curr`** = the current training forward (which we compute for the gradient anyway). In single-update async `logp_curr ≈ proximal`, so `exp(logp_curr − logp_rollout)` is the train/inference engine gap — without a proximal forward.

This deliberately **avoids recomputing a proximal log-prob**, which under partial rollout would require keeping trainer weights for every version a rollout spanned (infeasible). It matches how slime handles the same problem — lean on the per-token-correct rollout log-probs rather than a proximal — and it means `icepop` works on the default `bypass_mode=True` path across all three backends with no extra forward.

Trade-off (documented): gating on current weights instead of `θ_old` folds a little policy drift into the ratio under high staleness — fine for single-update, near-on-policy async (the same approximation the bypass path already makes).

**Standalone loss, not a composable add-on.** A `pg_loss *= correction` add-on would need a proximal *pivot* to telescope cleanly and a mutual-exclusion guard to avoid double-counting the rollout log-prob (`base π/rollout × correction ...`). As one self-contained loss there's a single ratio, so double-counting is structurally impossible — and it directly computes what the add-on route only reaches via telescoping.

## Guarded, not silently degraded

`icepop` requires `logp_rollout` and raises if it's `None` — it does **not** fall back to `logp_old`. On verl `logp_old` is the *proximal* (a training forward), not the inference log-prob; substituting it would make the discrepancy gate `exp(logp_curr − proximal) ≈ 1` (never fires) with no signal. `logp_rollout` is always populated on the managed (tinker/fireworks) path; on verl it's present only when rollout log-probs were captured.

## Ratio diagnostics

Emits, over the trainable (action-masked) tokens:
- `icepop/ratio_mean`, `icepop/ratio_min`, `icepop/ratio_max` — the discrepancy distribution, for tuning `alpha`/`beta`.
- `icepop/mask_frac` — fraction of tokens dropped.

On verl these are batch-true (whole `(B,T)` in one call); on the managed per-datum path `min`/`max` are per-sequence and the adapter averages them across the batch (`mean` remains a good batch-mean proxy).

## Changes

- `rllm/trainer/algorithms/loss.py` — `@register_loss("icepop")` (guarded; ratio metrics); tightened the `logp_rollout` field docstring to state exactly when it's `None` and that losses should guard rather than fall back to the proximal.
- `tests/unified_trainer/test_custom_loss.py` — `test_icepop_masks_out_of_band_and_reports_ratio` (ratios `[0.3, 1.0, 10.0]`, band `[0.5, 5.0]` → tokens 0 & 2 masked with zero grad, middle trains; `ratio_{min,max,mean}` = `0.3/10/3.77`) and `test_icepop_requires_logp_rollout` (raises on `None`).
- `docs/training/custom-loss.mdx` — `icepop` row in the built-in table; worked example updated to the guarded `logp_rollout` form (renamed `my_icepop` to avoid colliding with the built-in).

## Tests

`tests/unified_trainer/test_custom_loss.py` — **29 passing** (2 new). ruff clean + formatted (pinned v0.11.4).

## Notes for reviewers

- **Base is `terminal-rl`** (where the custom-loss abstraction landed via #713).
- No new plumbing: `icepop` is an rLLM-registered loss, so `resolve_loss` routes it to the custom (`forward_backward_custom`) path automatically on tinker/fireworks and in-process on verl.
- Builds on the `logp_rollout` field added in #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
