### PR TITLE
fix(tasks): drop phantom 600s agent_timeout default in the task loader

### DIFF
--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -282,7 +282,10 @@ def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     merged["agent_user"] = raw.get("agent", {}).get("user", merged.get("agent_user"))
     merged["verifier_user"] = raw.get("verifier", {}).get("user", merged.get("verifier_user"))
     merged["verifier_timeout"] = raw.get("verifier", {}).get("timeout_sec", merged.get("verifier_timeout", 600.0))
-    merged["agent_timeout"] = raw.get("agent", {}).get("timeout_sec", merged.get("agent_timeout", 600.0))
+    # No phantom default: an absent agent_timeout defers to RLLM_HARNESS_RUN_TIMEOUT_S.
+    _agent_timeout = raw.get("agent", {}).get("timeout_sec")
+    if _agent_timeout is not None:
+        merged["agent_timeout"] = _agent_timeout
     rllm_section = raw.get("rllm", {}) or {}
     merged["setup_commands"] = rllm_section.get("setup_commands", merged.get("setup_commands", [])) or []
     return merged
@@ -552,7 +555,10 @@ def _load_task_from_dir(
     metadata["agent_user"] = raw.get("agent", {}).get("user")
     metadata["verifier_user"] = raw.get("verifier", {}).get("user")
     metadata["verifier_timeout"] = raw.get("verifier", {}).get("timeout_sec", 600.0)
-    metadata["agent_timeout"] = raw.get("agent", {}).get("timeout_sec", 600.0)
+    # No phantom default (see _merge_task_toml_metadata).
+    _agent_timeout = raw.get("agent", {}).get("timeout_sec")
+    if _agent_timeout is not None:
+        metadata["agent_timeout"] = _agent_timeout
     rllm_section = raw.get("rllm", {}) or {}
     metadata["setup_commands"] = rllm_section.get("setup_commands", []) or []
 

--- a/tests/tasks/test_loader_agent_timeout.py
+++ b/tests/tasks/test_loader_agent_timeout.py
@@ -1,0 +1,24 @@
+"""An absent per-task agent_timeout must stay absent (no phantom 600s default),
+so the harness defers to the operator's RLLM_HARNESS_RUN_TIMEOUT_S instead of
+min()'ing it down to a hidden 600s cap.
+"""
+
+from rllm.tasks.loader import _merge_task_toml_metadata
+
+
+def test_undeclared_agent_timeout_is_omitted(tmp_path):
+    (tmp_path / "task.toml").write_text('[agent]\nuser = "root"\n')  # no timeout_sec
+    merged = _merge_task_toml_metadata(tmp_path, {})
+    assert "agent_timeout" not in merged  # no phantom 600.0
+
+
+def test_declared_agent_timeout_is_preserved(tmp_path):
+    (tmp_path / "task.toml").write_text("[agent]\ntimeout_sec = 1800\n")
+    merged = _merge_task_toml_metadata(tmp_path, {})
+    assert merged["agent_timeout"] == 1800
+
+
+def test_base_agent_timeout_survives_when_toml_silent(tmp_path):
+    (tmp_path / "task.toml").write_text('[agent]\nuser = "root"\n')
+    merged = _merge_task_toml_metadata(tmp_path, {"agent_timeout": 1234})
+    assert merged["agent_timeout"] == 1234


### PR DESCRIPTION
The loader set `agent_timeout = 600.0` whenever a task's `task.toml` didn't declare `[agent].timeout_sec`. That phantom default caps the agent budget at 600s and makes `RLLM_HARNESS_RUN_TIMEOUT_S` ineffective — `cli_harness._effective_timeout` does `min(agent_timeout, run_timeout)`, so `min(600, 3600)=600`. Symptom: opencode scaleswe rollouts SIGKILLed at ~660s (600 + 60s grace) despite `RLLM_HARNESS_RUN_TIMEOUT_S=3600`.

Fix: only set `agent_timeout` when the task declares `timeout_sec`. An absent value stays absent, so `_effective_timeout` / `eval._resolution` defer to `run_timeout`. The key is **omitted, not set to None**, so `bash.py`/`oracle.py`'s `.get("agent_timeout", <default>)` fallbacks still work. Tasks that declare a timeout are unchanged.

Test: `tests/tasks/test_loader_agent_timeout.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)