### PR TITLE
fix(tinker): use the unified renderer for tool calls, not ChatTemplateParser

### DIFF
--- a/rllm/engine/rollout/tinker_engine.py
+++ b/rllm/engine/rollout/tinker_engine.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any, cast
 
 import tinker
@@ -12,6 +13,8 @@ from rllm.engine.rollout.types import ImageProcessor, Processor, TinkerTokenInpu
 from rllm.parser import ChatTemplateParser
 from rllm.tools.tool_base import ToolCall
 from rllm.types import TerminationEvent, TerminationReason
+
+logger = logging.getLogger(__name__)
 
 """
 Utility functions for Tinker engine. Partly borrowed from
@@ -157,13 +160,14 @@ class TinkerEngine(RolloutEngine):
         max_response_length: int = 4096,
         max_model_length: int = 32768,
         sampling_params: dict | None = None,
-        bypass_render_with_parser: bool = True,  # default to True now
+        bypass_render_with_parser: bool = False,
         processor: Processor | None = None,
         image_processor: ImageProcessor | None = None,
         disable_thinking: bool = False,
         accumulate_reasoning: bool = False,
         reasoning_effort: str = "medium",
         renderer_name: str | None = None,
+        renderer_family: str = "auto",
         **kwargs,
     ):
         """
@@ -178,13 +182,24 @@ class TinkerEngine(RolloutEngine):
             max_response_length: Maximum response length in tokens
             max_model_length: Maximum total length (prompt + response) in tokens
             sampling_params: Default sampling parameters (temperature, top_p, etc.)
-            bypass_render_with_parser: If True, use ChatTemplateParser instead of Tinker's renderer
-            processor: Optional processor for multimodal models (used when bypass_render_with_parser=True)
-            image_processor: Optional image processor for vision-language models (used with renderer)
-            disable_thinking: Whether to disable thinking in generation prompt (used when bypass_render_with_parser=True)
-            accumulate_reasoning: Whether to accumulate reasoning (used when bypass_render_with_parser=True)
-            reasoning_effort: The effort level for reasoning (used when bypass_render_with_parser=True)
-            renderer_name: The name of the renderer to use (used when bypass_render_with_parser=True)
+            bypass_render_with_parser: Escape hatch. If True, force the legacy
+                ChatTemplateParser for rendering+parsing and skip the unified
+                renderer entirely. Default False: resolve the rllm.renderers
+                unified renderer (the same one the gateway uses for the
+                cumulative-token bridge), which owns rendering AND completion
+                parsing — including tool_calls. The tinker_cookbook renderer is
+                used only for VLM (image chunking); ChatTemplateParser is the
+                extreme fallback (no unified renderer resolves for the model).
+            processor: Optional processor for multimodal models (ChatTemplateParser path)
+            image_processor: Optional image processor for vision-language models
+                (VLM keeps the tinker_cookbook renderer, which owns image chunking)
+            disable_thinking: Whether to disable thinking in generation prompt (ChatTemplateParser path)
+            accumulate_reasoning: Whether to accumulate reasoning (ChatTemplateParser path)
+            reasoning_effort: The effort level for reasoning (ChatTemplateParser path)
+            renderer_name: Pin a specific renderer (tinker-style name, e.g. "qwen3_5").
+            renderer_family: Pin a prime-rl renderer family (e.g. "qwen3.6"); "auto"
+                infers from the model id. Should match rllm.gateway.renderer_family
+                so the engine renders turn 0 like the gateway bridges turns 1+.
         """
         super().__init__()
         self.base_url = base_url
@@ -193,35 +208,79 @@ class TinkerEngine(RolloutEngine):
         self.max_response_length = max_response_length
         self.max_model_length = max_model_length - 1
         self.tokenizer = tokenizer
-        self.bypass_render_with_parser = bypass_render_with_parser
         self.accumulate_reasoning = accumulate_reasoning
         self.reasoning_effort = reasoning_effort
-        # Optional unified renderer (rllm.renderers). When set, it owns prompt
-        # rendering and completion parsing for both backends; ``renderer`` (the
-        # tinker_cookbook renderer) and ``chat_parser`` remain the fallbacks.
-        # Base TinkerEngine leaves this None (no behavior change); FireworksEngine
-        # sets it via rllm.renderers.resolve.
-        self.unified_renderer = None
+        # Retained so a separate-process gateway can rebuild an equivalent engine.
+        self.renderer_family = renderer_family
 
         self.train_sampling_params = dict(sampling_params.get("train", {})) if sampling_params else {}
         self.val_sampling_params = dict(sampling_params.get("val", {})) if sampling_params else {}
         # Initialize Tinker service client
         self.service_client = service_client
 
-        # Initialize the renderer
-        if renderer_name is None:
-            try:
-                renderer_name = model_info.get_recommended_renderer_name(self.model_name)
-            except KeyError as e:
-                raise ValueError(
-                    f"tinker_cookbook's model_info does not know '{self.model_name}' (the cookbook release can lag "
-                    f"models the Tinker service already supports). Set rollout_engine.renderer_name explicitly to a "
-                    f"renderer matching the model's chat template (e.g. 'qwen3_5' for Qwen3.6 models)."
-                ) from e
-        # Pass image_processor for VLM support with Tinker renderer
-        self.renderer = renderers.get_renderer(renderer_name, self.tokenizer, image_processor=image_processor)
+        # --- Renderer / parser resolution --------------------------------------
+        # Mirror FireworksEngine so the engine renders turn 0 with the SAME renderer
+        # the gateway uses for the turn-1+ cumulative bridge (rllm.renderers, resolved
+        # from the model id + renderer_family/renderer_name). Priority:
+        #   1. rllm.renderers unified renderer (prime-rl / tinker-cookbook adapter):
+        #      owns rendering AND completion parsing, incl. <tool_call> -> tool_calls.
+        #      This is the default — Tinker's OpenAI endpoint and ChatTemplateParser do
+        #      NOT surface structured tool_calls, so function-calling harnesses
+        #      (opencode) get an empty tool call and take no action without a real
+        #      renderer. (assemble_model_output / _render_prompt_token_input prefer it.)
+        #   2. tinker_cookbook renderer: VLM only (owns image-chunk rendering).
+        #   3. ChatTemplateParser: extreme fallback — explicit bypass_render_with_parser,
+        #      or no unified renderer resolves for a text model.
+        self.unified_renderer = None
+        self.renderer = None
+        self.chat_parser = None
 
-        if bypass_render_with_parser:
+        if not bypass_render_with_parser and image_processor is None:
+            from rllm.renderers import resolve as _resolve_unified
+
+            res = _resolve_unified(
+                self.model_name,
+                self.tokenizer,
+                backend="tinker",
+                family=renderer_family,
+                renderer_name=renderer_name,
+            )
+            if res.source != "chat_template":
+                self.unified_renderer = res.renderer
+                logger.info("TinkerEngine rendering via %s renderer (source=%s)", res.name, res.source)
+            else:
+                logger.warning(
+                    "No prime-rl/tinker renderer resolved for model=%r (renderer_family=%r, renderer_name=%r); "
+                    "falling back to ChatTemplateParser. Tool-call parsing then depends on the served model "
+                    "matching the hand-rolled template — pin rollout_engine.renderer_name or "
+                    "rllm.gateway.renderer_family to a renderer matching the served model.",
+                    self.model_name,
+                    renderer_family,
+                    renderer_name,
+                )
+
+        if self.unified_renderer is not None:
+            # Unified renderer owns render+parse. bypass stays False so
+            # assemble_model_output/_render_prompt_token_input take the unified branch.
+            self.bypass_render_with_parser = False
+            self.stop_sequences = self.unified_renderer.get_stop_token_ids()
+        elif not bypass_render_with_parser and image_processor is not None:
+            # VLM: the tinker_cookbook renderer owns multimodal (image chunk) rendering.
+            self.bypass_render_with_parser = False
+            if renderer_name is None:
+                try:
+                    renderer_name = model_info.get_recommended_renderer_name(self.model_name)
+                except KeyError as e:
+                    raise ValueError(
+                        f"tinker_cookbook's model_info does not know '{self.model_name}' (the cookbook release can lag "
+                        f"models the Tinker service already supports). Set rollout_engine.renderer_name explicitly to a "
+                        f"renderer matching the model's chat template (e.g. 'qwen3_5' for Qwen3.6 models)."
+                    ) from e
+            self.renderer = renderers.get_renderer(renderer_name, self.tokenizer, image_processor=image_processor)
+            self.stop_sequences = self.renderer.get_stop_sequences()
+        else:
+            # Extreme fallback / explicit escape hatch: ChatTemplateParser owns render+parse.
+            self.bypass_render_with_parser = True
             self.chat_parser = ChatTemplateParser.get_parser(tokenizer, processor=processor, disable_thinking=disable_thinking)
             if hasattr(self.chat_parser, "stop_sequences") and self.chat_parser.stop_sequences:
                 self.stop_sequences = self.chat_parser.stop_sequences
@@ -229,9 +288,6 @@ class TinkerEngine(RolloutEngine):
                 self.stop_sequences = [tokenizer.eos_token_id]
             else:
                 raise ValueError("No stop sequences found for tokenizer or chat parser")
-        else:
-            self.chat_parser = None
-            self.stop_sequences = self.renderer.get_stop_sequences()
 
         # Sampling client will be set via set_sampling_client()
         self.sampling_client = None

--- a/rllm/trainer/config/rllm/backend/tinker.yaml
+++ b/rllm/trainer/config/rllm/backend/tinker.yaml
@@ -12,6 +12,10 @@ fuse_forward_backward_and_optim_step: false
 # Model Configuration
 model:
   name: "Qwen/Qwen3-8B"  # Default model for MATH dataset
+  # HF repo id used to load the tokenizer/renderer. Set this when model.name is a
+  # Tinker model id that isn't HF-resolvable (e.g. "nvidia/...:peft:262144").
+  # null -> tokenizer falls back to model.name.
+  tokenizer_model: null
   lora_rank: 32
   train_unembed: true  # Train LoRA on output embedding layer (set to false for Fireworks compatibility)
   train_attn: true     # Train LoRA on attention layers

--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -144,6 +144,12 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
             else:
                 raise RuntimeError(f"AutoProcessor for {self.full_config.model.name!r} has no .image_processor attribute; this model isn't a VLM or transformers can't expose its image processor.")
 
+        rollout_extra = dict(self.full_config.get("rollout_engine", {}))
+        # Resolve turn-0 rendering with the same renderer the gateway uses for the
+        # cumulative bridge (rllm.gateway.renderer_family), so engine and gateway
+        # agree across turns. An explicit rollout_engine.renderer_family wins.
+        gateway_family = self.full_config.rllm.gateway.get("renderer_family", "auto") if self.full_config.rllm.get("gateway") else "auto"
+        rollout_extra.setdefault("renderer_family", gateway_family)
         self.rollout_engine = TinkerEngine(
             base_url=self.full_config.tinker_base_url,
             model_name=self.full_config.model.name,
@@ -153,8 +159,8 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
             max_response_length=self.full_config.data.max_response_length,
             max_model_length=self.full_config.training.max_length,
             sampling_params=self.full_config.rllm.rollout,
-            **self.full_config.rollout_engine,
             image_processor=image_processor,
+            **rollout_extra,
         )
         return self.rollout_engine
 

--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -112,8 +112,12 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
             transform_config=kwargs.get("transform_config"),
             algorithm_config=kwargs.get("algorithm_config"),
         )
+        # model.name may be a Tinker model id (e.g. "nvidia/...:peft:262144") that
+        # isn't a valid HF repo id; render/tokenize from the HF tokenizer_model when
+        # set, falling back to model.name. (Mirrors the fireworks + SFT tinker backends.)
+        tokenizer_name = self.full_config.model.get("tokenizer_model") or self.full_config.model.name
         # we need to get it from `AutoTokenizer` since the `policy_trainer` has not been initialized yet
-        self.tokenizer = AutoTokenizer.from_pretrained(self.full_config.model.name)
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
 
         # Load image processor for vision-language models.
         # For VLM models, the tinker renderer requires an image_processor to
@@ -121,28 +125,28 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
         # on the first multimodal message). Fail fast here with an actionable
         # message rather than silently leaving image_processor=None.
         image_processor = None
-        model_name_lower = self.full_config.model.name.lower()
+        model_name_lower = tokenizer_name.lower()
         if "vl" in model_name_lower or "vision" in model_name_lower:
             try:
                 from transformers import AutoProcessor
 
-                processor = AutoProcessor.from_pretrained(self.full_config.model.name, trust_remote_code=True)
+                processor = AutoProcessor.from_pretrained(tokenizer_name, trust_remote_code=True)
             except ImportError as e:
                 # Common case: Qwen3-VL needs torchvision for the video
                 # processor, even though we only use the image side.
                 raise RuntimeError(
-                    f"Failed to load AutoProcessor for VLM model {self.full_config.model.name!r}: {e}. "
+                    f"Failed to load AutoProcessor for VLM model {tokenizer_name!r}: {e}. "
                     f"Install the missing dependency (e.g. `uv pip install torchvision` for Qwen3-VL) "
                     f"and retry — the tinker renderer needs an image_processor."
                 ) from e
             except Exception as e:
-                raise RuntimeError(f"Failed to load AutoProcessor for VLM model {self.full_config.model.name!r}: {e}") from e
+                raise RuntimeError(f"Failed to load AutoProcessor for VLM model {tokenizer_name!r}: {e}") from e
 
             if hasattr(processor, "image_processor") and processor.image_processor is not None:
                 image_processor = processor.image_processor
-                logger.info(f"Loaded image_processor for VLM model: {self.full_config.model.name}")
+                logger.info(f"Loaded image_processor for VLM model: {tokenizer_name}")
             else:
-                raise RuntimeError(f"AutoProcessor for {self.full_config.model.name!r} has no .image_processor attribute; this model isn't a VLM or transformers can't expose its image processor.")
+                raise RuntimeError(f"AutoProcessor for {tokenizer_name!r} has no .image_processor attribute; this model isn't a VLM or transformers can't expose its image processor.")
 
         rollout_extra = dict(self.full_config.get("rollout_engine", {}))
         # Resolve turn-0 rendering with the same renderer the gateway uses for the


### PR DESCRIPTION
> **Stacked on #765** (`fix/gateway-cumulative-toolcalls`). This PR's diff is a single commit — the tinker engine renderer change only. It depends on #765 for the handler-level `_to_openai_tool_calls` nested-shape conversion (without it, the tool_calls this renderer produces would flatten to empty). Merge #765 first, or merge this into that branch.

## Problem

Tinker multi-turn tool-calling (opencode / function-calling harnesses) collapsed to ~0 reward in **training**, while the *same* Qwen model works on Fireworks/OpenRouter. Each rollout took ~2 steps then `ENV_DONE` — the agent received no structured `tool_calls`, so it took no action.

## Root cause

Base `TinkerEngine` never resolved the `rllm.renderers` **unified renderer**. Even with `bypass_render_with_parser=false` (the tinker backend config default), it rendered + parsed through the hand-rolled `QwenChatTemplateParser`, which is pinned to the **old Hermes JSON** tool format:

```
<tool_call>{"name": "bash", "arguments": {...}}</tool_call>
```

But **Qwen3.6 emits a different format**:

```
<tool_call>
<function=bash>
<parameter=command>
ls -la
</parameter>
</function>
</tool_call>
```

So the parser extracted **zero** tool calls. Only the model-matched prime-rl `Qwen36Renderer` understands the new format. Fireworks/OpenRouter work because they parse tool calls **server-side** and return native OpenAI `tool_calls`.

## Fix

Mirror `FireworksEngine`:
- `bypass_render_with_parser` now defaults to **`False`**.
- When not bypassed (and not VLM), resolve the **same unified renderer the gateway uses** for the cumulative-token bridge (`rllm.renderers.resolve`, e.g. prime `Qwen36Renderer`). It owns rendering **and** completion parsing, including `<tool_call>` → structured `tool_calls` (nested shape → OpenAI wire format via #765's `_to_openai_tool_calls`).
- `tinker_cookbook` renderer is retained for **VLM** (image chunking).
- `ChatTemplateParser` is now only the **extreme fallback** (no renderer resolves for the model).
- `TinkerBackend` forwards `rllm.gateway.renderer_family` so engine turn-0 rendering matches the gateway's turn-1+ bridge.

## Verified

- `Qwen/Qwen3.6-35B-A3B` (`family=auto`) → prime `Qwen36Renderer`; `parse_response` on a real Qwen3.6 completion yields `[{'function': {'name': 'bash', 'arguments': {'command': 'ls -la'}}}]`.
- Default construction: `unified=Qwen36Renderer`, `chat_parser=None`. `bypass=True` escape hatch: legacy `QwenChatTemplateParser` unchanged.
- `Completer`/`TITOCompleter` (require `chat_parser`) are never instantiated on any live path; distillation guards `teacher_engine.chat_parser` explicitly.

## ⚠️ Eval note (separate issue, not fixed here)

`rllm eval` with `provider=tinker` routes through Tinker's **beta OpenAI-compatible endpoint**, which has **no tool/function-calling support at all** (no `tools` param, no `tool_calls` in responses). There is no client-side parser on that LiteLLM path, so tool-calling eval on Tinker cannot work regardless of this change. Use **Fireworks or OpenRouter** for tool-calling eval.

## Follow-up commit: `model.tokenizer_model` for non-HF Tinker model ids

Tinker `base_model` ids can carry suffixes (e.g. `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16:peft:262144`) that are valid Tinker strings but **invalid HF repo ids**, so `AutoTokenizer.from_pretrained(model.name)` raised `HFValidationError` before training could start. The RL `TinkerBackend` now honors an optional `model.tokenizer_model` (a plain HF repo) for tokenizer/renderer + VLM-processor loading, falling back to `model.name` when unset — mirroring the fireworks and SFT tinker backends. `model.name` still flows to Tinker's `create_lora_training_client_async(base_model=...)` unchanged. Added `tokenizer_model: null` to `rllm/backend/tinker.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
