### PR TITLE
feat(metrics): track IS-ratio min alongside max (offpolicy + reinforce_kl)

### DIFF
--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -162,9 +162,11 @@ def offpolicy_metrics(
         # KL(rollout || curr): k1 is signed (drift direction), k3 is the low-variance estimate
         "offpolicy/kl": (rollout_flat - curr_flat).mean().item(),
         "offpolicy/k3_kl": (torch.exp(log_ratio) - log_ratio - 1).mean().item(),
-        # importance weight pi_curr/pi_rollout: center (~1) + worst-case tail
+        # importance weight pi_curr/pi_rollout: center (~1) + both tails (min << 1 =
+        # sampler-overconfident tokens whose gradients get IS-suppressed)
         "offpolicy/ratio/mean": ratio.mean().item(),
         "offpolicy/ratio/max": ratio.max().item(),
+        "offpolicy/ratio/min": ratio.min().item(),
         # chi-square divergence = variance of the IS weight (stability)
         "offpolicy/chi2_token": (ratio.square().mean() - 1.0).item(),
         # absolute per-sequence confidence (catches temperature mismatch / collapse)
@@ -606,10 +608,17 @@ def reinforce_kl(ctx: LossContext):
 
     am = ctx.action_mask
     denom = am.sum().clamp(min=1.0)
+    # Ratio extremes over trainable tokens (same caveat as icepop: per-sequence on the
+    # managed per-datum path, true batch stats on verl). min << 1 flags sampler-overconfident
+    # tokens whose PG weight vanishes; max complements clamp_frac for the high tail.
+    active = am > 0
+    r_active = r.detach()[active] if active.any() else r.detach().new_ones(1)
     return ctx.aggregate(pg + bwd_coef * kl_bwd + fwd_coef * kl_fwd, am), {
         "reinforce_kl/kl_bwd": ((kl_bwd_est * am).sum() / denom).item(),
         "reinforce_kl/kl_fwd": ((kl_fwd_est * am).sum() / denom).item(),
         "reinforce_kl/ratio_mean": ((r.detach() * am).sum() / denom).item(),
+        "reinforce_kl/ratio_min": r_active.min().item(),
+        "reinforce_kl/ratio_max": r_active.max().item(),
         "reinforce_kl/clamp_frac": (((w != r.detach()).to(log_r.dtype) * am).sum() / denom).item(),
     }
 

--- a/tests/unified_trainer/test_custom_loss.py
+++ b/tests/unified_trainer/test_custom_loss.py
@@ -4,6 +4,8 @@ A loss is a single function selected by name that returns a scalar via ``ctx.agg
 Backend-agnostic: pure torch on toy tensors, no GPU / verl / tinker server needed.
 """
 
+import math
+
 import pytest
 from omegaconf import OmegaConf
 
@@ -724,3 +726,41 @@ def test_managed_echo_trains_observation_tokens():
     loss, _ = loss_fn(stripped, [logp_curr])
     loss.backward()
     assert logp_curr.grad[0].item() != 0.0 and logp_curr.grad[3].item() != 0.0  # ECHO trains observation tokens
+
+
+def test_reinforce_kl_reports_ratio_extremes():
+    from rllm.trainer.algorithms.loss import reinforce_kl
+
+    def _rk_ctx(curr, rollout, action_mask):
+        n = len(curr)
+        return LossContext(
+            logp_curr=torch.tensor(curr, requires_grad=True),
+            logp_old=torch.zeros(n),  # ignored: q is the sampler
+            logp_rollout=torch.tensor(rollout),
+            advantages=torch.ones(n),
+            action_mask=torch.tensor(action_mask),
+            obs_mask=torch.zeros(n),
+            aggregate=_agg_sum,
+            params={},
+        )
+
+    # token 0: curr << rollout (ratio e^-2, sampler-overconfident); token 2: curr >> rollout (e^1)
+    _, m = reinforce_kl(_rk_ctx([-3.0, -1.0, -0.5], [-1.0, -1.0, -1.5], [1.0, 1.0, 1.0]))
+    assert m["reinforce_kl/ratio_min"] == pytest.approx(math.exp(-2.0), abs=1e-5)
+    assert m["reinforce_kl/ratio_max"] == pytest.approx(math.exp(1.0), abs=1e-5)
+
+    # masked token must not contribute to the extremes
+    _, m = reinforce_kl(_rk_ctx([-9.0, -1.0], [-1.0, -1.0], [0.0, 1.0]))
+    assert m["reinforce_kl/ratio_min"] == pytest.approx(1.0, abs=1e-5)
+    assert m["reinforce_kl/ratio_max"] == pytest.approx(1.0, abs=1e-5)
+
+
+def test_offpolicy_metrics_report_both_ratio_tails():
+    from rllm.trainer.algorithms.loss import offpolicy_metrics
+
+    curr = [torch.tensor([-5.0, -1.0, -1.0])]
+    rollout = [torch.tensor([-1.0, -1.0, -2.0])]
+    masks = [torch.ones(3)]
+    m = offpolicy_metrics(curr, rollout, masks)
+    assert m["offpolicy/ratio/min"] == pytest.approx(math.exp(-4.0), abs=1e-6)
+    assert m["offpolicy/ratio/max"] == pytest.approx(math.exp(1.0), abs=1e-6)


### PR DESCRIPTION
## What

The importance-ratio diagnostics only reported the high tail:

- `offpolicy/ratio/*` logged `mean` + `max` (comment said "worst-case tail" — but only the high one)
- `reinforce_kl/*` logged `ratio_mean` + `clamp_frac`, no extremes

This adds:

- `offpolicy/ratio/min` — batch min over masked tokens, same tensor as mean/max
- `reinforce_kl/ratio_min` / `reinforce_kl/ratio_max` — over trainable tokens, icepop-style masked select (same per-datum caveat as icepop, noted in a comment)

## Why

Sampler↔trainer mismatch (e.g. fp8 rollout serving vs bf16 trainer, quantization noise, parallelism differences) pushes per-token log-ratios in **both** directions. `ratio ≪ 1` marks tokens where the trainer assigns far less probability than the sampler did — their policy-gradient weight vanishes under importance sampling (gradient starvation). Watching only `max` catches ratio explosion but is blind to that low tail. `icepop` already reports mean/min/max; this brings the other two families to parity.

## Tests

- `test_offpolicy_metrics_report_both_ratio_tails` — min/max match hand-computed `e^-4` / `e^1`
- `test_reinforce_kl_reports_ratio_extremes` — extremes match `e^-2` / `e^1`; masked tokens excluded
- Full `test_custom_loss.py` suite: 39 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)