### PR TITLE
fix(trainer): print task-group summary from the async buffer path too

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -24,12 +24,11 @@ import logging
 import resource
 import time
 import uuid
-from collections import Counter, defaultdict
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-import click
 from tqdm import tqdm
 
 from rllm.data.utils import task_from_row
@@ -38,6 +37,7 @@ from rllm.eval.types import EvalOutput
 from rllm.gateway.manager import container_reachable_url
 from rllm.types import INFRA_ERROR_REASONS, AgentConfig, Episode, Step, Task, TerminationReason, Trajectory, flow_accepts_env, run_agent_flow, termination_reason_from_error
 from rllm.utils import colorful_print
+from rllm.utils.group_summary import format_group_finished
 
 if TYPE_CHECKING:
     from rllm_model_gateway.models import TraceRecord
@@ -358,90 +358,6 @@ def _format_timing_breakdown(metrics: dict[str, float]) -> str:
     return f" in {total:.0f}s{inner}"
 
 
-def _rewards_by_trajectory_name(episodes: list[Episode]) -> dict[str, list[float]]:
-    """Per-trajectory-name reward lists across a task group.
-
-    GRPO groups trajectories by (task_id, trajectory name) and computes advantage
-    within each name-group, so reward stats are only meaningful *per name* — not
-    collapsed to one scalar per episode. Falls back to a trajectory's last step
-    reward when ``traj.reward`` is unset (mirrors the per-episode log line). Name
-    order is first-seen, for a stable readout.
-    """
-    by_name: dict[str, list[float]] = {}
-    for ep in episodes:
-        for traj in ep.trajectories:
-            reward = traj.reward
-            if reward is None and traj.steps and traj.steps[-1].reward is not None:
-                reward = traj.steps[-1].reward
-            if reward is None:
-                continue
-            by_name.setdefault(traj.name, []).append(float(reward))
-    return by_name
-
-
-def _mean(xs: list[float]) -> float:
-    return sum(xs) / len(xs) if xs else 0.0
-
-
-def _pstd(xs: list[float]) -> float:
-    """Population standard deviation (0 for <2 samples)."""
-    if len(xs) < 2:
-        return 0.0
-    m = _mean(xs)
-    return (sum((x - m) ** 2 for x in xs) / len(xs)) ** 0.5
-
-
-def _format_group_finished(task_id: str, episodes: list[Episode]) -> str:
-    """One-line colorful summary of a finished task group (all rollouts sharing a task_id).
-
-    Surfaces the GRPO-relevant signal at a glance: solve rate, reward spread
-    **per trajectory name** (GRPO forms one advantage group per name — a *flat*
-    name, all rewards equal, gives zero advantage and gets filtered), straggler
-    timing (the group only finishes when its slowest rollout does), and the
-    termination-reason breakdown. Segments are individually styled with
-    ``click.style`` and joined, so the line is multi-color.
-    """
-    n = len(episodes)
-    n_correct = sum(1 for e in episodes if e.is_correct)
-    rewards_by_name = _rewards_by_trajectory_name(episodes)
-    rollout_s = [e.metrics["time/rollout_s"] for e in episodes if "time/rollout_s" in e.metrics]
-    llm_s = [e.metrics["time/agentflow_llm_wall_s"] for e in episodes if "time/agentflow_llm_wall_s" in e.metrics]
-    steps = [e.metrics["n_turns"] for e in episodes if "n_turns" in e.metrics]
-    terms = Counter(e.termination_reason.value if e.termination_reason is not None else "None" for e in episodes)
-
-    short_id = task_id.split("-")[0]  # first uuid segment — enough to eyeball
-
-    seg = [click.style(f"█ group {short_id} ×{n}", fg="cyan", bold=True)]
-    seg.append(click.style(f"solved {n_correct}/{n} ({100.0 * n_correct / n if n else 0.0:.0f}%)", fg="bright_white", bold=True))
-
-    # Reward per trajectory name — this is the GRPO advantage group. A name whose
-    # rewards are all equal (flat) yields zero advantage and gets filtered, so mark
-    # it yellow; a name with spread carries a learning signal, so green.
-    if rewards_by_name:
-        for name, rs in rewards_by_name.items():
-            flat = len(rs) >= 2 and _pstd(rs) < 1e-9
-            txt = f"{name} μ{_mean(rs):.2f} σ{_pstd(rs):.2f} [{min(rs):.1f}, {max(rs):.1f}]"
-            seg.append(click.style(txt, fg="yellow" if flat else "green"))
-    else:
-        seg.append(click.style("reward N/A", fg="white"))
-
-    if rollout_s:
-        seg.append(click.style(f"rollout μ{_mean(rollout_s):.0f}s max{max(rollout_s):.0f}s", fg="blue"))
-    if llm_s:
-        seg.append(click.style(f"llm μ{_mean(llm_s):.0f}s", fg="blue"))
-    if steps:
-        seg.append(click.style(f"steps μ{_mean(steps):.0f}", fg="blue"))
-
-    # Termination — red if any rollout hit an infra/grading failure (a wasted,
-    # untrustworthy rollout that training filters), yellow otherwise. Normal
-    # agent outcomes (env_done, max_turns, timeout, length limits) stay yellow.
-    _infra = {r.value for r in INFRA_ERROR_REASONS}
-    any_infra = any(k in _infra for k in terms)
-    seg.append(click.style(" ".join(f"{k}×{v}" for k, v in terms.most_common()), fg="red" if any_infra else "yellow"))
-
-    return "  ".join(seg)
-
-
 def _raise_fd_limit(target: int = _MIN_FD_LIMIT) -> None:
     """Best-effort raise of the process soft file-descriptor limit.
 
@@ -632,7 +548,7 @@ class AgentFlowEngine:
                     group.append(episode)
                     if len(group) >= group_sizes[task_id]:
                         try:
-                            print(_format_group_finished(task_id, group_episodes.pop(task_id)), flush=True)
+                            print(format_group_finished(task_id, group_episodes.pop(task_id)), flush=True)
                         except Exception:
                             logger.debug("group summary formatting error", exc_info=True)
 

--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -267,29 +267,12 @@ class TrajectoryGroupBuffer:
         self._queue_update_event.set()
         self._record_classified_prompt_group()
 
-        # Per-task fine-grained accounting: a task is consumed as one GRPO group,
-        # which collapses into training rows/datums under prefix-merge. Surface
-        # trajectories / steps (turns) / datums (rows after merge) so the merge
-        # ratio is visible per task, not just as a batch aggregate. Also surface
-        # the group's reward distribution (mean/min/max): GRPO advantages come
-        # from within-group reward spread, so a min==max group carries no signal.
-        n_traj = sum(len(g.trajectories) for g in traj_groups)
+        # Prefix-merge accounting: a task's steps collapse into training rows/datums
+        # under prefix-merge; surface the ratio per task (not just as a batch
+        # aggregate) on the group summary below. Reward distribution is shown there
+        # too, per trajectory name.
         n_steps = sum(len(t.steps) for g in traj_groups for t in g.trajectories)
         n_datums = sum(self._segment_count(t) for g in traj_groups for t in g.trajectories)
-        rewards = [r for g in traj_groups for t in g.trajectories if (r := self._traj_reward(t)) is not None]
-        mean_reward = (sum(rewards) / len(rewards)) if rewards else 0.0
-        logger.info(
-            "Task %s queued: %d group(s), %d trajectories, %d steps -> %d datums (rows) [%.2f steps/datum] | reward avg=%.4f min=%.4f max=%.4f",
-            task_id,
-            len(traj_groups),
-            n_traj,
-            n_steps,
-            n_datums,
-            (n_steps / n_datums) if n_datums else 0.0,
-            mean_reward,
-            min(rewards) if rewards else 0.0,
-            max(rewards) if rewards else 0.0,
-        )
 
         self._log_prompt_group_finished(
             task_id=task_id,
@@ -299,6 +282,8 @@ class TrajectoryGroupBuffer:
             groups_after_transform=before_min_traj,
             groups_after_min_trajs=len(traj_groups) + filtered_zero_adv,
             groups_after_reward_filter=len(traj_groups),
+            n_steps=n_steps,
+            n_datums=n_datums,
         )
 
         return True
@@ -414,20 +399,6 @@ class TrajectoryGroupBuffer:
             full = ids + list(step.response_ids)
         return max(segments, 1)
 
-    @staticmethod
-    def _traj_reward(traj) -> float | None:
-        """Scalar reward for a trajectory, or ``None`` if unscored.
-
-        Prefer the trajectory-level reward; fall back to the last step's reward.
-        Mirrors the extraction in ``_log_prompt_group_finished`` so the per-task
-        average matches the per-episode rewards logged there.
-        """
-        if traj.reward is not None:
-            return traj.reward
-        if traj.steps:
-            return traj.steps[-1].reward
-        return None
-
     def _log_prompt_group_finished(
         self,
         *,
@@ -438,6 +409,8 @@ class TrajectoryGroupBuffer:
         groups_after_transform: int,
         groups_after_min_trajs: int,
         groups_after_reward_filter: int,
+        n_steps: int | None = None,
+        n_datums: int | None = None,
     ) -> None:
         termination_counts = Counter(self._termination_value(ep.termination_reason or TerminationReason.UNKNOWN) for ep in episodes)
         compact_masked = Counter(
@@ -474,7 +447,7 @@ class TrajectoryGroupBuffer:
         # filtered:<reason> — that only this path knows. Best-effort: never let a
         # formatting error interfere with buffering.
         try:
-            print(format_group_finished(task_id, episodes, status=status, reason=reason), flush=True)
+            print(format_group_finished(task_id, episodes, status=status, reason=reason, n_steps=n_steps, n_datums=n_datums), flush=True)
         except Exception:
             logger.debug("group summary formatting error", exc_info=True)
 

--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -29,6 +29,7 @@ from rllm.trainer.algorithms.transform import transform_episodes_to_trajectory_g
 from rllm.trainer.metrics_aggregator import MetricsAggregator
 from rllm.trainer.sync_coordinator import SyncCoordinator
 from rllm.types import INFRA_ERROR_REASONS, Episode, TerminationReason, TrajectoryGroup
+from rllm.utils.group_summary import format_group_finished
 
 logger = logging.getLogger(__name__)
 
@@ -467,6 +468,15 @@ class TrajectoryGroupBuffer:
             groups_after_min_trajs,
             groups_after_reward_filter,
         )
+
+        # Colorful per-group readout (the async training path's counterpart to the
+        # engine's execute_tasks summary). Carries the buffer verdict — queued vs.
+        # filtered:<reason> — that only this path knows. Best-effort: never let a
+        # formatting error interfere with buffering.
+        try:
+            print(format_group_finished(task_id, episodes, status=status, reason=reason), flush=True)
+        except Exception:
+            logger.debug("group summary formatting error", exc_info=True)
 
     @staticmethod
     def _min_weight_version(episodes: list[Episode]) -> int:

--- a/rllm/utils/group_summary.py
+++ b/rllm/utils/group_summary.py
@@ -65,6 +65,8 @@ def format_group_finished(
     *,
     status: str | None = None,
     reason: str | None = None,
+    n_steps: int | None = None,
+    n_datums: int | None = None,
 ) -> str:
     """One-line colorful summary of a finished task group (all rollouts sharing a task_id).
 
@@ -77,7 +79,8 @@ def format_group_finished(
 
     ``status`` / ``reason`` are optional and come from the async training buffer:
     ``queued`` (accepted into training, green) or ``filtered`` (dropped, with the
-    reason — e.g. ``uniform_reward`` — in yellow).
+    reason — e.g. ``uniform_reward`` — in yellow). ``n_steps`` / ``n_datums`` (also
+    buffer-only, queued groups) add the prefix-merge ratio ``rows N [X steps/row]``.
     """
     n = len(episodes)
     n_correct = sum(1 for e in episodes if e.is_correct)
@@ -116,6 +119,12 @@ def format_group_finished(
         seg.append(click.style(f"llm μ{_mean(llm_s):.0f}s", fg="blue"))
     if steps:
         seg.append(click.style(f"steps μ{_mean(steps):.0f}", fg="blue"))
+    # Prefix-merge ratio (buffer/queued path only): how many training rows the
+    # group's steps collapse into. rows == steps means no merge; rows << steps
+    # means heavy prefix sharing.
+    if n_datums:
+        ratio = (n_steps / n_datums) if n_steps else 0.0
+        seg.append(click.style(f"rows {n_datums} [{ratio:.1f} steps/row]", fg="blue"))
 
     # Termination — red if any rollout hit an infra/grading failure (a wasted,
     # untrustworthy rollout that training filters), yellow otherwise. Normal

--- a/rllm/utils/group_summary.py
+++ b/rllm/utils/group_summary.py
@@ -1,0 +1,127 @@
+"""Colorful one-line summary of a finished task group.
+
+A *task group* is all rollouts sharing a ``task_id`` (created by
+``interleave_tasks`` for GRPO). Both execution paths reduce to the same readout:
+
+- the sync/eval path (``AgentFlowEngine.execute_tasks``) prints it once a group's
+  last rollout lands, and
+- the async training path (``TrajectoryGroupBuffer`` in ``rllm.trainer.buffer``)
+  prints it from the per-group completion hook, passing the extra ``status`` /
+  ``reason`` it knows (queued vs. filtered, and why).
+
+Kept dependency-light (only ``rllm.types``) so both engine and trainer can import
+it without a cycle.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING
+
+import click
+
+from rllm.types import INFRA_ERROR_REASONS
+
+if TYPE_CHECKING:
+    from rllm.types import Episode
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _pstd(xs: list[float]) -> float:
+    """Population standard deviation (0 for <2 samples)."""
+    if len(xs) < 2:
+        return 0.0
+    m = _mean(xs)
+    return (sum((x - m) ** 2 for x in xs) / len(xs)) ** 0.5
+
+
+def rewards_by_trajectory_name(episodes: list[Episode]) -> dict[str, list[float]]:
+    """Per-trajectory-name reward lists across a task group.
+
+    GRPO groups trajectories by (task_id, trajectory name) and computes advantage
+    within each name-group, so reward stats are only meaningful *per name* — not
+    collapsed to one scalar per episode. Falls back to a trajectory's last step
+    reward when ``traj.reward`` is unset (mirrors the per-episode log line). Name
+    order is first-seen, for a stable readout.
+    """
+    by_name: dict[str, list[float]] = {}
+    for ep in episodes:
+        for traj in ep.trajectories:
+            reward = traj.reward
+            if reward is None and traj.steps and traj.steps[-1].reward is not None:
+                reward = traj.steps[-1].reward
+            if reward is None:
+                continue
+            by_name.setdefault(traj.name, []).append(float(reward))
+    return by_name
+
+
+def format_group_finished(
+    task_id: str,
+    episodes: list[Episode],
+    *,
+    status: str | None = None,
+    reason: str | None = None,
+) -> str:
+    """One-line colorful summary of a finished task group (all rollouts sharing a task_id).
+
+    Surfaces the GRPO-relevant signal at a glance: solve rate, reward spread
+    **per trajectory name** (GRPO forms one advantage group per name — a *flat*
+    name, all rewards equal, gives zero advantage and gets filtered), straggler
+    timing (the group only finishes when its slowest rollout does), and the
+    termination-reason breakdown. Segments are individually styled with
+    ``click.style`` and joined, so the line is multi-color.
+
+    ``status`` / ``reason`` are optional and come from the async training buffer:
+    ``queued`` (accepted into training, green) or ``filtered`` (dropped, with the
+    reason — e.g. ``uniform_reward`` — in yellow).
+    """
+    n = len(episodes)
+    n_correct = sum(1 for e in episodes if e.is_correct)
+    rewards_by_name = rewards_by_trajectory_name(episodes)
+    rollout_s = [e.metrics["time/rollout_s"] for e in episodes if "time/rollout_s" in e.metrics]
+    llm_s = [e.metrics["time/agentflow_llm_wall_s"] for e in episodes if "time/agentflow_llm_wall_s" in e.metrics]
+    steps = [e.metrics["n_turns"] for e in episodes if "n_turns" in e.metrics]
+    terms = Counter(e.termination_reason.value if e.termination_reason is not None else "None" for e in episodes)
+
+    short_id = task_id.split("-")[0]  # first uuid segment — enough to eyeball
+
+    seg = [click.style(f"█ group {short_id} ×{n}", fg="cyan", bold=True)]
+
+    # Buffer verdict (async path only): did this group make it into training?
+    if status == "queued":
+        seg.append(click.style("✓ queued", fg="green", bold=True))
+    elif status == "filtered":
+        seg.append(click.style(f"⊘ filtered:{reason}" if reason else "⊘ filtered", fg="yellow", bold=True))
+
+    seg.append(click.style(f"solved {n_correct}/{n} ({100.0 * n_correct / n if n else 0.0:.0f}%)", fg="bright_white", bold=True))
+
+    # Reward per trajectory name — this is the GRPO advantage group. A name whose
+    # rewards are all equal (flat) yields zero advantage and gets filtered, so mark
+    # it yellow; a name with spread carries a learning signal, so green.
+    if rewards_by_name:
+        for name, rs in rewards_by_name.items():
+            flat = len(rs) >= 2 and _pstd(rs) < 1e-9
+            txt = f"{name} μ{_mean(rs):.2f} σ{_pstd(rs):.2f} [{min(rs):.1f}, {max(rs):.1f}]"
+            seg.append(click.style(txt, fg="yellow" if flat else "green"))
+    else:
+        seg.append(click.style("reward N/A", fg="white"))
+
+    if rollout_s:
+        seg.append(click.style(f"rollout μ{_mean(rollout_s):.0f}s max{max(rollout_s):.0f}s", fg="blue"))
+    if llm_s:
+        seg.append(click.style(f"llm μ{_mean(llm_s):.0f}s", fg="blue"))
+    if steps:
+        seg.append(click.style(f"steps μ{_mean(steps):.0f}", fg="blue"))
+
+    # Termination — red if any rollout hit an infra/grading failure (a wasted,
+    # untrustworthy rollout that training filters), yellow otherwise. Normal
+    # agent outcomes (env_done, max_turns, timeout, length limits) stay yellow.
+    _infra = {r.value for r in INFRA_ERROR_REASONS}
+    any_infra = any(k in _infra for k in terms)
+    seg.append(click.style(" ".join(f"{k}×{v}" for k, v in terms.most_common()), fg="red" if any_infra else "yellow"))
+
+    return "  ".join(seg)


### PR DESCRIPTION
## Problem

#784 added the colorful task-group summary, but it lived **only** in `AgentFlowEngine.execute_tasks` — the sync/eval path. Async training doesn't go through `execute_tasks`; it dispatches rollouts through the `TrajectoryGroupBuffer` / coordinator (the run shows a `Tasks: … consumed=/filtered=/queued=/step=` bar, not `execute_tasks`'s `"Generating trajectories"`). So on an async training run the group summary **never printed** — the per-episode line still showed up (it's emitted from `process_task_with_retry`), which is exactly why it looked like the feature "wasn't adopted."

## Fix

- Extract the formatter into **`rllm/utils/group_summary.py`** — dependency-light (only `rllm.types`), so both `engine` and `trainer` import it with no cycle.
- Call it from `TrajectoryGroupBuffer._log_prompt_group_finished`, the single hook every group-completion outcome funnels through. It passes the **buffer verdict** that only this path knows:
  - `✓ queued` (green) — accepted into training, or
  - `⊘ filtered:<reason>` (yellow) — dropped, e.g. `uniform_reward` / `min_trajs` / `compact_filtering`.
- `execute_tasks` now imports the same shared `format_group_finished` (behaviour unchanged for eval / sync verl); the extra args are optional and omitted there.

## Cleanup: drop the redundant `Task queued` info log

The async buffer already had a per-group `logger.info("Task X queued: …")` (PR #690). It's now redundant with the colorful summary — same event, same reward info — but only for queued groups and plain-text. **Removed it**, folding its one unique field (the prefix-merge ratio) into the summary via optional `n_steps`/`n_datums`, so a queued line shows `rows N [X steps/row]` and nothing is lost. Also dropped the now-unused `_traj_reward` helper.

The DEBUG `_log_prompt_group_finished` log stays — it's level-suppressed (no console noise), covers all outcomes, and carries filter-stage counts (`compact_masked`, `groups_after_*`) useful when debugging filtering.

## Output

Async training (buffer path):
```
█ group ed898041 ×8  ✓ queued                 solved 5/8 (62%)  terminus2 μ0.62 σ0.48 [0.0, 1.0]  rollout μ150s max310s  llm μ40s  steps μ8  rows 80 [1.4 steps/row]  env_done×8
█ group cecd5958 ×8  ⊘ filtered:uniform_reward  solved 0/8 (0%)  terminus2 μ0.00 σ0.00 [0.0, 0.0]  rollout μ135s max170s  llm μ40s  steps μ8  env_done×8
```
Eval / sync path (no verdict tag, no rows) is unchanged.

## Notes

- Best-effort `try/except` around the print — a formatting bug can never disturb buffering or a rollout step.
- Verified: `buffer.py` imports cleanly (no circular import), rendering checked for queued / filtered / eval cases, `ruff` clean, all three files compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)