### PR TITLE
docs(README): add "Remember When It Matters" to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Under the hood:
 - [TherapyGym](https://therapygym.stanford.edu/) - Evaluating and Aligning Clinical Fidelity and Safety in Therapy Chatbots
 - [SandMLE](https://arxiv.org/pdf/2604.04872) - Synthetic Sandbox for Training MLE Agents
 - [AxPO](https://byungkwanlee.github.io/AXPO-page/) - Agent Explorative Policy Optimization for Multimodal Agentic Reasoning
+- [Remember When It Matters](https://arxiv.org/abs/2607.08716) — Proactive Memory Agent for Long-Horizon Agents
   
 ## Articles & Blog Posts
 


### PR DESCRIPTION
Adds [Remember When It Matters](https://arxiv.org/abs/2607.08716) — a proactive memory agent for long-horizon agents — to the Community Projects list in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)