### PR TITLE
feat(opencode): pin session --title to skip title-generation request during training

### DIFF
--- a/rllm/harnesses/opencode.py
+++ b/rllm/harnesses/opencode.py
@@ -79,6 +79,10 @@ class OpenCodeHarness(BaseCliHarness):
     # bypasses that validation.
     _RLLM_PROVIDER_ID = "rllm-gateway"
 
+    # Fixed session title passed via ``opencode run --title`` so opencode
+    # skips its separate title-generation LLM call (see ``build_invocation``).
+    _SESSION_TITLE = "rllm-training"
+
     def install_script(self) -> str:
         return _INSTALL_SCRIPT
 
@@ -159,6 +163,11 @@ class OpenCodeHarness(BaseCliHarness):
         # ``--model`` flag carries.
         _, model_id, _ = self._split_provider(config.model)
         qualified = f"{self._RLLM_PROVIDER_ID}/{model_id}"
+        # ``--title`` pins the session title to a fixed string so opencode
+        # skips its separate async title-generation LLM call. That call is
+        # wasted work during training (titles live only in the sandbox's
+        # local DB; trajectories come from gateway traces), and it forces the
+        # gateway to fork an extra lineage slot for its divergent prefix.
         # ``</dev/null`` is required: Modal's ``sandbox.exec`` leaves
         # stdin connected to a live socket that never receives EOF, and
         # opencode blocks on its initial stdin read forever — the run
@@ -167,6 +176,7 @@ class OpenCodeHarness(BaseCliHarness):
             f"{self._cd_prefix(task)}"
             f". $HOME/.nvm/nvm.sh 2>/dev/null; "
             f"opencode --model={shlex.quote(qualified)} run "
+            f"--title {shlex.quote(self._SESSION_TITLE)} "
             f"--dangerously-skip-permissions "
             f"-- {shlex.quote(instruction)} "
             f"</dev/null 2>&1 | tee {shlex.quote(self.stdout_log_path)}"

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -218,7 +218,10 @@ def test_opencode_writes_config_with_custom_provider_to_bypass_models_dev():
 def test_opencode_invocation_uses_custom_provider_prefix_and_detaches_stdin():
     """--model must carry the custom provider id, not the inferred
     openai/anthropic. And opencode blocks on its initial stdin read on
-    Modal sandboxes — the invocation must redirect stdin from /dev/null."""
+    Modal sandboxes — the invocation must redirect stdin from /dev/null.
+
+    ``--title`` must also be present: it pins the session title so opencode
+    skips its separate title-generation LLM call during training."""
     h = OpenCodeHarness()
     cmd = h.build_invocation(
         instruction="hi",
@@ -226,6 +229,7 @@ def test_opencode_invocation_uses_custom_provider_prefix_and_detaches_stdin():
         config=_make_config(model="gpt-5.4-mini"),
     )
     assert "--model=rllm-gateway/gpt-5.4-mini" in cmd
+    assert "--title " in cmd
     assert "</dev/null" in cmd
 
 


### PR DESCRIPTION
## What

Add `--title rllm-training` to the `opencode run` command built in `OpenCodeHarness.build_invocation` (`rllm/harnesses/opencode.py`), so opencode **skips its separate async title-generation LLM request** during RL training.

## Why

`opencode run` fires an extra LLM call to summarize the session into a title. During training that title is never read — opencode's session state lives only in the ephemeral sandbox's local DB, and trajectories are reconstructed from gateway traces, not opencode's session store. So the request is pure waste (one extra generation per session) and it forces the gateway to fork an additional lineage slot for its divergent prefix (`SessionSlots`/`lineage_id` in the model gateway).

Passing `--title` makes opencode use that fixed value instead of generating one ([sst/opencode#3507](https://github.com/anomalyco/opencode/pull/3507), resolving [#1237](https://github.com/anomalyco/opencode/issues/1237)). There is **no config key or env var** to disable title generation — `small_model` only *redirects* the call to another model (and is [frequently ignored](https://github.com/anomalyco/opencode/issues/2640)); `--title` is the only lever that removes the request.

## Scope / risk

- Pure efficiency win, **not** a correctness fix. The gateway already prevents title-gen calls from corrupting trajectories via lineage partitioning; this just removes the wasted request up front.
- Only touches the **training** harness (`rllm/harnesses/opencode.py`). The Harbor eval agent is untouched.
- `--title` has been in `opencode run` since Oct 2025; the harness installs `opencode-ai@latest`, so it's available.

## Test

- Added a `--title` assertion to `test_opencode_invocation_uses_custom_provider_prefix_and_detaches_stdin`.
- `pytest tests/harnesses/test_cli_harness.py` → 54 passed.

Rendered command:
```
opencode --model=rllm-gateway/gpt-5.4-mini run --title rllm-training --dangerously-skip-permissions -- 'fix the bug' </dev/null 2>&1 | tee /tmp/opencode.log
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)