### PR TITLE
feat(trainer): timestamp-namespaced run artifact dirs — <experiment>/<stamp>/<content>

### DIFF
--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -137,6 +137,16 @@ class FireworksSFTBackend(TinkerSFTBackend):
             raise SFTConfigError("FIREWORKS_API_KEY is not set; required for the fireworks SFT backend.")
         base_url = os.environ.get("FIREWORKS_BASE_URL", config.get("fireworks_base_url", "https://api.fireworks.ai"))
 
+        # <local dir>/<experiment>/<run stamp>/ — the template default is a fixed
+        # shared /tmp path, and even an explicit --output collides across
+        # relaunches; a per-run stamp keeps every run's logs/metadata separate.
+        # Safe here: Fireworks SFT resume is server-side (job DCP), not local.
+        run_stamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+        config.trainer.default_local_dir = os.path.join(
+            config.trainer.default_local_dir,
+            config.trainer.get("experiment_name") or "default",
+            run_stamp,
+        )
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
         lora_rank = config.model.get("lora_rank", 32)
 

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -330,6 +330,20 @@ class UnifiedTrainer:
             estimator_map=self.traj_group_adv_estimator_map,
         )
 
+    @property
+    def _run_stamp(self) -> str:
+        """Per-run UTC timestamp shared by all of this run's artifact trees.
+
+        Run outputs follow ``<experiment dir>/<stamp>/<content>`` so relaunches
+        with the same project/experiment name never clobber or interleave with
+        an earlier run's artifacts.
+        """
+        stamp = getattr(self, "_run_stamp_cache", None)
+        if stamp is None:
+            stamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+            self._run_stamp_cache = stamp
+        return stamp
+
     def _setup_logging(self):
         """Setup up both the tracking and episode logging."""
         # create episode logger if enabled in config
@@ -339,6 +353,8 @@ class UnifiedTrainer:
                 "episode_log_dir",
                 f"logs/{self.rllm_config.trainer.project_name}/{self.rllm_config.trainer.experiment_name}",
             )
+            # <experiment dir>/<run stamp>/episodes — relaunches never clobber.
+            episode_log_dir = f"{episode_log_dir}/{self._run_stamp}"
             self.episode_logger = EpisodeLogger(base_dir=episode_log_dir, subdirectory="episodes")
 
         source_metadata = extract_source_metadata(


### PR DESCRIPTION
## Problem

Relaunching a run with the same `project_name`/`experiment_name` reuses the same artifact directories, so the new run clobbers or interleaves with the previous run's outputs:

- **Episode logs** always go to `logs/<project>/<experiment>/episodes` — two runs write into one tree.
- **Fireworks SFT `default_local_dir`** defaults to a fixed shared `/tmp/rllm-fireworks-sft-checkpoints`, and even an explicit `--output` collides across relaunches.

## Change

Every run gets a per-run UTC stamp — `UnifiedTrainer._run_stamp`, computed once and shared across all of a run's artifact trees — and run outputs follow the convention `**<experiment dir>/<stamp>/<content>**`:

| artifact | before | after |
|---|---|---|
| episode logs | `logs/<proj>/<exp>/episodes` | `logs/<proj>/<exp>/<stamp>/episodes` |
| fireworks SFT local dir | `/tmp/rllm-fireworks-sft-checkpoints` (shared) | `<dir>/<experiment>/<stamp>/` |

**Deliberately not stamped:** tinker-SFT and verl checkpoint dirs — their crash resume reads the stable path (`get_last_checkpoint` / `resume_mode`), so a blind stamp would break recovery; those want a resume-aware layout as a separate change. The Fireworks SFT dir is safe because its resume is server-side (job DCP); the local dir holds only logs/metadata.

## Testing

- `ruff check` clean; module parses and imports.
- Stamp property verified stable across calls within a run (computed once, cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)