### PR TITLE
fix(eval): join Dockerfile RUN-continuation lines with a space, not a newline

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -275,7 +275,7 @@ def _dockerfile_run_commands(task: Task) -> list[str]:
                 if i >= len(lines):
                     break
                 parts.append(lines[i])
-            cmd = "\n".join(parts).strip()
+            cmd = " ".join(part.strip() for part in parts).strip()
             if cmd:
                 commands.append(cmd)
         i += 1

--- a/tests/eval/test_dockerfile_replay.py
+++ b/tests/eval/test_dockerfile_replay.py
@@ -1,0 +1,46 @@
+"""Tests for :func:`rllm.eval._resolution._dockerfile_run_commands`.
+
+Non-docker sandbox backends (modal, daytona) replay a task Dockerfile's
+``RUN`` steps by extracting each step as a shell command and exec'ing it
+via ``bash -c`` (see ``_replay_dockerfile``). A multi-line ``RUN`` with
+``\\``-continuations must collapse into one valid shell command.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from rllm.eval._resolution import _dockerfile_run_commands
+from rllm.types import Task
+
+
+def _task_with_dockerfile(tmp_path: Path, dockerfile_body: str) -> Task:
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text(dockerfile_body)
+    return Task(id="t", instruction="", metadata={}, dataset_dir=tmp_path)
+
+
+def test_multiline_run_continuation_collapses_to_one_valid_shell_command(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM python:3.11-slim\nRUN apt-get update && apt-get install -y \\\n    python3-pip \\\n    && rm -rf /var/lib/apt/lists/*\n",
+    )
+
+    commands = _dockerfile_run_commands(task)
+
+    assert len(commands) == 1
+    assert "\n" not in commands[0]
+    # The extracted command must parse as a single valid shell command
+    # (bash -n only checks syntax, no execution).
+    result = subprocess.run(["bash", "-n", "-c", commands[0]], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_single_line_run_step_is_unaffected(tmp_path):
+    task = _task_with_dockerfile(tmp_path, "FROM python:3.11-slim\nRUN echo hello\n")
+
+    commands = _dockerfile_run_commands(task)
+
+    assert commands == ["echo hello"]


### PR DESCRIPTION
## Summary

`_dockerfile_run_commands` rejoins a Dockerfile `RUN` step's backslash-continued lines with `"\n".join(parts)` before `_replay_dockerfile` execs the result via `bash -c` on the modal/daytona sandbox backends. A `\`-continuation is a shell line continuation (one logical command), so joining with a newline instead of a space turns a valid multi-line `&&` chain into invalid shell and fails with `bash: -c: line N: syntax error near unexpected token '&&'`.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- `rllm/eval/_resolution.py`: `_dockerfile_run_commands` now joins continuation parts with `" ".join(part.strip() for part in parts)` instead of `"\n".join(parts)`.
- Added `tests/eval/test_dockerfile_replay.py`, a regression test that fails on main (asserts no embedded newline and that the extracted command parses as valid shell via `bash -n`) and passes with the fix.

## Validation

- [x] `pre-commit run --all-files`
- [x] Targeted tests: `pytest tests/eval/test_dockerfile_replay.py tests/eval/test_resolver.py tests/sandbox/test_snapshot.py`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Reproduced in a clean Docker container against HEAD `af40b7fa`: extracted the RUN step from a synthetic Dockerfile with a `\`-continuation, ran it through `bash -c`, got the exact syntax error from the issue. Applied the fix, same repro now runs clean (`returncode: 0`).
- New test fails on the pre-fix code (`assert "\n" not in commands[0]`) and passes after the fix, both run in the same container with `rllm.eval._resolution.__file__` printed to confirm it's exercising `/repo/rllm/eval/_resolution.py`, not a cached install.
- `pytest tests/eval/ tests/sandbox/test_snapshot.py` (excluding files that fail to collect in this scratch container for an unrelated reason, see below): 2 new + 35 existing pass, 1 pre-existing skip. 3 pre-existing failures in `test_snapshot.py` (`test_modal_ref_absent_confirmed_notfound_only`, `test_daytona_ref_absent_reads_enum_or_string_state`, `test_hook_install_honors_baked_script[cold-installs]`) reproduce identically on unpatched HEAD in the same container: `rllm_model_gateway` imports `fastapi.FastAPI`, which isn't installed in this minimal container. Unrelated to this change.
- `pre-commit run --files rllm/eval/_resolution.py tests/eval/test_dockerfile_replay.py`: ruff and ruff-format both pass.
- Did not run the full suite (`tests/eval/test_eval_engine.py` and others fail to collect in this container for the same missing `fastapi` reason) or exercise a real modal/daytona sandbox; the fix and test are scoped to the pure string-transform function.

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- Fixes #655
- Related to #656 (same fix, merged to `terminal-rl` instead of `main`; see note below)

## Screenshots / logs

None.

## Note on prior art

#656 fixed this exact join bug (and a separate double-apply-on-a-prebuilt-image defect from the same issue, via a new `[environment].replay_dockerfile` toggle) but its base branch was `terminal-rl`, not `main`, so `main` never picked it up and #655 stayed open. This PR ports only the line-continuation fix to `main`; the toggle for the double-apply defect is a separate concern and out of scope here.
