### PR TITLE
Filter empty response attempts before trace enrichment

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from tqdm import tqdm
 
 from rllm.data.utils import task_from_row
-from rllm.engine.trace_converter import compute_step_metrics, trace_record_to_step
+from rllm.engine.trace_converter import compute_step_metrics, filter_empty_response_traces, trace_record_to_step
 from rllm.eval.types import EvalOutput
 from rllm.gateway.manager import container_reachable_url
 from rllm.types import INFRA_ERROR_REASONS, AgentConfig, Episode, Step, Task, TerminationReason, Trajectory, flow_accepts_env, run_agent_flow, termination_reason_from_error
@@ -149,6 +149,16 @@ def enrich_episode_with_traces(
     the evaluator reads ``model_response`` / ``chat_completions``, which are
     populated regardless of token-ID availability.
     """
+    trace_attempt_count = len(traces)
+    traces = filter_empty_response_traces(traces)
+    empty_response_traces_dropped = trace_attempt_count - len(traces)
+    if empty_response_traces_dropped:
+        logger.warning(
+            "[%s] dropping %d empty-response trace(s) before episode enrichment",
+            uid,
+            empty_response_traces_dropped,
+        )
+
     if not traces:
         logger.warning("[%s] No traces found — returning episode without token data", uid)
         # Coerce to the canonical Trajectory/Episode shape so downstream
@@ -160,7 +170,12 @@ def enrich_episode_with_traces(
             is_correct=episode.is_correct,
             termination_reason=episode.termination_reason,
             trajectories=[t if isinstance(t, Trajectory) else Trajectory(**t.model_dump()) for t in episode.trajectories],
-            metrics=episode.metrics,
+            metrics={
+                **episode.metrics,
+                "empty": 1,
+                "steps_collected": 0,
+                "empty_response_traces_dropped": empty_response_traces_dropped,
+            },
             metadata=episode.metadata,
             artifacts=episode.artifacts,
         )
@@ -254,8 +269,10 @@ def enrich_episode_with_traces(
 
     # Compute metrics
     metrics = compute_step_metrics(enriched_trajectories)
-    metrics["empty"] = int(len(traces) == 0)
-    metrics["steps_collected"] = len(traces)
+    steps_collected = sum(len(trajectory.steps) for trajectory in enriched_trajectories)
+    metrics["empty"] = int(steps_collected == 0)
+    metrics["steps_collected"] = steps_collected
+    metrics["empty_response_traces_dropped"] = empty_response_traces_dropped
     metrics.update(episode.metrics)
 
     return Episode(
@@ -785,7 +802,7 @@ class AgentFlowEngine:
             _llm_sum_s, _llm_wall_s = _summarize_llm_latencies(traces, _agentflow_s)
             _timings["time/agentflow_llm_sum_s"] = _llm_sum_s
             _timings["time/agentflow_llm_wall_s"] = _llm_wall_s
-            _timings["n_turns"] = float(len(traces))
+            _timings["n_turns"] = float(enriched.metrics.get("steps_collected", 0))
 
         # Preserve per-trajectory rewards set by multi-trajectory evaluators.
         for traj in enriched.trajectories:

--- a/rllm/engine/remote_agent_flow_engine.py
+++ b/rllm/engine/remote_agent_flow_engine.py
@@ -15,7 +15,7 @@ from rllm.engine.remote_runtime.protocol import (
     RemoteTaskResult,
     TaskSubmission,
 )
-from rllm.engine.trace_converter import compute_step_metrics, trace_record_to_step
+from rllm.engine.trace_converter import compute_step_metrics, filter_empty_response_traces, trace_record_to_step
 from rllm.gateway.manager import GatewayManager
 from rllm.types import Episode, Step, TerminationReason, Trajectory
 from rllm.utils.episode_logger import EpisodeLogger
@@ -162,6 +162,10 @@ def _build_episode(
     Converts all traces to training Steps via trace_record_to_step(),
     creates a single Trajectory with the remote reward, and computes metrics.
     """
+    trace_attempt_count = len(traces)
+    traces = filter_empty_response_traces(traces)
+    empty_response_traces_dropped = trace_attempt_count - len(traces)
+
     # Convert traces to training steps
     training_steps: list[Step] = []
     if traces:
@@ -191,8 +195,9 @@ def _build_episode(
 
     # Compute metrics
     metrics = compute_step_metrics(trajectories)
-    metrics["empty"] = int(len(traces) == 0)
-    metrics["steps_collected"] = len(traces)
+    metrics["empty"] = int(len(training_steps) == 0)
+    metrics["steps_collected"] = len(training_steps)
+    metrics["empty_response_traces_dropped"] = empty_response_traces_dropped
 
     is_correct = bool(result.reward and result.reward >= 1.0)
 

--- a/rllm/engine/trace_converter.py
+++ b/rllm/engine/trace_converter.py
@@ -10,6 +10,23 @@ from rllm.tools.tool_base import ToolCall
 from rllm.types import Step, Trajectory
 
 
+def is_empty_response_trace(trace: TraceRecord) -> bool:
+    """Return whether a stored request attempt produced no model response.
+
+    Transient HTTP failures can be persisted as traces even though they have
+    no assistant response envelope.  They are request-attempt diagnostics, not
+    model turns, and must be discarded before strict token validation.  A
+    response with empty text is still valid when it has an assistant envelope
+    or a finish reason (for example, a tool-only turn).
+    """
+    return not trace.response_message and trace.finish_reason is None and not trace.completion_token_ids
+
+
+def filter_empty_response_traces(traces: list[TraceRecord]) -> list[TraceRecord]:
+    """Keep only traces that contain evidence of a model response."""
+    return [trace for trace in traces if not is_empty_response_trace(trace)]
+
+
 def _parse_openai_tool_calls(raw_tool_calls: list[dict[str, Any]]) -> list[ToolCall]:
     """Convert OpenAI-format tool_calls to rLLM ToolCall objects."""
     result = []

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -4,7 +4,7 @@ import pytest
 
 from rllm.agents.agent import Episode, Trajectory
 from rllm.data.utils import task_from_row
-from rllm.engine.agentflow_engine import AgentFlowEngine
+from rllm.engine.agentflow_engine import AgentFlowEngine, enrich_episode_with_traces
 from rllm.eval.types import EvalOutput
 from rllm.workflows.workflow import TerminationReason
 
@@ -90,6 +90,64 @@ def _empty_token_trace(session_id: str):
         finish_reason="stop",
         metadata={},
     )
+
+
+def _empty_response_trace(session_id: str, trace_id: str):
+    from rllm_model_gateway.models import TraceRecord
+
+    return TraceRecord(
+        trace_id=trace_id,
+        session_id=session_id,
+        model="m",
+        messages=[{"role": "user", "content": "Q"}],
+        response_message={},
+        prompt_token_ids=[],
+        completion_token_ids=[],
+        logprobs=[],
+        finish_reason=None,
+        metadata={},
+    )
+
+
+def _valid_token_trace(session_id: str):
+    from rllm_model_gateway.models import TraceRecord
+
+    return TraceRecord(
+        trace_id=f"valid-{session_id}",
+        session_id=session_id,
+        model="m",
+        messages=[{"role": "user", "content": "Q"}],
+        response_message={"role": "assistant", "content": "A"},
+        prompt_token_ids=[1, 2],
+        completion_token_ids=[3],
+        logprobs=[-0.1],
+        finish_reason="stop",
+        metadata={},
+    )
+
+
+def test_empty_response_retries_are_filtered_before_strict_enrichment():
+    """Transient API attempts have no response envelope and must not poison
+    the successful same-turn retry that follows them."""
+    session_id = "task:0"
+    episode = Episode(id=session_id, trajectories=[Trajectory(name="solver")])
+    traces = [
+        _empty_response_trace(session_id, "empty-1"),
+        _empty_response_trace(session_id, "empty-2"),
+        _valid_token_trace(session_id),
+    ]
+
+    enriched = enrich_episode_with_traces(
+        episode,
+        traces,
+        session_id,
+        {"question": "q"},
+        strict=True,
+    )
+
+    assert [step.id for step in enriched.trajectories[0].steps] == [f"valid-{session_id}"]
+    assert enriched.metrics["steps_collected"] == 1
+    assert enriched.metrics["empty_response_traces_dropped"] == 2
 
 
 @pytest.mark.parametrize("is_validation", [False, True])

--- a/tests/engine/test_remote_runtime.py
+++ b/tests/engine/test_remote_runtime.py
@@ -227,6 +227,31 @@ class TestBuildEpisodeWithTraces:
         assert episode.metrics["steps_collected"] == 3
         assert episode.metrics["empty"] == 0
 
+    def test_empty_response_attempt_is_not_converted_to_a_step(self):
+        empty_trace = MagicMock(
+            response_message={},
+            finish_reason=None,
+            completion_token_ids=[],
+        )
+        valid_trace = MagicMock(
+            response_message={"role": "assistant", "content": "answer"},
+            finish_reason="stop",
+            completion_token_ids=[1],
+        )
+        result = RemoteTaskResult(
+            finished=True,
+            session_id="sess-1",
+            task_id="task-1",
+            reward=1.0,
+        )
+
+        with patch("rllm.engine.remote_agent_flow_engine.trace_record_to_step", return_value=_make_step()) as mock_convert:
+            episode = _build_episode([empty_trace, valid_trace], result, "task-1:0", {"prompt": "test"})
+
+        mock_convert.assert_called_once_with(valid_trace)
+        assert episode.metrics["steps_collected"] == 1
+        assert episode.metrics["empty_response_traces_dropped"] == 1
+
 
 class TestBuildEpisodeNoTraces:
     def test_no_traces_with_reward(self):

--- a/tests/engine/test_trace_converter.py
+++ b/tests/engine/test_trace_converter.py
@@ -4,6 +4,8 @@ from rllm_model_gateway.models import TraceRecord
 
 from rllm.engine.trace_converter import (
     _parse_openai_tool_calls,
+    filter_empty_response_traces,
+    is_empty_response_trace,
     trace_record_to_step,
 )
 
@@ -183,3 +185,53 @@ class TestTraceRecordToStep:
         )
         step = trace_record_to_step(trace)
         assert step.model_output.tool_calls is None
+
+
+class TestEmptyResponseTraceFilter:
+    def _make_trace(self, **overrides) -> TraceRecord:
+        defaults = {
+            "trace_id": "t-001",
+            "session_id": "s-001",
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "prompt_token_ids": [],
+            "response_message": {},
+            "completion_token_ids": [],
+            "logprobs": [],
+            "finish_reason": None,
+        }
+        defaults.update(overrides)
+        return TraceRecord(**defaults)
+
+    def test_detects_empty_response_without_consulting_logprobs(self):
+        trace = self._make_trace(logprobs=[-0.1])
+
+        assert is_empty_response_trace(trace)
+        assert filter_empty_response_traces([trace]) == []
+
+    def test_preserves_external_response_without_token_ids(self):
+        trace = self._make_trace(
+            response_message={"role": "assistant", "content": "answer"},
+            finish_reason="stop",
+        )
+
+        assert not is_empty_response_trace(trace)
+        assert filter_empty_response_traces([trace]) == [trace]
+
+    def test_preserves_tool_only_response_with_empty_content(self):
+        trace = self._make_trace(
+            response_message={
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            },
+            finish_reason="tool_calls",
+        )
+
+        assert not is_empty_response_trace(trace)


### PR DESCRIPTION
## Summary

- discard persisted request attempts that have no response envelope, finish reason, or completion tokens before converting traces into model steps
- preserve valid tokenless external-provider responses and valid tool-only turns
- report dropped attempt counts and count only usable model turns in episode metrics
- apply the shared filter to both local AgentFlow and remote-runtime episode construction

## Why

A transient API failure such as HTTP 429 can be persisted as a TraceRecord with an empty response_message, no finish_reason, and no completion tokens. The harness retries the same turn successfully, but strict training enrichment currently treats the blank attempt as a missing-token model turn and retries the entire rollout. Evaluation artifacts also gain blank steps.

## Tests

- 40 passed across the directly affected trace converter, AgentFlow engine, and remote-runtime tests
- 55 passed across the engine suite with optional dependency-bound tests excluded
- changed-file Ruff check and format check pass
- regression test reproduces two empty attempts followed by one valid same-turn response