### PR TITLE
fix(sandbox): make SnapshotRegistry picklable for Ray actor serialization

### DIFF
--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -173,6 +173,23 @@ class SnapshotRegistry:
         self._groups: dict[str, dict] = groups if groups is not None else {}
         self._lock = threading.Lock()
 
+    def __getstate__(self) -> dict:
+        # ``threading.Lock`` is not picklable. This class instance travels
+        # through ``ray.put`` / actor arg serialization when ``SandboxTaskHooks``
+        # (which holds a ``_registry: SnapshotRegistry``) is sent to a verl
+        # ``VerlTaskRunner`` actor. Ray uses cloudpickle, which rejects locks
+        # with ``TypeError: cannot pickle '_thread.lock' object``. Strip the
+        # lock on pickle; it will be recreated fresh on unpickle. Any
+        # cross-process consistency was already going to break at the object-
+        # copy boundary — locks don't survive serialization semantically.
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
     @classmethod
     def load(cls) -> SnapshotRegistry:
         path = _registry_path()

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -506,3 +506,45 @@ def test_hook_install_honors_baked_script(monkeypatch, baked_install, expected_c
     ctx = _hook_setup(monkeypatch, sandbox, _install_flow())
     assert sandbox.calls == expected_calls
     assert ctx.env is sandbox
+
+
+class TestSnapshotRegistryPickle:
+    """SnapshotRegistry travels through cloudpickle/pickle when SandboxTaskHooks
+    (which holds a ``_registry: SnapshotRegistry``) is sent to a Ray actor
+    (e.g. verl ``VerlTaskRunner``). Without ``__getstate__`` / ``__setstate__``
+    the built-in ``threading.Lock`` fails with
+    ``TypeError: cannot pickle '_thread.lock' object`` and every rollout crashes
+    before it starts.
+    """
+
+    def test_registry_survives_pickle_roundtrip(self, tmp_path):
+        import pickle
+
+        original = SnapshotRegistry(
+            path=str(tmp_path / "registry.json"),
+            envs={"env-1": {"image": "foo:1"}},
+            groups={"group-a": {"envs": ["env-1"]}},
+        )
+        restored = pickle.loads(pickle.dumps(original))
+        # State survives the roundtrip.
+        assert restored.path == original.path
+        assert restored._envs == original._envs
+        assert restored._groups == original._groups
+        # Lock is recreated fresh on unpickle (was stripped on pickle).
+        assert restored._lock is not original._lock
+        # Restored lock is a fully functional threading.Lock.
+        assert restored._lock.acquire(blocking=False)
+        restored._lock.release()
+
+    def test_registry_pickles_via_cloudpickle(self, tmp_path):
+        """Ray uses cloudpickle under the hood; ensure that path also works."""
+        try:
+            import cloudpickle
+        except ImportError:
+            pytest.skip("cloudpickle not installed")
+
+        original = SnapshotRegistry(path=str(tmp_path / "registry.json"))
+        restored = cloudpickle.loads(cloudpickle.dumps(original))
+        assert restored.path == original.path
+        assert restored._lock.acquire(blocking=False)
+        restored._lock.release()


### PR DESCRIPTION
## Summary

`SandboxTaskHooks` holds a `_registry: SnapshotRegistry`, which travels through cloudpickle when Ray sends the hooks to a `VerlTaskRunner` actor at rollout time. `SnapshotRegistry.__init__` creates a `threading.Lock`, cloudpickle rejects native locks, and every rollout crashes before it starts on any `SandboxedAgentFlow + verl` training config.

## Minimal repro

Runs directly against `main` (no cookbook / no cluster / no verl needed):

```python
import cloudpickle
from rllm.sandbox.snapshot import SnapshotRegistry

cloudpickle.loads(cloudpickle.dumps(SnapshotRegistry()))
# TypeError: cannot pickle '_thread.lock' object
```

At training time, this surfaces at `rllm/trainer/verl/verl_launcher.py::VerlTaskRunner.run.remote(...)` with:

```
ray.exceptions.RayTaskError: TypeError: Could not serialize the argument
    <rllm.hooks.SandboxTaskHooks ...>
================================================================================
Checking Serializability of <rllm.hooks.SandboxTaskHooks ...>
================================================================================
!!! FAIL serialization: cannot pickle '_thread.lock' object
Serializing '_registry' <rllm.sandbox.snapshot.SnapshotRegistry ...>
```

## Fix

Add the standard `__getstate__` / `__setstate__` pickle protocol on `SnapshotRegistry` — strip `_lock` on pickle, recreate it fresh on unpickle. The lock guards in-process registry-file writes; it never survived serialization semantically, so recreating on the receiving side is the correct behavior (each process gets its own lock over its own copy of state).

9 lines in `rllm/sandbox/snapshot.py`, no other code files touched.

## Tests

`tests/sandbox/test_snapshot.py::TestSnapshotRegistryPickle` covers:

- **stdlib `pickle`** roundtrip — validates `path`, `_envs`, `_groups` survive and the restored `_lock` is a fresh functional `threading.Lock`
- **`cloudpickle`** roundtrip (Ray's actual serializer) — same assertions, `pytest.skip` gracefully if `cloudpickle` isn't installed

Local run: both new tests pass; existing `test_snapshot.py` remains green (the 2 skips are pre-existing `modal` / `daytona` optional-dep skips unrelated to this change).

## Risk

Minimal. `__getstate__` / `__setstate__` is stdlib pickle protocol; the change only takes effect when someone actually pickles a `SnapshotRegistry` (previously an unconditional crash). In-process behavior is byte-identical.

## Notes

- Discovered while running a verl-backend training smoke on Koala GPU cluster. Any `SandboxTaskHooks + verl` combination on `main` reproduces.
- A separate PR proposes URL-encoding `session_id` in `GatewayManager.get_session_url` — unrelated defensive hardening, no bug-fix claim; I'll link if useful.
