### PR TITLE
fix(terminus2): honor RLLM_TERMINUS_ENABLE_SUMMARIZE from the host env

### DIFF
--- a/rllm/harnesses/terminus2.py
+++ b/rllm/harnesses/terminus2.py
@@ -124,8 +124,12 @@ class Terminus2Harness(BaseCliHarness):
     # context fills, which fragments the trajectory the gateway captures. Set
     # ``enable_summarize=False`` (e.g. via the harness constructor) to turn both
     # proactive and context-limit summarization off — the agent then simply hits
-    # its context limit instead of compacting.
-    enable_summarize: bool = True
+    # its context limit instead of compacting. The env default lets ``rllm eval``
+    # toggle it without a constructor, mirroring interleaved_thinking above:
+    # export RLLM_TERMINUS_ENABLE_SUMMARIZE=0. (build_env re-exports this
+    # attribute into the sandbox, so a plain ``True`` default silently
+    # overwrote the operator's host env var with "1".)
+    enable_summarize: bool = os.environ.get("RLLM_TERMINUS_ENABLE_SUMMARIZE", "1") == "1"
 
     def install_script(self) -> str:
         return _install_script(self.harbor_version, self.terminus_python)

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -734,3 +734,42 @@ def test_run_exec_timeout_without_sentinel_stays_timeout():
     result = h.run(_make_task(), _make_config(), env=sandbox)
 
     assert result.termination_reason == TerminationReason.TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# Terminus2Harness — env knob toggles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("host_env", "expected_summarize", "expected_interleaved"),
+    [
+        # No host overrides → Harbor-matching defaults.
+        ({}, "1", "0"),
+        # Both knobs flipped from their defaults. RLLM_TERMINUS_ENABLE_SUMMARIZE=0
+        # used to be silently ignored (the class default never read the env var,
+        # and build_env then hard-coded "1" into the sandbox), so eval runs
+        # compacted their trajectories despite the operator turning it off.
+        ({"RLLM_TERMINUS_ENABLE_SUMMARIZE": "0", "RLLM_TERMINUS_INTERLEAVED_THINKING": "1"}, "0", "1"),
+    ],
+)
+def test_terminus2_env_knobs_reach_the_sandbox(monkeypatch, host_env, expected_summarize, expected_interleaved):
+    """The RLLM_TERMINUS_* toggles set on the host where ``rllm eval`` runs must
+    land in the sandbox env verbatim — build_env overwrites the vars from the
+    class attributes, so those defaults must read the host env (at import time,
+    like every knob here; reload simulates a fresh launch)."""
+    import importlib
+
+    import rllm.harnesses.terminus2 as t2
+
+    with monkeypatch.context() as m:
+        for var in ("RLLM_TERMINUS_ENABLE_SUMMARIZE", "RLLM_TERMINUS_INTERLEAVED_THINKING"):
+            m.delenv(var, raising=False)
+        for var, value in host_env.items():
+            m.setenv(var, value)
+        mod = importlib.reload(t2)
+        env = mod.Terminus2Harness().build_env(_make_task(), _make_config())
+    importlib.reload(t2)  # restore class defaults from the real host env
+
+    assert env["RLLM_TERMINUS_ENABLE_SUMMARIZE"] == expected_summarize
+    assert env["RLLM_TERMINUS_INTERLEAVED_THINKING"] == expected_interleaved


### PR DESCRIPTION
## Problem

`RLLM_TERMINUS_ENABLE_SUMMARIZE=0` set on the host where `rllm eval` runs is silently ignored. `interleaved_thinking` reads its env var as the class-attribute default, but `enable_summarize` was a plain `True` — and `build_env` re-exports the attribute into the sandbox, unconditionally overwriting the operator's setting with `"1"`. The in-sandbox driver only ever sees what `build_env` gives it, so the host env var was dead code.

Observed on a terminal-bench-2 eval launched with `RLLM_TERMINUS_ENABLE_SUMMARIZE=0 RLLM_TERMINUS_INTERLEAVED_THINKING=1`: 30 of 171 episodes still ran Terminus-2 context-limit summarization handoffs ("You are picking up work from a previous AI agent…"), collapsing e.g. a 78-message history to 2 and breaking the cumulative prefix structure of the recorded trajectories (the interleaved-thinking flag, which does read the env, worked as expected on the same run).

## Fix

Read the env var as the class default, mirroring `interleaved_thinking` one attribute above:

```python
enable_summarize: bool = os.environ.get("RLLM_TERMINUS_ENABLE_SUMMARIZE", "1") == "1"
```

## Test

Added a `build_env` round-trip test covering both knobs (defaults and flipped), reloading the module under a patched env to simulate a fresh launch. It fails on the old code (`ENABLE_SUMMARIZE` comes back `"1"` despite the host setting `0`) and passes with the fix; the full `tests/harnesses/test_cli_harness.py` file passes (66 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)