### PR TITLE
feat(algorithm): reinforce_kl loss — IS-weighted REINFORCE with opt-in forward/backward KL to the sampler

### DIFF
--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -461,6 +461,67 @@ def reinforce(ctx: LossContext):
     return ctx.aggregate(-ctx.advantages * ctx.logp_curr, ctx.action_mask), {}
 
 
+@register_loss("reinforce_kl")
+def reinforce_kl(ctx: LossContext):
+    """IS-weighted REINFORCE plus forward/backward KL to the **sampler** policy.
+
+    Per token, with ``r = p/q = exp(logp_curr - logp_rollout)`` (trainer ``p`` vs sampler
+    ``q``), ``sg`` = stop-gradient and ``A`` the advantage::
+
+        L = -sg[r]·A·logp_curr + bwd_kl_coef·(-log r + r - 1) + fwd_kl_coef·(r·log r - r + 1)
+
+    The PG term is REINFORCE with a detached, *unclipped* importance weight: unlike PPO's
+    clip (zeros out-of-band gradients) or CISPO/IcePop (clamp/mask the weight), every token
+    always keeps its gradient. The trust region is instead enforced softly by the KL terms,
+    which penalize divergence from the *behavior* policy ``q = logp_rollout`` — not a frozen
+    reference — using the sample-wise non-negative unbiased estimators under ``q`` (Schulman,
+    http://joschu.net/blog/kl-approx.html): backward KL(q‖p) is k3 ``-log r + r - 1``;
+    forward KL(p‖q) is ``r·log r - r + 1`` (each has mean KL and minimum 0 at ``r = 1``
+    since ``E_q[r] = 1``). Both coefficients default to 0.0 (pure IS-weighted REINFORCE);
+    enable a term explicitly, e.g. ``loss_params: {bwd_kl_coef: 0.0025}``.
+
+    ``ratio_clamp_min`` / ``ratio_clamp_max`` (default None = raw ratio, faithful to the
+    doc) optionally bound the detached PG weight CISPO-style — a clamped token keeps its
+    gradient, and the KL terms always see the true ``r``.
+
+    Ignores ``logp_old`` entirely, so it needs no proximal forward — pair with
+    ``rollout_correction.bypass_mode: true``.
+    """
+    import torch
+
+    if ctx.logp_rollout is None:
+        raise ValueError(
+            "reinforce_kl needs rollout (inference) log-probs, but ctx.logp_rollout is None. The managed "
+            "backends (tinker/fireworks) always provide them; on verl, enable rollout log-prob "
+            "capture so rollout_log_probs is in the batch."
+        )
+    fwd_coef = float(ctx.params.get("fwd_kl_coef", 0.0))
+    bwd_coef = float(ctx.params.get("bwd_kl_coef", 0.0))
+    clamp_min = ctx.params.get("ratio_clamp_min")
+    clamp_max = ctx.params.get("ratio_clamp_max")
+
+    log_r = ctx.logp_curr - ctx.logp_rollout
+    r = torch.exp(torch.clamp(log_r, min=-_RATIO_CLAMP, max=_RATIO_CLAMP))  # clamp = inf protection only
+
+    w = r.detach()
+    if clamp_min is not None or clamp_max is not None:
+        w = w.clamp(min=clamp_min, max=clamp_max)  # bounds the PG weight only; KL terms keep the true r
+    pg = -w * ctx.advantages * ctx.logp_curr
+    # r must stay differentiable here — the estimators' gradients, (r-1)·∇logp and
+    # r·log r·∇logp, are what pull p toward q; detaching r degenerates bwd into -∇logp.
+    kl_bwd = -log_r + r - 1.0
+    kl_fwd = r * log_r - r + 1.0
+
+    am = ctx.action_mask
+    denom = am.sum().clamp(min=1.0)
+    return ctx.aggregate(pg + bwd_coef * kl_bwd + fwd_coef * kl_fwd, am), {
+        "reinforce_kl/kl_bwd": ((kl_bwd.detach() * am).sum() / denom).item(),
+        "reinforce_kl/kl_fwd": ((kl_fwd.detach() * am).sum() / denom).item(),
+        "reinforce_kl/ratio_mean": ((r.detach() * am).sum() / denom).item(),
+        "reinforce_kl/clamp_frac": (((w != r.detach()).to(log_r.dtype) * am).sum() / denom).item(),
+    }
+
+
 @register_loss("echo")
 def echo(ctx: LossContext):
     """ECHO (arXiv:2605.24517) in the verl-style single-loss model: PPO/GRPO plus a

--- a/tests/unified_trainer/test_custom_loss.py
+++ b/tests/unified_trainer/test_custom_loss.py
@@ -269,6 +269,201 @@ def test_icepop_requires_logp_rollout():
         icepop(ctx)
 
 
+# --------------------------------------------------------------------------- REINFORCE + KL-to-sampler
+def test_reinforce_kl_matches_doc_formula():
+    """L = -sg[r]·A·logp + bwd·(-log r + r - 1) + fwd·(r·log r - r + 1), with r = p/q against
+    the SAMPLER (logp_rollout) — logp_old (the proximal) must be ignored entirely."""
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    torch.manual_seed(4)
+    n = 16
+    logp_curr = (torch.rand(n) * -2).requires_grad_(True)
+    logp_rollout = torch.rand(n) * -2
+    adv = torch.randn(n)
+    ctx = LossContext(
+        logp_curr=logp_curr,
+        logp_old=torch.zeros(n),  # garbage on purpose: q is the sampler, not the proximal
+        logp_rollout=logp_rollout,
+        advantages=adv,
+        action_mask=torch.ones(n),
+        obs_mask=torch.zeros(n),
+        aggregate=_agg_sum,
+        params={"fwd_kl_coef": 0.3, "bwd_kl_coef": 0.7},
+    )
+    ours, m = reinforce_kl(ctx)
+
+    log_r = logp_curr.detach() - logp_rollout
+    r = torch.exp(torch.clamp(log_r, -20.0, 20.0))
+    pg = -r * adv * logp_curr.detach()
+    kl_bwd = -log_r + r - 1.0
+    kl_fwd = r * log_r - r + 1.0
+    ref = (pg + 0.7 * kl_bwd + 0.3 * kl_fwd).sum()
+    assert torch.allclose(ours.detach(), ref, atol=1e-5)
+    # metrics: masked means of the per-token estimators, each sample-wise non-negative
+    assert m["reinforce_kl/kl_bwd"] == pytest.approx(kl_bwd.mean().item(), abs=1e-5)
+    assert m["reinforce_kl/kl_fwd"] == pytest.approx(kl_fwd.mean().item(), abs=1e-5)
+    assert m["reinforce_kl/ratio_mean"] == pytest.approx(r.mean().item(), abs=1e-5)
+    assert m["reinforce_kl/kl_bwd"] >= 0.0 and m["reinforce_kl/kl_fwd"] >= 0.0
+
+
+def test_reinforce_kl_default_coefs_are_zero():
+    """Both KL coefficients default to 0.0: the default loss is pure IS-weighted REINFORCE,
+    and a KL term only activates when its coef is set explicitly (e.g. bwd_kl_coef=0.0025)."""
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    def _make(**params):
+        return LossContext(
+            logp_curr=torch.tensor([-0.5, -1.2], requires_grad=True),
+            logp_old=torch.zeros(2),
+            logp_rollout=torch.tensor([-0.9, -0.4]),
+            advantages=torch.tensor([1.0, -1.0]),
+            action_mask=torch.ones(2),
+            obs_mask=torch.zeros(2),
+            aggregate=_agg_sum,
+            params=params,
+        )
+
+    default_loss, _ = reinforce_kl(_make())
+    pg_only, _ = reinforce_kl(_make(fwd_kl_coef=0.0, bwd_kl_coef=0.0))
+    with_bwd, _ = reinforce_kl(_make(bwd_kl_coef=0.0025))
+    assert torch.allclose(default_loss, pg_only)
+    assert not torch.allclose(default_loss, with_bwd)
+
+
+def test_reinforce_kl_keeps_gradient_where_ppo_clip_drops_it():
+    """The doc's REINFORCE-vs-GRPO/PPO contrast: at ratio 1.8 (>1+eps) with adv>0 PPO clip
+    zeros the gradient; here the token still trains, weighted by the full detached IS ratio."""
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    logp_q = [float(torch.tensor(0.5).log())]
+    a = torch.tensor([float(torch.tensor(0.9).log())], requires_grad=True)
+    ppo_clip(LossContext(logp_curr=a, logp_old=torch.tensor(logp_q), advantages=torch.tensor([1.0]), action_mask=torch.ones(1), obs_mask=torch.zeros(1), aggregate=_agg_sum, params={"eps_clip": 0.2}))[
+        0
+    ].backward()
+
+    b = torch.tensor([float(torch.tensor(0.9).log())], requires_grad=True)
+    reinforce_kl(
+        LossContext(
+            logp_curr=b,
+            logp_old=torch.zeros(1),
+            logp_rollout=torch.tensor(logp_q),
+            advantages=torch.tensor([1.0]),
+            action_mask=torch.ones(1),
+            obs_mask=torch.zeros(1),
+            aggregate=_agg_sum,
+            params={"fwd_kl_coef": 0.0, "bwd_kl_coef": 0.0},
+        )
+    )[0].backward()
+
+    assert a.grad[0].item() == 0.0  # PPO clip: out-of-band, no gradient
+    assert b.grad[0].item() == pytest.approx(-1.8, abs=1e-4)  # -sg[r]·A: unclipped weight, grad via log p only
+
+
+def test_reinforce_kl_kl_gradients_match_analytic_forms():
+    """The KL terms must keep the ratio differentiable: with A=0, backward KL's gradient is
+    (r-1)·∇logp and forward KL's is r·log r·∇logp — both pull p toward the sampler q.
+    (Detaching r inside the estimators would break this and de-regularize the loss.)"""
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    logp_rollout = torch.tensor([-1.0, -0.5])
+
+    def _make(logp_curr, **params):
+        return LossContext(
+            logp_curr=logp_curr, logp_old=torch.zeros(2), logp_rollout=logp_rollout, advantages=torch.zeros(2), action_mask=torch.ones(2), obs_mask=torch.zeros(2), aggregate=_agg_sum, params=params
+        )
+
+    log_r = torch.tensor([0.5, -0.5])  # logp_curr - logp_rollout below
+    r = log_r.exp()
+
+    bwd = torch.tensor([-0.5, -1.0], requires_grad=True)
+    reinforce_kl(_make(bwd, bwd_kl_coef=1.0, fwd_kl_coef=0.0))[0].backward()
+    assert torch.allclose(bwd.grad, r - 1.0, atol=1e-5)
+
+    fwd = torch.tensor([-0.5, -1.0], requires_grad=True)
+    reinforce_kl(_make(fwd, bwd_kl_coef=0.0, fwd_kl_coef=1.0))[0].backward()
+    assert torch.allclose(fwd.grad, r * log_r, atol=1e-5)
+
+
+def test_reinforce_kl_ratio_clamp_bounds_pg_weight():
+    """ratio_clamp_min/max bound the detached PG weight CISPO-style: with adv=1 and KL off,
+    grad = -clamp(r) — clamped tokens still train (unlike a mask). Default None = raw ratio."""
+    import math
+
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    # rollout = logp_curr - ln(d) so r = exp(logp_curr - rollout) hits [0.2, 5.0] exactly.
+    rollout = torch.tensor([-0.5 - math.log(0.2), -0.5 - math.log(5.0)])
+
+    def _run(**params):
+        logp_curr = torch.tensor([-0.5, -0.5], requires_grad=True)
+        ctx = LossContext(
+            logp_curr=logp_curr,
+            logp_old=torch.zeros(2),
+            logp_rollout=rollout,
+            advantages=torch.tensor([1.0, 1.0]),
+            action_mask=torch.ones(2),
+            obs_mask=torch.zeros(2),
+            aggregate=_agg_sum,
+            params={"fwd_kl_coef": 0.0, "bwd_kl_coef": 0.0, **params},
+        )
+        loss, m = reinforce_kl(ctx)
+        loss.backward()
+        return logp_curr.grad, m
+
+    grad, m = _run(ratio_clamp_min=0.5, ratio_clamp_max=2.0)
+    assert torch.allclose(grad, torch.tensor([-0.5, -2.0]), atol=1e-4)  # both bounded, both still train
+    assert m["reinforce_kl/clamp_frac"] == pytest.approx(1.0)
+
+    grad, m = _run()  # default None/None: raw detached ratio, faithful to the doc
+    assert torch.allclose(grad, torch.tensor([-0.2, -5.0]), atol=1e-4)
+    assert m["reinforce_kl/clamp_frac"] == 0.0
+
+    grad, m = _run(ratio_clamp_max=2.0)  # one-sided: min stays unbounded
+    assert torch.allclose(grad, torch.tensor([-0.2, -2.0]), atol=1e-4)
+    assert m["reinforce_kl/clamp_frac"] == pytest.approx(0.5)
+
+
+def test_reinforce_kl_ratio_clamp_leaves_kl_terms_alone():
+    """The clamp applies to the PG weight only: the KL estimators must keep the TRUE r, or a
+    tight clamp would silently weaken the regularizer. With A=0 and a clamp band around 1,
+    backward KL's gradient must still be (r-1) with the unclamped r."""
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    logp_curr = torch.tensor([-0.5, -1.0], requires_grad=True)
+    ctx = LossContext(
+        logp_curr=logp_curr,
+        logp_old=torch.zeros(2),
+        logp_rollout=torch.tensor([-1.0, -0.5]),  # log r = [0.5, -0.5]
+        advantages=torch.zeros(2),
+        action_mask=torch.ones(2),
+        obs_mask=torch.zeros(2),
+        aggregate=_agg_sum,
+        params={"bwd_kl_coef": 1.0, "fwd_kl_coef": 0.0, "ratio_clamp_min": 0.9, "ratio_clamp_max": 1.1},
+    )
+    reinforce_kl(ctx)[0].backward()
+    r = torch.tensor([0.5, -0.5]).exp()
+    assert torch.allclose(logp_curr.grad, r - 1.0, atol=1e-5)  # NOT clamp(r) - 1 = [0.1, -0.1]
+
+
+def test_reinforce_kl_requires_logp_rollout():
+    """q is the sampler distribution: a missing rollout log-prob is a loud error, not a
+    silent fallback to logp_old (same contract as icepop)."""
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    ctx = LossContext(
+        logp_curr=torch.tensor([-0.5]),
+        logp_old=torch.tensor([-0.5]),
+        logp_rollout=None,
+        advantages=torch.tensor([1.0]),
+        action_mask=torch.ones(1),
+        obs_mask=torch.zeros(1),
+        aggregate=_agg_sum,
+        params={},
+    )
+    with pytest.raises(ValueError, match="rollout"):
+        reinforce_kl(ctx)
+
+
 # --------------------------------------------------------------------------- ECHO as one loss function
 def test_echo_zero_coef_equals_ppo_clip():
     args = dict(logp_curr=[-0.5, -0.6, -0.7], logp_old=[-0.5, -0.6, -0.7], adv=[1.0, 1.0, 0.0], action_mask=[1.0, 1.0, 0.0], obs_mask=[0.0, 0.0, 1.0])


### PR DESCRIPTION
## Summary

Adds a new built-in loss `reinforce_kl` to `rllm/trainer/algorithms/loss.py`. Per token, with `r = p/q = exp(logp_curr − logp_rollout)` (trainer `p` vs **sampler** `q`), `sg` = stop-gradient, `A` = advantage:

```
L = −sg[r]·A·log p + bwd_kl_coef·(−log r + r − 1) + fwd_kl_coef·(r·log r − r + 1)
```

- **PG term**: REINFORCE with a detached, unclipped importance weight. Unlike PPO clip (zeros out-of-band gradients) or CISPO/IcePop (clamp/mask the weight), every token always keeps its gradient.
- **KL terms**: forward and backward KL between trainer and **sampler** policy (`ctx.logp_rollout`, not a frozen reference), as the soft trust region replacing hard clipping. Both use the sample-wise non-negative unbiased estimators under `q` (Schulman's k3-style forms; each has mean KL and minimum 0 at `r = 1`). The ratio deliberately stays differentiable inside them — their gradients, `(r−1)·∇log p` and `r·log r·∇log p`, are what pull `p` toward `q`.
- **All knobs opt-in**: `fwd_kl_coef` / `bwd_kl_coef` default to 0.0 (pure IS-weighted REINFORCE), `ratio_clamp_min` / `ratio_clamp_max` default to None and, when set, bound the detached PG weight CISPO-style (clamped tokens keep their gradient; KL terms always see the true `r`).
- Metrics: `reinforce_kl/{kl_bwd, kl_fwd, ratio_mean, clamp_frac}`.
- Ignores `logp_old` entirely (no proximal forward needed — pairs with `rollout_correction.bypass_mode: true`). Raises loudly if `ctx.logp_rollout` is missing, same contract as `icepop`.

Usage:

```yaml
algorithm:
  loss_fn: reinforce_kl
  loss_params: {bwd_kl_coef: 0.0025, ratio_clamp_min: 0.5, ratio_clamp_max: 2.0}
```

## Test plan

7 new unit tests in `tests/unified_trainer/test_custom_loss.py` (TDD, each watched fail first):

- loss matches the hand-computed formula, with `logp_old` set to garbage to prove `q` is the sampler; metrics equal the masked estimator means and are non-negative
- both KL coefficients default to 0.0 and only activate when set explicitly
- at ratio 1.8 with adv>0, `ppo_clip`'s gradient is 0 while `reinforce_kl`'s is exactly −1.8 (the unclipped detached weight)
- KL gradients match their analytic forms `(r−1)` and `r·log r` — fails if the ratio is ever detached inside the estimators
- `ratio_clamp_min/max` bound the PG-weight gradient exactly (two-sided, default-off, and one-sided), with correct `clamp_frac`
- a tight clamp band leaves backward KL's gradient at `(r−1)` with the **unclamped** `r`
- missing `logp_rollout` raises `ValueError`

`uv run pytest tests/unified_trainer/test_custom_loss.py` → 36 passed; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)