### PR TITLE
fix(gateway): carry R3 routing matrices through the cumulative-token path

### DIFF
--- a/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_token_mode_local.py
@@ -162,3 +162,110 @@ def test_cumulative_local_replay_regenerates_in_place_without_advancing():
     assert record and record[0]["prompt"] == [1, 2, 3]  # regenerated, not cached
     assert acc.turn_count == 1  # overwritten in place, NOT advanced
     assert acc.prev_completion_ids == [91, 92]  # fresh sample replaced the old one
+
+
+# ----------------------------------------------------------------------------
+# R3 router replay over the cumulative-token path.
+#
+# The token-in path (_token_prompt_completion) must surface the TokenOutput's
+# per-token routing matrices on the choice, and the proxy must carry them onto
+# the persisted trace. Without this, router replay silently no-ops whenever
+# cumulative_token_mode is on (turns 2+ all take the token-in path).
+# ----------------------------------------------------------------------------
+
+
+def _routing_engine(routing_matrices):
+    """Fake TinkerEngine token-in path: TokenOutput carries routing_matrices,
+    but assemble_model_output does NOT copy them onto the ModelOutput (mirrors
+    the real TinkerEngine — only the get_model_response* wrappers copy them)."""
+    from types import SimpleNamespace
+
+    class _Engine:
+        model_name = "q"
+
+        async def get_token_output_from_token_input(self, prompt_ids, **kwargs):
+            return SimpleNamespace(routing_matrices=routing_matrices)
+
+        def assemble_model_output(self, prompt_ids, token_output):
+            return SimpleNamespace(
+                content="next action",
+                text="next action",
+                prompt_ids=list(prompt_ids),
+                completion_ids=[91, 92],
+                logprobs=[-0.1, -0.2],
+                finish_reason="stop",
+                prompt_length=len(prompt_ids),
+                completion_length=2,
+                weight_version=7,
+            )
+
+    return _Engine()
+
+
+def test_token_prompt_completion_carries_routing_matrices():
+    from rllm.gateway.tinker_adapter import _token_prompt_completion
+
+    rm = ["layer-blob-a", "layer-blob-b"]
+    resp = asyncio.run(_token_prompt_completion(_routing_engine(rm), {"model": "q"}, [1, 2, 3], {}))
+    # Read off TokenOutput, not ModelOutput (which never carried them here).
+    assert resp["choices"][0]["routing_matrices"] == rm
+
+
+def test_token_prompt_completion_routing_matrices_none_when_absent():
+    """Dense models / R3 disabled: no matrices → field is None, not an error."""
+    from rllm.gateway.tinker_adapter import _token_prompt_completion
+
+    resp = asyncio.run(_token_prompt_completion(_routing_engine(None), {"model": "q"}, [1, 2, 3], {}))
+    assert resp["choices"][0]["routing_matrices"] is None
+
+
+def test_cumulative_local_persists_routing_matrices_to_trace():
+    """End-to-end over the proxy: a handler emitting per-token routing matrices
+    (as the fixed token-in path now does) must land them on the persisted trace
+    so training can replay expert routing."""
+    rm = ["blob-a", "blob-b"]
+
+    async def handler(body):
+        return {
+            "id": "cmpl-x",
+            "object": "text_completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "next action",
+                    "token_ids": [91, 92],
+                    "finish_reason": "stop",
+                    "routing_matrices": rm,
+                    "logprobs": {"token_logprobs": [-0.1, -0.2]},
+                }
+            ],
+            "prompt_token_ids": body["prompt"],
+            "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
+        }
+
+    store = MemoryTraceStore()
+    proxy = ReverseProxy(
+        router=None,
+        store=store,
+        sync_traces=True,
+        local_handler=handler,
+        cumulative_token_mode=True,
+        renderer=None,
+    )
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    bridged = [1, 2, 3, 4, 5, 6, 7]
+
+    asyncio.run(
+        proxy._handle_cumulative_non_streaming(
+            _Request(),
+            {"messages": [{"role": "user", "content": "x"}]},
+            {"prompt": bridged, "add_special_tokens": False, "model": "q"},
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+
+    traces = asyncio.run(store.get_session_traces("sess1"))
+    assert traces and traces[0]["routing_matrices"] == rm

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -93,6 +93,10 @@ async def _token_prompt_completion(
     finish_reason = model_output.finish_reason or "stop"
     prompt_len = model_output.prompt_length or len(out_prompt_ids)
     completion_len = model_output.completion_length or len(completion_ids)
+    # R3 router replay: read matrices off the TokenOutput (assemble_model_output
+    # drops them) and carry on the choice like the chat path, else the trace loses
+    # them every cumulative turn.
+    routing_matrices = getattr(token_output, "routing_matrices", None)
 
     return {
         "id": f"cmpl-{uuid.uuid4().hex[:12]}",
@@ -105,6 +109,7 @@ async def _token_prompt_completion(
                 "text": text,
                 "token_ids": completion_ids,
                 "finish_reason": finish_reason,
+                "routing_matrices": routing_matrices,
                 "logprobs": {"token_logprobs": logprobs},
             }
         ],


### PR DESCRIPTION
## Problem

With `rllm.algorithm.router_replay=R3` **and** `rllm.gateway.cumulative_token_mode=true` on the Fireworks backend, router replay is silently a **no-op end-to-end**.

The engine correctly requests routing matrices (`include_routing_matrix=True`) and Fireworks returns them per token. But in cumulative-token mode, turns 2+ are dispatched to the in-process handler's token-in path, `_token_prompt_completion` in `rllm/gateway/tinker_adapter.py`, which:

1. calls `engine.assemble_model_output(...)` **directly** — and `TinkerEngine.assemble_model_output` (inherited by `FireworksEngine`) does **not** copy `routing_matrices` onto the `ModelOutput`; only the `get_model_response*` wrappers do, and this path bypasses them; and
2. omits `routing_matrices` from the returned `choices[0]` entirely (the chat path already includes it).

So `extract_routing_matrices` finds nothing → the persisted trace stores `routing_matrices=None` for every cumulative turn → the transform has nothing to stitch onto `datum.model_input` → `forward_backward_custom` replays no experts.

This bites the swe-rl a35b (Qwen3.5-35B-A3B MoE) cookbook, which runs exactly this config. The verl/vLLM backend is unaffected — its `/v1/completions` body carries `choices[0].routing_matrices` natively.

## Fix

Read the per-token routing matrices straight off the `TokenOutput` (which does carry them) and stamp them on the choice, mirroring the chat path. One field; the `getattr(..., None)` default keeps dense / R3-disabled runs unchanged.

## Tests

- `_token_prompt_completion` surfaces `TokenOutput.routing_matrices` on the choice (and is `None` when absent).
- Proxy end-to-end: a handler emitting routing matrices lands them on the persisted trace via the cumulative-local path.

Full gateway unit suite green (243 passed).