### PR TITLE
feat(trainer): off-policy metrics in the custom-loss path (no proximal forward)

### DIFF
--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -172,6 +172,7 @@ def offpolicy_metrics(
         "offpolicy/rollout_ppl": torch.exp(-rollout_seq).mean().item(),
     }
 
+
 # Canonical loss-aggregation modes, shared across backends (verl's names). A loss body stays
 # agnostic and just calls ``ctx.aggregate``; each backend's injected ``aggregate`` (+ its
 # optimizer-step normalization) realizes these semantics with GLOBAL normalization spanning

--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -113,12 +113,19 @@ def offpolicy_metrics(
     *,
     safety_bound: float = 20.0,
 ) -> dict[str, float]:
-    """Train/inference-mismatch diagnostics: current policy vs rollout (sampling) log-probs.
+    """Off-policy diagnostics: current policy (training engine) vs the rollout/behavior
+    distribution, over action tokens (samples are drawn from the rollout policy).
 
-    Samples are drawn from the rollout policy; every metric compares the current policy
-    against it over action tokens. On the managed path ``curr`` is ``ctx.logp_curr`` (the
-    genuine current-policy forward the loss pass already ran) — distinct from ``logp_rollout``
-    even under bypass_mode, so this is well-defined for free without a proximal forward pass.
+    The current-vs-rollout gap has two sources, which these metrics do NOT separate:
+      * staleness — the current weights have drifted from the sampler snapshot that generated
+        the rollout (gradient steps taken since sampling; this is *why* the rollout log-probs
+        are off-policy in the first place), and
+      * train/inference mismatch — the training forward and the inference sampler disagree
+        even at identical weights (precision / kernel / implementation differences).
+
+    On the managed path ``curr`` is ``ctx.logp_curr`` (the genuine current-policy forward the
+    loss pass already ran) — distinct from ``logp_rollout`` even under bypass_mode, so this is
+    well-defined for free without a proximal forward pass.
 
     Args:
         curr / rollout / masks: parallel lists of per-datum per-token log-probs and action

--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -105,6 +105,66 @@ class LossContext:
 # A loss: (ctx) -> (scalar_loss, metrics)
 LossFn = Callable[[LossContext], "tuple[torch.Tensor, dict[str, float]]"]
 
+
+def offpolicy_metrics(
+    curr: list,
+    rollout: list,
+    masks: list,
+    *,
+    safety_bound: float = 20.0,
+) -> dict[str, float]:
+    """Train/inference-mismatch diagnostics: current policy vs rollout (sampling) log-probs.
+
+    Samples are drawn from the rollout policy; every metric compares the current policy
+    against it over action tokens. On the managed path ``curr`` is ``ctx.logp_curr`` (the
+    genuine current-policy forward the loss pass already ran) — distinct from ``logp_rollout``
+    even under bypass_mode, so this is well-defined for free without a proximal forward pass.
+
+    Args:
+        curr / rollout / masks: parallel lists of per-datum per-token log-probs and action
+            masks (1-D tensors or float lists). ``masks`` is 1.0 on action tokens.
+
+    Returns ``{}`` when no active tokens. Keys are ``offpolicy/*``.
+    """
+    import torch
+
+    seq_curr_means, seq_rollout_means, tok_curr, tok_rollout = [], [], [], []
+    for c, r, m in zip(curr, rollout, masks, strict=False):
+        c = torch.as_tensor(c, dtype=torch.float32)
+        r = torch.as_tensor(r, dtype=torch.float32)
+        m = torch.as_tensor(m, dtype=torch.float32) > 0
+        if not bool(m.any()):
+            continue
+        c, r = c[m], r[m]
+        seq_curr_means.append(c.mean())
+        seq_rollout_means.append(r.mean())
+        tok_curr.append(c)
+        tok_rollout.append(r)
+
+    if not tok_curr:
+        return {}
+
+    curr_flat = torch.cat(tok_curr)
+    rollout_flat = torch.cat(tok_rollout)
+    log_ratio = curr_flat - rollout_flat  # log(pi_curr / pi_rollout)
+    ratio = torch.exp(torch.clamp(log_ratio, min=-safety_bound, max=safety_bound))
+    curr_seq = torch.stack(seq_curr_means)
+    rollout_seq = torch.stack(seq_rollout_means)
+
+    return {
+        # KL(rollout || curr): k1 is signed (drift direction), k3 is the low-variance estimate
+        "offpolicy/kl": (rollout_flat - curr_flat).mean().item(),
+        "offpolicy/k3_kl": (torch.exp(log_ratio) - log_ratio - 1).mean().item(),
+        # importance weight pi_curr/pi_rollout: center (~1) + worst-case tail
+        "offpolicy/ratio/mean": ratio.mean().item(),
+        "offpolicy/ratio/max": ratio.max().item(),
+        # chi-square divergence = variance of the IS weight (stability)
+        "offpolicy/chi2_token": (ratio.square().mean() - 1.0).item(),
+        # absolute per-sequence confidence (catches temperature mismatch / collapse)
+        "offpolicy/training_ppl": torch.exp(-curr_seq).mean().item(),
+        "offpolicy/rollout_ppl": torch.exp(-rollout_seq).mean().item(),
+    }
+
 # Canonical loss-aggregation modes, shared across backends (verl's names). A loss body stays
 # agnostic and just calls ``ctx.aggregate``; each backend's injected ``aggregate`` (+ its
 # optimizer-step normalization) realizes these semantics with GLOBAL normalization spanning

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -437,14 +437,15 @@ class FireworksPolicyTrainer:
 
     @staticmethod
     def _compute_offpolicy_metrics(
-        old_logprobs: list[list[float]],
+        curr_logprobs: list[list[float]],
         rollout_logprobs: list[list[float]],
         masks: list[list[int]],
     ) -> dict[str, float]:
-        # Non-bypass builtin path: old_logprobs is the proximal forward (current policy at
-        # batch start). Delegate to the shared helper so this and the custom-loss path emit
-        # the same curated offpolicy/* set.
-        return offpolicy_metrics(old_logprobs, rollout_logprobs, masks)
+        # Non-bypass builtin path: curr_logprobs is the proximal forward, i.e. the current
+        # policy at batch start (a single pre-optimizer-step forward, so proximal == current).
+        # Delegate to the shared helper so this and the custom-loss path emit the same curated
+        # offpolicy/* set (current vs rollout).
+        return offpolicy_metrics(curr_logprobs, rollout_logprobs, masks)
 
     def resolve_builtin_loss(self, algorithm_config: AlgorithmConfig, profile=None):
         """Resolve the builtin server-side loss kernel at setup time.
@@ -579,7 +580,7 @@ class FireworksPolicyTrainer:
             # where prox == rollout), so only compute it when we did the proximal forward.
             adv_metrics.update(
                 self._compute_offpolicy_metrics(
-                    old_logprobs=prox_logprobs,
+                    curr_logprobs=prox_logprobs,
                     rollout_logprobs=inf_logprobs,
                     masks=[list(datum.loss_fn_inputs["mask"].data) for datum in raw_datums],
                 )

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -532,9 +532,10 @@ class FireworksPolicyTrainer:
             from rllm.trainer.tinker.custom_loss import build_custom_loss
 
             # Custom (DPPO) path: logp_old = the inference log-probs on the datums, so pi_old is
-            # never recomputed. offpolicy/* IS logged: the closure compares logp_curr (the
-            # current-policy forward this pass already runs) against the rollout log-probs, so
-            # the train/inference mismatch is free — no proximal forward needed.
+            # never recomputed. offpolicy/* IS logged even under bypass_mode: the closure compares
+            # logp_curr (the current-policy forward this pass already runs) against the rollout
+            # log-probs — the off-policy gap (staleness + train/inference mismatch), free, no
+            # proximal forward. (The bypass gate below only applies to the native builtin path.)
 
             # server_normalized=True: the closure returns a RAW SUM; optim_step sets
             # GradAccNormalization from resolved.agg_mode so the server normalizes once across all

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -30,7 +30,7 @@ from rllm.trainer.algorithms import (
     CompactFilteringConfig,
     TransformConfig,
 )
-from rllm.trainer.algorithms.loss import native_loss_names, resolve_loss
+from rllm.trainer.algorithms.loss import native_loss_names, offpolicy_metrics, resolve_loss
 from rllm.trainer.tinker.tinker_policy_trainer import (
     compute_schedule_lr_multiplier,
     require_training_client,
@@ -441,86 +441,10 @@ class FireworksPolicyTrainer:
         rollout_logprobs: list[list[float]],
         masks: list[list[int]],
     ) -> dict[str, float]:
-        import torch
-
-        safety_bound = 20.0
-        training_means = []
-        rollout_means = []
-        log_ratio_sums = []
-        token_old = []
-        token_rollout = []
-
-        for old_lp, rollout_lp, mask in zip(old_logprobs, rollout_logprobs, masks, strict=False):
-            active_old = []
-            active_rollout = []
-            for old, rollout, m in zip(old_lp, rollout_lp, mask, strict=False):
-                if m:
-                    active_old.append(float(old))
-                    active_rollout.append(float(rollout))
-            if not active_old:
-                continue
-
-            old_t = torch.tensor(active_old, dtype=torch.float32)
-            rollout_t = torch.tensor(active_rollout, dtype=torch.float32)
-            training_means.append(old_t.mean())
-            rollout_means.append(rollout_t.mean())
-            log_ratio_sums.append((old_t - rollout_t).sum())
-            token_old.append(old_t)
-            token_rollout.append(rollout_t)
-
-        if not token_old:
-            return {}
-
-        mean_log_prob_training = torch.stack(training_means)
-        mean_log_prob_rollout = torch.stack(rollout_means)
-        old_flat = torch.cat(token_old)
-        rollout_flat = torch.cat(token_rollout)
-        log_ratio = old_flat - rollout_flat
-        logprob_abs_diff = log_ratio.abs()
-        old_prob = torch.exp(old_flat)
-        rollout_prob = torch.exp(rollout_flat)
-        prob_abs_diff = (old_prob - rollout_prob).abs()
-        log_ratio_safe = torch.clamp(log_ratio, min=-safety_bound, max=safety_bound)
-        ratio = torch.exp(log_ratio_safe)
-        log_ppl_diff = mean_log_prob_rollout - mean_log_prob_training
-
-        metrics = {
-            "offpolicy/kl": (rollout_flat - old_flat).mean().item(),
-            "offpolicy/k3_kl": (torch.exp(log_ratio) - log_ratio - 1).mean().item(),
-            "offpolicy/logprob_abs_diff/mean": logprob_abs_diff.mean().item(),
-            "offpolicy/logprob_abs_diff/min": logprob_abs_diff.min().item(),
-            "offpolicy/logprob_abs_diff/max": logprob_abs_diff.max().item(),
-            "offpolicy/prob_abs_diff/mean": prob_abs_diff.mean().item(),
-            "offpolicy/prob_abs_diff/min": prob_abs_diff.min().item(),
-            "offpolicy/prob_abs_diff/max": prob_abs_diff.max().item(),
-            "offpolicy/training_ppl": torch.exp(-mean_log_prob_training).mean().item(),
-            "offpolicy/training_log_ppl": (-mean_log_prob_training).mean().item(),
-            "offpolicy/rollout_ppl": torch.exp(-mean_log_prob_rollout).mean().item(),
-            "offpolicy/rollout_log_ppl": (-mean_log_prob_rollout).mean().item(),
-            "offpolicy/log_ppl_diff": log_ppl_diff.mean().item(),
-            "offpolicy/log_ppl_abs_diff": log_ppl_diff.abs().mean().item(),
-            "offpolicy/log_ppl_diff_min": log_ppl_diff.min().item(),
-            "offpolicy/log_ppl_diff_max": log_ppl_diff.max().item(),
-            "offpolicy/ppl_ratio": torch.exp(log_ppl_diff).mean().item(),
-            "offpolicy/ratio/mean": ratio.mean().item(),
-            "offpolicy/ratio/min": ratio.min().item(),
-            "offpolicy/ratio/max": ratio.max().item(),
-        }
-
-        if old_prob.numel() > 1:
-            old_centered = old_prob - old_prob.mean()
-            rollout_centered = rollout_prob - rollout_prob.mean()
-            denom = torch.sqrt(old_centered.square().sum() * rollout_centered.square().sum())
-            if denom.item() > 0.0:
-                metrics["offpolicy/prob_pearson_corr"] = ((old_centered * rollout_centered).sum() / denom).item()
-
-        metrics["offpolicy/chi2_token"] = (ratio.square().mean() - 1.0).item()
-
-        log_ratio_sum = torch.stack(log_ratio_sums)
-        log_ratio_sum_safe = torch.clamp(log_ratio_sum, min=-safety_bound, max=safety_bound)
-        metrics["offpolicy/chi2_seq"] = (torch.exp(2.0 * log_ratio_sum_safe).mean() - 1.0).item()
-
-        return metrics
+        # Non-bypass builtin path: old_logprobs is the proximal forward (current policy at
+        # batch start). Delegate to the shared helper so this and the custom-loss path emit
+        # the same curated offpolicy/* set.
+        return offpolicy_metrics(old_logprobs, rollout_logprobs, masks)
 
     def resolve_builtin_loss(self, algorithm_config: AlgorithmConfig, profile=None):
         """Resolve the builtin server-side loss kernel at setup time.
@@ -607,8 +531,9 @@ class FireworksPolicyTrainer:
             from rllm.trainer.tinker.custom_loss import build_custom_loss
 
             # Custom (DPPO) path: logp_old = the inference log-probs on the datums, so pi_old is
-            # never recomputed. offpolicy/* isn't logged (it needs a real proximal forward — a
-            # per-pass diagnostic cost); the loss emits its own (e.g. dppo_tv/mask_frac).
+            # never recomputed. offpolicy/* IS logged: the closure compares logp_curr (the
+            # current-policy forward this pass already runs) against the rollout log-probs, so
+            # the train/inference mismatch is free — no proximal forward needed.
 
             # server_normalized=True: the closure returns a RAW SUM; optim_step sets
             # GradAccNormalization from resolved.agg_mode so the server normalizes once across all
@@ -623,8 +548,10 @@ class FireworksPolicyTrainer:
             )
             if hasattr(fwd_bwd_result, "metrics") and fwd_bwd_result.metrics:
                 for k, v in fwd_bwd_result.metrics.items():
-                    if k not in self._METRIC_SKIP_KEYS:
-                        adv_metrics[f"train/{k}"] = v
+                    if k in self._METRIC_SKIP_KEYS:
+                        continue
+                    # keep the offpolicy/ namespace consistent with the builtin path
+                    adv_metrics[k if k.startswith("offpolicy/") else f"train/{k}"] = v
             logger.info("Fireworks custom-loss pass: loss_fn=%s agg_mode=%s params=%s", resolved.name, resolved.agg_mode, resolved.params)
             return raw_datums, [], adv_metrics
 

--- a/rllm/trainer/tinker/custom_loss.py
+++ b/rllm/trainer/tinker/custom_loss.py
@@ -128,8 +128,9 @@ def build_custom_loss(
 
         out = {k: v / max(1, n) for k, v in metric_sums.items()}
         out["custom_loss/num_datums"] = float(n)
-        # current-policy (logp_curr) vs rollout mismatch — free here (no proximal forward),
-        # and meaningful even under bypass_mode where logp_old == logp_rollout.
+        # off-policy gap: current policy (logp_curr) vs rollout — captures staleness +
+        # train/inference mismatch. Free here (no proximal forward) and non-zero even under
+        # bypass_mode, where logp_old == logp_rollout.
         out.update(offpolicy_metrics(offp_curr, offp_rollout, offp_mask))
         return loss, out
 

--- a/rllm/trainer/tinker/custom_loss.py
+++ b/rllm/trainer/tinker/custom_loss.py
@@ -31,7 +31,7 @@ from collections import defaultdict
 
 import tinker
 
-from rllm.trainer.algorithms.loss import LossContext, ResolvedLoss
+from rllm.trainer.algorithms.loss import LossContext, ResolvedLoss, offpolicy_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +94,7 @@ def build_custom_loss(
         n = len(logprobs_list)
         num_tokens = 0.0
         num_seqs = 0.0
+        offp_curr, offp_rollout, offp_mask = [], [], []  # for off-policy diagnostics
         for i, logp_curr in enumerate(logprobs_list):
             action_mask = torch.tensor(action_mask_list[i], dtype=logp_curr.dtype)
             ctx = LossContext(
@@ -114,6 +115,9 @@ def build_custom_loss(
             num_seqs += 1.0 if tok > 0 else 0.0
             for k, v in metrics_i.items():
                 metric_sums[k] += float(v)
+            offp_curr.append(logp_curr.detach())
+            offp_rollout.append(ctx.logp_rollout)
+            offp_mask.append(action_mask)
 
         if server_normalized:
             loss = total  # server divides by NUM_LOSS_TOKENS / NUM_SEQUENCES across the window
@@ -124,6 +128,9 @@ def build_custom_loss(
 
         out = {k: v / max(1, n) for k, v in metric_sums.items()}
         out["custom_loss/num_datums"] = float(n)
+        # current-policy (logp_curr) vs rollout mismatch — free here (no proximal forward),
+        # and meaningful even under bypass_mode where logp_old == logp_rollout.
+        out.update(offpolicy_metrics(offp_curr, offp_rollout, offp_mask))
         return loss, out
 
     return stripped, loss_fn


### PR DESCRIPTION
## What

The managed custom-loss path (`forward_backward_custom`, shared by tinker/fireworks) never logged `offpolicy/*` metrics. Those metrics compared a **recomputed proximal** against the rollout, but under `bypass_mode` (the default) `logp_old == logp_rollout`, so the comparison was inert and skipped — you only got them by paying for an extra proximal forward pass (`bypass_mode=false`).

This computes the metric we actually want — **current policy (`logp_curr`) vs rollout (`logp_rollout`)** — inside the loss closure. `logp_curr` is the current-policy forward that `forward_backward_custom` already runs, so:

- it captures the **off-policy gap** — both **staleness** (current weights have drifted from the sampler snapshot that generated the rollout — the reason the rollout log-probs are off-policy at all) and **train/inference engine mismatch** (they disagree even at identical weights); the metrics don't separate the two,
- the gap is **non-trivial even under `bypass_mode`** (unlike `logp_old` vs `logp_rollout`, which is identically zero there),
- it costs **no extra forward pass**.

## Changes

- **`algorithms/loss.py`**: new shared `offpolicy_metrics(curr, rollout, masks)` helper, curated to the genuinely useful set:
  - `offpolicy/kl` (signed k1, drift direction), `offpolicy/k3_kl` (low-variance KL)
  - `offpolicy/ratio/{mean,max}` (IS weight center + tail)
  - `offpolicy/chi2_token` (IS-weight variance / stability)
  - `offpolicy/training_ppl`, `offpolicy/rollout_ppl` (absolute confidence)
  - Drops the noisy/redundant ones: `logprob_abs_diff/*`, `prob_abs_diff/*`, `log_ppl_*` family, `ratio/min`, `prob_pearson_corr`, `chi2_seq`.
- **`tinker/custom_loss.py`**: wire it into `build_custom_loss` — accumulate `logp_curr.detach()`/`logp_rollout`/`action_mask` per datum, merge once after the loop. Benefits **both** fireworks and tinker (shared closure).
- **`fireworks/fireworks_policy_trainer.py`**:
  - keep the `offpolicy/` namespace on the custom-loss metric surfacing (no `train/` prefix).
  - collapse the non-bypass builtin `_compute_offpolicy_metrics` to delegate to the shared helper, so both paths emit the identical curated set. Its `curr_logprobs` arg is fed the proximal forward, i.e. the current policy at batch start (proximal == current for a single pre-step forward). Net **−86/+80 lines** on the feature commit.

## Testing

- Unit-tested the helper: on-policy → `kl`/`k3`/`chi2`=0, `ratio`=1, equal ppls; off-policy hand-verified (`log_ratio=−1` → `kl=1.0`, `k3=ratio=e⁻¹`); masking, all-masked → `{}`, and list/tensor inputs all correct.
- `py_compile` + import of all three touched modules.
- Not exercised: the live `forward_backward_custom` step (needs a Fireworks/Tinker service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)