### PR TITLE
fix(fireworks): port builtin-loss integration to fireworks-ai 1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ tinker = [
 ]
 
 fireworks = [
-    "fireworks-ai[training]==1.2.0a83 ; python_version >= '3.11'",
+    "fireworks-ai[training]==1.2.1 ; python_version >= '3.11'",
     "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
 ]
 

--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -295,9 +295,7 @@ def native_loss_names(backend: str) -> set[str]:
       (vanilla, dppo_tv, dppo_kl, gspo, sapo, gpg, clip_cov, kl_cov, geo_mean, cispo, …)
     * ``tinker``   → ``tinker.types.LossFnType``
       (cross_entropy, importance_sampling, ppo, cispo, dro)
-    * ``fireworks``→ ``tinker.types.LossFnType`` plus the Fireworks-only kernels the
-      training SDK patches onto ``ForwardBackwardInput.loss_fn`` (dapo, gspo — see
-      ``fireworks.training.sdk.patches._builtin_loss_fn_patch``).
+    * ``fireworks``→ ``tinker.types.LossFnType`` + the SDK-patched ``dapo``/``gspo``
       (cross_entropy, importance_sampling, ppo, cispo, dro, dapo, gspo)
 
     Returns an empty set if the backend isn't importable in this process (→ everything falls
@@ -314,8 +312,7 @@ def native_loss_names(backend: str) -> set[str]:
 
             return set(get_args(LossFnType))
         if backend == "fireworks":
-            # fireworks-ai >=1.2.1 removed training.utils.rl.builtin_losses; the builtin RL
-            # kernels are tinker's base LossFnType plus the Fireworks-patched additions.
+            # fireworks-ai >=1.2.1 dropped builtin_losses; use LossFnType + patched dapo/gspo.
             from typing import get_args
 
             from tinker.types import LossFnType

--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -295,8 +295,10 @@ def native_loss_names(backend: str) -> set[str]:
       (vanilla, dppo_tv, dppo_kl, gspo, sapo, gpg, clip_cov, kl_cov, geo_mean, cispo, …)
     * ``tinker``   → ``tinker.types.LossFnType``
       (cross_entropy, importance_sampling, ppo, cispo, dro)
-    * ``fireworks``→ ``training.utils.rl.builtin_losses.BUILTIN_LOSSES``
-      (grpo, importance_sampling, dapo, dro, gspo, cispo)
+    * ``fireworks``→ ``tinker.types.LossFnType`` plus the Fireworks-only kernels the
+      training SDK patches onto ``ForwardBackwardInput.loss_fn`` (dapo, gspo — see
+      ``fireworks.training.sdk.patches._builtin_loss_fn_patch``).
+      (cross_entropy, importance_sampling, ppo, cispo, dro, dapo, gspo)
 
     Returns an empty set if the backend isn't importable in this process (→ everything falls
     back to the rLLM custom path)."""
@@ -312,9 +314,13 @@ def native_loss_names(backend: str) -> set[str]:
 
             return set(get_args(LossFnType))
         if backend == "fireworks":
-            from training.utils.rl.builtin_losses import BUILTIN_LOSSES
+            # fireworks-ai >=1.2.1 removed training.utils.rl.builtin_losses; the builtin RL
+            # kernels are tinker's base LossFnType plus the Fireworks-patched additions.
+            from typing import get_args
 
-            return set(BUILTIN_LOSSES)
+            from tinker.types import LossFnType
+
+            return set(get_args(LossFnType)) | {"dapo", "gspo"}
     except Exception as e:  # backend not installed here → treat as "no native kernels"
         logger.debug("native_loss_names(%r): backend not available (%s)", backend, e)
     return set()

--- a/rllm/trainer/fireworks/fireworks_backend.py
+++ b/rllm/trainer/fireworks/fireworks_backend.py
@@ -42,7 +42,7 @@ from rllm.trainer.algorithms import AlgorithmConfig, simple_timer
 # def _patched_rc_optim_step(self, params, grad_accumulation_normalization=None):
 #     return self._client.optim_step(params).result(timeout=self._default_timeout)
 # _RC.optim_step = _patched_rc_optim_step
-from rllm.trainer.fireworks.fireworks_policy_trainer import FireworksPolicyTrainer, builtin_loss_args
+from rllm.trainer.fireworks.fireworks_policy_trainer import FireworksPolicyTrainer
 from rllm.trainer.tinker.tinker_backend import TinkerBackend
 from rllm.trainer.tinker.tinker_metrics_utils import (
     update_training_metrics,
@@ -148,17 +148,10 @@ class FireworksBackend(TinkerBackend):
         """Provision the trainer job, deployment, and sampler via the
         cookbook's ``training.provision.init_fireworks_infra``."""
         cfg = self.full_config
-        # Fail fast on loss misconfiguration before provisioning any
-        # (expensive, slow-to-create) remote infrastructure.
-        from training.utils.rl.losses import validate_loss_path
-
-        from rllm.trainer.algorithms.loss import native_loss_names, resolve_loss
-
         algorithm_config = kwargs.get("algorithm_config") or AlgorithmConfig.from_config(cfg.rllm.algorithm)
-        # A custom rLLM loss (e.g. dppo_tv) runs on the client forward_backward_custom path,
-        # not a Fireworks builtin kernel, so the builtin-loss validation does not apply.
-        if resolve_loss(algorithm_config, native_losses=native_loss_names("fireworks")) is None:
-            validate_loss_path(builtin_loss_args(algorithm_config))
+        # fireworks-ai >=1.2.1 removed training.utils.rl.losses.validate_loss_path (the old
+        # pre-provision fail-fast for builtin losses); the builtin loss config is now resolved
+        # and validated in FireworksPolicyTrainer.resolve_builtin_loss at setup instead.
 
         provision_cfg = self._build_provision_config(algorithm_config)
 

--- a/rllm/trainer/fireworks/fireworks_backend.py
+++ b/rllm/trainer/fireworks/fireworks_backend.py
@@ -149,9 +149,8 @@ class FireworksBackend(TinkerBackend):
         cookbook's ``training.provision.init_fireworks_infra``."""
         cfg = self.full_config
         algorithm_config = kwargs.get("algorithm_config") or AlgorithmConfig.from_config(cfg.rllm.algorithm)
-        # fireworks-ai >=1.2.1 removed training.utils.rl.losses.validate_loss_path (the old
-        # pre-provision fail-fast for builtin losses); the builtin loss config is now resolved
-        # and validated in FireworksPolicyTrainer.resolve_builtin_loss at setup instead.
+        # (fireworks-ai >=1.2.1 dropped validate_loss_path; builtin loss is resolved in
+        # FireworksPolicyTrainer.resolve_builtin_loss instead.)
 
         provision_cfg = self._build_provision_config(algorithm_config)
 

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -44,20 +44,9 @@ DEFAULT_DCP_TIMEOUT = 2700
 
 
 def builtin_loss_args(algorithm_config: AlgorithmConfig) -> tuple[str, object | None]:
-    """Map an rllm ``AlgorithmConfig`` to a Fireworks builtin ``(loss_fn, loss_fn_config)``.
-
-    fireworks-ai >=1.2.1 replaced the ``LossConfig`` / ``get_builtin_loss_config`` /
-    ``validate_loss_path`` machinery: datums are built by ``build_grpo_datums`` (which folds the
-    advantage + TIS weight into the ``advantages`` field), and the policy loss is a **name**
-    passed to ``forward_backward(data, loss_fn=..., loss_fn_config=...)``. Valid names are
-    tinker's base kernels + the Fireworks-patched ``dapo``/``gspo``:
-    ``importance_sampling, ppo, cispo, dro, dapo, gspo``.
-
-    There is no ``grpo`` kernel name anymore — GRPO == ``build_grpo_datums`` (group-normalized,
-    advantage-weighted datums) + the ``importance_sampling`` loss — so ``loss_fn`` unset (or the
-    legacy ``"grpo"``) maps to ``importance_sampling``. ``dapo``/``gspo``/``cispo`` carry their
-    own clip config; the others take ``None``.
-    """
+    """rllm ``AlgorithmConfig`` -> Fireworks builtin ``(loss_fn, loss_fn_config)`` (fireworks-ai
+    >=1.2.1). No ``grpo`` kernel: GRPO is build_grpo_datums + ``importance_sampling``, so
+    unset/"grpo" maps there; dapo/gspo/cispo carry their own clip config."""
     eps = algorithm_config.eps_clip
     eps_high = algorithm_config.eps_clip_high
     name = algorithm_config.loss_fn or "grpo"
@@ -462,17 +451,14 @@ class FireworksPolicyTrainer:
         """
         from rllm.trainer.algorithms.loss import native_loss_names, resolve_loss
 
-        # A custom rLLM loss (e.g. dppo_tv, icepop) uses forward_backward_custom, not a builtin
-        # kernel — nothing to resolve here (self._builtin_loss stays unused). Do this check
-        # BEFORE touching training.utils.rl so a custom-loss run never imports the builtin API
-        # (fireworks-ai >=1.2.1 reshaped it).
+        # Custom rLLM loss (icepop/dppo_tv) -> forward_backward_custom, no builtin kernel. Check
+        # first so a custom-loss run never imports the (1.2.1-reshaped) builtin API.
         if resolve_loss(algorithm_config, native_losses=native_loss_names("fireworks")) is not None:
             self._builtin_loss = None
             logger.info("Custom rLLM loss %r -> forward_backward_custom (no builtin kernel)", algorithm_config.loss_fn)
             return
 
-        # Builtin server-side kernel path. fireworks-ai >=1.2.1 dropped validate_loss_path /
-        # get_builtin_loss_config; the loss is just a (name, config) pair for forward_backward.
+        # Builtin kernel: just a (loss_fn, config) name pair for forward_backward.
         self._builtin_loss = builtin_loss_args(algorithm_config)
         logger.info("Resolved builtin loss: kernel=%s, config=%s", self._builtin_loss[0], self._builtin_loss[1])
 
@@ -593,10 +579,8 @@ class FireworksPolicyTrainer:
             )
             adv_metrics["time/proximal_forward"] = time.perf_counter() - t0
 
-        # Build datums for the builtin kernel. fireworks-ai >=1.2.1: build_grpo_datums folds the
-        # advantage + TIS weight into the per-token advantages (server sees only logprobs +
-        # advantages); the policy loss is no longer selected here but passed to forward_backward
-        # as loss_fn (see resolve_builtin_loss / self._builtin_loss).
+        # build_grpo_datums folds advantage + TIS into per-token advantages (fireworks-ai 1.2.1);
+        # the loss name is passed separately to forward_backward (self._builtin_loss).
         tis_config = TISConfig(level=rc.tis_mode or "token", cap=rc.tis_cap) if rc.tis_mode else None
         builtin_datums = build_grpo_datums(
             clean_datums,

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -43,35 +43,41 @@ logger = logging.getLogger(__name__)
 DEFAULT_DCP_TIMEOUT = 2700
 
 
-def builtin_loss_args(algorithm_config: AlgorithmConfig):
-    """Map an rllm ``AlgorithmConfig`` to the cookbook's ``LossArgs`` for the
-    builtin (server-side) loss path."""
-    from training.utils.rl.cispo import CISPOConfig
-    from training.utils.rl.dapo import DAPOConfig
-    from training.utils.rl.gspo import GSPOConfig
-    from training.utils.rl.losses import LossConfig
+def builtin_loss_args(algorithm_config: AlgorithmConfig) -> tuple[str, object | None]:
+    """Map an rllm ``AlgorithmConfig`` to a Fireworks builtin ``(loss_fn, loss_fn_config)``.
 
+    fireworks-ai >=1.2.1 replaced the ``LossConfig`` / ``get_builtin_loss_config`` /
+    ``validate_loss_path`` machinery: datums are built by ``build_grpo_datums`` (which folds the
+    advantage + TIS weight into the ``advantages`` field), and the policy loss is a **name**
+    passed to ``forward_backward(data, loss_fn=..., loss_fn_config=...)``. Valid names are
+    tinker's base kernels + the Fireworks-patched ``dapo``/``gspo``:
+    ``importance_sampling, ppo, cispo, dro, dapo, gspo``.
+
+    There is no ``grpo`` kernel name anymore — GRPO == ``build_grpo_datums`` (group-normalized,
+    advantage-weighted datums) + the ``importance_sampling`` loss — so ``loss_fn`` unset (or the
+    legacy ``"grpo"``) maps to ``importance_sampling``. ``dapo``/``gspo``/``cispo`` carry their
+    own clip config; the others take ``None``.
+    """
     eps = algorithm_config.eps_clip
     eps_high = algorithm_config.eps_clip_high
-    return LossConfig(
-        policy_loss=algorithm_config.loss_fn or "grpo",
-        loss_path="builtin",
-        kl_beta=algorithm_config.kl_beta,
-        eps_clip=eps,
-        eps_clip_high=eps_high,
-        dapo=DAPOConfig(
-            eps_clip=eps,
-            eps_clip_high=eps_high if eps_high is not None else 0.28,
-        ),
-        gspo=GSPOConfig(
-            clip_ratio_low=eps,
-            clip_ratio_high=eps_high,
-        ),
-        cispo=CISPOConfig(
-            eps_low=eps,
-            eps_high=eps_high if eps_high is not None else 0.28,
-        ),
-    )
+    name = algorithm_config.loss_fn or "grpo"
+    if name == "grpo":
+        name = "importance_sampling"
+
+    config: object | None = None
+    if name == "dapo":
+        from training.utils.rl.dapo import DAPOConfig
+
+        config = DAPOConfig(eps_clip=eps, eps_clip_high=eps_high if eps_high is not None else 0.28)
+    elif name == "gspo":
+        from training.utils.rl.gspo import GSPOConfig
+
+        config = GSPOConfig(clip_ratio_low=eps, clip_ratio_high=eps_high)
+    elif name == "cispo":
+        from training.utils.rl.cispo import CISPOConfig
+
+        config = CISPOConfig(eps_low=eps, eps_high=eps_high if eps_high is not None else 0.28)
+    return name, config
 
 
 class FireworksPolicyTrainer:
@@ -454,22 +460,21 @@ class FireworksPolicyTrainer:
         Raises ValueError if the loss has no builtin kernel or the config is
         incompatible with the builtin path (e.g. kl_beta > 0).
         """
-        from training.utils.rl.losses import get_builtin_loss_config, validate_loss_path
-
         from rllm.trainer.algorithms.loss import native_loss_names, resolve_loss
 
-        # A custom rLLM loss (e.g. dppo_tv) uses forward_backward_custom, not a builtin
-        # kernel — nothing to resolve/validate here (self._builtin_loss stays unused).
+        # A custom rLLM loss (e.g. dppo_tv, icepop) uses forward_backward_custom, not a builtin
+        # kernel — nothing to resolve here (self._builtin_loss stays unused). Do this check
+        # BEFORE touching training.utils.rl so a custom-loss run never imports the builtin API
+        # (fireworks-ai >=1.2.1 reshaped it).
         if resolve_loss(algorithm_config, native_losses=native_loss_names("fireworks")) is not None:
             self._builtin_loss = None
             logger.info("Custom rLLM loss %r -> forward_backward_custom (no builtin kernel)", algorithm_config.loss_fn)
             return
 
-        args = builtin_loss_args(algorithm_config)
-        validate_loss_path(args, profile)
-        result = get_builtin_loss_config(args)
-        self._builtin_loss = result
-        logger.info("Resolved builtin loss: kernel=%s, config=%s", result[0], result[1])
+        # Builtin server-side kernel path. fireworks-ai >=1.2.1 dropped validate_loss_path /
+        # get_builtin_loss_config; the loss is just a (name, config) pair for forward_backward.
+        self._builtin_loss = builtin_loss_args(algorithm_config)
+        logger.info("Resolved builtin loss: kernel=%s, config=%s", self._builtin_loss[0], self._builtin_loss[1])
 
     # ------------------------------------------------------------------
     # Forward-backward
@@ -490,7 +495,7 @@ class FireworksPolicyTrainer:
         Returns:
             ``(training_datums, training_logprobs, adv_metrics)``
         """
-        from training.utils.rl.losses import build_builtin_loss_datums
+        from training.utils.rl.losses import build_grpo_datums
         from training.utils.rl.tis import TISConfig
 
         if algorithm_config is None:
@@ -588,16 +593,18 @@ class FireworksPolicyTrainer:
             )
             adv_metrics["time/proximal_forward"] = time.perf_counter() - t0
 
-        # Build datums for the builtin kernel.
+        # Build datums for the builtin kernel. fireworks-ai >=1.2.1: build_grpo_datums folds the
+        # advantage + TIS weight into the per-token advantages (server sees only logprobs +
+        # advantages); the policy loss is no longer selected here but passed to forward_backward
+        # as loss_fn (see resolve_builtin_loss / self._builtin_loss).
         tis_config = TISConfig(level=rc.tis_mode or "token", cap=rc.tis_cap) if rc.tis_mode else None
-        builtin_datums = build_builtin_loss_datums(
+        builtin_datums = build_grpo_datums(
             clean_datums,
             advantages,
             prox_logprobs,
             inf_logprobs,
             prompt_lens,
             tis_config=tis_config,
-            policy_loss=algorithm_config.loss_fn or "grpo",
         )
 
         kernel_loss, kernel_config = self._builtin_loss


### PR DESCRIPTION
## Problem

fireworks-ai[training] **1.2.1** refactored the server-side RL loss API and removed the symbols rLLM's Fireworks backend imported, so `bash train_fireworks_*.sh` fails at startup:

```
ImportError: cannot import name 'validate_loss_path' from 'training.utils.rl.losses'
```

Also gone: `get_builtin_loss_config`, `build_builtin_loss_datums`, `LossConfig`, and the whole `training.utils.rl.builtin_losses` module. rLLM's backend was written for 1.2.0a83.

## New 1.2.1 model

- Datums are built by `build_grpo_datums(data, advantages, old_policy_logprobs, inf_logprobs, prompt_lens, tis_config=None)` — it folds advantage × TIS × mask into the `advantages` field (server sees only `logprobs` + `advantages`).
- The policy loss is a **name** passed to `forward_backward(data, loss_fn=…, loss_fn_config=…)`.
- Valid names: tinker `LossFnType` `{cross_entropy, importance_sampling, ppo, cispo, dro}` + Fireworks-patched `{dapo, gspo}`. **No `grpo`** (GRPO = `build_grpo_datums` + `importance_sampling`).

## Port

- **`algorithms/loss.py` `native_loss_names("fireworks")`** → derive from `tinker.LossFnType | {dapo, gspo}` (removed `BUILTIN_LOSSES`).
- **`fireworks_backend.py` `_init_fireworks_infra`** → drop the removed `validate_loss_path` pre-provision check + its now-unused import.
- **`fireworks_policy_trainer.py`**
  - `builtin_loss_args` → returns `(loss_fn_name, loss_fn_config)`; `None`/`"grpo"`→`importance_sampling(None)`, `dapo`/`gspo`/`cispo`→their config objects.
  - `resolve_builtin_loss` → no `validate_loss_path`/`get_builtin_loss_config`; runs the custom-loss check **first** so custom-loss runs never import the builtin API; else stores `(name, config)`.
  - `forward_backward_from_trajectory_groups` → `build_grpo_datums` (drops the removed `policy_loss` arg).

Only the client-facing loss integration changed; token capture / provisioning are untouched.

## Verification

- Modules import cleanly (no `validate_loss_path` error); `native_loss_names` = `{cross_entropy, importance_sampling, ppo, cispo, dro, dapo, gspo}`.
- **Custom rLLM losses (icepop / dppo_tv) route to `forward_backward_custom` untouched** — this is what the swe-rl/terminal-rl cookbooks run.
- The **builtin server-side kernel path** (plain `grpo`/`dapo`/`gspo`/`cispo`) is ported but **not yet live-validated** against a running Fireworks builtin-loss job. Two things to confirm there: (a) `forward_backward` accepting `DAPOConfig`/`GSPOConfig`/`CISPOConfig` objects as `loss_fn_config`, and (b) GRPO ≡ `importance_sampling` + `build_grpo_datums`.

Base: `terminal-rl` (per the repo convention that algo/loss changes are based there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)