### PR TITLE
feat(engine): colorful task-group summary when all rollouts of a group finish

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -416,12 +416,12 @@ def _format_group_finished(task_id: str, episodes: list[Episode]) -> str:
 
     # Reward per trajectory name — this is the GRPO advantage group. A name whose
     # rewards are all equal (flat) yields zero advantage and gets filtered, so mark
-    # it red; a name with spread carries a learning signal, so green.
+    # it yellow; a name with spread carries a learning signal, so green.
     if rewards_by_name:
         for name, rs in rewards_by_name.items():
             flat = len(rs) >= 2 and _pstd(rs) < 1e-9
-            txt = f"{name} μ{_mean(rs):.2f} σ{_pstd(rs):.2f} [{min(rs):.1f}, {max(rs):.1f}]" + (" ⚠ flat" if flat else "")
-            seg.append(click.style(txt, fg="red" if flat else "green"))
+            txt = f"{name} μ{_mean(rs):.2f} σ{_pstd(rs):.2f} [{min(rs):.1f}, {max(rs):.1f}]"
+            seg.append(click.style(txt, fg="yellow" if flat else "green"))
     else:
         seg.append(click.style("reward N/A", fg="white"))
 

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -358,14 +358,25 @@ def _format_timing_breakdown(metrics: dict[str, float]) -> str:
     return f" in {total:.0f}s{inner}"
 
 
-def _episode_primary_reward(episode: Episode) -> float | None:
-    """Scalar reward for one episode: first trajectory's reward, else its last step's."""
-    for traj in episode.trajectories:
-        if traj.reward is not None:
-            return float(traj.reward)
-        if traj.steps and traj.steps[-1].reward is not None:
-            return float(traj.steps[-1].reward)
-    return None
+def _rewards_by_trajectory_name(episodes: list[Episode]) -> dict[str, list[float]]:
+    """Per-trajectory-name reward lists across a task group.
+
+    GRPO groups trajectories by (task_id, trajectory name) and computes advantage
+    within each name-group, so reward stats are only meaningful *per name* — not
+    collapsed to one scalar per episode. Falls back to a trajectory's last step
+    reward when ``traj.reward`` is unset (mirrors the per-episode log line). Name
+    order is first-seen, for a stable readout.
+    """
+    by_name: dict[str, list[float]] = {}
+    for ep in episodes:
+        for traj in ep.trajectories:
+            reward = traj.reward
+            if reward is None and traj.steps and traj.steps[-1].reward is not None:
+                reward = traj.steps[-1].reward
+            if reward is None:
+                continue
+            by_name.setdefault(traj.name, []).append(float(reward))
+    return by_name
 
 
 def _mean(xs: list[float]) -> float:
@@ -384,32 +395,33 @@ def _format_group_finished(task_id: str, episodes: list[Episode]) -> str:
     """One-line colorful summary of a finished task group (all rollouts sharing a task_id).
 
     Surfaces the GRPO-relevant signal at a glance: solve rate, reward spread
-    (a *flat* group — all rewards equal — gives zero advantage and gets filtered),
-    straggler timing (the group only finishes when its slowest rollout does), and
-    the termination-reason breakdown. Segments are individually styled with
+    **per trajectory name** (GRPO forms one advantage group per name — a *flat*
+    name, all rewards equal, gives zero advantage and gets filtered), straggler
+    timing (the group only finishes when its slowest rollout does), and the
+    termination-reason breakdown. Segments are individually styled with
     ``click.style`` and joined, so the line is multi-color.
     """
     n = len(episodes)
     n_correct = sum(1 for e in episodes if e.is_correct)
-    rewards = [r for r in (_episode_primary_reward(e) for e in episodes) if r is not None]
+    rewards_by_name = _rewards_by_trajectory_name(episodes)
     rollout_s = [e.metrics["time/rollout_s"] for e in episodes if "time/rollout_s" in e.metrics]
     llm_s = [e.metrics["time/agentflow_llm_wall_s"] for e in episodes if "time/agentflow_llm_wall_s" in e.metrics]
     steps = [e.metrics["n_turns"] for e in episodes if "n_turns" in e.metrics]
     terms = Counter(e.termination_reason.value if e.termination_reason is not None else "None" for e in episodes)
 
     short_id = task_id.split("-")[0]  # first uuid segment — enough to eyeball
-    flat = len(rewards) >= 2 and _pstd(rewards) < 1e-9
 
     seg = [click.style(f"█ group {short_id} ×{n}", fg="cyan", bold=True)]
+    seg.append(click.style(f"solved {n_correct}/{n} ({100.0 * n_correct / n if n else 0.0:.0f}%)", fg="bright_white", bold=True))
 
-    # Solve rate — the headline. Red when the group is flat (no GRPO gradient,
-    # will be filtered), green when it carries a learning signal.
-    pct = 100.0 * n_correct / n if n else 0.0
-    solved = f"solved {n_correct}/{n} ({pct:.0f}%)" + (" ⚠ flat" if flat else "")
-    seg.append(click.style(solved, fg="red" if flat else "green", bold=True))
-
-    if rewards:
-        seg.append(click.style(f"reward μ{_mean(rewards):.2f} σ{_pstd(rewards):.2f} [{min(rewards):.1f}, {max(rewards):.1f}]", fg="white"))
+    # Reward per trajectory name — this is the GRPO advantage group. A name whose
+    # rewards are all equal (flat) yields zero advantage and gets filtered, so mark
+    # it red; a name with spread carries a learning signal, so green.
+    if rewards_by_name:
+        for name, rs in rewards_by_name.items():
+            flat = len(rs) >= 2 and _pstd(rs) < 1e-9
+            txt = f"{name} μ{_mean(rs):.2f} σ{_pstd(rs):.2f} [{min(rs):.1f}, {max(rs):.1f}]" + (" ⚠ flat" if flat else "")
+            seg.append(click.style(txt, fg="red" if flat else "green"))
     else:
         seg.append(click.style("reward N/A", fg="white"))
 

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -24,11 +24,12 @@ import logging
 import resource
 import time
 import uuid
-from collections import defaultdict
+from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+import click
 from tqdm import tqdm
 
 from rllm.data.utils import task_from_row
@@ -357,6 +358,78 @@ def _format_timing_breakdown(metrics: dict[str, float]) -> str:
     return f" in {total:.0f}s{inner}"
 
 
+def _episode_primary_reward(episode: Episode) -> float | None:
+    """Scalar reward for one episode: first trajectory's reward, else its last step's."""
+    for traj in episode.trajectories:
+        if traj.reward is not None:
+            return float(traj.reward)
+        if traj.steps and traj.steps[-1].reward is not None:
+            return float(traj.steps[-1].reward)
+    return None
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _pstd(xs: list[float]) -> float:
+    """Population standard deviation (0 for <2 samples)."""
+    if len(xs) < 2:
+        return 0.0
+    m = _mean(xs)
+    return (sum((x - m) ** 2 for x in xs) / len(xs)) ** 0.5
+
+
+def _format_group_finished(task_id: str, episodes: list[Episode]) -> str:
+    """One-line colorful summary of a finished task group (all rollouts sharing a task_id).
+
+    Surfaces the GRPO-relevant signal at a glance: solve rate, reward spread
+    (a *flat* group — all rewards equal — gives zero advantage and gets filtered),
+    straggler timing (the group only finishes when its slowest rollout does), and
+    the termination-reason breakdown. Segments are individually styled with
+    ``click.style`` and joined, so the line is multi-color.
+    """
+    n = len(episodes)
+    n_correct = sum(1 for e in episodes if e.is_correct)
+    rewards = [r for r in (_episode_primary_reward(e) for e in episodes) if r is not None]
+    rollout_s = [e.metrics["time/rollout_s"] for e in episodes if "time/rollout_s" in e.metrics]
+    llm_s = [e.metrics["time/agentflow_llm_wall_s"] for e in episodes if "time/agentflow_llm_wall_s" in e.metrics]
+    steps = [e.metrics["n_turns"] for e in episodes if "n_turns" in e.metrics]
+    terms = Counter(e.termination_reason.value if e.termination_reason is not None else "None" for e in episodes)
+
+    short_id = task_id.split("-")[0]  # first uuid segment — enough to eyeball
+    flat = len(rewards) >= 2 and _pstd(rewards) < 1e-9
+
+    seg = [click.style(f"█ group {short_id} ×{n}", fg="cyan", bold=True)]
+
+    # Solve rate — the headline. Red when the group is flat (no GRPO gradient,
+    # will be filtered), green when it carries a learning signal.
+    pct = 100.0 * n_correct / n if n else 0.0
+    solved = f"solved {n_correct}/{n} ({pct:.0f}%)" + (" ⚠ flat" if flat else "")
+    seg.append(click.style(solved, fg="red" if flat else "green", bold=True))
+
+    if rewards:
+        seg.append(click.style(f"reward μ{_mean(rewards):.2f} σ{_pstd(rewards):.2f} [{min(rewards):.1f}, {max(rewards):.1f}]", fg="white"))
+    else:
+        seg.append(click.style("reward N/A", fg="white"))
+
+    if rollout_s:
+        seg.append(click.style(f"rollout μ{_mean(rollout_s):.0f}s max{max(rollout_s):.0f}s", fg="blue"))
+    if llm_s:
+        seg.append(click.style(f"llm μ{_mean(llm_s):.0f}s", fg="blue"))
+    if steps:
+        seg.append(click.style(f"steps μ{_mean(steps):.0f}", fg="blue"))
+
+    # Termination — red if any rollout hit an infra/grading failure (a wasted,
+    # untrustworthy rollout that training filters), yellow otherwise. Normal
+    # agent outcomes (env_done, max_turns, timeout, length limits) stay yellow.
+    _infra = {r.value for r in INFRA_ERROR_REASONS}
+    any_infra = any(k in _infra for k in terms)
+    seg.append(click.style(" ".join(f"{k}×{v}" for k, v in terms.most_common()), fg="red" if any_infra else "yellow"))
+
+    return "  ".join(seg)
+
+
 def _raise_fd_limit(target: int = _MIN_FD_LIMIT) -> None:
     """Best-effort raise of the process soft file-descriptor limit.
 
@@ -487,6 +560,13 @@ class AgentFlowEngine:
             futures.append(self.process_task_with_retry(task, task_id, rollout_idx, idx, is_validation=is_validation))
 
         results: list[Episode | None] = [None] * len(tasks)
+        # Group-level accounting: a "task group" is all rollouts sharing a task_id
+        # (created by interleave_tasks for GRPO grouping). ``task_id_counter`` now
+        # holds each group's final size; accumulate finished episodes per group and
+        # print a summary once the last one lands. Singleton groups (n=1) are skipped
+        # as noise — the per-episode line already says everything.
+        group_sizes: dict[str, int] = dict(task_id_counter)
+        group_episodes: dict[str, list[Episode]] = defaultdict(list)
         # Running tallies for a live accuracy/reward readout on the progress bar.
         n_correct = 0
         reward_sum = 0.0
@@ -529,6 +609,15 @@ class AgentFlowEngine:
                 if n_scored:
                     postfix += f" reward={reward_sum / n_scored:.3f}"
                 pbar.set_postfix_str(postfix)
+
+                # Task-group summary: fires once the group's last rollout lands.
+                if episode is not None:
+                    group_episodes[task_id].append(episode)
+                    if len(group_episodes[task_id]) >= group_sizes.get(task_id, 1) and group_sizes.get(task_id, 1) > 1:
+                        try:
+                            print(_format_group_finished(task_id, group_episodes.pop(task_id)), flush=True)
+                        except Exception:
+                            logger.debug("group summary formatting error", exc_info=True)
 
         ordered_results: list[Episode] = results  # type: ignore[assignment]
 

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -623,9 +623,14 @@ class AgentFlowEngine:
                 pbar.set_postfix_str(postfix)
 
                 # Task-group summary: fires once the group's last rollout lands.
-                if episode is not None:
-                    group_episodes[task_id].append(episode)
-                    if len(group_episodes[task_id]) >= group_sizes.get(task_id, 1) and group_sizes.get(task_id, 1) > 1:
+                # Only multi-rollout groups are tracked (singletons add nothing over
+                # the per-episode line); the accumulator holds references already kept
+                # alive by ``results`` and is popped on completion, so it adds no
+                # meaningful memory and is empty by the time this loop exits.
+                if episode is not None and group_sizes.get(task_id, 1) > 1:
+                    group = group_episodes[task_id]
+                    group.append(episode)
+                    if len(group) >= group_sizes[task_id]:
                         try:
                             print(_format_group_finished(task_id, group_episodes.pop(task_id)), flush=True)
                         except Exception:


### PR DESCRIPTION
## What

Per-rollout lines already log each episode:

```
[ed898041…:5] Rewards: [terminus2: 1.0] in 359s (setup=38s agentflow=316s [llm=256s/14 steps] evaluator=4s teardown=0s), Termination: ENV_DONE
```

…but nothing summarized a whole **task group** (all rollouts sharing a `task_id`, created by `interleave_tasks` for GRPO). This adds a colorful group-level readout that fires once the group's last rollout lands:

```
█ group ed898041 ×8  solved 5/8 (62%)  terminus2 μ0.62 σ0.48 [0.0, 1.0]  rollout μ205s max310s  llm μ40s  steps μ8  env_done×8
```

## Fields & colors

- **`solved N/M (%)`** — episode-level `is_correct` rate; neutral (bright-white) headline.
- **reward, per trajectory name** — GRPO forms one advantage group per `(task_id, trajectory name)`, so reward is aggregated **per name** (not collapsed to one scalar per episode), matching the per-episode line's `terminus2: …` naming. Each name shows `μ σ [min, max]`. Colored **green** when it has spread (carries a learning signal) and **yellow** when all its rewards are equal (flat → zero advantage → filtered; informational, not an error). A multi-agent flow renders one segment per name, e.g. `planner μ0.50 σ0.50 [0.0, 1.0]` (green) `coder μ0.50 σ0.00 [0.5, 0.5]` (yellow).
- **timing** (blue) — per-rollout `μ` and `max` wall time (the group only finishes when its slowest straggler does, so `max` is what matters), plus mean LLM wall time and turn count.
- **termination breakdown** — **red** if any rollout hit an infra/grading failure (`INFRA_ERROR_REASONS`; a wasted, filtered rollout), **yellow** for normal outcomes (`env_done`, `max_turns`, `timeout`, length limits). Red is reserved for genuine failures.

## Implementation

- New pure helpers `_rewards_by_trajectory_name`, `_mean`, `_pstd`, `_format_group_finished` next to `_format_timing_breakdown` in `agentflow_engine.py`. Multi-color via `click.style` segments. Reward falls back to a trajectory's last step reward when `traj.reward` is unset (mirrors the per-episode line).
- `execute_tasks` captures each group's final size from `task_id_counter` and accumulates finished episodes per group in the `asyncio.as_completed` stream, printing the summary when the last one lands. Only **multi-rollout** groups are tracked — singletons (n=1, e.g. eval) add nothing over the per-episode line.
- Formatting is wrapped in try/except (logged at debug) so a summary bug can never break a rollout step.

## Memory

Negligible. `execute_tasks` already retains every episode of the batch in `results` for the whole call; the group accumulator holds only *references* to those same objects (no payload copies) and `.pop()`s each group on completion, so it drains to empty before the loop exits. Skipping singletons guarantees nothing lingers.

## Testing

Verified rendering against synthetic groups matching the log in the request: single-name mixed (green), single-name flat (yellow), multi-trajectory-name (one green + one flat yellow, aggregated independently), infra-error termination (red term), and empty-reward (`reward N/A`) edge cases. `ruff check` passes; module imports and compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)