### PR TITLE
fix(gateway): emit structured tool_calls for OpenAI clients (opencode) in RL rollouts

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -92,28 +92,42 @@ def _to_openai_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, An
 
 
 def _assistant_message_from_completion(
-    text: str,
+    choice: dict[str, Any],
     completion_token_ids: list[int] | None,
     request_body: dict[str, Any],
     renderer: Any,
 ) -> dict[str, Any]:
-    """Build the assistant ``message`` for a cumulative-mode chat response.
+    """Build the assistant chat ``message`` for a cumulative-mode turn.
 
-    Default (and for every client today): the raw completion ``text`` as ``content`` —
-    byte-identical to the prior behavior. Text-protocol harnesses (Terminus-2 etc.) send
-    no OpenAI ``tools`` field and parse the raw output themselves, so they are unaffected.
+    Two producers feed the cumulative-turn path:
 
-    When the client DID send ``tools`` (OpenAI function-calling clients such as opencode),
-    parse the completion tokens via the renderer into structured
-    ``content`` / ``reasoning_content`` / ``tool_calls``. The ``/v1/completions`` bridge
-    used in ``cumulative_token_mode`` skips the serving stack's own chat tool-call parser,
-    so without this such clients receive only raw ``<think>…</think><tool_call>…`` text,
-    never see structured ``tool_calls``, and take no action (0 reward in training). This
-    only shapes the CLIENT-facing message; training token capture uses the raw
-    ``completion_token_ids`` and is unchanged. Falls back to raw ``text`` if the renderer
-    can't parse or finds nothing structured.
+    * The in-process handler (Fireworks/Tinker ``local_handler``) already parsed the
+      completion with the engine's renderer, so its choice carries structured
+      ``tool_calls`` / ``reasoning`` (see ``rllm.gateway.tinker_adapter``). Pass them
+      straight through — this is the source of truth.
+    * A raw vLLM ``/v1/completions`` worker (verl backend) returns only ``text``. When
+      the client sent ``tools`` (OpenAI function-calling clients such as opencode), parse
+      the completion tokens via the renderer into structured tool_calls; the
+      ``/v1/completions`` bridge skips the serving stack's own chat tool-call parser, so
+      without this such clients get only raw ``<tool_call>…`` text and take no action.
+
+    Text-protocol harnesses (Terminus-2) send no ``tools`` and get the raw text (unchanged).
+    Only the CLIENT-facing message is shaped; training token capture uses the raw
+    ``completion_token_ids`` and is untouched.
     """
-    message: dict[str, Any] = {"role": "assistant", "content": text}
+    text = choice.get("text", "") if isinstance(choice, dict) else ""
+
+    # (a) Handler already produced structured fields — pass through.
+    if isinstance(choice, dict) and (choice.get("tool_calls") or choice.get("reasoning")):
+        message: dict[str, Any] = {"role": "assistant", "content": text}
+        if choice.get("reasoning"):
+            message["reasoning"] = choice["reasoning"]
+        if choice.get("tool_calls"):
+            message["tool_calls"] = choice["tool_calls"]
+        return message
+
+    # (b) Raw completion (HTTP worker): parse tokens when the client wants tool calls.
+    message = {"role": "assistant", "content": text}
     if not request_body.get("tools"):
         return message
     parse = getattr(renderer, "parse_response", None)
@@ -706,11 +720,16 @@ class ReverseProxy:
         acc.ingest_turn(prompt_token_ids, completion_token_ids, advance=not replay)
         acc.update_prefix(request_body.get("messages", []))
 
-        # Translate to chat format
+        # Translate to chat format. The handler (Fireworks/Tinker) may have parsed
+        # tool_calls/reasoning onto the choice; _assistant_message_from_completion prefers
+        # those, else parses tokens (raw vLLM worker) when the client sent tools.
         choices = response_body.get("choices") or []
         if choices:
             first_choice = choices[0]
-            first_choice["message"] = _assistant_message_from_completion(first_choice.pop("text", ""), completion_token_ids, request_body, acc.renderer)
+            message = _assistant_message_from_completion(first_choice, completion_token_ids, request_body, acc.renderer)
+            for k in ("text", "tool_calls", "reasoning"):
+                first_choice.pop(k, None)  # completions-level fields now live in message
+            first_choice["message"] = message
         response_body["object"] = "chat.completion"
 
         if session_id and response_body:
@@ -865,8 +884,11 @@ class ReverseProxy:
                 # completion and fake-stream it (role → content+tool_calls → finish → DONE).
                 if tools_mode and chunks:
                     built_trace = _build_trace()
+                    # Raw vLLM stream: no per-choice tool_calls, so pass a text-only choice
+                    # and let the renderer parse the buffered completion tokens.
+                    joined_text = "".join((c.get("choices") or [{}])[0].get("text", "") for c in chunks)
                     message = _assistant_message_from_completion(
-                        "".join((c.get("choices") or [{}])[0].get("text", "") for c in chunks),
+                        {"text": joined_text},
                         built_trace.completion_token_ids,
                         request_body,
                         acc.renderer,
@@ -950,17 +972,18 @@ class ReverseProxy:
         acc.update_prefix(request_body.get("messages", []))
 
         choices = response_body.get("choices") or []
-        content = choices[0].pop("text", "") if choices else ""
-        finish_reason = (choices[0].get("finish_reason") if choices else None) or "stop"
-        completion_logprobs = choices[0].get("logprobs") if choices else None
+        choice0 = choices[0] if choices else {}
+        finish_reason = choice0.get("finish_reason") or "stop"
+        completion_logprobs = choice0.get("logprobs")
 
-        # When the client requested OpenAI tools, reconstruct structured
-        # content/reasoning_content/tool_calls; otherwise `message` is just the raw
-        # content and `extra_delta` is empty (behavior unchanged). See
-        # _assistant_message_from_completion.
-        message = _assistant_message_from_completion(content, completion_token_ids, request_body, acc.renderer)
+        # Prefer the handler's structured tool_calls/reasoning (parsed onto the choice);
+        # else raw content. extra_delta carries the structured fields into the streamed
+        # content chunk. See _assistant_message_from_completion.
+        message = _assistant_message_from_completion(choice0, completion_token_ids, request_body, acc.renderer)
+        for k in ("text", "tool_calls", "reasoning"):
+            choice0.pop(k, None)  # completions-level fields now live in message
         content = message["content"]
-        extra_delta = {k: message[k] for k in ("reasoning_content", "tool_calls") if k in message}
+        extra_delta = {k: message[k] for k in ("reasoning", "reasoning_content", "tool_calls") if k in message}
 
         if session_id and response_body:
             chat_body = dict(response_body)

--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -67,6 +67,75 @@ def _strip_logprobs(response: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _to_openai_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Renderer ``parse_response`` tool_calls -> OpenAI chat ``tool_calls`` shape.
+
+    The renderer emits ``{"function": {"name", "arguments": <dict|str>}}``; the OpenAI
+    wire shape a client (e.g. opencode's OpenAI-compatible provider) expects is
+    ``{"id", "type": "function", "index", "function": {"name", "arguments": <json str>}}``.
+    """
+    out: list[dict[str, Any]] = []
+    for i, tc in enumerate(tool_calls):
+        fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+        args = fn.get("arguments", {})
+        if not isinstance(args, str):
+            args = json.dumps(args)
+        out.append(
+            {
+                "id": tc.get("id") or f"call_{i}",
+                "type": "function",
+                "index": i,
+                "function": {"name": fn.get("name", ""), "arguments": args},
+            }
+        )
+    return out
+
+
+def _assistant_message_from_completion(
+    text: str,
+    completion_token_ids: list[int] | None,
+    request_body: dict[str, Any],
+    renderer: Any,
+) -> dict[str, Any]:
+    """Build the assistant ``message`` for a cumulative-mode chat response.
+
+    Default (and for every client today): the raw completion ``text`` as ``content`` —
+    byte-identical to the prior behavior. Text-protocol harnesses (Terminus-2 etc.) send
+    no OpenAI ``tools`` field and parse the raw output themselves, so they are unaffected.
+
+    When the client DID send ``tools`` (OpenAI function-calling clients such as opencode),
+    parse the completion tokens via the renderer into structured
+    ``content`` / ``reasoning_content`` / ``tool_calls``. The ``/v1/completions`` bridge
+    used in ``cumulative_token_mode`` skips the serving stack's own chat tool-call parser,
+    so without this such clients receive only raw ``<think>…</think><tool_call>…`` text,
+    never see structured ``tool_calls``, and take no action (0 reward in training). This
+    only shapes the CLIENT-facing message; training token capture uses the raw
+    ``completion_token_ids`` and is unchanged. Falls back to raw ``text`` if the renderer
+    can't parse or finds nothing structured.
+    """
+    message: dict[str, Any] = {"role": "assistant", "content": text}
+    if not request_body.get("tools"):
+        return message
+    parse = getattr(renderer, "parse_response", None)
+    if not callable(parse) or not completion_token_ids:
+        return message
+    try:
+        parsed = parse(list(completion_token_ids))
+    except Exception:
+        logger.warning("cumulative-turn tool-call parse failed; returning raw content", exc_info=True)
+        return message
+    tool_calls = _to_openai_tool_calls(parsed.tool_calls) if getattr(parsed, "tool_calls", None) else None
+    reasoning = getattr(parsed, "reasoning_content", None)
+    if not tool_calls and not reasoning:
+        return message  # nothing structured recovered -> keep raw text (defensive)
+    message["content"] = parsed.content or ""
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return message
+
+
 def _build_trace_data(
     session_id: str,
     request_body: dict[str, Any],
@@ -641,7 +710,7 @@ class ReverseProxy:
         choices = response_body.get("choices") or []
         if choices:
             first_choice = choices[0]
-            first_choice["message"] = {"role": "assistant", "content": first_choice.pop("text", "")}
+            first_choice["message"] = _assistant_message_from_completion(first_choice.pop("text", ""), completion_token_ids, request_body, acc.renderer)
         response_body["object"] = "chat.completion"
 
         if session_id and response_body:
@@ -721,19 +790,30 @@ class ReverseProxy:
 
         t0 = time.perf_counter()
         chunks: list[dict[str, Any]] = []
+        # OpenAI function-calling clients (e.g. opencode) need structured tool_calls, which
+        # require the full completion to parse. Buffer the stream and fake-stream a single
+        # reconstructed message at the end; text-protocol clients (no tools) stream through
+        # unchanged. See _assistant_message_from_completion.
+        tools_mode = bool(request_body.get("tools"))
+
+        def _build_trace():
+            latency_ms = (time.perf_counter() - t0) * 1000
+            return build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
 
         async def event_generator():
+            built_trace = None
             try:
                 first_chunk_sent = False
                 async for line in resp.aiter_lines():
                     if not line.startswith("data: "):
-                        if line:
+                        if line and not tools_mode:
                             yield line + "\n"
                         continue
 
                     data_str = line[6:].strip()
                     if data_str == "[DONE]":
-                        yield "data: [DONE]\n\n"
+                        if not tools_mode:
+                            yield "data: [DONE]\n\n"
                         continue
 
                     try:
@@ -742,6 +822,9 @@ class ReverseProxy:
                         continue
 
                     chunks.append(chunk)
+
+                    if tools_mode:
+                        continue  # buffer; structured message emitted after the stream
 
                     # Translate completions chunk → chat chunk
                     choices = chunk.get("choices", [])
@@ -778,16 +861,46 @@ class ReverseProxy:
                     sanitized = strip_vllm_fields(chat_chunk) if self.strip_vllm else chat_chunk
                     yield f"data: {json.dumps(sanitized)}\n\n"
 
+                # Tools client: reconstruct one structured chat message from the full
+                # completion and fake-stream it (role → content+tool_calls → finish → DONE).
+                if tools_mode and chunks:
+                    built_trace = _build_trace()
+                    message = _assistant_message_from_completion(
+                        "".join((c.get("choices") or [{}])[0].get("text", "") for c in chunks),
+                        built_trace.completion_token_ids,
+                        request_body,
+                        acc.renderer,
+                    )
+                    cid = chunks[0].get("id", "")
+                    created = chunks[0].get("created", 0)
+                    model = chunks[0].get("model", "")
+                    usage = next((c["usage"] for c in reversed(chunks) if c.get("usage")), {})
+                    finish_reason = next((fr for c in reversed(chunks) for ch in (c.get("choices") or []) if (fr := ch.get("finish_reason"))), "stop")
+                    base = {"id": cid, "object": "chat.completion.chunk", "created": created, "model": model}
+                    delta = {"content": message["content"]}
+                    for k in ("reasoning_content", "tool_calls"):
+                        if k in message:
+                            delta[k] = message[k]
+                    role_chunk = {**base, "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}
+                    msg_chunk = {**base, "choices": [{"index": 0, "delta": delta, "finish_reason": None}]}
+                    fin_chunk = {**base, "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}], "usage": usage}
+                    if self.strip_vllm:
+                        msg_chunk = strip_vllm_fields(msg_chunk)
+                    yield f"data: {json.dumps(role_chunk)}\n\n"
+                    yield f"data: {json.dumps(msg_chunk)}\n\n"
+                    yield f"data: {json.dumps(fin_chunk)}\n\n"
+                    yield "data: [DONE]\n\n"
+
             finally:
                 await upstream.__aexit__(None, None, None)
                 if retry_client is not None:
                     await retry_client.aclose()
                 self.router.release(worker.url)
 
-                # Ingest accumulated token data
+                # Ingest accumulated token data (reuse the trace already built for the
+                # tools-mode emission, so chunks are parsed once).
                 if chunks:
-                    latency_ms = (time.perf_counter() - t0) * 1000
-                    trace = build_trace_record_from_chunks(session_id, request_body, chunks, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
+                    trace = built_trace or _build_trace()
                     prompt_ids = trace.prompt_token_ids or token_ids
                     completion_ids = trace.completion_token_ids
 
@@ -841,11 +954,19 @@ class ReverseProxy:
         finish_reason = (choices[0].get("finish_reason") if choices else None) or "stop"
         completion_logprobs = choices[0].get("logprobs") if choices else None
 
+        # When the client requested OpenAI tools, reconstruct structured
+        # content/reasoning_content/tool_calls; otherwise `message` is just the raw
+        # content and `extra_delta` is empty (behavior unchanged). See
+        # _assistant_message_from_completion.
+        message = _assistant_message_from_completion(content, completion_token_ids, request_body, acc.renderer)
+        content = message["content"]
+        extra_delta = {k: message[k] for k in ("reasoning_content", "tool_calls") if k in message}
+
         if session_id and response_body:
             chat_body = dict(response_body)
             chat_body["object"] = "chat.completion"
             if chat_body.get("choices"):
-                chat_body["choices"][0]["message"] = {"role": "assistant", "content": content}
+                chat_body["choices"][0]["message"] = message
             trace = build_trace_record(session_id, request_body, chat_body, latency_ms, weight_version=request.state.weight_version, capture_raw=self.capture_raw_payloads)
             await self._persist(trace)
 
@@ -880,7 +1001,7 @@ class ReverseProxy:
                             "object": "chat.completion.chunk",
                             "created": created,
                             "model": model,
-                            "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None, "token_ids": completion_token_ids, "logprobs": completion_logprobs}],
+                            "choices": [{"index": 0, "delta": {"content": content, **extra_delta}, "finish_reason": None, "token_ids": completion_token_ids, "logprobs": completion_logprobs}],
                             "prompt_token_ids": prompt_token_ids,
                         }
                     )

--- a/rllm-model-gateway/tests/unit/test_cumulative_tool_call_reconstruction.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_tool_call_reconstruction.py
@@ -1,0 +1,185 @@
+"""Structured tool_call / reasoning reconstruction on the cumulative-token path.
+
+In ``cumulative_token_mode`` the gateway bridges chat/completions to
+``/v1/completions`` with a pre-tokenized prompt, so the serving stack's own chat
+tool-call parser never runs. Text-protocol harnesses (Terminus-2) parse the raw
+output themselves and send no OpenAI ``tools``. OpenAI function-calling clients
+(opencode) send ``tools`` and need structured ``tool_calls`` back — without them
+the agent sees only raw ``<think>…<tool_call>…`` text and never acts.
+
+These tests pin: (1) a ``tools`` request gets structured content/reasoning/tool_calls
+reconstructed via the renderer; (2) a request WITHOUT tools is byte-identical to the
+old raw-text behavior; (3) missing/failing renderer falls back to raw text.
+
+Driven directly (no HTTP server) via ``asyncio.run``, mirroring
+``test_cumulative_token_mode_local.py``.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from rllm_model_gateway.proxy import (
+    ReverseProxy,
+    _assistant_message_from_completion,
+    _to_openai_tool_calls,
+)
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+from rllm_model_gateway.token_accumulator import TokenAccumulator
+
+
+class _State:
+    weight_version = 0
+
+
+class _Request:
+    state = _State()
+
+
+class _FakeRenderer:
+    """parse_response returns a reasoning block + one tool call, no plain content —
+    the shape a Qwen3.5 reasoning turn that emits a tool call decodes to."""
+
+    def parse_response(self, token_ids):
+        return SimpleNamespace(
+            content="",
+            reasoning_content="let me think",
+            tool_calls=[{"function": {"name": "bash", "arguments": {"cmd": "ls"}}}],
+        )
+
+
+def _make_proxy(local_handler):
+    return ReverseProxy(
+        router=None,
+        store=MemoryTraceStore(),
+        sync_traces=True,
+        local_handler=local_handler,
+        cumulative_token_mode=True,
+        renderer=None,
+    )
+
+
+def _completion_handler():
+    async def handler(body):
+        return {
+            "id": "cmpl-x",
+            "object": "text_completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "<think>let me think</think><tool_call>{...}</tool_call>",
+                    "token_ids": [91, 92],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2]},
+                }
+            ],
+            "prompt_token_ids": body["prompt"],
+            "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
+        }
+
+    return handler
+
+
+_MSGS = [{"role": "user", "content": "x"}]
+_TOOLS = [{"type": "function", "function": {"name": "bash", "description": "run a command"}}]
+
+
+def _run_non_streaming(acc, request_body, bridged):
+    proxy = _make_proxy(_completion_handler())
+    resp = asyncio.run(
+        proxy._handle_cumulative_non_streaming(
+            _Request(),
+            request_body,
+            {"prompt": bridged, "add_special_tokens": False, "model": "q"},
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+    return json.loads(resp.body)
+
+
+# --- unit: tool_call shape conversion ---------------------------------------
+
+
+def test_to_openai_tool_calls_shapes_arguments_and_ids():
+    out = _to_openai_tool_calls([{"function": {"name": "bash", "arguments": {"cmd": "ls"}}}])
+    assert out == [{"id": "call_0", "type": "function", "index": 0, "function": {"name": "bash", "arguments": '{"cmd": "ls"}'}}]
+    # Already-string arguments pass through unchanged.
+    out2 = _to_openai_tool_calls([{"id": "abc", "function": {"name": "x", "arguments": "{}"}}])
+    assert out2[0]["id"] == "abc" and out2[0]["function"]["arguments"] == "{}"
+
+
+def test_assistant_message_raw_when_no_tools_or_no_renderer():
+    # No tools requested -> raw content regardless of renderer.
+    assert _assistant_message_from_completion("hi", [1, 2], {}, _FakeRenderer()) == {"role": "assistant", "content": "hi"}
+    # Tools requested but no renderer -> raw fallback.
+    assert _assistant_message_from_completion("hi", [1, 2], {"tools": _TOOLS}, None) == {"role": "assistant", "content": "hi"}
+
+
+# --- non-streaming path ------------------------------------------------------
+
+
+def test_cumulative_tools_reconstructs_structured_message():
+    acc = TokenAccumulator(renderer=_FakeRenderer())
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    body = _run_non_streaming(acc, {"messages": _MSGS, "tools": _TOOLS}, [1, 2, 3, 4, 5, 6, 7])
+
+    msg = body["choices"][0]["message"]
+    assert msg["role"] == "assistant"
+    assert msg["reasoning_content"] == "let me think"
+    assert msg["tool_calls"][0]["function"] == {"name": "bash", "arguments": '{"cmd": "ls"}'}
+    assert msg["tool_calls"][0]["type"] == "function"
+    assert "text" not in body["choices"][0]  # raw text popped, not leaked
+
+
+def test_cumulative_no_tools_keeps_raw_content():
+    """Terminus-2 style: no tools field -> byte-identical to prior raw behavior."""
+    acc = TokenAccumulator(renderer=_FakeRenderer())  # renderer present but must be unused
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    body = _run_non_streaming(acc, {"messages": _MSGS}, [1, 2, 3, 4, 5, 6, 7])
+
+    msg = body["choices"][0]["message"]
+    assert msg == {"role": "assistant", "content": "<think>let me think</think><tool_call>{...}</tool_call>"}
+    assert "tool_calls" not in msg and "reasoning_content" not in msg
+
+
+def test_cumulative_tools_no_renderer_falls_back_to_raw():
+    acc = TokenAccumulator(renderer=None)
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    body = _run_non_streaming(acc, {"messages": _MSGS, "tools": _TOOLS}, [1, 2, 3, 4, 5, 6, 7])
+    assert body["choices"][0]["message"]["content"] == "<think>let me think</think><tool_call>{...}</tool_call>"
+    assert "tool_calls" not in body["choices"][0]["message"]
+
+
+# --- local streaming path ----------------------------------------------------
+
+
+def test_cumulative_local_streaming_tools_emits_tool_calls():
+    proxy = _make_proxy(_completion_handler())
+    acc = TokenAccumulator(renderer=_FakeRenderer())
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    bridged = [1, 2, 3, 4, 5, 6, 7]
+    resp = asyncio.run(
+        proxy._handle_cumulative_streaming_local(
+            _Request(),
+            {"messages": _MSGS, "tools": _TOOLS},
+            {"prompt": bridged},
+            "sess1",
+            acc,
+            bridged,
+        )
+    )
+    chunks = []
+
+    async def drain():
+        async for c in resp.body_iterator:
+            chunks.append(c if isinstance(c, str) else c.decode())
+
+    asyncio.run(drain())
+    joined = "".join(chunks)
+    assert '"tool_calls"' in joined and '"bash"' in joined
+    assert '"reasoning_content"' in joined
+    assert chunks[-1].strip().endswith("[DONE]")
+    # Training token capture is unaffected: the completion tokens still ingest.
+    assert acc.turn_count == 2 and acc.prev_completion_ids == [91, 92]

--- a/rllm-model-gateway/tests/unit/test_cumulative_tool_call_reconstruction.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_tool_call_reconstruction.py
@@ -1,15 +1,15 @@
-"""Structured tool_call / reasoning reconstruction on the cumulative-token path.
+"""Structured tool_call / reasoning on the cumulative-token chat translation.
 
-In ``cumulative_token_mode`` the gateway bridges chat/completions to
-``/v1/completions`` with a pre-tokenized prompt, so the serving stack's own chat
-tool-call parser never runs. Text-protocol harnesses (Terminus-2) parse the raw
-output themselves and send no OpenAI ``tools``. OpenAI function-calling clients
-(opencode) send ``tools`` and need structured ``tool_calls`` back — without them
-the agent sees only raw ``<think>…<tool_call>…`` text and never acts.
+In ``cumulative_token_mode`` the gateway bridges chat/completions to ``/v1/completions``
+with a pre-tokenized prompt, so the serving stack's own chat tool-call parser never runs.
+OpenAI function-calling clients (opencode) send ``tools`` and need structured ``tool_calls``
+back; text-protocol harnesses (Terminus-2) send none and parse raw output themselves.
 
-These tests pin: (1) a ``tools`` request gets structured content/reasoning/tool_calls
-reconstructed via the renderer; (2) a request WITHOUT tools is byte-identical to the
-old raw-text behavior; (3) missing/failing renderer falls back to raw text.
+Two producers feed tool_calls into the cumulative-turn translation, and both are covered:
+  * the in-process handler (Fireworks/Tinker) parses and puts ``tool_calls``/``reasoning``
+    on the choice — the gateway passes them through;
+  * a raw vLLM worker returns only ``text`` — the gateway parses the completion tokens via
+    the renderer when the client sent ``tools``.
 
 Driven directly (no HTTP server) via ``asyncio.run``, mirroring
 ``test_cumulative_token_mode_local.py``.
@@ -37,14 +37,14 @@ class _Request:
 
 
 class _FakeRenderer:
-    """parse_response returns a reasoning block + one tool call, no plain content —
-    the shape a Qwen3.5 reasoning turn that emits a tool call decodes to."""
+    """parse_response returns reasoning + one tool call (prime-rl nested shape) — the
+    shape a raw vLLM completion is parsed into on the HTTP-worker fallback path."""
 
     def parse_response(self, token_ids):
         return SimpleNamespace(
             content="",
             reasoning_content="let me think",
-            tool_calls=[{"function": {"name": "bash", "arguments": {"cmd": "ls"}}}],
+            tool_calls=[{"function": {"name": "bash", "arguments": {"command": "ls"}}}],
         )
 
 
@@ -59,7 +59,8 @@ def _make_proxy(local_handler):
     )
 
 
-def _completion_handler():
+# A handler that already parsed tool_calls onto the choice (the fixed tinker_adapter).
+def _handler_with_tool_calls():
     async def handler(body):
         return {
             "id": "cmpl-x",
@@ -67,12 +68,28 @@ def _completion_handler():
             "choices": [
                 {
                     "index": 0,
-                    "text": "<think>let me think</think><tool_call>{...}</tool_call>",
+                    "text": "",  # parse-stripped; tool call carries the action
                     "token_ids": [91, 92],
-                    "finish_reason": "stop",
+                    "finish_reason": "tool_calls",
+                    "reasoning": "let me think",
+                    "tool_calls": [{"id": "call_0", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}],
                     "logprobs": {"token_logprobs": [-0.1, -0.2]},
                 }
             ],
+            "prompt_token_ids": body["prompt"],
+            "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
+        }
+
+    return handler
+
+
+# A raw-completion handler (text only, no tool_calls) — the vLLM-worker shape.
+def _handler_text_only():
+    async def handler(body):
+        return {
+            "id": "cmpl-x",
+            "object": "text_completion",
+            "choices": [{"index": 0, "text": "<tool_call>...</tool_call>", "token_ids": [91, 92], "finish_reason": "stop", "logprobs": {"token_logprobs": [-0.1, -0.2]}}],
             "prompt_token_ids": body["prompt"],
             "usage": {"prompt_tokens": len(body["prompt"]), "completion_tokens": 2},
         }
@@ -84,91 +101,92 @@ _MSGS = [{"role": "user", "content": "x"}]
 _TOOLS = [{"type": "function", "function": {"name": "bash", "description": "run a command"}}]
 
 
-def _run_non_streaming(acc, request_body, bridged):
-    proxy = _make_proxy(_completion_handler())
+def _run_non_streaming(handler, acc, request_body):
+    proxy = _make_proxy(handler)
     resp = asyncio.run(
         proxy._handle_cumulative_non_streaming(
             _Request(),
             request_body,
-            {"prompt": bridged, "add_special_tokens": False, "model": "q"},
+            {"prompt": [1, 2, 3, 4, 5, 6, 7], "add_special_tokens": False, "model": "q"},
             "sess1",
             acc,
-            bridged,
+            [1, 2, 3, 4, 5, 6, 7],
         )
     )
     return json.loads(resp.body)
 
 
-# --- unit: tool_call shape conversion ---------------------------------------
+# --- unit: proxy _to_openai_tool_calls (nested shape) -----------------------
 
 
 def test_to_openai_tool_calls_shapes_arguments_and_ids():
-    out = _to_openai_tool_calls([{"function": {"name": "bash", "arguments": {"cmd": "ls"}}}])
-    assert out == [{"id": "call_0", "type": "function", "index": 0, "function": {"name": "bash", "arguments": '{"cmd": "ls"}'}}]
-    # Already-string arguments pass through unchanged.
-    out2 = _to_openai_tool_calls([{"id": "abc", "function": {"name": "x", "arguments": "{}"}}])
-    assert out2[0]["id"] == "abc" and out2[0]["function"]["arguments"] == "{}"
+    out = _to_openai_tool_calls([{"function": {"name": "bash", "arguments": {"command": "ls"}}}])
+    assert out == [{"id": "call_0", "type": "function", "index": 0, "function": {"name": "bash", "arguments": '{"command": "ls"}'}}]
 
 
-def test_assistant_message_raw_when_no_tools_or_no_renderer():
-    # No tools requested -> raw content regardless of renderer.
-    assert _assistant_message_from_completion("hi", [1, 2], {}, _FakeRenderer()) == {"role": "assistant", "content": "hi"}
-    # Tools requested but no renderer -> raw fallback.
-    assert _assistant_message_from_completion("hi", [1, 2], {"tools": _TOOLS}, None) == {"role": "assistant", "content": "hi"}
+# --- unit: _assistant_message_from_completion (choice-based) -----------------
+
+
+def test_message_prefers_handler_provided_tool_calls():
+    tc = [{"id": "call_0", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}]
+    choice = {"text": "", "tool_calls": tc, "reasoning": "thinking"}
+    msg = _assistant_message_from_completion(choice, [1, 2], {"tools": _TOOLS}, _FakeRenderer())
+    assert msg["tool_calls"] == tc  # passed through verbatim, not re-parsed
+    assert msg["reasoning"] == "thinking"
+
+
+def test_message_parses_tokens_when_handler_gave_only_text():
+    choice = {"text": "<tool_call>...</tool_call>"}
+    msg = _assistant_message_from_completion(choice, [1, 2], {"tools": _TOOLS}, _FakeRenderer())
+    assert msg["tool_calls"][0]["function"] == {"name": "bash", "arguments": '{"command": "ls"}'}
+    assert msg["reasoning_content"] == "let me think"
+
+
+def test_message_raw_when_no_tools_or_no_renderer():
+    assert _assistant_message_from_completion({"text": "hi"}, [1, 2], {}, _FakeRenderer()) == {"role": "assistant", "content": "hi"}
+    assert _assistant_message_from_completion({"text": "hi"}, [1, 2], {"tools": _TOOLS}, None) == {"role": "assistant", "content": "hi"}
 
 
 # --- non-streaming path ------------------------------------------------------
 
 
-def test_cumulative_tools_reconstructs_structured_message():
+def test_cumulative_passes_through_handler_tool_calls():
+    acc = TokenAccumulator(renderer=None)  # renderer unused: handler already parsed
+    acc.ingest_turn([1, 2, 3], [4, 5])
+    body = _run_non_streaming(_handler_with_tool_calls(), acc, {"messages": _MSGS, "tools": _TOOLS})
+    msg = body["choices"][0]["message"]
+    assert msg["tool_calls"][0]["function"] == {"name": "bash", "arguments": '{"command": "ls"}'}
+    assert msg["reasoning"] == "let me think"
+    assert "text" not in body["choices"][0] and "tool_calls" not in body["choices"][0]
+
+
+def test_cumulative_parses_raw_completion_when_tools_requested():
     acc = TokenAccumulator(renderer=_FakeRenderer())
     acc.ingest_turn([1, 2, 3], [4, 5])
-    body = _run_non_streaming(acc, {"messages": _MSGS, "tools": _TOOLS}, [1, 2, 3, 4, 5, 6, 7])
-
+    body = _run_non_streaming(_handler_text_only(), acc, {"messages": _MSGS, "tools": _TOOLS})
     msg = body["choices"][0]["message"]
-    assert msg["role"] == "assistant"
-    assert msg["reasoning_content"] == "let me think"
-    assert msg["tool_calls"][0]["function"] == {"name": "bash", "arguments": '{"cmd": "ls"}'}
-    assert msg["tool_calls"][0]["type"] == "function"
-    assert "text" not in body["choices"][0]  # raw text popped, not leaked
+    assert msg["tool_calls"][0]["function"] == {"name": "bash", "arguments": '{"command": "ls"}'}
 
 
 def test_cumulative_no_tools_keeps_raw_content():
-    """Terminus-2 style: no tools field -> byte-identical to prior raw behavior."""
-    acc = TokenAccumulator(renderer=_FakeRenderer())  # renderer present but must be unused
+    acc = TokenAccumulator(renderer=_FakeRenderer())  # present but must be unused
     acc.ingest_turn([1, 2, 3], [4, 5])
-    body = _run_non_streaming(acc, {"messages": _MSGS}, [1, 2, 3, 4, 5, 6, 7])
-
+    body = _run_non_streaming(_handler_text_only(), acc, {"messages": _MSGS})
     msg = body["choices"][0]["message"]
-    assert msg == {"role": "assistant", "content": "<think>let me think</think><tool_call>{...}</tool_call>"}
-    assert "tool_calls" not in msg and "reasoning_content" not in msg
-
-
-def test_cumulative_tools_no_renderer_falls_back_to_raw():
-    acc = TokenAccumulator(renderer=None)
-    acc.ingest_turn([1, 2, 3], [4, 5])
-    body = _run_non_streaming(acc, {"messages": _MSGS, "tools": _TOOLS}, [1, 2, 3, 4, 5, 6, 7])
-    assert body["choices"][0]["message"]["content"] == "<think>let me think</think><tool_call>{...}</tool_call>"
-    assert "tool_calls" not in body["choices"][0]["message"]
+    assert msg == {"role": "assistant", "content": "<tool_call>...</tool_call>"}
+    assert "tool_calls" not in msg
 
 
 # --- local streaming path ----------------------------------------------------
 
 
-def test_cumulative_local_streaming_tools_emits_tool_calls():
-    proxy = _make_proxy(_completion_handler())
-    acc = TokenAccumulator(renderer=_FakeRenderer())
+def test_cumulative_local_streaming_emits_tool_calls():
+    proxy = _make_proxy(_handler_with_tool_calls())
+    acc = TokenAccumulator(renderer=None)
     acc.ingest_turn([1, 2, 3], [4, 5])
     bridged = [1, 2, 3, 4, 5, 6, 7]
     resp = asyncio.run(
-        proxy._handle_cumulative_streaming_local(
-            _Request(),
-            {"messages": _MSGS, "tools": _TOOLS},
-            {"prompt": bridged},
-            "sess1",
-            acc,
-            bridged,
-        )
+        proxy._handle_cumulative_streaming_local(_Request(), {"messages": _MSGS, "tools": _TOOLS}, {"prompt": bridged}, "sess1", acc, bridged)
     )
     chunks = []
 
@@ -179,7 +197,6 @@ def test_cumulative_local_streaming_tools_emits_tool_calls():
     asyncio.run(drain())
     joined = "".join(chunks)
     assert '"tool_calls"' in joined and '"bash"' in joined
-    assert '"reasoning_content"' in joined
     assert chunks[-1].strip().endswith("[DONE]")
-    # Training token capture is unaffected: the completion tokens still ingest.
+    # Training token capture unaffected: the completion tokens still ingest.
     assert acc.turn_count == 2 and acc.prev_completion_ids == [91, 92]

--- a/rllm-model-gateway/tests/unit/test_cumulative_tool_call_reconstruction.py
+++ b/rllm-model-gateway/tests/unit/test_cumulative_tool_call_reconstruction.py
@@ -185,9 +185,7 @@ def test_cumulative_local_streaming_emits_tool_calls():
     acc = TokenAccumulator(renderer=None)
     acc.ingest_turn([1, 2, 3], [4, 5])
     bridged = [1, 2, 3, 4, 5, 6, 7]
-    resp = asyncio.run(
-        proxy._handle_cumulative_streaming_local(_Request(), {"messages": _MSGS, "tools": _TOOLS}, {"prompt": bridged}, "sess1", acc, bridged)
-    )
+    resp = asyncio.run(proxy._handle_cumulative_streaming_local(_Request(), {"messages": _MSGS, "tools": _TOOLS}, {"prompt": bridged}, "sess1", acc, bridged))
     chunks = []
 
     async def drain():

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -23,15 +23,31 @@ logger = logging.getLogger(__name__)
 
 
 def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
-    """Convert rLLM ToolCall objects to OpenAI-format tool_calls."""
+    """Convert tool calls from any producer shape to the OpenAI wire format.
+
+    ``ModelOutput.tool_calls`` arrives in one of three shapes depending on which parser
+    ``assemble_model_output`` used:
+
+    * prime-rl ``renderers`` (the unified renderer, e.g. ``parse_qwen35``): a **nested**
+      dict ``{"function": {"name", "arguments"}}`` — the OpenAI-ish shape.
+    * rLLM ``ToolCall`` object: ``.name`` / ``.arguments`` attributes.
+    * flat dict: ``{"name", "arguments"}``.
+
+    The nested form is easy to mis-read: pulling top-level ``name``/``arguments`` off it
+    yields empty tool calls (name=""), which is exactly what broke OpenAI function-calling
+    clients like opencode — they received a structurally-present but empty tool call and
+    took no action. Extract ``function`` first, then object attrs, then flat keys.
+    """
     result = []
     for i, tc in enumerate(tool_calls):
-        name = tc.name if hasattr(tc, "name") else tc.get("name", "")
-        args = tc.arguments if hasattr(tc, "arguments") else tc.get("arguments", {})
-        if isinstance(args, dict):
-            args_str = json.dumps(args)
-        else:
-            args_str = str(args)
+        fn = tc.get("function") if isinstance(tc, dict) else None
+        if isinstance(fn, dict):  # prime-rl nested shape
+            name, args = fn.get("name", ""), fn.get("arguments", {})
+        elif isinstance(tc, dict):  # flat dict
+            name, args = tc.get("name", ""), tc.get("arguments", {})
+        else:  # rLLM ToolCall object
+            name, args = getattr(tc, "name", ""), getattr(tc, "arguments", {})
+        args_str = json.dumps(args) if isinstance(args, dict) else str(args)
         result.append(
             {
                 "id": f"call_{i}",
@@ -85,12 +101,23 @@ async def _token_prompt_completion(
     token_output = await engine.get_token_output_from_token_input(prompt_ids, **sampling_kwargs)
     model_output = engine.assemble_model_output(prompt_ids, token_output)
 
-    # Text the agent sees as the assistant turn (same precedence as the chat path).
-    text = model_output.content or model_output.text or ""
+    # Structured tool calls (parsed by the engine's renderer). Carried on the choice
+    # so the gateway's cumulative-turn translation can surface them to OpenAI
+    # function-calling clients (opencode) — the token-in bridge skips the serving
+    # stack's own chat parser, so this is the only place they get produced here.
+    raw_tool_calls = getattr(model_output, "tool_calls", None)
+    tool_calls = _to_openai_tool_calls(raw_tool_calls) if raw_tool_calls else None
+    # Text the agent sees as the assistant turn. With structured tool calls, use the
+    # parse-stripped content (may be "") — don't fall back to model_output.text, which
+    # would reinject the raw <tool_call> XML. Without tool calls, keep the text fallback
+    # so text-protocol harnesses (Terminus-2) still see the full output.
+    text = (model_output.content or "") if tool_calls else (model_output.content or model_output.text or "")
     out_prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else list(prompt_ids)
     completion_ids = list(model_output.completion_ids) if model_output.completion_ids else []
     logprobs = model_output.logprobs or []
     finish_reason = model_output.finish_reason or "stop"
+    if tool_calls and finish_reason == "stop":
+        finish_reason = "tool_calls"
     prompt_len = model_output.prompt_length or len(out_prompt_ids)
     completion_len = model_output.completion_length or len(completion_ids)
     # R3 router replay: read matrices off the TokenOutput (assemble_model_output
@@ -98,21 +125,25 @@ async def _token_prompt_completion(
     # them every cumulative turn.
     routing_matrices = getattr(token_output, "routing_matrices", None)
 
+    choice: dict[str, Any] = {
+        "index": 0,
+        "text": text,
+        "token_ids": completion_ids,
+        "finish_reason": finish_reason,
+        "routing_matrices": routing_matrices,
+        "logprobs": {"token_logprobs": logprobs},
+    }
+    if tool_calls:
+        choice["tool_calls"] = tool_calls
+    if getattr(model_output, "reasoning", None):
+        choice["reasoning"] = model_output.reasoning
+
     return {
         "id": f"cmpl-{uuid.uuid4().hex[:12]}",
         "object": "text_completion",
         "created": int(time.time()),
         "model": request_body.get("model", getattr(engine, "model_name", "default")),
-        "choices": [
-            {
-                "index": 0,
-                "text": text,
-                "token_ids": completion_ids,
-                "finish_reason": finish_reason,
-                "routing_matrices": routing_matrices,
-                "logprobs": {"token_logprobs": logprobs},
-            }
-        ],
+        "choices": [choice],
         "usage": {
             "prompt_tokens": prompt_len,
             "completion_tokens": completion_len,
@@ -177,7 +208,10 @@ def create_tinker_handler(engine: TinkerEngine) -> Callable[[dict[str, Any]], Aw
         except TerminationEvent as e:
             raise _termination_http_error(e.reason) from e
 
-        response_text = model_output.content or model_output.text or ""
+        # With structured tool calls, use parse-stripped content (don't fall back to
+        # model_output.text, which reinjects the raw <tool_call> XML); otherwise keep
+        # the text fallback so text-protocol harnesses see the full output.
+        response_text = (model_output.content or "") if model_output.tool_calls else (model_output.content or model_output.text or "")
         prompt_ids = list(model_output.prompt_ids) if model_output.prompt_ids else []
         completion_ids = list(model_output.completion_ids) if model_output.completion_ids else []
         logprobs = model_output.logprobs or []

--- a/tests/test_tinker_adapter_cumulative.py
+++ b/tests/test_tinker_adapter_cumulative.py
@@ -10,8 +10,9 @@ Uses a fake engine so no Tinker service / model is required.
 """
 
 import asyncio
+from types import SimpleNamespace
 
-from rllm.gateway.tinker_adapter import create_tinker_handler
+from rllm.gateway.tinker_adapter import _to_openai_tool_calls, create_tinker_handler
 
 
 class _ModelOutput:
@@ -89,3 +90,60 @@ def test_non_int_prompt_falls_through_to_chat():
     asyncio.run(handler({"prompt": "hello", "messages": [{"role": "user", "content": "hi"}]}))
     assert engine.token_input is None
     assert engine.messages == [{"role": "user", "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# Tool-call conversion. The prime-rl ``renderers`` parsers (parse_qwen35 etc.)
+# return tool calls nested under ``function`` — reading top-level ``name`` there
+# silently produced empty tool calls, which broke OpenAI function-calling clients
+# (opencode) in cumulative-mode training. Both handler paths must now emit correct,
+# structured tool_calls, and must NOT reinject the raw <tool_call> XML into content.
+# ---------------------------------------------------------------------------
+
+
+def test_to_openai_tool_calls_handles_all_producer_shapes():
+    # prime-rl nested shape (the one that used to yield name="").
+    assert _to_openai_tool_calls([{"function": {"name": "bash", "arguments": {"command": "ls"}}}]) == [
+        {"id": "call_0", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}
+    ]
+    # flat dict and ToolCall object still work.
+    assert _to_openai_tool_calls([{"name": "edit", "arguments": {"p": 1}}])[0]["function"]["name"] == "edit"
+    assert _to_openai_tool_calls([SimpleNamespace(name="read", arguments={"f": "x"})])[0]["function"]["name"] == "read"
+
+
+class _ToolModelOutput(_ModelOutput):
+    content = ""  # parse-stripped when the whole turn is a tool call
+    text = "<tool_call>\n<function=bash>\n<parameter=command>\nls\n</parameter>\n</function>\n</tool_call>"
+    reasoning = "let me think"
+    tool_calls = [{"function": {"name": "bash", "arguments": {"command": "ls"}}}]  # prime-rl nested
+
+
+class _ToolEngine(_FakeEngine):
+    def assemble_model_output(self, token_input, token_output):
+        return _ToolModelOutput()
+
+    async def get_model_response(self, messages, **kwargs):
+        self.messages = messages
+        return _ToolModelOutput()
+
+
+_TOOLS = [{"type": "function", "function": {"name": "bash"}}]
+
+
+def test_token_path_emits_structured_tool_calls():
+    handler = create_tinker_handler(_ToolEngine())
+    resp = asyncio.run(handler({"prompt": [1, 2, 3, 4], "tools": _TOOLS, "model": "qwen"}))
+    ch = resp["choices"][0]
+    assert ch["tool_calls"][0]["function"] == {"name": "bash", "arguments": '{"command": "ls"}'}
+    assert ch["finish_reason"] == "tool_calls"
+    assert ch["reasoning"] == "let me think"
+    assert ch["text"] == ""  # raw XML NOT reinjected into content
+
+
+def test_chat_path_emits_structured_tool_calls():
+    handler = create_tinker_handler(_ToolEngine())
+    resp = asyncio.run(handler({"messages": [{"role": "user", "content": "hi"}], "tools": _TOOLS, "model": "qwen"}))
+    ch = resp["choices"][0]
+    assert ch["message"]["tool_calls"][0]["function"] == {"name": "bash", "arguments": '{"command": "ls"}'}
+    assert ch["message"]["content"] == ""  # raw XML NOT reinjected
+    assert ch["finish_reason"] == "tool_calls"


### PR DESCRIPTION
## Problem

Training with `--agent opencode` on scaleswe scored **reward 0 on every rollout** while the *same* opencode + model solves ~70% under `rllm eval`, and terminus2 solves ~24% on the identical training path.

Root cause (confirmed by probing the live training gateway): the in-process Fireworks/Tinker handler returned a tool call with an **empty name** — `{"name":"","arguments":"{}"}` — with the raw `<function=bash><parameter=command>` XML left in `content`. opencode (OpenAI function-calling via the Vercel AI SDK) got a structurally-present but empty tool call, executed nothing, and terminated early.

The prime-rl `renderers` parsers (`parse_qwen35` etc.) are **correct** and return tool calls nested as `{"function": {"name","arguments"}}`. But `tinker_adapter._to_openai_tool_calls` read a **top-level** `name`/`arguments`, so it dropped the fields → empty tool call. This hit **both** cumulative and non-cumulative modes (both use the in-process handler + this converter).

- **Eval** was unaffected: it HTTP-proxies to Fireworks' native chat parser and never calls this converter.
- **Terminus-2** was unaffected: it parses raw `content` itself and sends no OpenAI `tools`.

## Fix (refocused to the handler, where all local-handler paths converge)

- **`tinker_adapter._to_openai_tool_calls`**: handle all three producer shapes — prime-rl **nested** `{"function":{…}}`, rLLM `ToolCall` objects, and flat dicts. (This is the core bug.)
- **`_token_prompt_completion`** (cumulative token path): emit structured `tool_calls` + `reasoning` on the choice so the gateway can surface them (the token-in bridge skips the serving stack's own chat parser).
- **Both handler paths**: stop reinjecting the raw `<tool_call>` XML into `content` when structured tool_calls are present (use parse-stripped content).
- **`proxy.py`**: `_assistant_message_from_completion` now **prefers handler-provided** `choice.tool_calls`/`reasoning` (single source of truth) and only parses tokens via the renderer as a **fallback for raw vLLM workers** (verl backend). Gated on the client sending `tools`, so Terminus-2 / no-tools clients are byte-identical.

Client-facing only — training token capture uses the raw `completion_token_ids` and is unchanged.

## Tests

- `tests/test_tinker_adapter_cumulative.py`: nested/flat/object conversion; both handler paths emit correct tool_calls with no raw-XML leakage.
- `rllm-model-gateway/.../test_cumulative_tool_call_reconstruction.py`: gateway pass-through of handler tool_calls, renderer-parse fallback for raw workers, no-tools raw path, local-streaming.
- **251 gateway unit tests + 37 rllm-side tests pass.**

## Validation note

The live training gateway is running the pre-fix code, so a black-box probe there still shows the empty tool call; end-to-end confirmation needs the run restarted on this branch. The correctness chain is proven by tests: renderer emits the nested shape (verified against the live model) → fixed converter maps it → both handler paths emit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)