### PR TITLE
feat(trainer): multi-lineage (DAG) prefix merge for subagent trajectories

### DIFF
--- a/design/subagent-dag-merge.md
+++ b/design/subagent-dag-merge.md
@@ -1,0 +1,142 @@
+# Design: Multi-lineage (DAG) prefix merge for subagent trajectories
+
+- **Status:** Layer 1 implemented (trainer-side multi-segment merger in `rllm/trainer/verl/transform.py` + `rllm/trainer/tinker/transform.py`, with tests). Layer 2 (gateway multi-slot accumulator) proposed.
+- **Related:** `design/gateway-dag-token-storage.md` (delta-chain token storage — this is its deferred §7 "full branching DAG", motivated by subagents); `PR_dev-multiturn-merged-rows.md` (the `merge_compression_ratio` metric); `rllm-model-gateway` `token_accumulator.py` / `proxy.py`; `rllm/harnesses/{opencode,cli_harness}.py`.
+- **Scope:** how a multi-turn rollout whose turns do **not** all share one growing prefix (a subagent runs mid-rollout) is merged into training rows, and (proposed) how the gateway should tag such turns.
+
+---
+
+## Summary
+
+`merge_compression_ratio = total_agent_steps / total_emitted_rows` measures how well a
+trajectory's turns collapse into shared-prefix training rows (`= N` for a clean N-turn
+cumulative rollout → 1 row; `= 1` when nothing merges). Under the **opencode** harness with
+**subagents** the ratio collapses toward 1.
+
+Root cause: opencode's `task`-tool subagent runs **inside the same process**, which points at a
+single session-scoped gateway URL `/sessions/<uid>/v1`. The gateway derives session id purely
+from that path, so every LLM call — parent agent *and* subagent — lands in **one** session /
+**one** trajectory, interleaved in time. But a subagent turn is a *fresh conversation* with a
+*different system prompt and tool set*, so it is **not** a byte-prefix-extension of the parent.
+Both the gateway accumulator and the trainer transforms assume a **single** growing prefix, so
+the interleaving `A1, B1, A2, B2, …` breaks merging at every switch.
+
+The fix is the one the [gateway-dag-token-storage RFC §7](gateway-dag-token-storage.md) deferred:
+maintain a **set of open prefix slots** (a forest / DAG of lineages) instead of one linear chain.
+Each turn attaches to the deepest slot it prefix-extends; a turn that extends none opens a new
+slot. Parent turns merge among themselves, subagent turns merge among themselves.
+
+Two layers, independent and separately shippable:
+
+- **Layer 1 — trainer transform (implemented here).** Directly restores the metric, works on
+  already-stored `prompt_ids`, needs **no gateway change and no rerun**.
+- **Layer 2 — gateway multi-slot accumulator (proposed).** Keeps generation drift-free across
+  lineages and materializes the DAG (`parent_trace_id`), composing with the RFC's Phase-1
+  delta-chain storage.
+
+---
+
+## 1. Why it breaks today
+
+**One session per rollout, subagent shares it.** `rllm/engine/agentflow_engine.py` mints one
+`uid` per rollout and hands opencode `base_url = /sessions/<uid>/v1`; the subagent uses the same
+process/URL. `middleware.py` parses the sid from the path (there is no per-subagent header), so
+all traces are stored under that one session and — because the CLI-harness episode has an empty
+trajectory — assigned wholesale to **one** `Trajectory`, ordered by time
+(`enrich_episode_with_traces`).
+
+**Single-prefix assumption, two places:**
+
+- **Gateway** `TokenAccumulator` holds one snapshot (`prev_prompt_ids`, `_prefix_fps`). A subagent
+  turn → `_REL_PREFIX_CHANGED` → `reset()`; returning to the parent → `reset()` again. A reset
+  storm, and each reset drops drift-free token state (next turn re-renders from chat text).
+- **Trainer** `_process_trajectory` (verl) / `trajectory_to_datums` (tinker) keep one running
+  `full_seq` and walk steps in order: a step that doesn't extend it **emits the row and reseeds**,
+  discarding the prior prefix. So `A1,B1,A2,B2` → B1 doesn't extend A1; once A1 is emitted, A2
+  can't rejoin it → one row per turn → ratio → 1.
+
+## 2. Layer 1 — trainer multi-segment merger (implemented)
+
+Replace the single running segment with a **list of open segments**. For each step:
+
+1. Find the open segment whose `full_seq` is a byte-prefix of the step's `prompt_ids`; pick the
+   **longest** match.
+2. Match → extend that segment (append `delta_obs` mask-0, then action mask-1) — unchanged logic.
+3. No match → open a **new** segment (a new lineage root).
+4. At the end, emit **every** open segment as one row.
+
+`A1,B1,A2,B2` → `{A1,A2}` + `{B1,B2}` = 2 rows, each fully merged.
+
+**Why it's safe / contained:**
+
+- **Byte-exact prefix match** is the same cumulative-extension invariant used today; merging is
+  never lossy. Distinct lineages have distinct roots (different system prompt), so at most one
+  segment matches — `longest` also keeps a genuine DAG branch attached to its nearest ancestor.
+- **Backward compatible:** a single-lineage trajectory keeps exactly one open segment and emits
+  one row — byte-identical to the previous behavior. Sequential non-prefix breaks (context reset
+  with no later return) still produce the same row count.
+- **Multi-row-per-trajectory is already supported.** `_emit` keys every row by `trajectory.uid`
+  with the same broadcast scalar advantage; the batch builder and advantage join already handle
+  it. Layer 1 only *reduces* row count (from `#turns` to `#lineages`), improving per-trajectory
+  weight uniformity — it does not introduce a new code path downstream.
+- **Cost** is `~O(#open_segments · prefix_len)` per step (length-guarded before the slice);
+  `#open_segments` is tiny (parent + a few subagent types).
+- The `merge_compression_ratio` / `steps_per_traj` metrics need no change — `total_emitted_rows`
+  now counts `#lineages` and the ratio rises accordingly.
+
+**Open question (not blocking):** whether all lineages of one trajectory should share gradient
+weight (scale advantage by `1/#lineages`) or keep per-row weighting. Layer 1 works either way;
+default keeps current behavior, revisit if it skews.
+
+## 3. Layer 2 — gateway multi-slot accumulator (proposed)
+
+This is the user's "dict of prefix tokens → new prefix takes a new slot → the trajectory becomes a
+DAG," and the fix for the *generation-time* reset storm.
+
+Replace the single-prefix `TokenAccumulator` with a **registry of live slots**, each carrying its
+own `prev_prompt_ids` / `prev_completion_ids` / `_prefix_fps`. `plan_turn` matches an incoming
+request against **all** slots (message-prefix match): extend the matching slot; if none matches,
+**open a new slot instead of `reset()`**. `DUPLICATE`/replay is handled per-slot. A genuine
+compaction (history shrank under an existing slot's snapshot) still resets that slot.
+
+Wins beyond Layer 1:
+
+- Generation stays **drift-free** (cumulative `/v1/completions`) for *both* the parent and each
+  subagent lineage, instead of falling back to chat re-tokenization at every switch.
+- The reset storm (and its log spam) disappears.
+- Each trace can be tagged `parent_trace_id` = the tip of its slot's chain, composing directly
+  with the RFC's Phase-1 delta-chain storage (`token_chain.py`). The DAG is then **materialized**,
+  so a Phase-2 trainer transform could group by lineage from the stored parent pointers instead of
+  re-deriving by byte-match (Layer 1 becomes an optimization, not a necessity).
+
+Slot lifetime is session-local; `delete_session` drops the whole forest. Bounded by a max-slots
+guard (log + fall back to reset on overflow) so a pathological session can't grow slots unbounded.
+
+## 4. Relationship to the token-storage RFC
+
+`design/gateway-dag-token-storage.md` implemented a **linear** delta chain (one accumulator; a
+reset starts a new root) and explicitly deferred (§7) the **branching DAG** for "compaction
+branches" and "cross-rollout prefix sharing." Subagents are exactly the branching case. Layer 2
+generalizes that RFC's single chain into a forest keyed by prefix; the same machinery later
+unlocks its other deferred win (G GRPO rollouts sharing one system prefix, stored once).
+
+## 5. Testing
+
+- **tinker** (`tests/unified_trainer/test_tinker_transform.py`):
+  `test_interleaved_subagent_lineage_remerges` (parent–subagent–parent → 2 Datums, parent mask
+  intact), `test_two_subagents_between_parent_turns` (parent + 2 subagents → 3 Datums). Existing
+  sequential-break and single-lineage tests unchanged.
+- **verl** (`tests/unified_trainer/test_verl_transform.py`):
+  `test_interleaved_subagent_lineage_remerges` (→ 2 rows, parent mask `[1,1,0,1,1]`). The verl
+  module isn't importable in the doc env; the merge algorithm was additionally validated with a
+  standalone replica (interleaved → 2, single-lineage → 1, sequential non-prefix → 2, two
+  subagents → 3).
+- **Layer 2** (proposed): `TokenAccumulator` multi-slot routing across extend / new-slot / replay /
+  reset; parent-pointer round-trip; parity of reconstructed prompts against full-mode output.
+
+## 6. Impact
+
+For a rollout with `S` subagent invocations interleaved through `T` parent turns, the trajectory
+drops from ~`T + S` unmerged rows back to `1 + (#distinct subagent lineages)` rows —
+`merge_compression_ratio` recovers from ~1 toward its no-subagent value. Not opencode-specific:
+claude-code and any subagent-spawning CLI harness benefit.

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -57,33 +57,40 @@ def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[
 
     Then we will merge the first two observation-action pairs into a single Datum,
     and the last observation-action pair into a separate Datum.
+
+    Multiple lineages are kept open at once, so *interleaved* sequences also
+    merge correctly. Given
+
+    (O1, A1)
+    (O3, A3)          # a subagent turn — a fresh conversation, not an extension
+    (O1+A1+O4, A4)    # the parent conversation resumes
+
+    the parent turns (O1,A1) and (O1+A1+O4,A4) merge into one Datum even
+    though a subagent turn ran between them, and (O3,A3) becomes its own
+    Datum — two Datums, not three. Each step attaches to the deepest open
+    lineage it prefix-extends; one that extends none starts a new lineage.
     """
 
     class SequenceAccumulator:
-        full_sequence: TinkerTokenInput = []
-        sampled_logprobs: list[float] = []
-        advantages: list[float] = []
-        mask: list[float] = []
-        routing_matrices: list[str] = []
+        """One open lineage: a growing (obs+action) sequence with aligned arrays."""
 
-        @classmethod
-        def clear(cls):
-            cls.full_sequence = []
-            cls.sampled_logprobs = []
-            cls.advantages = []
-            cls.mask = []
-            cls.routing_matrices = []
+        def __init__(self) -> None:
+            self.full_sequence: TinkerTokenInput = []
+            self.sampled_logprobs: list[float] = []
+            self.advantages: list[float] = []
+            self.mask: list[float] = []
+            self.routing_matrices: list[str] = []
 
-    def make_datum_from_state():
-        all_tokens_T = _flat_token_input_to_model_input(SequenceAccumulator.full_sequence)
+    def make_datum_from_segment(seg: SequenceAccumulator):
+        all_tokens_T = _flat_token_input_to_model_input(seg.full_sequence)
         # this should help handle image chunk as well
         input_tokens_T, target_tokens_T = create_rightshifted_model_input_and_leftshifted_targets(list(all_tokens_T.chunks))
-        sampled_logprobs_T = SequenceAccumulator.sampled_logprobs[1:]
-        advantages_T = SequenceAccumulator.advantages[1:]
-        mask_T = SequenceAccumulator.mask[1:]
+        sampled_logprobs_T = seg.sampled_logprobs[1:]
+        advantages_T = seg.advantages[1:]
+        mask_T = seg.mask[1:]
         assert input_tokens_T.length == len(target_tokens_T) == len(sampled_logprobs_T) == len(advantages_T) == len(mask_T)
-        if router_replay and SequenceAccumulator.routing_matrices:
-            rm_shifted = SequenceAccumulator.routing_matrices[1:]  # match rightshift
+        if router_replay and seg.routing_matrices:
+            rm_shifted = seg.routing_matrices[1:]  # match rightshift
             input_tokens_T = input_tokens_T.model_copy(update={"routing_matrices": rm_shifted})
         return tinker.Datum(
             model_input=input_tokens_T,
@@ -95,7 +102,14 @@ def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[
             },
         )
 
-    data: list[tinker.Datum] = []
+    # Open lineages. Each step merges into the deepest open segment whose
+    # full sequence it prefix-extends; a step that extends none opens a new
+    # segment. This keeps interleaved sub-conversations (e.g. a subagent run
+    # under the same gateway session with a different system prompt/tool set,
+    # whose turns are not prefix-extensions of the parent) each merged into
+    # their own Datum instead of fragmenting into one Datum per turn. A
+    # single-lineage trajectory keeps exactly one segment.
+    segments: list[SequenceAccumulator] = []
     for step in traj.steps:
         token_input = cast(TinkerTokenInput, step.prompt_ids)
         token_input_flat = _flatten_token_input(token_input)
@@ -111,29 +125,33 @@ def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[
         else:  # float
             advantages = [step.advantage] * len(output_token_ids)
 
-        if len(SequenceAccumulator.full_sequence) == 0:
+        # Deepest open segment this step prefix-extends (longest full_sequence).
+        # Distinct lineages have distinct roots, so at most one matches.
+        seg = None
+        seg_len = -1
+        for candidate in segments:
+            clen = len(candidate.full_sequence)
+            if clen > seg_len and _is_prefix(candidate.full_sequence, token_input_flat):
+                seg = candidate
+                seg_len = clen
+        if seg is None:
+            seg = SequenceAccumulator()
+            segments.append(seg)
             delta_token_input_flat = token_input_flat
-        elif _is_prefix(SequenceAccumulator.full_sequence, token_input_flat):
-            delta_token_input_flat = token_input_flat[len(SequenceAccumulator.full_sequence) :]
         else:
-            data.append(make_datum_from_state())
-            SequenceAccumulator.clear()
-            delta_token_input_flat = token_input_flat
+            delta_token_input_flat = token_input_flat[len(seg.full_sequence) :]
 
         delta_token_input_length = _flat_token_input_length(delta_token_input_flat)
-        SequenceAccumulator.full_sequence.extend(delta_token_input_flat)
-        SequenceAccumulator.full_sequence.extend(output_token_ids)
-        SequenceAccumulator.sampled_logprobs.extend([0.0] * delta_token_input_length + output_logprobs)
-        SequenceAccumulator.advantages.extend([0] * delta_token_input_length + advantages)
-        SequenceAccumulator.mask.extend([0.0] * delta_token_input_length + [1.0] * len(output_token_ids))
+        seg.full_sequence.extend(delta_token_input_flat)
+        seg.full_sequence.extend(output_token_ids)
+        seg.sampled_logprobs.extend([0.0] * delta_token_input_length + output_logprobs)
+        seg.advantages.extend([0] * delta_token_input_length + advantages)
+        seg.mask.extend([0.0] * delta_token_input_length + [1.0] * len(output_token_ids))
         if router_replay:
             step_rm = step.routing_matrices or []
-            SequenceAccumulator.routing_matrices.extend([""] * delta_token_input_length + (list(step_rm) if step_rm else [""] * len(output_token_ids)))
+            seg.routing_matrices.extend([""] * delta_token_input_length + (list(step_rm) if step_rm else [""] * len(output_token_ids)))
 
-    if SequenceAccumulator.full_sequence:
-        data.append(make_datum_from_state())
-
-    return data
+    return [make_datum_from_segment(seg) for seg in segments]
 
 
 def transform_trajectory_groups_to_datums(

--- a/rllm/trainer/verl/transform.py
+++ b/rllm/trainer/verl/transform.py
@@ -264,11 +264,15 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
     Tinker's per-Datum aggregation. Without merging, verl emits one row per
     step and per-trajectory weight scales with step count.
 
-    A step that is *not* a prefix-extension of the running segment (e.g.
-    the agent reset its context mid-trajectory) closes the current segment
-    and starts a new one — the trajectory then contributes multiple rows.
-    For typical agents this never fires, so the common case is one row per
-    trajectory.
+    Steps are grouped into one or more *open* segments (lineages): each
+    step is merged into the deepest open segment whose full sequence it
+    prefix-extends, and a step that extends none opens a new segment. This
+    handles interleaved sub-conversations — e.g. a subagent that runs under
+    the same gateway session but with a different system prompt/tool set,
+    whose turns are not prefix-extensions of the parent conversation — so
+    each lineage merges into its own row instead of the whole trajectory
+    fragmenting into one row per turn. A single-lineage trajectory keeps
+    exactly one segment, so the common case is still one row per trajectory.
 
     Args:
         trajectory: Trajectory to process.
@@ -368,38 +372,54 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
             group_role=name,
         )
 
-    seg = _new_segment(valid_steps[0])
-    segments_emitted = 0
+    def _extend_segment(seg, step, prompt_ids):
+        # Cumulative — merge this step into an existing open segment.
+        delta_obs = prompt_ids[len(seg["full_seq"]) :]
+        action = list(step.model_output.completion_ids)
+        action_lp = list(step.model_output.logprobs or [])
+        if action_lp and len(action_lp) != len(action):
+            action_lp = list(action_lp) + [0.0] * (len(action) - len(action_lp))
+
+        seg["response"].extend(delta_obs)
+        seg["response"].extend(action)
+        seg["mask"].extend([0] * len(delta_obs))
+        seg["mask"].extend([1] * len(action))
+        seg["logprobs"].extend([0.0] * len(delta_obs))
+        seg["logprobs"].extend(action_lp)
+        seg["full_seq"].extend(delta_obs)
+        seg["full_seq"].extend(action)
+
+        if step.routing_matrices is not None:
+            seg["last_routing_step"] = step
+
+    def _match_segment(open_segments, prompt_ids):
+        # Deepest (longest) open segment whose full_seq is a prefix of
+        # prompt_ids. Distinct lineages have distinct roots, so at most one
+        # segment matches; ``longest`` also keeps a true DAG branch attached
+        # to its nearest ancestor. Compare lengths before the slice so the
+        # per-step cost stays ~O(#open_segments · prefix_len).
+        best = None
+        best_len = -1
+        for seg in open_segments:
+            fs_len = len(seg["full_seq"])
+            if fs_len > best_len and len(prompt_ids) >= fs_len and prompt_ids[:fs_len] == seg["full_seq"]:
+                best = seg
+                best_len = fs_len
+        return best
+
+    open_segments = [_new_segment(valid_steps[0])]
     for step in valid_steps[1:]:
         prompt_ids = list(step.model_output.prompt_ids)
-        if len(prompt_ids) >= len(seg["full_seq"]) and prompt_ids[: len(seg["full_seq"])] == seg["full_seq"]:
-            # Cumulative — extend the current segment.
-            delta_obs = prompt_ids[len(seg["full_seq"]) :]
-            action = list(step.model_output.completion_ids)
-            action_lp = list(step.model_output.logprobs or [])
-            if action_lp and len(action_lp) != len(action):
-                action_lp = list(action_lp) + [0.0] * (len(action) - len(action_lp))
-
-            seg["response"].extend(delta_obs)
-            seg["response"].extend(action)
-            seg["mask"].extend([0] * len(delta_obs))
-            seg["mask"].extend([1] * len(action))
-            seg["logprobs"].extend([0.0] * len(delta_obs))
-            seg["logprobs"].extend(action_lp)
-            seg["full_seq"].extend(delta_obs)
-            seg["full_seq"].extend(action)
-
-            if step.routing_matrices is not None:
-                seg["last_routing_step"] = step
+        seg = _match_segment(open_segments, prompt_ids)
+        if seg is not None:
+            _extend_segment(seg, step, prompt_ids)
         else:
-            # Non-cumulative — close out current segment, start a new one.
-            _emit(seg)
-            segments_emitted += 1
-            seg = _new_segment(step)
+            # Extends no open lineage — start a new segment (new DAG branch).
+            open_segments.append(_new_segment(step))
 
-    _emit(seg)
-    segments_emitted += 1
-    return segments_emitted
+    for seg in open_segments:
+        _emit(seg)
+    return len(open_segments)
 
 
 def _process_episode(episode: Episode, task_id: str, accumulated: AccumulatedData) -> int:

--- a/tests/unified_trainer/test_tinker_transform.py
+++ b/tests/unified_trainer/test_tinker_transform.py
@@ -357,6 +357,50 @@ class TestTrajectoryToDataNoPrefix:
         for datum in datums:
             verify_datum_structure(datum)
 
+    def test_interleaved_subagent_lineage_remerges(self):
+        """A subagent turn between two parent turns must not fragment the parent.
+
+        This is the opencode/claude-code subagent case: the parent conversation
+        (O1, A1) / (O1+A1+O4, A4) is interleaved with a subagent turn (O3, A3)
+        that runs under the same session but with a different system prompt, so
+        it is NOT a prefix-extension of the parent. With a single running
+        accumulator the parent's second turn could no longer re-merge onto the
+        first (3 Datums); keeping both lineages open yields 2 Datums.
+        """
+        parent1 = make_step(prompt_ids=[1, 2], response_tokens=[3, 4], advantage=1.0)
+        subagent = make_step(prompt_ids=[100, 101, 102], response_tokens=[103, 104], advantage=1.0)
+        # parent resumes: extends parent1's full sequence [1,2,3,4] with obs [5]
+        parent2 = make_step(prompt_ids=[1, 2, 3, 4, 5], response_tokens=[6, 7], advantage=1.0)
+        trajectory = Trajectory(steps=[parent1, subagent, parent2])
+
+        datums = trajectory_to_datums(trajectory)
+
+        # parent1 + parent2 merge; subagent is its own Datum → 2, not 3.
+        assert len(datums) == 2
+        for datum in datums:
+            verify_datum_structure(datum)
+
+        # The parent lineage merged both turns: full seq [1,2,3,4,5,6,7],
+        # mask before shift [0,0,1,1,0,1,1] → after [1:] shift [0,1,1,0,1,1].
+        parent_datum = max(datums, key=lambda d: len(d.loss_fn_inputs["mask"].data))
+        assert parent_datum.loss_fn_inputs["mask"].data == [0.0, 1.0, 1.0, 0.0, 1.0, 1.0]
+
+    def test_two_subagents_between_parent_turns(self):
+        """Several distinct lineages stay open concurrently (parent + 2 subagents)."""
+        p1 = make_step(prompt_ids=[1, 2], response_tokens=[3, 4])
+        sub_a = make_step(prompt_ids=[100, 101], response_tokens=[102])
+        sub_b = make_step(prompt_ids=[200, 201], response_tokens=[202])
+        p2 = make_step(prompt_ids=[1, 2, 3, 4, 5], response_tokens=[6, 7])
+        sub_a2 = make_step(prompt_ids=[100, 101, 102, 103], response_tokens=[104])  # extends sub_a
+        trajectory = Trajectory(steps=[p1, sub_a, sub_b, p2, sub_a2])
+
+        datums = trajectory_to_datums(trajectory)
+
+        # Three lineages: parent {p1,p2}, sub_a {sub_a,sub_a2}, sub_b {sub_b}.
+        assert len(datums) == 3
+        for datum in datums:
+            verify_datum_structure(datum)
+
 
 # =============================================================================
 # Tests for trajectory_to_datums - With Chunks

--- a/tests/unified_trainer/test_verl_transform.py
+++ b/tests/unified_trainer/test_verl_transform.py
@@ -192,6 +192,37 @@ class TestRolloutLogProbsPropagation:
         response_mask = batch.batch["response_mask"][0]
         assert response_mask[:6].tolist() == [1, 1, 0, 1, 1, 1]
 
+    def test_interleaved_subagent_lineage_remerges(self):
+        """A subagent turn between two parent turns must not fragment the parent.
+
+        opencode/claude-code subagents run under the same gateway session but
+        with a different system prompt, so their turns are not prefix-extensions
+        of the parent conversation. With a single running segment the parent's
+        second turn could no longer re-merge onto the first, giving one row per
+        turn (3 rows) and driving merge_compression_ratio toward 1. Keeping
+        every lineage open re-merges the parent into one row → 2 rows total.
+        """
+        parent1 = ModelOutput(prompt_ids=[1, 2], completion_ids=[3, 4], logprobs=[-0.1, -0.2])
+        subagent = ModelOutput(prompt_ids=[100, 101, 102], completion_ids=[103, 104], logprobs=[-0.5, -0.6])
+        # Parent resumes: [1,2,3,4,5] prefix-extends parent1's full seq [1,2,3,4].
+        parent2 = ModelOutput(prompt_ids=[1, 2, 3, 4, 5], completion_ids=[6, 7], logprobs=[-0.3, -0.4])
+        steps = [
+            Step(prompt_ids=m.prompt_ids, response_ids=m.completion_ids, model_output=m, reward=0.0)
+            for m in (parent1, subagent, parent2)
+        ]
+        trajectory = Trajectory(steps=steps, reward=1.0)
+        episode = Episode(id="task_0:0", trajectories=[trajectory], is_correct=True)
+
+        engine = _make_mock_rollout_engine()
+        batch = transform_episodes_to_dataproto([episode], engine, max_prompt_length=8, max_response_length=8)
+
+        # Parent lineage merges to 1 row; subagent is its own row → 2, not 3.
+        assert batch.batch["responses"].shape[0] == 2
+
+        # The parent row's response is [3,4,(5),6,7] with mask [1,1,0,1,1].
+        masks = [batch.batch["response_mask"][i][:5].tolist() for i in range(2)]
+        assert [1, 1, 0, 1, 1] in masks, masks
+
     def test_other_batch_fields_unchanged(self):
         """Adding logprobs should not affect existing batch fields."""
         episodes = [


### PR DESCRIPTION
## Problem

Training runs with the **opencode** harness (and any subagent-spawning CLI harness — claude-code too) show a low `batch/merge_compression_ratio` (`= total_agent_steps / total_emitted_rows`; `1` means no merging, `N` means an N-turn trajectory collapsed to one row).

**Root cause.** opencode's `task`-tool subagent runs inside the same process, which points at one session-scoped gateway URL `/sessions/<uid>/v1`. The gateway derives the session id purely from that path, so **every** LLM call — parent agent *and* subagent — lands in one session / one `Trajectory`, interleaved in time. But a subagent turn is a fresh conversation with a **different system prompt and tool set**, so it is *not* a byte-prefix-extension of the parent. The verl/tinker transforms kept a **single** running segment and reseeded on any non-extension, so `A1, B1, A2, B2, …` never re-merged: once `A1`'s segment was emitted, `A2` could no longer rejoin it → one row per turn → ratio → 1.

## Change (Layer 1 — trainer side)

Replace the single running segment with a **set of open segments** (a forest/DAG of lineages) in both `_process_trajectory` (verl) and `trajectory_to_datums` (tinker):

1. Each step attaches to the **deepest** open segment whose `full_seq` is a byte-prefix of its `prompt_ids`.
2. A step that extends no open segment opens a **new** segment (new lineage root).
3. Emit every open segment as one row.

Parent turns merge among themselves; subagent turns merge among themselves. `A1,B1,A2,B2` → `{A1,A2}` + `{B1,B2}` = 2 rows instead of 4.

**Safety / compatibility**
- Byte-exact prefix match = the same cumulative-extension invariant used today; merging is never lossy.
- A single-lineage trajectory keeps exactly one segment → **byte-identical** to prior behavior. Sequential non-prefix breaks keep the same row count.
- Multi-row-per-trajectory was already supported (`_emit` keys rows by `trajectory.uid` with a broadcast scalar advantage). This only *reduces* row count (`#turns` → `#lineages`), improving per-trajectory weight uniformity.
- Runs on **already-stored** `prompt_ids` — **no gateway change, no rerun** needed.

## Tests
- tinker: `test_interleaved_subagent_lineage_remerges` (parent–subagent–parent → 2 Datums, parent mask intact), `test_two_subagents_between_parent_turns` (parent + 2 subagents → 3).
- verl: `test_interleaved_subagent_lineage_remerges` (→ 2 rows, parent mask `[1,1,0,1,1]`).
- The `verl` module isn't importable in this env (pre-existing: the whole `test_verl_transform.py` can't be collected without it); the merge algorithm was additionally validated with a standalone replica. Two unrelated `test_tinker_transform.py` single-step failures are **pre-existing float32-precision** asserts on `main`, not touched by this PR.

## Follow-up (Layer 2 — proposed, in `design/subagent-dag-merge.md`)
Gateway multi-slot `TokenAccumulator`: route each request to the slot it extends (new slot instead of `reset()` on divergence), keeping generation drift-free across lineages and tagging each trace `parent_trace_id` to **materialize** the DAG — composing with the Phase-1 delta-chain work in `design/gateway-dag-token-storage.md` and implementing its deferred §7 branching case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)