### PR TITLE
feat(algorithm): expose @rllm.register_adv_estimator (mirrors @rllm.register_loss)

### DIFF
--- a/rllm/__init__.py
+++ b/rllm/__init__.py
@@ -7,7 +7,7 @@ import sys
 
 from rllm.utils.logging import configure_logging_from_env
 
-__all__ = ["BaseAgent", "Action", "Step", "Trajectory", "Episode", "rollout", "evaluator", "Task", "register_loss", "LossContext"]
+__all__ = ["BaseAgent", "Action", "Step", "Trajectory", "Episode", "rollout", "evaluator", "Task", "register_loss", "LossContext", "register_adv_estimator"]
 
 configure_logging_from_env()
 
@@ -28,6 +28,13 @@ def __getattr__(name: str):
         _mod.register_loss = register_loss
         _mod.LossContext = LossContext
         return register_loss if name == "register_loss" else LossContext
+
+    if name == "register_adv_estimator":
+        from rllm.trainer.algorithms.advantage import register_adv_estimator
+
+        _mod = sys.modules[__name__]
+        _mod.register_adv_estimator = register_adv_estimator
+        return register_adv_estimator
 
     if name == "Task":
         from rllm.types import Task

--- a/rllm/trainer/algorithms/__init__.py
+++ b/rllm/trainer/algorithms/__init__.py
@@ -4,7 +4,12 @@ Common utilities for rLLM trainers.
 This module provides shared functionality across different trainer backends (verl, tinker, etc.).
 """
 
-from rllm.trainer.algorithms.advantage import collect_reward_and_advantage_from_trajectory_groups
+from rllm.trainer.algorithms.advantage import (
+    RLLM_ADV_ESTIMATOR_REGISTRY,
+    collect_reward_and_advantage_from_trajectory_groups,
+    get_adv_estimator,
+    register_adv_estimator,
+)
 from rllm.trainer.algorithms.config import (
     AlgorithmConfig,
     AsyncTrainingConfig,
@@ -54,6 +59,9 @@ __all__ = [
     # Advantage computation
     "rLLMAdvantageEstimator",
     "collect_reward_and_advantage_from_trajectory_groups",
+    "register_adv_estimator",
+    "get_adv_estimator",
+    "RLLM_ADV_ESTIMATOR_REGISTRY",
     # Custom losses (single-selector, verl-style)
     "register_loss",
     "get_loss",

--- a/rllm/trainer/algorithms/advantage.py
+++ b/rllm/trainer/algorithms/advantage.py
@@ -22,7 +22,7 @@ logger.addFilter(DuplicateLoggingFilter())  # prevent duplicate logging messages
 RLLM_ADV_ESTIMATOR_REGISTRY: dict[str, Callable] = {}
 
 
-def register_rllm_adv_estimator(name: str | rLLMAdvantageEstimator) -> Callable:
+def register_adv_estimator(name: str | rLLMAdvantageEstimator) -> Callable:
     """Register a rLLM advantage estimator — either built-in or custom.
 
     Registered estimators must follow the canonical signature:
@@ -60,18 +60,24 @@ def register_rllm_adv_estimator(name: str | rLLMAdvantageEstimator) -> Callable:
     return decorator
 
 
-def get_rllm_adv_estimator(name: str | rLLMAdvantageEstimator) -> Callable:
+def get_adv_estimator(name: str | rLLMAdvantageEstimator) -> Callable:
     """Get a rLLM advantage estimator by name.
 
     Args:
         name: Name of the advantage estimator.
     """
     if name not in RLLM_ADV_ESTIMATOR_REGISTRY:
-        raise ValueError(f"Unknown advantage estimator {name}. If you have a custom advantage estimator, please register it using `register_rllm_adv_estimator`.")
+        raise ValueError(f"Unknown advantage estimator {name}. If you have a custom advantage estimator, please register it using `register_adv_estimator`.")
     return RLLM_ADV_ESTIMATOR_REGISTRY[name]
 
 
-@register_rllm_adv_estimator(rLLMAdvantageEstimator.GRPO)
+# Backwards-compatible aliases for the pre-rename names. Prefer the shorter
+# `register_adv_estimator` / `get_adv_estimator` (mirrors `register_loss` / `get_loss`).
+register_rllm_adv_estimator = register_adv_estimator
+get_rllm_adv_estimator = get_adv_estimator
+
+
+@register_adv_estimator(rLLMAdvantageEstimator.GRPO)
 def calculate_grpo_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
     norm_adv_by_std_in_grpo = algorithm_config.norm_adv_by_std_in_grpo
     advantages_by_group, returns_by_group = zip(
@@ -82,13 +88,13 @@ def calculate_grpo_advantages(rewards: list[np.ndarray], algorithm_config: Algor
     return advantages_by_group, returns_by_group
 
 
-@register_rllm_adv_estimator(rLLMAdvantageEstimator.REINFORCE)
+@register_adv_estimator(rLLMAdvantageEstimator.REINFORCE)
 def calculate_reinforce_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """REINFORCE: advantage = reward (no baseline)"""
     return rewards, rewards
 
 
-@register_rllm_adv_estimator(rLLMAdvantageEstimator.REINFORCE_PLUS_PLUS_BASELINE)
+@register_adv_estimator(rLLMAdvantageEstimator.REINFORCE_PLUS_PLUS_BASELINE)
 def calculate_reinforce_plus_plus_baseline_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, epsilon: float = 1e-6, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """REINFORCE++ baseline estimator.
 
@@ -111,7 +117,7 @@ def calculate_reinforce_plus_plus_baseline_advantages(rewards: list[np.ndarray],
     return advantages_by_group, advantages_by_group
 
 
-@register_rllm_adv_estimator(rLLMAdvantageEstimator.PRPO)
+@register_adv_estimator(rLLMAdvantageEstimator.PRPO)
 def calculate_prpo_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, epsilon: float = 1e-6, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """PRPO advantage estimator, centering and normalizing rewards across the batch. See https://rllm-project.com/post.html?post=continual_learning.md
 
@@ -129,14 +135,14 @@ def calculate_prpo_advantages(rewards: list[np.ndarray], algorithm_config: Algor
     return advantages_by_group, advantages_by_group
 
 
-@register_rllm_adv_estimator(rLLMAdvantageEstimator.RLOO)
+@register_adv_estimator(rLLMAdvantageEstimator.RLOO)
 def calculate_rloo_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """Reinforce Leave-one-out (RLOO): https://arxiv.org/abs/2402.14740"""
     advantages_by_group, returns_by_group = zip(*[calculate_rloo_advantages_per_group(group_rewards) for group_rewards in rewards], strict=True)
     return advantages_by_group, returns_by_group
 
 
-@register_rllm_adv_estimator(rLLMAdvantageEstimator.ECHO)
+@register_adv_estimator(rLLMAdvantageEstimator.ECHO)
 def calculate_echo_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """ECHO (arXiv:2605.24517): advantages are identical to GRPO.
 
@@ -228,7 +234,7 @@ def collect_reward_and_advantage_from_trajectory_groups(
 
     if collect_advantage:
         for group_role, traj_groups in traj_groups_by_role.items():
-            advantage_fn = get_rllm_adv_estimator(algorithm_config.estimator_map.get(group_role, algorithm_config.estimator))
+            advantage_fn = get_adv_estimator(algorithm_config.estimator_map.get(group_role, algorithm_config.estimator))
             traj_rewards = traj_rewards_by_role[group_role]
             advantages_by_group, _ = advantage_fn(  # ignore returns here
                 rewards=traj_rewards,


### PR DESCRIPTION
## What

Exposes a top-level **`@rllm.register_adv_estimator`** decorator for registering custom advantage estimators, mirroring the existing **`@rllm.register_loss`** API (from #713).

## Why

Custom advantage estimators are a natural extension point (e.g. a Pass@K reward-reweighting estimator that scales GRPO-normalized advantages by a per-group `w(p)`). Today the registration hook is `register_rllm_adv_estimator`, buried in `rllm.trainer.algorithms.advantage` and never exported. This makes it a first-class, discoverable API on par with custom losses.

## Changes

- **`rllm/__init__.py`** — lazy top-level export so users can write `@rllm.register_adv_estimator("my_est")`, exactly like `@rllm.register_loss`.
- **`rllm/trainer/algorithms/__init__.py`** — export `register_adv_estimator`, `get_adv_estimator`, `RLLM_ADV_ESTIMATOR_REGISTRY`.
- **`rllm/trainer/algorithms/advantage.py`** — rename `register_rllm_adv_estimator` → `register_adv_estimator` and `get_rllm_adv_estimator` → `get_adv_estimator` (drops the redundant `rllm` infix to match `register_loss`/`get_loss`). All six built-in estimators (grpo, reinforce, reinforce++_baseline, prpo, rloo, echo) now register under the new name.

## Back-compat

`register_rllm_adv_estimator` and `get_rllm_adv_estimator` are kept as aliases to the renamed functions, so any existing direct imports keep working.

## Base branch

Targets `terminal-rl` rather than `main`: this mirrors `rllm.register_loss`, which is introduced by #713 and not yet on `main`.

## Verification

Sanity-checked against this worktree copy:
- `rllm.register_adv_estimator` resolves top-level and is callable
- package-level `register_adv_estimator` / `get_adv_estimator` / `RLLM_ADV_ESTIMATOR_REGISTRY` export correctly
- all six built-ins remain registered under the renamed decorator
- back-compat aliases (`register_rllm_adv_estimator`, `get_rllm_adv_estimator`) resolve to the same objects
- round-trip: register a custom estimator via `@rllm.register_adv_estimator(...)`, fetch via `get_adv_estimator(...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)