### PR TITLE
feat(algorithm): kl_approx knob for reinforce_kl — default to exact-gradient KL forms

### DIFF
--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -468,17 +468,30 @@ def reinforce_kl(ctx: LossContext):
     Per token, with ``r = p/q = exp(logp_curr - logp_rollout)`` (trainer ``p`` vs sampler
     ``q``), ``sg`` = stop-gradient and ``A`` the advantage::
 
-        L = -sg[r]·A·logp_curr + bwd_kl_coef·(-log r + r - 1) + fwd_kl_coef·(r·log r - r + 1)
+        L = -sg[r]·A·logp_curr + bwd_kl_coef·KL_bwd + fwd_kl_coef·KL_fwd
 
     The PG term is REINFORCE with a detached, *unclipped* importance weight: unlike PPO's
     clip (zeros out-of-band gradients) or CISPO/IcePop (clamp/mask the weight), every token
     always keeps its gradient. The trust region is instead enforced softly by the KL terms,
     which penalize divergence from the *behavior* policy ``q = logp_rollout`` — not a frozen
-    reference — using the sample-wise non-negative unbiased estimators under ``q`` (Schulman,
-    http://joschu.net/blog/kl-approx.html): backward KL(q‖p) is k3 ``-log r + r - 1``;
-    forward KL(p‖q) is ``r·log r - r + 1`` (each has mean KL and minimum 0 at ``r = 1``
-    since ``E_q[r] = 1``). Both coefficients default to 0.0 (pure IS-weighted REINFORCE);
-    enable a term explicitly, e.g. ``loss_params: {bwd_kl_coef: 0.0025}``.
+    reference. Both coefficients default to 0.0 (pure IS-weighted REINFORCE); enable a term
+    explicitly, e.g. ``loss_params: {bwd_kl_coef: 0.0025}``.
+
+    ``kl_approx`` selects the KL term form (default False):
+
+    * False — score-function forms whose gradients are the *exact* KL gradients in
+      expectation under ``q``: backward ``-logp`` (∇ = -∇logp = ∇KL(q‖p); plain
+      cross-entropy on the sampled tokens) and forward ``sg[r·log r]·logp``
+      (∇ = r·log r·∇logp = ∇KL(p‖q), using ``E_q[r·∇logp] = 0``). The term *values*
+      are not KL estimates.
+    * True — Schulman's sample-wise non-negative unbiased value estimators
+      (http://joschu.net/blog/kl-approx.html): backward k3 ``-log r + r - 1``
+      (∇ = (r-1)·∇logp — the exact gradient plus the zero-mean control variate
+      ``r·∇logp``), forward ``r·log r - r + 1`` (identical per-token gradient to the
+      False form; each has mean KL and minimum 0 at ``r = 1`` since ``E_q[r] = 1``).
+
+    The ``reinforce_kl/kl_bwd``/``kl_fwd`` metrics always report the estimator values,
+    so logged KLs are comparable across the knob.
 
     ``ratio_clamp_min`` / ``ratio_clamp_max`` (default None = raw ratio, faithful to the
     doc) optionally bound the detached PG weight CISPO-style — a clamped token keeps its
@@ -497,6 +510,7 @@ def reinforce_kl(ctx: LossContext):
         )
     fwd_coef = float(ctx.params.get("fwd_kl_coef", 0.0))
     bwd_coef = float(ctx.params.get("bwd_kl_coef", 0.0))
+    kl_approx = bool(ctx.params.get("kl_approx", False))
     clamp_min = ctx.params.get("ratio_clamp_min")
     clamp_max = ctx.params.get("ratio_clamp_max")
 
@@ -507,16 +521,26 @@ def reinforce_kl(ctx: LossContext):
     if clamp_min is not None or clamp_max is not None:
         w = w.clamp(min=clamp_min, max=clamp_max)  # bounds the PG weight only; KL terms keep the true r
     pg = -w * ctx.advantages * ctx.logp_curr
-    # r must stay differentiable here — the estimators' gradients, (r-1)·∇logp and
-    # r·log r·∇logp, are what pull p toward q; detaching r degenerates bwd into -∇logp.
-    kl_bwd = -log_r + r - 1.0
-    kl_fwd = r * log_r - r + 1.0
+    # Metrics always use the estimator forms (mean = KL, per-sample >= 0), whichever
+    # variant drives the loss, so logged KLs are comparable across the knob.
+    kl_bwd_est = (-log_r + r - 1.0).detach()
+    kl_fwd_est = (r * log_r - r + 1.0).detach()
+    if kl_approx:
+        # Estimator terms as the loss: r must stay differentiable here — the gradients,
+        # (r-1)·∇logp and r·log r·∇logp, are what pull p toward q; detaching r would
+        # degenerate bwd into -∇logp without its control variate.
+        kl_bwd = -log_r + r - 1.0
+        kl_fwd = r * log_r - r + 1.0
+    else:
+        # Exact-gradient (score-function) forms; values are not KL estimates.
+        kl_bwd = -ctx.logp_curr  # ∇ = -∇logp = ∇KL(q‖p): CE on the sampled tokens
+        kl_fwd = (r * log_r).detach() * ctx.logp_curr  # ∇ = r·log r·∇logp = ∇KL(p‖q)
 
     am = ctx.action_mask
     denom = am.sum().clamp(min=1.0)
     return ctx.aggregate(pg + bwd_coef * kl_bwd + fwd_coef * kl_fwd, am), {
-        "reinforce_kl/kl_bwd": ((kl_bwd.detach() * am).sum() / denom).item(),
-        "reinforce_kl/kl_fwd": ((kl_fwd.detach() * am).sum() / denom).item(),
+        "reinforce_kl/kl_bwd": ((kl_bwd_est * am).sum() / denom).item(),
+        "reinforce_kl/kl_fwd": ((kl_fwd_est * am).sum() / denom).item(),
         "reinforce_kl/ratio_mean": ((r.detach() * am).sum() / denom).item(),
         "reinforce_kl/clamp_frac": (((w != r.detach()).to(log_r.dtype) * am).sum() / denom).item(),
     }

--- a/tests/unified_trainer/test_custom_loss.py
+++ b/tests/unified_trainer/test_custom_loss.py
@@ -270,9 +270,9 @@ def test_icepop_requires_logp_rollout():
 
 
 # --------------------------------------------------------------------------- REINFORCE + KL-to-sampler
-def test_reinforce_kl_matches_doc_formula():
-    """L = -sg[r]·A·logp + bwd·(-log r + r - 1) + fwd·(r·log r - r + 1), with r = p/q against
-    the SAMPLER (logp_rollout) — logp_old (the proximal) must be ignored entirely."""
+def test_reinforce_kl_matches_doc_formula_approx():
+    """kl_approx=True: L = -sg[r]·A·logp + bwd·(-log r + r - 1) + fwd·(r·log r - r + 1), with
+    r = p/q against the SAMPLER (logp_rollout) — logp_old (the proximal) is ignored entirely."""
     from rllm.trainer.algorithms.loss import reinforce_kl
 
     torch.manual_seed(4)
@@ -288,7 +288,7 @@ def test_reinforce_kl_matches_doc_formula():
         action_mask=torch.ones(n),
         obs_mask=torch.zeros(n),
         aggregate=_agg_sum,
-        params={"fwd_kl_coef": 0.3, "bwd_kl_coef": 0.7},
+        params={"fwd_kl_coef": 0.3, "bwd_kl_coef": 0.7, "kl_approx": True},
     )
     ours, m = reinforce_kl(ctx)
 
@@ -304,6 +304,48 @@ def test_reinforce_kl_matches_doc_formula():
     assert m["reinforce_kl/kl_fwd"] == pytest.approx(kl_fwd.mean().item(), abs=1e-5)
     assert m["reinforce_kl/ratio_mean"] == pytest.approx(r.mean().item(), abs=1e-5)
     assert m["reinforce_kl/kl_bwd"] >= 0.0 and m["reinforce_kl/kl_fwd"] >= 0.0
+
+
+def test_reinforce_kl_default_kl_is_exact_gradient_form():
+    """kl_approx defaults to False: backward KL is plain CE on the sampled tokens (-logp,
+    grad = -1 — the exact ∇KL(q‖p) under q), NOT the k3 form's (r-1). Forward KL is
+    sg[r·log r]·logp — same gradient as the approx form (r·log r) but a different loss value.
+    Metrics always report the non-negative estimator values regardless of the knob."""
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    logp_rollout = torch.tensor([-1.0, -0.5])
+
+    def _make(logp_curr, **params):
+        return LossContext(
+            logp_curr=logp_curr, logp_old=torch.zeros(2), logp_rollout=logp_rollout, advantages=torch.zeros(2), action_mask=torch.ones(2), obs_mask=torch.zeros(2), aggregate=_agg_sum, params=params
+        )
+
+    log_r = torch.tensor([0.5, -0.5])  # logp_curr - logp_rollout below
+    r = log_r.exp()
+
+    # backward, default (exact): grad = -coef per token, independent of r
+    bwd = torch.tensor([-0.5, -1.0], requires_grad=True)
+    loss_bwd, m = reinforce_kl(_make(bwd, bwd_kl_coef=1.0, fwd_kl_coef=0.0))
+    loss_bwd.backward()
+    assert torch.allclose(bwd.grad, torch.tensor([-1.0, -1.0]), atol=1e-5)
+    # default == explicit kl_approx=False; != the approx variant
+    bwd2 = torch.tensor([-0.5, -1.0], requires_grad=True)
+    explicit, _ = reinforce_kl(_make(bwd2, bwd_kl_coef=1.0, fwd_kl_coef=0.0, kl_approx=False))
+    assert torch.allclose(loss_bwd.detach(), explicit.detach())
+    approx, _ = reinforce_kl(_make(torch.tensor([-0.5, -1.0], requires_grad=True), bwd_kl_coef=1.0, fwd_kl_coef=0.0, kl_approx=True))
+    assert not torch.allclose(loss_bwd.detach(), approx.detach())
+
+    # forward, default (exact): grad = r·log r (identical to approx), value differs from approx
+    fwd = torch.tensor([-0.5, -1.0], requires_grad=True)
+    loss_fwd, _ = reinforce_kl(_make(fwd, bwd_kl_coef=0.0, fwd_kl_coef=1.0))
+    loss_fwd.backward()
+    assert torch.allclose(fwd.grad, r * log_r, atol=1e-5)
+    approx_fwd, _ = reinforce_kl(_make(torch.tensor([-0.5, -1.0], requires_grad=True), bwd_kl_coef=0.0, fwd_kl_coef=1.0, kl_approx=True))
+    assert not torch.allclose(loss_fwd.detach(), approx_fwd.detach())
+
+    # metrics stay the estimator values (comparable across the knob)
+    assert m["reinforce_kl/kl_bwd"] == pytest.approx((-log_r + r - 1.0).mean().item(), abs=1e-5)
+    assert m["reinforce_kl/kl_fwd"] == pytest.approx((r * log_r - r + 1.0).mean().item(), abs=1e-5)
 
 
 def test_reinforce_kl_default_coefs_are_zero():
@@ -360,9 +402,9 @@ def test_reinforce_kl_keeps_gradient_where_ppo_clip_drops_it():
 
 
 def test_reinforce_kl_kl_gradients_match_analytic_forms():
-    """The KL terms must keep the ratio differentiable: with A=0, backward KL's gradient is
-    (r-1)·∇logp and forward KL's is r·log r·∇logp — both pull p toward the sampler q.
-    (Detaching r inside the estimators would break this and de-regularize the loss.)"""
+    """kl_approx=True: the estimator terms must keep the ratio differentiable — with A=0,
+    backward KL's gradient is (r-1)·∇logp and forward KL's is r·log r·∇logp, both pulling p
+    toward the sampler q. (Detaching r inside them would break this and de-regularize.)"""
     from rllm.trainer.algorithms.loss import reinforce_kl
 
     logp_rollout = torch.tensor([-1.0, -0.5])
@@ -376,11 +418,11 @@ def test_reinforce_kl_kl_gradients_match_analytic_forms():
     r = log_r.exp()
 
     bwd = torch.tensor([-0.5, -1.0], requires_grad=True)
-    reinforce_kl(_make(bwd, bwd_kl_coef=1.0, fwd_kl_coef=0.0))[0].backward()
+    reinforce_kl(_make(bwd, bwd_kl_coef=1.0, fwd_kl_coef=0.0, kl_approx=True))[0].backward()
     assert torch.allclose(bwd.grad, r - 1.0, atol=1e-5)
 
     fwd = torch.tensor([-0.5, -1.0], requires_grad=True)
-    reinforce_kl(_make(fwd, bwd_kl_coef=0.0, fwd_kl_coef=1.0))[0].backward()
+    reinforce_kl(_make(fwd, bwd_kl_coef=0.0, fwd_kl_coef=1.0, kl_approx=True))[0].backward()
     assert torch.allclose(fwd.grad, r * log_r, atol=1e-5)
 
 
@@ -438,7 +480,7 @@ def test_reinforce_kl_ratio_clamp_leaves_kl_terms_alone():
         action_mask=torch.ones(2),
         obs_mask=torch.zeros(2),
         aggregate=_agg_sum,
-        params={"bwd_kl_coef": 1.0, "fwd_kl_coef": 0.0, "ratio_clamp_min": 0.9, "ratio_clamp_max": 1.1},
+        params={"bwd_kl_coef": 1.0, "fwd_kl_coef": 0.0, "ratio_clamp_min": 0.9, "ratio_clamp_max": 1.1, "kl_approx": True},
     )
     reinforce_kl(ctx)[0].backward()
     r = torch.tensor([0.5, -0.5]).exp()


### PR DESCRIPTION
## Summary

Follow-up to #746, implementing the latest spec for the `reinforce_kl` KL regularizers: a **`kl_approx` switch in `loss_params`, defaulting to `False`**.

With `r = p/q = exp(logp_curr − logp_rollout)` (trainer `p` vs sampler `q`):

| term | `kl_approx=False` (new default) | `kl_approx=True` (previous behavior) |
|---|---|---|
| backward KL(q‖p) | `−log p` — plain CE on the sampled tokens; grad `−∇log p` = exact `∇KL(q‖p)` | k3 `−log r + r − 1`; grad `(r−1)·∇log p` (exact grad + zero-mean control variate `r·∇log p`) |
| forward KL(p‖q) | `sg[r·log r]·log p`; grad `r·log r·∇log p` = exact `∇KL(p‖q)` (uses `E_q[r·∇log p] = 0`) | `r·log r − r + 1`; **identical per-token gradient** to the False form |

Notes:

- The forward-KL variants differ only in loss *value* (the estimator form is a valid non-negative KL estimate; the exact form's value is not a KL) — their gradients are literally identical. The backward-KL variants genuinely differ in gradient: `−1` vs `(r−1)` per token.
- The `reinforce_kl/kl_bwd` / `kl_fwd` **metrics always report the estimator values** regardless of the knob, so logged KLs stay comparable across runs.
- ⚠️ Semantics change vs #746: a config that sets `bwd_kl_coef` without `kl_approx` now gets the exact-gradient (CE) form instead of k3. Per the spec this is the intended default; pass `loss_params: {kl_approx: true}` to keep the old behavior.
- Coefficient defaults unchanged (`fwd_kl_coef=0.0`, `bwd_kl_coef=0.0`); `ratio_clamp_min/max` still bound only the detached PG weight.

```yaml
algorithm:
  loss_fn: reinforce_kl
  loss_params: {bwd_kl_coef: 0.0025}              # exact-gradient forms (default)
  # loss_params: {bwd_kl_coef: 0.0025, kl_approx: true}   # k3-style estimator forms
```

## Test plan

TDD; the new default-behavior test was watched failing against the old (approx-only) implementation before the knob existed.

- **New** `test_reinforce_kl_default_kl_is_exact_gradient_form`: default backward grad is exactly `−1` per token (not `(r−1)`); default == explicit `kl_approx=False` ≠ `kl_approx=True`; forward grad `r·log r` with a loss value different from the approx variant; metrics equal the estimator means under the default.
- Existing approx-form tests pinned to `kl_approx=True` (formula match, `(r−1)`/`r·log r` analytic gradients, clamp-doesn't-touch-KL).
- `pytest tests/unified_trainer/test_custom_loss.py` → **37 passed**; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)