### PR TITLE
feat(algorithm): minus_length_weighted_mean advantage estimator (length-weighted / per-token baseline)

### DIFF
--- a/rllm/trainer/algorithms/advantage.py
+++ b/rllm/trainer/algorithms/advantage.py
@@ -142,6 +142,81 @@ def calculate_rloo_advantages(rewards: list[np.ndarray], algorithm_config: Algor
     return advantages_by_group, returns_by_group
 
 
+@register_adv_estimator(rLLMAdvantageEstimator.MINUS_LENGTH_WEIGHTED_MEAN)
+def calculate_minus_length_weighted_mean_advantages(
+    rewards: list[np.ndarray],
+    algorithm_config: AlgorithmConfig,
+    traj_groups: list[TrajectoryGroup] | None = None,
+    **kwargs,
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """MinusLengthWeightedMean: baseline = length-weighted mean over the batch pool.
+
+    Outcome mode (default)::
+
+        baseline     = sum_i(shaped_reward_i * L_i) / sum_i(L_i)
+        advantage_i  = shaped_reward_i - baseline
+
+    Token mode — when a step carries ``metadata["per_token_rewards"]`` (a list
+    aligned to ``response_ids``), the baseline is the mean per-token reward over
+    ALL tokens in the pool, and advantages are emitted **per token**::
+
+        baseline              = sum_i sum_t ptr[i,t] / sum_i L_i
+        token_advantage[i,t]  = ptr[i,t] - baseline
+        sample_advantage[i]   = shaped_reward_i - baseline   (metrics/tracking)
+
+    The two modes are one formula: a step without per-token rewards contributes
+    its trajectory's shaped reward at every token, which makes the pooled token
+    mean exactly the length-weighted mean of scalar rewards — so mixed batches
+    compose. ``shaped_reward`` is ``traj.reward`` (shaping happens upstream).
+    ``L_i`` counts response (action) tokens. The pool is every trajectory passed
+    to this call (all groups of the role), matching "the entire generation pool".
+
+    Unlike the other estimators, this one writes ``step.advantage`` itself
+    (per-token lists); the caller's scalar broadcast is skipped via the
+    ``writes_step_advantages`` attribute. Returned scalars are the
+    ``sample_advantage`` values, used for advantage/* metrics.
+    """
+    assert traj_groups is not None, "minus_length_weighted_mean needs traj_groups (per-token rewards and lengths live on the steps)"
+
+    def _step_ptr(step) -> list[float]:
+        ptr = (step.metadata or {}).get("per_token_rewards") if step.metadata else None
+        n = len(step.response_ids)
+        if ptr is not None and len(ptr) != n:
+            logger.warning("per_token_rewards length %d != response_ids length %d; falling back to the trajectory reward for this step", len(ptr), n)
+            ptr = None
+        return [float(x) for x in ptr] if ptr is not None else None
+
+    # Pool pass: baseline over every token of every trajectory in the batch.
+    total_reward, total_tokens = 0.0, 0
+    for group, group_rewards in zip(traj_groups, rewards, strict=True):
+        for traj, r in zip(group.trajectories, group_rewards, strict=True):
+            for step in traj.steps:
+                ptr = _step_ptr(step)
+                n = len(step.response_ids)
+                total_reward += sum(ptr) if ptr is not None else float(r) * n
+                total_tokens += n
+    baseline = total_reward / total_tokens if total_tokens else 0.0
+
+    # Write per-token advantages onto the steps; return scalar sample advantages.
+    advantages_by_group: list[np.ndarray] = []
+    for group, group_rewards in zip(traj_groups, rewards, strict=True):
+        for traj, r in zip(group.trajectories, group_rewards, strict=True):
+            for step in traj.steps:
+                ptr = _step_ptr(step)
+                if ptr is not None:
+                    step.advantage = [p - baseline for p in ptr]
+                else:
+                    step.advantage = [float(r) - baseline] * len(step.response_ids)
+        advantages_by_group.append(np.asarray(group_rewards, dtype=np.float64) - baseline)
+
+    return advantages_by_group, advantages_by_group
+
+
+# The estimator assigns per-token step.advantage lists itself; the caller must
+# not overwrite them with the broadcast scalar.
+calculate_minus_length_weighted_mean_advantages.writes_step_advantages = True
+
+
 @register_adv_estimator(rLLMAdvantageEstimator.ECHO)
 def calculate_echo_advantages(rewards: list[np.ndarray], algorithm_config: AlgorithmConfig, **kwargs) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """ECHO (arXiv:2605.24517): advantages are identical to GRPO.
@@ -242,9 +317,16 @@ def collect_reward_and_advantage_from_trajectory_groups(
                 traj_groups=traj_groups,
             )
             assert len(advantages_by_group) == len(traj_groups), "length mismatch between advantages and trajectory groups"
+            # Estimators that emit per-token advantages set step.advantage
+            # themselves (e.g. minus_length_weighted_mean); skip the scalar
+            # broadcast so their lists survive. Scalar returns still feed the
+            # advantage/* metrics below either way.
+            estimator_writes_steps = getattr(advantage_fn, "writes_step_advantages", False)
             for traj_group, advantages_by_traj in zip(traj_groups, advantages_by_group, strict=True):
                 assert len(advantages_by_traj) == len(traj_group.trajectories), "length mismatch between trajectory rewards and computed advantages"
                 advantages_by_role[group_role].extend(np.asarray(advantages_by_traj).tolist())  # for metrics calculation
+                if estimator_writes_steps:
+                    continue
                 for traj, advantage in zip(traj_group.trajectories, advantages_by_traj, strict=True):
                     for step in traj.steps:
                         step.advantage = float(advantage)

--- a/rllm/trainer/algorithms/config.py
+++ b/rllm/trainer/algorithms/config.py
@@ -276,6 +276,11 @@ class rLLMAdvantageEstimator(str, Enum):
     REINFORCE_PLUS_PLUS_BASELINE = "reinforce_plus_plus_baseline"
     PRPO = "prpo"
     RLOO = "rloo"
+    # Baseline = length-weighted mean of shaped rewards over the batch pool; in
+    # token mode (steps carrying metadata["per_token_rewards"]) the baseline is
+    # the mean per-token reward over ALL tokens in the pool and advantages are
+    # emitted per token.
+    MINUS_LENGTH_WEIGHTED_MEAN = "minus_length_weighted_mean"
     # ECHO (arXiv:2605.24517): GRPO advantages + an auxiliary cross-entropy loss
     # on environment-observation tokens. The advantage math is identical to GRPO;
     # selecting `echo` flips on the env-loss term (see `env_loss_coef`).

--- a/tests/unified_trainer/test_minus_length_weighted_mean.py
+++ b/tests/unified_trainer/test_minus_length_weighted_mean.py
@@ -1,0 +1,108 @@
+"""Tests for the minus_length_weighted_mean advantage estimator.
+
+Baseline = length-weighted mean of shaped rewards over the whole batch pool;
+in token mode (steps carrying metadata["per_token_rewards"]) the baseline is the
+mean per-token reward over all tokens and advantages are emitted per token.
+The two doc examples are reproduced exactly.
+"""
+
+import numpy as np
+import pytest
+from omegaconf import OmegaConf
+
+from rllm.types import Step, Trajectory, TrajectoryGroup
+from rllm.trainer.algorithms.advantage import (
+    collect_reward_and_advantage_from_trajectory_groups,
+    get_adv_estimator,
+)
+from rllm.trainer.algorithms.config import AlgorithmConfig, rLLMAdvantageEstimator
+
+
+def _step(per_token_rewards, n):
+    return Step(
+        response_ids=list(range(n)),
+        metadata={"per_token_rewards": per_token_rewards} if per_token_rewards is not None else None,
+    )
+
+
+def _traj(reward, steps):
+    t = Trajectory(steps=steps)
+    t.reward = reward
+    return t
+
+
+def _approx(xs):
+    return [pytest.approx(x, abs=1e-4) for x in xs]
+
+
+class TestMinusLengthWeightedMean:
+    def _fn(self):
+        return get_adv_estimator(rLLMAdvantageEstimator.MINUS_LENGTH_WEIGHTED_MEAN)
+
+    def test_token_mode_matches_doc_example(self):
+        # Doc example 2: baseline = (1+1+0.8+0.6+0+0)/6 = 0.5667
+        a = _traj(1.0, [_step([1.0, 1.0, 0.8, 0.6], 4)])
+        b = _traj(0.0, [_step([0.0, 0.0], 2)])
+        g = TrajectoryGroup(group_id="g", trajectories=[a, b])
+        adv, ret = self._fn()(rewards=[np.array([1.0, 0.0])], algorithm_config=None, traj_groups=[g])
+
+        assert a.steps[0].advantage == _approx([0.4333, 0.4333, 0.2333, 0.0333])
+        assert b.steps[0].advantage == _approx([-0.5667, -0.5667])
+        # returned scalars are the sample advantages (shaped_reward - baseline)
+        assert list(adv[0]) == _approx([0.4333, -0.5667])
+        assert list(ret[0]) == _approx([0.4333, -0.5667])
+
+    def test_outcome_mode_matches_doc_example(self):
+        # Doc example 1: no per-token rewards -> length-weighted mean = 0.6
+        a = _traj(0.9, [_step(None, 100)])
+        b = _traj(0.0, [_step(None, 50)])
+        g = TrajectoryGroup(group_id="g", trajectories=[a, b])
+        adv, _ = self._fn()(rewards=[np.array([0.9, 0.0])], algorithm_config=None, traj_groups=[g])
+
+        assert list(adv[0]) == _approx([0.3, -0.6])
+        # a constant per-token advantage is broadcast across the response
+        assert a.steps[0].advantage == _approx([0.3] * 100)
+        assert b.steps[0].advantage == _approx([-0.6] * 50)
+
+    def test_mixed_batch_shares_one_pooled_baseline(self):
+        # token-mode + outcome-mode trajectories pool into a single token mean
+        a = _traj(1.0, [_step([1.0, 1.0, 0.8, 0.6], 4)])
+        c = _traj(0.0, [_step(None, 2)])  # contributes 0.0 at each of its 2 tokens
+        g = TrajectoryGroup(group_id="g", trajectories=[a, c])
+        self._fn()(rewards=[np.array([1.0, 0.0])], algorithm_config=None, traj_groups=[g])
+
+        baseline = (1.0 + 1.0 + 0.8 + 0.6 + 0.0 + 0.0) / 6
+        assert a.steps[0].advantage == _approx([1.0 - baseline, 1.0 - baseline, 0.8 - baseline, 0.6 - baseline])
+        assert c.steps[0].advantage == _approx([-baseline, -baseline])
+
+    def test_multi_step_trajectory_pools_across_steps(self):
+        d = _traj(0.8, [_step([0.5, 0.5], 2), _step([1.0], 1)])
+        g = TrajectoryGroup(group_id="g", trajectories=[d])
+        self._fn()(rewards=[np.array([0.8])], algorithm_config=None, traj_groups=[g])
+
+        baseline = (0.5 + 0.5 + 1.0) / 3
+        assert d.steps[0].advantage == _approx([0.5 - baseline, 0.5 - baseline])
+        assert d.steps[1].advantage == _approx([1.0 - baseline])
+
+    def test_length_mismatch_falls_back_to_trajectory_reward(self):
+        # per_token_rewards shorter than response_ids -> that step uses the scalar reward
+        a = _traj(0.5, [_step([1.0], 3)])  # 1 ptr vs 3 tokens
+        g = TrajectoryGroup(group_id="g", trajectories=[a])
+        self._fn()(rewards=[np.array([0.5])], algorithm_config=None, traj_groups=[g])
+        # pooled over 3 tokens each contributing the trajectory reward 0.5 -> baseline 0.5
+        assert a.steps[0].advantage == _approx([0.0, 0.0, 0.0])
+
+    def test_end_to_end_via_collect_writes_per_token_and_metrics(self):
+        alg = AlgorithmConfig.from_config(OmegaConf.create({"adv_estimator": "minus_length_weighted_mean"}))
+        assert alg.estimator == rLLMAdvantageEstimator.MINUS_LENGTH_WEIGHTED_MEAN
+
+        a = _traj(1.0, [_step([1.0, 1.0, 0.8, 0.6], 4)])
+        b = _traj(0.0, [_step([0.0, 0.0], 2)])
+        g = TrajectoryGroup(group_id="g", group_role="default", trajectories=[a, b])
+        metrics = collect_reward_and_advantage_from_trajectory_groups([g], alg)
+
+        # per-token lists survive the caller (not collapsed to scalar broadcast)
+        assert isinstance(a.steps[0].advantage, list) and len(a.steps[0].advantage) == 4
+        assert a.steps[0].advantage == _approx([0.4333, 0.4333, 0.2333, 0.0333])
+        # scalar sample advantages still feed advantage/* metrics
+        assert any(k.startswith("advantage/") and k.endswith("/mean") for k in metrics)


### PR DESCRIPTION
## Summary

Adds a rLLM advantage estimator, `minus_length_weighted_mean`, whose baseline is the **length-weighted mean of shaped rewards over the whole batch pool**, with a **per-token** mode.

```
outcome mode (default):
  baseline    = Σ_i (shaped_reward_i · L_i) / Σ_i L_i
  advantage_i = shaped_reward_i − baseline

token mode (steps carry metadata["per_token_rewards"]):
  baseline             = Σ_i Σ_t ptr[i,t] / Σ_i L_i        # mean per-token reward over ALL tokens
  token_advantage[i,t] = ptr[i,t] − baseline
  sample_advantage[i]  = shaped_reward_i − baseline        # scalar, for advantage/* metrics
```

## Design notes

- **One formula, two modes.** A step *without* per-token rewards contributes its trajectory's scalar reward at every token, so the pooled token mean is exactly the length-weighted mean of scalar rewards. Outcome and token trajectories therefore share a single pooled baseline and **mixed batches compose** — no special-casing.
- **Per-token rewards** are read from `step.metadata["per_token_rewards"]` (aligned to `response_ids`). A length mismatch logs a warning and falls back to the trajectory reward for that step.
- **`L_i`** counts response (action) tokens; the pool is every trajectory in the call (all groups of the role), matching "the entire generation pool".
- **Writeback.** Unlike the scalar estimators, this one emits per-token advantages, so it writes `step.advantage` (per-token lists) itself. `collect_reward_and_advantage_from_trajectory_groups` skips its scalar broadcast when an estimator sets a `writes_step_advantages` attribute; the returned `sample_advantage` scalars still feed the `advantage/*` metrics. Both the tinker (`trajectory_to_datums`) and verl (`_build_per_step_advantages`) transforms already accept list-valued `step.advantage`, so **no transform changes are needed**.

## Testing

`tests/unified_trainer/test_minus_length_weighted_mean.py` — 6 cases, all passing:
- both documented examples reproduced **exactly** (token baseline 0.5667 → advantages `[0.4333, 0.4333, 0.2333, 0.0333]` / `[-0.5667, -0.5667]`; outcome baseline 0.6 → `[0.3, -0.6]`)
- mixed token+outcome batch shares one pooled baseline
- multi-step trajectory pools across steps
- length-mismatch fallback
- end-to-end via `collect_reward_and_advantage_from_trajectory_groups` (per-token lists survive; metrics populated)

`ruff check` clean.

## Usage

```
rllm.algorithm.adv_estimator=minus_length_weighted_mean
```
Token mode activates automatically when the workflow populates `step.metadata["per_token_rewards"]`; otherwise it runs as the outcome-level length-weighted-mean baseline.

Draft — opening for review of the estimator semantics and the `writes_step_advantages` caller hook before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)