### PR TITLE
fix(tasks): drop phantom 600s agent_timeout default in the task loader

### DIFF
--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -230,7 +230,14 @@ def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     merged["agent_user"] = raw.get("agent", {}).get("user", merged.get("agent_user"))
     merged["verifier_user"] = raw.get("verifier", {}).get("user", merged.get("verifier_user"))
     merged["verifier_timeout"] = raw.get("verifier", {}).get("timeout_sec", merged.get("verifier_timeout", 600.0))
-    merged["agent_timeout"] = raw.get("agent", {}).get("timeout_sec", merged.get("agent_timeout", 600.0))
+    # Only carry a per-task agent_timeout when the task actually declares one.
+    # No phantom default: an absent agent_timeout means "no per-task budget", so
+    # the harness falls back to the operator's RLLM_HARNESS_RUN_TIMEOUT_S (see
+    # cli_harness._effective_timeout / eval._resolution) instead of a hidden 600s
+    # cap that min()'s the operator's setting down.
+    _declared_agent_timeout = raw.get("agent", {}).get("timeout_sec")
+    if _declared_agent_timeout is not None:
+        merged["agent_timeout"] = _declared_agent_timeout
     rllm_section = raw.get("rllm", {}) or {}
     merged["setup_commands"] = rllm_section.get("setup_commands", merged.get("setup_commands", [])) or []
     return merged
@@ -554,7 +561,11 @@ def _load_task_from_dir(
     metadata["agent_user"] = raw.get("agent", {}).get("user")
     metadata["verifier_user"] = raw.get("verifier", {}).get("user")
     metadata["verifier_timeout"] = raw.get("verifier", {}).get("timeout_sec", 600.0)
-    metadata["agent_timeout"] = raw.get("agent", {}).get("timeout_sec", 600.0)
+    # No phantom default — see _merge_task_toml_metadata: an absent agent_timeout
+    # defers to the operator's RLLM_HARNESS_RUN_TIMEOUT_S rather than a hidden 600s.
+    _declared_agent_timeout = raw.get("agent", {}).get("timeout_sec")
+    if _declared_agent_timeout is not None:
+        metadata["agent_timeout"] = _declared_agent_timeout
     rllm_section = raw.get("rllm", {}) or {}
     metadata["setup_commands"] = rllm_section.get("setup_commands", []) or []
 

--- a/tests/tasks/test_loader_agent_timeout.py
+++ b/tests/tasks/test_loader_agent_timeout.py
@@ -1,0 +1,28 @@
+"""agent_timeout comes from the task spec, never a phantom default.
+
+An absent per-task agent_timeout must stay absent so the harness defers to the
+operator's RLLM_HARNESS_RUN_TIMEOUT_S (cli_harness._effective_timeout /
+eval._resolution) instead of a hidden 600s cap that min()'d the operator down.
+"""
+
+from rllm.tasks.loader import _merge_task_toml_metadata
+
+
+def test_undeclared_agent_timeout_is_omitted(tmp_path):
+    (tmp_path / "task.toml").write_text('[agent]\nuser = "root"\n')  # no timeout_sec
+    merged = _merge_task_toml_metadata(tmp_path, {})
+    assert "agent_timeout" not in merged  # no phantom 600.0
+
+
+def test_declared_agent_timeout_is_preserved(tmp_path):
+    (tmp_path / "task.toml").write_text("[agent]\ntimeout_sec = 1800\n")
+    merged = _merge_task_toml_metadata(tmp_path, {})
+    assert merged["agent_timeout"] == 1800
+
+
+def test_base_agent_timeout_survives_when_toml_silent(tmp_path):
+    # A value the row already carried must not be dropped just because task.toml
+    # doesn't re-declare it.
+    (tmp_path / "task.toml").write_text('[agent]\nuser = "root"\n')
+    merged = _merge_task_toml_metadata(tmp_path, {"agent_timeout": 1234})
+    assert merged["agent_timeout"] == 1234


### PR DESCRIPTION
## Problem

When a task's \`task.toml\` doesn't declare \`[agent].timeout_sec\`, the loader injected \`agent_timeout = 600.0\` into task metadata (\`rllm/tasks/loader.py\`, both \`_merge_task_toml_metadata\` and \`_load_task_from_dir\`). That phantom default silently caps the agent's wall-clock budget at 600s and makes an operator-set \`RLLM_HARNESS_RUN_TIMEOUT_S\` ineffective:

- On the CLI harness (opencode/claude-code/etc.), the effective budget is \`min(agent_timeout, run_timeout)\` — so \`min(600, 3600) = 600\` no matter what the operator sets.
- Symptom in the wild: opencode SWE rollouts (scaleswe, whose task specs don't declare \`timeout_sec\`) getting SIGKILLed at ~660s (600 budget + 60s harness grace), even with \`RLLM_HARNESS_RUN_TIMEOUT_S=3600\`.

## Fix

Only set \`agent_timeout\` when the task actually declares \`[agent].timeout_sec\`. An absent value now stays absent, and the downstream consumers already do the right thing with it:
- \`cli_harness._effective_timeout\`: \`if per_task is None: return run_timeout\`
- \`eval/_resolution.py\`: \`if _per_task is None: agent_t = run_cap or 3600\`

So the operator's \`RLLM_HARNESS_RUN_TIMEOUT_S\` (or its default) governs for tasks that don't declare their own budget, instead of a hidden 600s floor. Tasks that *do* declare \`timeout_sec\` are unchanged.

Other readers keep their own explicit fallbacks (\`bash.py\` → 600, \`oracle.py\` → 7200), so behavior there is unchanged.

## Test

\`tests/tasks/test_loader_agent_timeout.py\` — undeclared → key omitted (fails without the fix), declared → preserved, base value survives a silent \`task.toml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)