### PR TITLE
fix(sandbox): checked Modal upload writes; demote per-command failure logs to debug

### DIFF
--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -478,7 +478,7 @@ class DaytonaSandbox:
 
         if exit_code != 0:
             tail = stdout[-500:]
-            logger.warning(
+            logger.debug(
                 "Command failed in sandbox %s: %s\noutput tail: %s",
                 self.name,
                 command,

--- a/rllm/sandbox/backends/local.py
+++ b/rllm/sandbox/backends/local.py
@@ -42,7 +42,7 @@ class LocalSandbox:
             env=self._env,
         )
         if result.returncode != 0:
-            logger.warning("Command failed in sandbox %s: %s\nstderr: %s", self.name, translated_cmd, result.stderr[:500])
+            logger.debug("Command failed in sandbox %s: %s\nstderr: %s", self.name, translated_cmd, result.stderr[:500])
             raise subprocess.CalledProcessError(result.returncode, translated_cmd, result.stdout, result.stderr)
         return result.stdout
 

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -299,7 +299,7 @@ class ModalSandbox:
                     command[:200],
                 )
                 raise SandboxCommandTimeout(f"Command hit its {int(timeout)}s timeout in sandbox {self.name} (killed after {elapsed:.0f}s)")
-            logger.warning(
+            logger.debug(
                 "Command failed in sandbox %s: %s\nstderr: %s",
                 self.name,
                 command,
@@ -316,7 +316,11 @@ class ModalSandbox:
         argv-sized chunks and streamed from there.
         """
         if len(b64) <= _B64_ARGV_LIMIT:
-            self._exec_unchecked(f"echo '{b64}' | {consume}")
+            # Checked: a failed write here means the upload silently no-ops,
+            # and a broken environment's reward-0 would train as a legitimate
+            # failure. Callers (setup hooks / evaluator) classify the raise as
+            # SANDBOX_ERROR / AddTestsDirError.
+            self.exec(f"echo '{b64}' | {consume}")
             return
         import uuid as _uuid
 
@@ -326,7 +330,8 @@ class ModalSandbox:
             self._exec_unchecked(f"printf %s '{b64[i : i + _B64_ARGV_LIMIT]}' >> {tmp}")
         # Brace group so the stdin redirect feeds the FIRST pipeline member
         # (`cmd1 | cmd2 < f` would bind f to cmd2 and leave cmd1 blocked).
-        self._exec_unchecked(f"{{ {consume}; }} < {tmp}; rc=$?; rm -f {tmp}; exit $rc")
+        # Checked (see above): the script propagates the consume rc on purpose.
+        self.exec(f"{{ {consume}; }} < {tmp}; rc=$?; rm -f {tmp}; exit $rc")
 
     def upload_file(self, local_path: str, remote_path: str) -> None:
         """Upload a single file into the Modal sandbox.


### PR DESCRIPTION
## Summary

Split out of #732 (part 2 of the split; part 1 was #748). Two sandbox fixes:

1. **Checked Modal upload writes — a training-signal correctness fix.** Small-file uploads (the `echo <b64> | ...` path in `ModalSandbox`) ran via `_exec_unchecked`, so a failed write **silently no-op'd**. The consequence: the task environment came up broken (missing test dir / instruction / config), the rollout ran against it anyway, and its reward-0 **trained as a legitimate failure** instead of being classified as infrastructure error. Routing the write through `exec()` makes the failure raise, which callers (setup hooks / evaluator) already classify as `SANDBOX_ERROR` / `AddTestsDirError` — so the episode is excluded rather than poisoning the batch.
2. **Per-command failure logs → DEBUG** on modal/daytona/local. Agents fail shell commands constantly as part of normal task exploration; logging every nonzero exit at WARNING floods multi-hour training logs. The exception path still carries full details for anything that actually needs handling.

## Test plan

`pytest tests/sandbox` → **85 passed** with the changes applied (includes the modal and daytona backend suites). Battle-tested on the `terminus2-native` branch through multi-hour terminal-bench training runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)