### PR TITLE
feat(fireworks): emit grad-norm; loss_agg_mode for custom losses; builtin=token-sum; add token-sum mode

### DIFF
--- a/rllm/trainer/algorithms/config.py
+++ b/rllm/trainer/algorithms/config.py
@@ -340,7 +340,7 @@ class AlgorithmConfig:
     kl_beta: float = 0.0
     eps_clip: float = 0.2
     eps_clip_high: float | None = None
-    loss_agg_mode: Literal["token-mean", "seq-mean-token-sum", "seq-mean-token-mean", None] = "seq-mean-token-mean"
+    loss_agg_mode: Literal["token-mean", "token-sum", "seq-mean-token-sum", "seq-mean-token-mean", None] = "token-mean"
     rollout_correction: RolloutCorrectionConfig = field(default_factory=RolloutCorrectionConfig)
     router_replay: Literal["disabled", "R2", "R3"] = "disabled"
 
@@ -383,7 +383,7 @@ class AlgorithmConfig:
             kl_beta=algorithm_config.get("kl_beta", 0.0),
             eps_clip=algorithm_config.get("eps_clip", 0.2),
             eps_clip_high=algorithm_config.get("eps_clip_high", None),
-            loss_agg_mode=algorithm_config.get("loss_agg_mode", "seq-mean-token-mean"),
+            loss_agg_mode=algorithm_config.get("loss_agg_mode", "token-mean"),
             rollout_correction=rollout_correction,
             router_replay=algorithm_config.get("router_replay", "disabled"),
         )

--- a/rllm/trainer/algorithms/loss.py
+++ b/rllm/trainer/algorithms/loss.py
@@ -180,10 +180,11 @@ def offpolicy_metrics(
 # optimizer-step normalization) realizes these semantics with GLOBAL normalization spanning
 # the whole optimizer step (all micro-batches / grad-accumulation passes / DP ranks):
 #   token-mean           Σ_tokens(loss·mask) / Σ_tokens(mask)          — every token equal
+#   token-sum            Σ_tokens(loss·mask)                            — no normalization
 #   seq-mean-token-mean  mean within a sequence, then mean over sequences — every seq equal
 #   seq-mean-token-sum   sum within a sequence, then mean over sequences
-LOSS_AGG_MODES = ("token-mean", "seq-mean-token-mean", "seq-mean-token-sum")
-DEFAULT_LOSS_AGG_MODE = "seq-mean-token-mean"  # rLLM default: weight every sequence equally
+LOSS_AGG_MODES = ("token-mean", "token-sum", "seq-mean-token-mean", "seq-mean-token-sum")
+DEFAULT_LOSS_AGG_MODE = "token-mean"  # rLLM default: weight every token equally
 
 RLLM_LOSS_REGISTRY: dict[str, LossFn] = {}
 # Optional per-loss aggregation-mode override. A sequence-level loss (e.g. GSPO) must

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -81,7 +81,7 @@ algorithm:
   # Loss-specific hyperparameters → ctx.params, e.g. {delta: 0.2} for dppo_tv, or
   # {env_loss_coef: 0.05} for echo's env-observation cross-entropy term (arXiv:2605.24517).
   loss_params: {}
-  loss_agg_mode: seq-mean-token-mean     # [null, token-mean, seq-mean-token-sum, seq-mean-token-mean]; null lets verl's own default stand
+  loss_agg_mode: token-mean     # [null, token-mean, token-sum, seq-mean-token-sum, seq-mean-token-mean]; null lets verl's own default stand
   lr_schedule: constant   # [constant, linear, cosine]
   warmup_steps: -1        # Absolute optimizer-step warmup; <=0 uses warmup_steps_ratio
   warmup_steps_ratio: 0.0 # Fractional warmup fallback

--- a/rllm/trainer/fireworks/fireworks_backend.py
+++ b/rllm/trainer/fireworks/fireworks_backend.py
@@ -267,9 +267,9 @@ class FireworksBackend(TinkerBackend):
                 loss_fn,
             )
 
-        valid_loss_agg_modes = {None, "token-mean", "seq-mean-token-sum", "seq-mean-token-mean"}
+        valid_loss_agg_modes = {None, "token-mean", "token-sum", "seq-mean-token-sum", "seq-mean-token-mean"}
         if loss_agg_mode not in valid_loss_agg_modes:
-            raise ValueError(f"rllm.algorithm.loss_agg_mode must be null, 'token-mean', 'seq-mean-token-sum', or 'seq-mean-token-mean' for the Fireworks backend, got {loss_agg_mode!r}")
+            raise ValueError(f"rllm.algorithm.loss_agg_mode must be null, 'token-mean', 'token-sum', 'seq-mean-token-sum', or 'seq-mean-token-mean' for the Fireworks backend, got {loss_agg_mode!r}")
         logger.info("Fireworks loss aggregation mode: %s", loss_agg_mode or "backend default")
 
         if router_replay == "R2":

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -30,7 +30,7 @@ from rllm.trainer.algorithms import (
     CompactFilteringConfig,
     TransformConfig,
 )
-from rllm.trainer.algorithms.loss import DEFAULT_LOSS_AGG_MODE, native_loss_names, offpolicy_metrics, resolve_loss
+from rllm.trainer.algorithms.loss import native_loss_names, offpolicy_metrics, resolve_loss
 from rllm.trainer.tinker.tinker_policy_trainer import (
     compute_schedule_lr_multiplier,
     require_training_client,
@@ -392,38 +392,6 @@ class FireworksPolicyTrainer:
 
         return clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens
 
-    @staticmethod
-    def _normalize_advantages(
-        advantages: list[float],
-        num_loss_tokens: list[int],
-        loss_agg_mode: str | None,
-    ) -> list[float]:
-        """Fold the loss-aggregation denominator into the per-sequence advantage (client-side
-        loss normalization; optim_step then passes ``GradAccNormalization.NONE``).
-
-        The server sums the per-token loss ``-(ratio · adv)`` over the whole batch, so dividing
-        each sequence's advantage by the mode's denominator makes that raw sum equal the intended
-        reduction. Denominators span the whole batch (invariant to server-side micro-batching):
-
-        - ``token-sum``:            no scaling.
-        - ``token-mean`` (default): ÷ total active tokens (Σ num_loss_tokens).
-        - ``seq-mean-token-sum``:   ÷ number of sequences.
-        - ``seq-mean-token-mean``:  ÷ (number of sequences · that sequence's active tokens).
-        """
-        mode = loss_agg_mode or DEFAULT_LOSS_AGG_MODE
-        n_seqs = len(advantages)
-        if mode == "token-sum":
-            return advantages
-        if mode == "token-mean":
-            denom = max(1, sum(num_loss_tokens))
-            return [a / denom for a in advantages]
-        if mode == "seq-mean-token-sum":
-            denom = max(1, n_seqs)
-            return [a / denom for a in advantages]
-        if mode == "seq-mean-token-mean":
-            return [a / (max(1, n_seqs) * max(1, num_loss_tokens[i])) for i, a in enumerate(advantages)]
-        raise ValueError(f"Unknown loss_agg_mode {mode!r}")
-
     async def _compute_proximal_logprobs(
         self,
         datums: list[tinker.Datum],
@@ -585,12 +553,19 @@ class FireworksPolicyTrainer:
         rc = algorithm_config.rollout_correction
         clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens = self._process_datums(raw_datums)
 
-        # rLLM normalizes the loss client-side by folding the loss-aggregation denominator into
-        # the per-sequence advantage; optim_step then passes GradAccNormalization.NONE. The
-        # server backprops a raw token-sum, so scaling the (per-token) advantage IS the loss
-        # normalization. Denominators are computed over the whole batch, so this is invariant to
-        # server-side micro-batching. num_loss_tokens[i] = active (mask=1) tokens in sequence i.
-        advantages = self._normalize_advantages(advantages, num_loss_tokens, algorithm_config.loss_agg_mode)
+        # Builtin server kernel: the loss is computed server-side (Σ -(ratio·adv)), so rLLM cannot
+        # normalize the loss client-side. We leave it at its default raw token-SUM (optim_step
+        # passes GradAccNormalization.NONE) — same as the Tinker builtin path. loss_agg_mode is
+        # honored only on the custom-loss path (forward_backward_custom), which computes the loss
+        # client-side. Warn so a requested mode is not silently ignored here.
+        if algorithm_config.loss_agg_mode not in (None, "token-sum") and not getattr(self, "_warned_builtin_agg", False):
+            self._warned_builtin_agg = True  # log once, not every step
+            logger.warning(
+                "loss_agg_mode=%r is not applied to the builtin loss kernel %r, which uses raw "
+                "token-sum. loss_agg_mode is honored only for rLLM custom losses.",
+                algorithm_config.loss_agg_mode,
+                self._builtin_loss[0],
+            )
 
         # bypass_mode defaults True: one optim step per batch means a recomputed proximal ==
         # pi_theta, so the clip ratio is ~1 (inert) and the recompute is wasted. Using the rollout
@@ -678,10 +653,10 @@ class FireworksPolicyTrainer:
         )
         from fireworks.training.sdk.client import GradAccNormalization
 
-        # No server-side normalization: rLLM normalizes the loss itself (builtin path folds the
-        # loss-agg denominator into the advantages via _normalize_advantages; custom path divides
-        # client-side via build_custom_loss server_normalized=False). The server backprops a raw
-        # token-sum, so pass NONE. Matches the Tinker path.
+        # No server-side normalization (GradAccNormalization.NONE), matching the Tinker path:
+        # - builtin loss kernel: left at raw token-sum (loss is server-side; not normalized here).
+        # - custom loss (forward_backward_custom): normalized client-side per loss_agg_mode by
+        #   build_custom_loss (server_normalized=False).
         optim_result = await self._run_training_op(
             self.training_client.optim_step,
             adam_params,

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -640,7 +640,7 @@ class FireworksPolicyTrainer:
             eps=eps,
             weight_decay=weight_decay,
             grad_clip_norm=grad_clip_norm,
-            emit_grad_norm_metrics=True,  # emit train/grad_norm* telemetry (parity with verl)
+            emit_grad_norm_metrics=True,
         )
         from fireworks.training.sdk.client import GradAccNormalization
 

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -561,8 +561,7 @@ class FireworksPolicyTrainer:
         if algorithm_config.loss_agg_mode not in (None, "token-sum") and not getattr(self, "_warned_builtin_agg", False):
             self._warned_builtin_agg = True  # log once, not every step
             logger.warning(
-                "loss_agg_mode=%r is not applied to the builtin loss kernel %r, which uses raw "
-                "token-sum. loss_agg_mode is honored only for rLLM custom losses.",
+                "loss_agg_mode=%r is not applied to the builtin loss kernel %r, which uses raw token-sum. loss_agg_mode is honored only for rLLM custom losses.",
                 algorithm_config.loss_agg_mode,
                 self._builtin_loss[0],
             )

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -108,11 +108,6 @@ class FireworksPolicyTrainer:
         # Transient-fault tolerance for training-client RPCs (see _run_training_op).
         self._step_max_retries = max(0, int(OmegaConf.select(config, "fireworks_infra.common.step_max_retries", default=2)))
         self._step_retry_backoff_s = float(OmegaConf.select(config, "fireworks_infra.common.step_retry_backoff_s", default=10.0))
-        # Trainer-side grad-norm telemetry: default ON so optim_step emits train/grad_norm*
-        # (parity with verl's grad_norm metric). Accepts a bool or "off"/"basic"/"detailed";
-        # set training.emit_grad_norm_metrics=false to disable. Threaded onto AdamParams in
-        # optim_step (ReconnectableClient.optim_step forwards AdamParams but not the kwarg).
-        self._emit_grad_norm_metrics = OmegaConf.select(config, "training.emit_grad_norm_metrics", default=True)
         self._resume_checkpoint_name = self.config.training.get("resume_from_dcp_checkpoint")
         self._resume_source_job_id = self.config.training.get("resume_from_fireworks_job_id") or policy_job_id
 
@@ -645,13 +640,8 @@ class FireworksPolicyTrainer:
             eps=eps,
             weight_decay=weight_decay,
             grad_clip_norm=grad_clip_norm,
+            emit_grad_norm_metrics=True,  # emit train/grad_norm* telemetry (parity with verl)
         )
-        # Enable trainer-side grad-norm telemetry (train/grad_norm*) by default. The SDK reads
-        # emit_grad_norm_metrics off AdamParams when the optim_step kwarg is None, and
-        # ReconnectableClient.optim_step forwards AdamParams but not that kwarg — so set it here.
-        # Guarded on the field the Fireworks grad-norm patch adds to AdamParams.
-        if self._emit_grad_norm_metrics is not None and "emit_grad_norm_metrics" in AdamParams.model_fields:
-            adam_params = adam_params.model_copy(update={"emit_grad_norm_metrics": self._emit_grad_norm_metrics})
         from fireworks.training.sdk.client import GradAccNormalization
 
         _LOSS_AGG_MAP = {

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -30,7 +30,7 @@ from rllm.trainer.algorithms import (
     CompactFilteringConfig,
     TransformConfig,
 )
-from rllm.trainer.algorithms.loss import native_loss_names, offpolicy_metrics, resolve_loss
+from rllm.trainer.algorithms.loss import DEFAULT_LOSS_AGG_MODE, native_loss_names, offpolicy_metrics, resolve_loss
 from rllm.trainer.tinker.tinker_policy_trainer import (
     compute_schedule_lr_multiplier,
     require_training_client,
@@ -392,6 +392,38 @@ class FireworksPolicyTrainer:
 
         return clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens
 
+    @staticmethod
+    def _normalize_advantages(
+        advantages: list[float],
+        num_loss_tokens: list[int],
+        loss_agg_mode: str | None,
+    ) -> list[float]:
+        """Fold the loss-aggregation denominator into the per-sequence advantage (client-side
+        loss normalization; optim_step then passes ``GradAccNormalization.NONE``).
+
+        The server sums the per-token loss ``-(ratio · adv)`` over the whole batch, so dividing
+        each sequence's advantage by the mode's denominator makes that raw sum equal the intended
+        reduction. Denominators span the whole batch (invariant to server-side micro-batching):
+
+        - ``token-sum``:            no scaling.
+        - ``token-mean`` (default): ÷ total active tokens (Σ num_loss_tokens).
+        - ``seq-mean-token-sum``:   ÷ number of sequences.
+        - ``seq-mean-token-mean``:  ÷ (number of sequences · that sequence's active tokens).
+        """
+        mode = loss_agg_mode or DEFAULT_LOSS_AGG_MODE
+        n_seqs = len(advantages)
+        if mode == "token-sum":
+            return advantages
+        if mode == "token-mean":
+            denom = max(1, sum(num_loss_tokens))
+            return [a / denom for a in advantages]
+        if mode == "seq-mean-token-sum":
+            denom = max(1, n_seqs)
+            return [a / denom for a in advantages]
+        if mode == "seq-mean-token-mean":
+            return [a / (max(1, n_seqs) * max(1, num_loss_tokens[i])) for i, a in enumerate(advantages)]
+        raise ValueError(f"Unknown loss_agg_mode {mode!r}")
+
     async def _compute_proximal_logprobs(
         self,
         datums: list[tinker.Datum],
@@ -528,10 +560,12 @@ class FireworksPolicyTrainer:
             # log-probs — the off-policy gap (staleness + train/inference mismatch), free, no
             # proximal forward. (The bypass gate below only applies to the native builtin path.)
 
-            # server_normalized=True: the closure returns a RAW SUM; optim_step sets
-            # GradAccNormalization from resolved.agg_mode so the server normalizes once across all
-            # grad-accum passes. A per-pass mean here + NONE would scale the grad by num passes.
-            stripped, loss_fn = build_custom_loss(resolved, raw_datums, server_normalized=True)
+            # server_normalized=False: rLLM normalizes the loss client-side (the closure divides
+            # by this pass's global token/sequence count per resolved.agg_mode), so optim_step
+            # passes GradAccNormalization.NONE. Correct because the Fireworks path runs a single
+            # forward_backward_custom over the whole batch (one pass); under multi-pass grad
+            # accumulation the client divisor would be per-pass. Matches the Tinker path.
+            stripped, loss_fn = build_custom_loss(resolved, raw_datums, server_normalized=False)
             fwd_bwd_result = await self._run_training_op(
                 self.training_client.forward_backward_custom,
                 stripped,
@@ -551,12 +585,12 @@ class FireworksPolicyTrainer:
         rc = algorithm_config.rollout_correction
         clean_datums, advantages, inf_logprobs, prompt_lens, num_loss_tokens = self._process_datums(raw_datums)
 
-        # seq-mean-token-mean: normalize advantages by number of loss tokens so that
-        # token-sum within each sequence equals token-mean, then NUM_SEQUENCES
-        # at optim_step gives seq-mean-token-mean overall.
-        if algorithm_config.loss_agg_mode == "seq-mean-token-mean":
-            for i in range(len(advantages)):
-                advantages[i] /= max(1, num_loss_tokens[i])
+        # rLLM normalizes the loss client-side by folding the loss-aggregation denominator into
+        # the per-sequence advantage; optim_step then passes GradAccNormalization.NONE. The
+        # server backprops a raw token-sum, so scaling the (per-token) advantage IS the loss
+        # normalization. Denominators are computed over the whole batch, so this is invariant to
+        # server-side micro-batching. num_loss_tokens[i] = active (mask=1) tokens in sequence i.
+        advantages = self._normalize_advantages(advantages, num_loss_tokens, algorithm_config.loss_agg_mode)
 
         # bypass_mode defaults True: one optim step per batch means a recomputed proximal ==
         # pi_theta, so the clip ratio is ~1 (inert) and the recompute is wasted. Using the rollout
@@ -644,24 +678,14 @@ class FireworksPolicyTrainer:
         )
         from fireworks.training.sdk.client import GradAccNormalization
 
-        _LOSS_AGG_MAP = {
-            "token-mean": GradAccNormalization.NUM_LOSS_TOKENS,
-            "seq-mean-token-sum": GradAccNormalization.NUM_SEQUENCES,
-            "seq-mean-token-mean": GradAccNormalization.NUM_SEQUENCES,
-        }
-        grad_norm = _LOSS_AGG_MAP.get(self.algorithm_config.loss_agg_mode)
-        # Custom-loss path (forward_backward_custom): the closure returns a RAW SUM over
-        # sequences (build_custom_loss server_normalized=True), so the server must divide by
-        # the count spanning ALL grad-accumulation passes — NUM_LOSS_TOKENS for token-mean,
-        # NUM_SEQUENCES for seq-mean-*. (NONE here would leave the gradient scaled by the
-        # per-step token/sequence count and inflate it by num_fwd_bwd_passes.)
-        resolved = resolve_loss(self.algorithm_config, native_losses=native_loss_names("fireworks"))
-        if resolved is not None:
-            grad_norm = GradAccNormalization.NUM_LOSS_TOKENS if resolved.agg_mode == "token-mean" else GradAccNormalization.NUM_SEQUENCES
+        # No server-side normalization: rLLM normalizes the loss itself (builtin path folds the
+        # loss-agg denominator into the advantages via _normalize_advantages; custom path divides
+        # client-side via build_custom_loss server_normalized=False). The server backprops a raw
+        # token-sum, so pass NONE. Matches the Tinker path.
         optim_result = await self._run_training_op(
             self.training_client.optim_step,
             adam_params,
-            grad_accumulation_normalization=grad_norm,
+            grad_accumulation_normalization=GradAccNormalization.NONE,
             op_name="optim_step",
             reconnect=True,
         )

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -108,6 +108,11 @@ class FireworksPolicyTrainer:
         # Transient-fault tolerance for training-client RPCs (see _run_training_op).
         self._step_max_retries = max(0, int(OmegaConf.select(config, "fireworks_infra.common.step_max_retries", default=2)))
         self._step_retry_backoff_s = float(OmegaConf.select(config, "fireworks_infra.common.step_retry_backoff_s", default=10.0))
+        # Trainer-side grad-norm telemetry: default ON so optim_step emits train/grad_norm*
+        # (parity with verl's grad_norm metric). Accepts a bool or "off"/"basic"/"detailed";
+        # set training.emit_grad_norm_metrics=false to disable. Threaded onto AdamParams in
+        # optim_step (ReconnectableClient.optim_step forwards AdamParams but not the kwarg).
+        self._emit_grad_norm_metrics = OmegaConf.select(config, "training.emit_grad_norm_metrics", default=True)
         self._resume_checkpoint_name = self.config.training.get("resume_from_dcp_checkpoint")
         self._resume_source_job_id = self.config.training.get("resume_from_fireworks_job_id") or policy_job_id
 
@@ -641,6 +646,12 @@ class FireworksPolicyTrainer:
             weight_decay=weight_decay,
             grad_clip_norm=grad_clip_norm,
         )
+        # Enable trainer-side grad-norm telemetry (train/grad_norm*) by default. The SDK reads
+        # emit_grad_norm_metrics off AdamParams when the optim_step kwarg is None, and
+        # ReconnectableClient.optim_step forwards AdamParams but not that kwarg — so set it here.
+        # Guarded on the field the Fireworks grad-norm patch adds to AdamParams.
+        if self._emit_grad_norm_metrics is not None and "emit_grad_norm_metrics" in AdamParams.model_fields:
+            adam_params = adam_params.model_copy(update={"emit_grad_norm_metrics": self._emit_grad_norm_metrics})
         from fireworks.training.sdk.client import GradAccNormalization
 
         _LOSS_AGG_MAP = {

--- a/rllm/trainer/tinker/custom_loss.py
+++ b/rllm/trainer/tinker/custom_loss.py
@@ -121,6 +121,8 @@ def build_custom_loss(
 
         if server_normalized:
             loss = total  # server divides by NUM_LOSS_TOKENS / NUM_SEQUENCES across the window
+        elif agg_mode == "token-sum":
+            loss = total  # raw token-sum, no normalization
         elif agg_mode == "token-mean":
             loss = total / max(num_tokens, 1.0)
         else:  # seq-mean-token-mean / seq-mean-token-sum


### PR DESCRIPTION
## Motivation: why set `grad_accumulation_normalization=None`

`optim_step`'s `GradAccNormalization` is a **server-side** knob: when set to `NUM_LOSS_TOKENS`/`NUM_SEQUENCES`, the Fireworks trainer divides the accumulated gradient by a **server-computed** token/sequence count before the Adam step. We set it to **`NONE`** — the server never normalizes — and make normalization rLLM's responsibility. Reasons:

1. **The normalizer should be explicit and owned by rLLM, not delegated to an opaque server count.** The flag's `NUM_LOSS_TOKENS` divides by the server's notion of "non-zero-grad tokens", which we don't control and which differs from the reference frameworks (verl divides by `loss_mask.sum()` = all response tokens; prime-rl by an all-reduced masked-token count). Relying on the flag makes the *effective* objective backend-defined and non-obvious.

2. **A server flag can't normalize the loss the way verl/prime-rl do anyway.** Both frameworks normalize the **loss** (reduce the per-token loss matrix), and prime-rl even folds a KL term *inside* that reduction — which only works because they divide the loss. The server flag divides the *gradient* of a raw-sum loss; for our purposes we'd rather normalize the loss itself, in the one place rLLM actually computes it (the custom-loss path).

3. **Avoids double-normalization and keeps one code path.** The custom-loss path (`forward_backward_custom`) already computes and normalizes the loss client-side per `loss_agg_mode` (via `build_custom_loss`, `server_normalized=False`). Leaving the server flag on there would divide twice. Setting it to `NONE` everywhere gives a single, consistent rule: **the server never normalizes; rLLM does (where it owns the loss).**

4. **Consistency with the Tinker path.** Tinker's trainer calls `optim_step` with Adam params only (no normalization knob) and its builtin path is a raw token-sum. `NONE` makes Fireworks behave the same way, so the two managed backends share one normalization story.

### Consequence of `NONE`
- **Builtin server kernel** (importance_sampling/dapo/gspo/cispo): the loss is computed server-side and rLLM has no loss tensor to normalize, so it stays at the SDK's default **raw token-sum** — same as Tinker's builtin path. (We deliberately do *not* fold `1/N` into the advantage to fake normalization: that's exact only for losses linear in the advantage and breaks the moment a loss adds a non-advantage term like KL/entropy.) `loss_agg_mode` is not applied here; it warns once if set to a non-token-sum mode.
- **Custom-loss path**: rLLM normalizes the loss client-side per `loss_agg_mode` — the loss-level normalization matching verl/prime-rl.

## Also in this PR
- **Emit grad-norm telemetry** — `emit_grad_norm_metrics=True` on `AdamParams`, so `train/grad_norm*` is logged each step (was silently off; needed for comparing gradient scale vs verl). Metric is global/RMS (≈ L2/√#params); verl reports pre-clip L2, so compare trends not raw magnitudes.
- **`token-mean` default** for `loss_agg_mode` (applies to verl and the custom-loss path; matches verl's own native default).
- **Add `token-sum`** as a selectable mode (custom-loss path; also names the builtin default).

## Test
- ruff check + ruff-format clean (pinned 0.11.4).
- `emit_grad_norm_metrics=True` round-trips into the `OptimStepRequest` wire payload.
- `build_custom_loss` normalization verified for token-sum / token-mean / seq-mean-*; builtin path passes unscaled advantages (raw token-sum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)