### PR TITLE
fix(verl): group GRPO advantage by task, not per-trajectory uid

### DIFF
--- a/rllm/trainer/verl/agent_workflow_trainer.py
+++ b/rllm/trainer/verl/agent_workflow_trainer.py
@@ -387,10 +387,12 @@ class AgentWorkflowPPOTrainer(RayPPOTrainer):
                             batch = batch.union(values)
 
                     with marked_timer("adv", timing_raw, color="brown"):
-                        # step_ids is safe to always use for advantage computation
-                        # if we're not using computing advantages stepwise (i.e., for cumulative agents or single turn workflows)
-                        # then step_ids == trajectory_ids
-                        batch.non_tensor_batch["uid"] = batch.non_tensor_batch["step_ids"]
+                        # GRPO (and other group-relative estimators) group rows by "uid" and need
+                        # every rollout.n repeat of the same task in the same group. step_ids is
+                        # trajectory.uid, a fresh id per trajectory instance, so it puts every
+                        # repeat in its own group of one; task_ids is the id interleave_tasks()
+                        # shares across a task's repeats and is what grouping needs.
+                        batch.non_tensor_batch["uid"] = batch.non_tensor_batch["task_ids"]
 
                         if self.config.rllm.stepwise_advantage.enable and self.config.rllm.stepwise_advantage.mode == "per_step":
                             batch.batch["token_level_scores"] = batch.batch["step_rewards"]

--- a/rllm/trainer/verl/dataclass.py
+++ b/rllm/trainer/verl/dataclass.py
@@ -42,6 +42,7 @@ class AccumulatedData:
     # ID tracking (parallel to tensor lists)
     trajectory_ids: list[str] = field(default_factory=list)
     step_ids: list[str] = field(default_factory=list)
+    task_ids: list[str] = field(default_factory=list)  # shared across all rollout.n repeats of one task, for GRPO grouping
     episode_ids: list[str] = field(default_factory=list)  # unique identifier for each rollout
 
     # Metadata (parallel to tensor lists)
@@ -74,6 +75,7 @@ class AccumulatedData:
         self,
         step_data: ProcessedStepData,
         trajectory_id: str,
+        task_id: str,
         traj_reward: float,
         step_num: int,
         is_last: bool,
@@ -94,6 +96,7 @@ class AccumulatedData:
             self.advantages.append(step_data.advantage)
 
         self.trajectory_ids.append(trajectory_id)
+        self.task_ids.append(task_id)
         self.step_nums.append(step_num)
         self.is_last_step.append(is_last)
         self.multi_modal_inputs.append(step_data.multi_modal_inputs)

--- a/rllm/trainer/verl/transform.py
+++ b/rllm/trainer/verl/transform.py
@@ -174,6 +174,7 @@ def _batch_tensors_and_build_data_proto(accumulated: AccumulatedData, pad_token_
         "episode_ids": np.array(accumulated.episode_ids),  # unique identifier for each rollout
         "trajectory_ids": np.array(accumulated.trajectory_ids),
         "step_ids": np.array(accumulated.step_ids),
+        "task_ids": np.array(accumulated.task_ids),
         "batch_ids": np.array([str(uuid.uuid4())] * len(accumulated.trajectory_ids)),
         "step_nums": np.array(accumulated.step_nums),
         "is_correct": np.array(accumulated.is_correct),
@@ -362,6 +363,7 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
         accumulated.add_step(
             step_data=step_data,
             trajectory_id=trajectory_id,
+            task_id=task_id,
             traj_reward=traj_reward,
             step_num=1,
             is_last=True,

--- a/tests/unified_trainer/test_verl_transform.py
+++ b/tests/unified_trainer/test_verl_transform.py
@@ -8,6 +8,7 @@ so that downstream importance sampling and bypass mode work.
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import torch
 
 from rllm.agents.agent import Episode, Step, Trajectory
@@ -208,3 +209,81 @@ class TestRolloutLogProbsPropagation:
         # All standard fields should still be present
         for key in ["input_ids", "attention_mask", "position_ids", "prompts", "responses", "response_mask", "traj_rewards", "step_rewards"]:
             assert key in batch.batch, f"Standard field '{key}' should be present"
+
+
+class TestTaskIdsForGrpoGrouping:
+    """Regression tests for #605: GRPO needs the task-level id, not the per-trajectory one.
+
+    `interleave_tasks` gives every `rollout.n` repeat of one task a shared id and encodes it as
+    the `task_id:rollout_idx` prefix of `Episode.id` (see `Episode.task_id`). The transform must
+    carry that shared id through as its own field so the trainer can group repeats of the same
+    task for GRPO's baseline, instead of falling back to `step_ids` (== `Trajectory.uid`, a fresh
+    id per trajectory instance that never repeats even for two rollouts of the same task).
+    """
+
+    def test_task_ids_shared_across_rollout_repeats(self):
+        episodes = [
+            _make_episode(prompt_ids=[1, 2], completion_ids=[3, 4], reward=1.0, episode_id="task_0:0"),
+            _make_episode(prompt_ids=[1, 2], completion_ids=[3, 4], reward=0.0, episode_id="task_0:1"),
+            _make_episode(prompt_ids=[5, 6], completion_ids=[7, 8], reward=1.0, episode_id="task_1:0"),
+            _make_episode(prompt_ids=[5, 6], completion_ids=[7, 8], reward=0.0, episode_id="task_1:1"),
+        ]
+        engine = _make_mock_rollout_engine()
+
+        batch = transform_episodes_to_dataproto(episodes, engine, max_prompt_length=8, max_response_length=8)
+
+        assert "task_ids" in batch.non_tensor_batch
+        task_ids = list(batch.non_tensor_batch["task_ids"])
+        step_ids = list(batch.non_tensor_batch["step_ids"])
+
+        # The two rollouts of task_0 (rows 0, 1) share one task id, and likewise for task_1
+        # (rows 2, 3) -- that is what makes GRPO grouping possible.
+        assert task_ids[0] == task_ids[1] == "task_0"
+        assert task_ids[2] == task_ids[3] == "task_1"
+        assert task_ids[0] != task_ids[2]
+
+        # step_ids is Trajectory.uid: a fresh id per row, so it can never group repeats. If this
+        # assertion ever fails, step_ids stopped being trajectory-unique and the bug this test
+        # guards against may have changed shape.
+        assert len(set(step_ids)) == 4
+
+    def test_grpo_advantage_degenerates_on_step_ids_task_ids_fixes_it(self):
+        """Differential against verl's real compute_grpo_outcome_advantage (verl==0.8.0).
+
+        Two rollouts of the same task score 1.0 and 0.0. Grouped correctly, GRPO subtracts the
+        pair's own mean (0.5) so the two rollouts get opposite-signed advantages. Grouped by
+        step_ids (the pre-fix code), each rollout is alone in its group of one, and
+        compute_grpo_outcome_advantage's own size-1 branch hardcodes mean=0/std=1 -- so the
+        "advantage" collapses to the raw, unbaselined reward instead.
+        """
+        from verl.trainer.ppo.core_algos import compute_grpo_outcome_advantage
+
+        token_level_rewards = torch.tensor(
+            [
+                [0.0, 1.0],  # task_0 rollout 0, reward 1.0
+                [0.0, 0.0],  # task_0 rollout 1, reward 0.0
+            ]
+        )
+        response_mask = torch.ones(2, 2)
+
+        step_ids = np.array(["traj-aaa", "traj-bbb"])  # Trajectory.uid: unique per rollout
+        task_ids = np.array(["task_0", "task_0"])  # shared across the pair, as the fix produces
+
+        buggy_advantages, _ = compute_grpo_outcome_advantage(
+            token_level_rewards=token_level_rewards,
+            response_mask=response_mask,
+            index=step_ids,
+        )
+        fixed_advantages, _ = compute_grpo_outcome_advantage(
+            token_level_rewards=token_level_rewards,
+            response_mask=response_mask,
+            index=task_ids,
+        )
+
+        # Pre-fix: each rollout is its own group of one -> mean=0, std=1 -> advantage == raw reward.
+        assert torch.allclose(buggy_advantages[:, 0], torch.tensor([1.0, 0.0]))
+
+        # Fixed: grouped by task -> mean=0.5, sample std=0.7071 (verl's default
+        # norm_adv_by_std_in_grpo=True divides by std) -> baselined, opposite-signed advantages,
+        # instead of collapsing to the raw, unbaselined reward.
+        assert torch.allclose(fixed_advantages[:, 0], torch.tensor([0.70710678, -0.70710678]))


### PR DESCRIPTION
## Summary

`AgentWorkflowPPOTrainer` groups rows for GRPO (and other group-relative advantage
estimators) by `batch.non_tensor_batch["uid"]`, but that field was set to `step_ids`,
which is `Trajectory.uid`, a fresh id per trajectory instance. Every `rollout.n` repeat
of the same prompt got a distinct uid, so verl's `compute_grpo_outcome_advantage` grouped
each repeat alone and hit its size-1 branch (`mean=0`, `std=1`), silently dropping the
group baseline whenever `stepwise_advantage.enable=False` (the default) or `mode=broadcast`.

## Type of change

- [x] Fix

## What changed

- `AgentWorkflowPPOTrainer` sets `uid` from the new `task_ids` field instead of `step_ids`.
- `AccumulatedData` gains a `task_ids` list, populated in `_process_trajectory` from the
  `task_id` already threaded through `_process_episode`/`_process_trajectory_group`, and
  carried into the batched `DataProto` in `_batch_tensors_and_build_data_proto`.
- `task_id` is what `interleave_tasks` shares across all `rollout.n` repeats of one task,
  unlike `step_ids`, so rows for the same prompt now land in the same GRPO group.

## Validation

- [x] `pre-commit run --files <changed files>` (ruff, ruff-format): clean
- [x] Targeted tests: `pytest tests/unified_trainer/test_verl_transform.py -k TestTaskIdsForGrpoGrouping`
- [x] Manual validation performed

Validation details:
- Docker differential (`python:3.11-slim`, `verl==0.8.0` from PyPI, `rllm` installed
  `--no-deps` to skip the CUDA-only extras): the new
  `test_task_ids_shared_across_rollout_repeats` fails on `main` (`task_ids` absent from
  the transform output) and passes on this branch.
- `test_grpo_advantage_degenerates_on_step_ids_task_ids_fixes_it` calls the real
  `verl.trainer.ppo.core_algos.compute_grpo_outcome_advantage` (installed from PyPI, not
  vendored) directly: grouping two same-task rollouts (rewards 1.0, 0.0) by `step_ids`
  gives `[1.0, 0.0]` (raw reward, no baseline); grouping the same pair by `task_ids` gives
  `[0.7071, -0.7071]` (mean-subtracted, std-normalized per verl's default
  `norm_adv_by_std_in_grpo=True`).
- Full `tests/unified_trainer/` suite: 43 passed, no regressions (two `test_tinker_*`
  files fail to collect on this environment because the optional `tinker` package isn't
  installed; that is pre-existing and unrelated to this change, and the `test-tinker.yml`
  CI workflow only triggers on paths under `rllm/trainer/tinker/**` / `rllm/engine/rollout/**`,
  neither of which this PR touches).
- Not run: an actual GPU training run through verl. This is a source-level fix verified
  by installing the real `verl==0.8.0` package and calling its own advantage function; I
  don't have a GPU/verl training environment to confirm the end-to-end training loop.

## Breaking changes / migration notes

- None. `uid` changes what it groups by, but its shape and consumers are unchanged.

## Docs / examples

- [x] Not needed

## Related issues / PRs

- Fixes #605
