### PR TITLE
fix(trainer): drop trajectories with out-of-vocab token ids before forward_backward

### DIFF
--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -121,6 +121,26 @@ class FireworksPolicyTrainer:
         self.algorithm_config = algorithm_config or AlgorithmConfig.from_config(self.config.rllm.algorithm)
         self.resolve_builtin_loss(self.algorithm_config)
 
+    def _get_vocab_size(self) -> int | None:
+        """Tokenizer vocab bound for the out-of-vocab trajectory filter (None = disabled).
+
+        The serving stack can (rarely) return a sampled token id past the trainer's
+        embedding (a padded-lm-head slot); one such id fails the whole
+        forward_backward with "Invalid token id", so the transform drops those
+        trajectories up front. The tokenizer is the authority on the bound —
+        the served model path is not HF-resolvable, but ``model.tokenizer_model`` is.
+        """
+        if not hasattr(self, "_vocab_size_cache"):
+            try:
+                from transformers import AutoTokenizer
+
+                tok_name = OmegaConf.select(self.config, "model.tokenizer_model")
+                self._vocab_size_cache = len(AutoTokenizer.from_pretrained(tok_name)) if tok_name else None
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Out-of-vocab trajectory filter disabled (could not resolve tokenizer vocab size): %s", e)
+                self._vocab_size_cache = None
+        return self._vocab_size_cache
+
     # ------------------------------------------------------------------
     # Transient-fault tolerance for training-client RPCs
     # ------------------------------------------------------------------
@@ -554,6 +574,7 @@ class FireworksPolicyTrainer:
         raw_datums, adv_metrics = transform_trajectory_groups_to_datums(
             trajectory_groups,
             algorithm_config=algorithm_config,
+            vocab_size=self._get_vocab_size(),
         )
 
         # Whole batch dropped as malformed (e.g. empty logprobs from overloaded generations).

--- a/rllm/trainer/tinker/tinker_policy_trainer.py
+++ b/rllm/trainer/tinker/tinker_policy_trainer.py
@@ -245,6 +245,7 @@ class TinkerPolicyTrainer:
         training_datums, adv_metrics = transform_trajectory_groups_to_datums(
             trajectory_groups,
             algorithm_config=algorithm_config,
+            vocab_size=self._get_vocab_size(),
         )
 
         # Every trajectory dropped as malformed (e.g. empty logprobs from failed/overloaded
@@ -337,6 +338,7 @@ class TinkerPolicyTrainer:
         training_datums, adv_metrics = transform_trajectory_groups_to_datums(
             trajectory_groups,
             algorithm_config=self.algorithm_config,
+            vocab_size=self._get_vocab_size(),
         )
 
         # Forward-backward and optimizer future together.
@@ -448,6 +450,21 @@ class TinkerPolicyTrainer:
     def get_tokenizer(self) -> Tokenizer:
         """Get tokenizer from training client."""
         return self.training_client.get_tokenizer()  # type: ignore[attr-defined]
+
+    def _get_vocab_size(self) -> int | None:
+        """Tokenizer vocab bound for the out-of-vocab trajectory filter (None = disabled).
+
+        A rare corrupt sampled id past the trainer's vocab fails the whole
+        forward_backward with "Invalid token id"; the transform drops those
+        trajectories up front (metric: ``batch/oov_drop_rate``).
+        """
+        if not hasattr(self, "_vocab_size_cache"):
+            try:
+                self._vocab_size_cache = len(self.get_tokenizer())
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Out-of-vocab trajectory filter disabled (could not resolve tokenizer vocab size): %s", e)
+                self._vocab_size_cache = None
+        return self._vocab_size_cache
 
 
 """

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -39,6 +39,25 @@ def _flatten_token_input(token_input: TinkerTokenInput) -> TinkerTokenInput:
     return flattened
 
 
+def _trajectory_oov_token(traj: Trajectory, vocab_size: int) -> int | None:
+    """Return the first out-of-vocab token id (>= ``vocab_size``) in the trajectory, or None.
+
+    Sampled ids come back raw from the serving stack; a rare corrupt id past the
+    trainer's vocab (e.g. a padded-lm-head slot drawn under full-distribution
+    sampling) fails the whole forward_backward with "Invalid token id", so such
+    trajectories are dropped up front. Prompt ids are scanned too — in cumulative
+    token mode past sampled turns are echoed back inside later prompts.
+    """
+    for step in traj.steps:
+        for t in step.response_ids or []:
+            if isinstance(t, int) and t >= vocab_size:
+                return t
+        for elem in _flatten_token_input(cast(TinkerTokenInput, step.prompt_ids or [])):
+            if isinstance(elem, int) and elem >= vocab_size:
+                return elem
+    return None
+
+
 def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[tinker.Datum]:
     """
     Return one or more Datum objects corresponding to the trajectory.
@@ -139,6 +158,7 @@ def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[
 def transform_trajectory_groups_to_datums(
     trajectory_groups: list[TrajectoryGroup],
     algorithm_config: AlgorithmConfig,
+    vocab_size: int | None = None,
 ) -> tuple[list[tinker.Datum] | dict[str, list[tinker.Datum]], dict]:
     """
     Transform a list of TrajectoryGroup objects to a list of Tinker Datum objects. Two things are done here:
@@ -184,9 +204,24 @@ def transform_trajectory_groups_to_datums(
     step_response_lengths = []
     action_token_ratios = []
     total_agent_steps = 0
+    total_trajectories = 0
     dropped_malformed_sequences = 0
+    dropped_oov_sequences = 0
     for group in trajectory_groups:
         for traj_idx, trajectory in enumerate(group.trajectories):
+            total_trajectories += 1
+            if vocab_size is not None:
+                bad_token = _trajectory_oov_token(trajectory, vocab_size)
+                if bad_token is not None:
+                    dropped_oov_sequences += 1
+                    logger.warning(
+                        "Dropping trajectory with out-of-vocab token id %d (vocab_size=%d) group_id=%s traj_idx=%d: corrupt sampled id from the serving stack",
+                        bad_token,
+                        vocab_size,
+                        group.group_id,
+                        traj_idx,
+                    )
+                    continue
             try:
                 traj_datums = trajectory_to_datums(trajectory, router_replay=(algorithm_config.router_replay == "R3"))
             except AssertionError as e:
@@ -220,6 +255,8 @@ def transform_trajectory_groups_to_datums(
                 datums.extend(traj_datums)
 
     adv_metrics["batch/dropped_malformed_sequences"] = dropped_malformed_sequences
+    adv_metrics["batch/dropped_oov_sequences"] = dropped_oov_sequences
+    adv_metrics["batch/oov_drop_rate"] = dropped_oov_sequences / max(1, total_trajectories)
 
     if steps_per_traj:
         import numpy as _np

--- a/tests/unified_trainer/test_tinker_transform.py
+++ b/tests/unified_trainer/test_tinker_transform.py
@@ -580,3 +580,73 @@ class TestAllMalformedBatch:
         assert len(datums) == 1  # only the valid trajectory survives
         assert metrics["batch/dropped_malformed_sequences"] == 1
         assert datums  # non-empty -> loop runs optim as usual
+
+
+class TestOutOfVocabDrop:
+    """A trajectory containing a token id >= vocab_size is dropped whole, before
+    datum construction — one such id fails the entire forward_backward with
+    'Invalid token id' server-side (padded-lm-head slot sampled under full-
+    distribution sampling). Drop rate is logged as batch/oov_drop_rate."""
+
+    def _alg(self):
+        from omegaconf import OmegaConf
+
+        from rllm.trainer.algorithms.config import AlgorithmConfig
+
+        return AlgorithmConfig.from_config(OmegaConf.create({"adv_estimator": "grpo"}))
+
+    def test_oov_response_token_drops_trajectory(self):
+        from rllm.agents.agent import TrajectoryGroup
+        from rllm.trainer.tinker.transform import transform_trajectory_groups_to_datums
+
+        good = Trajectory(steps=[make_step(prompt_ids=[1, 2, 3], response_tokens=[4, 5], response_logprobs=[-0.5, -0.8])])
+        bad = Trajectory(steps=[make_step(prompt_ids=[1, 2, 3], response_tokens=[4, 248090], response_logprobs=[-0.5, -0.8])])
+        group = TrajectoryGroup(group_id="g0", trajectories=[good, bad])
+
+        datums, metrics = transform_trajectory_groups_to_datums([group], algorithm_config=self._alg(), vocab_size=248077)
+
+        assert len(datums) == 1  # only the clean trajectory survives
+        assert metrics["batch/dropped_oov_sequences"] == 1
+        assert metrics["batch/oov_drop_rate"] == 0.5
+
+    def test_oov_prompt_token_drops_trajectory(self):
+        # Cumulative token mode echoes past sampled turns inside later prompts,
+        # so prompt ids are scanned too.
+        from rllm.agents.agent import TrajectoryGroup
+        from rllm.trainer.tinker.transform import transform_trajectory_groups_to_datums
+
+        bad = Trajectory(steps=[make_step(prompt_ids=[1, 248090, 3], response_tokens=[4, 5], response_logprobs=[-0.5, -0.8])])
+        group = TrajectoryGroup(group_id="g1", trajectories=[bad])
+
+        datums, metrics = transform_trajectory_groups_to_datums([group], algorithm_config=self._alg(), vocab_size=248077)
+
+        assert datums == []
+        assert metrics["batch/dropped_oov_sequences"] == 1
+        assert metrics["batch/oov_drop_rate"] == 1.0
+
+    def test_disabled_without_vocab_size(self):
+        # vocab_size=None (unresolvable tokenizer) leaves behavior unchanged.
+        from rllm.agents.agent import TrajectoryGroup
+        from rllm.trainer.tinker.transform import transform_trajectory_groups_to_datums
+
+        bad = Trajectory(steps=[make_step(prompt_ids=[1, 2, 3], response_tokens=[4, 248090], response_logprobs=[-0.5, -0.8])])
+        group = TrajectoryGroup(group_id="g2", trajectories=[bad])
+
+        datums, metrics = transform_trajectory_groups_to_datums([group], algorithm_config=self._alg())
+
+        assert len(datums) == 1  # passes through (would fail server-side, as before)
+        assert metrics["batch/dropped_oov_sequences"] == 0
+        assert metrics["batch/oov_drop_rate"] == 0.0
+
+    def test_boundary_token_not_dropped(self):
+        from rllm.agents.agent import TrajectoryGroup
+        from rllm.trainer.tinker.transform import transform_trajectory_groups_to_datums
+
+        # highest valid id (vocab_size - 1) must NOT be dropped
+        edge = Trajectory(steps=[make_step(prompt_ids=[1, 2, 3], response_tokens=[248076, 5], response_logprobs=[-0.5, -0.8])])
+        group = TrajectoryGroup(group_id="g3", trajectories=[edge])
+
+        datums, metrics = transform_trajectory_groups_to_datums([group], algorithm_config=self._alg(), vocab_size=248077)
+
+        assert len(datums) == 1
+        assert metrics["batch/dropped_oov_sequences"] == 0


### PR DESCRIPTION
## Problem

The serving stack can (rarely) return a sampled token id past the trainer's embedding. One such id fails the **entire** `forward_backward` server-side and kills the run:

```
tinker.RequestFailedError: Request failed: Invalid token id 248090 at datum[0]
model_input.chunks[97828]. Valid range is [0, 248076] (vocab_size=248077).
```

Observed in production on `qwen3p5-35b-a3b` (vocab 248077): id 248090 — a **padded-lm-head slot** that doesn't exist in the tokenizer — was sampled once in ~30M tokens under full-distribution sampling (`temperature=1.0, top_p=1.0`, no `top_k`), crashing a full-parameter run at step 5. LoRA-shape trainers tolerate these ids (padded trainer vocab); full-param `POLICY_TRAINER` shapes have exact-size embeddings and do not. Verified it was not a tokenizer/version mismatch: all ~30M recorded prompt+completion ids across 4 dumped steps were in-range, and no Qwen tokenizer variant defines 248090 — the id can only originate from the sampled stream.

## Fix

`transform_trajectory_groups_to_datums` now takes `vocab_size` and **drops any trajectory containing an id ≥ vocab_size** before datum construction, mirroring the existing dropped-malformed-sequences idiom. Prompt ids are scanned too — cumulative token mode echoes past sampled turns into later prompts, so the corrupt id can sit in either region.

- **Metrics**: `batch/dropped_oov_sequences` (count) and `batch/oov_drop_rate` (dropped ÷ trajectories in batch), so a rising rate is observable in W&B.
- **Fireworks**: vocab bound from `len(AutoTokenizer(model.tokenizer_model))` — the served model path isn't HF-resolvable and the model config may carry `vocab_size: null`, so the tokenizer is the authority (lazy, cached).
- **Tinker**: bound from the training client's tokenizer.
- **Fail-open**: if the tokenizer can't be resolved, the filter disables itself with one warning — never blocks training.

## Testing

- 4 new tests in `tests/unified_trainer/test_tinker_transform.py` (OOV in response, OOV in prompt, disabled without vocab_size, boundary id kept) — all pass; existing malformed-batch tests unaffected.
- Production-path check: helper resolves 248077 for `Qwen/Qwen3.5-35B-A3B`, drops 248090, keeps 248076; unresolvable tokenizer → `None` + warning.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)