### PR TITLE
perf(gateway): pack token-id/logprob traces as array.array in memory store

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -1,8 +1,53 @@
 """In-memory trace store for testing and embedded usage."""
 
+import array
 import time
 from collections import defaultdict
 from typing import Any
+
+# Token-id / logprob lists dominate trace memory. As Python list[int]/list[float]
+# each element costs ~32-36 B (an 8 B pointer plus a boxed int/float object) since
+# vocab ids exceed CPython's small-int intern cap (256). Packed into array.array
+# they cost 4-8 B/element with no per-item object — ~9x smaller for ids, ~4x for
+# logprobs — and collapse N objects into 1, cutting GC pressure. We pack on store
+# and unpack on read so the external dict contract (plain lists) is unchanged.
+_INT_ARRAY_FIELDS = ("prompt_token_ids", "completion_token_ids")
+_FLOAT_ARRAY_FIELDS = ("logprobs",)
+
+
+def _pack(data: dict[str, Any]) -> dict[str, Any]:
+    """Return ``data`` with large id/logprob lists packed into ``array.array``.
+
+    The dict is copied lazily (only if something is packed) so the caller's
+    original lists can be released; any non-numeric/out-of-range content is left
+    untouched, so this never changes what a reader sees after :func:`_unpack`.
+    """
+    out: dict[str, Any] | None = None
+    for fields, typecode in ((_INT_ARRAY_FIELDS, "i"), (_FLOAT_ARRAY_FIELDS, "d")):
+        for name in fields:
+            value = data.get(name)
+            if type(value) is not list or not value:
+                continue
+            try:
+                packed = array.array(typecode, value)
+            except (TypeError, ValueError, OverflowError):
+                continue  # non-numeric / out-of-range: keep the original list
+            if out is None:
+                out = dict(data)
+            out[name] = packed
+    return out if out is not None else data
+
+
+def _unpack(data: dict[str, Any]) -> dict[str, Any]:
+    """Inverse of :func:`_pack` — restore packed arrays to plain lists."""
+    out: dict[str, Any] | None = None
+    for name in (*_INT_ARRAY_FIELDS, *_FLOAT_ARRAY_FIELDS):
+        value = data.get(name)
+        if isinstance(value, array.array):
+            if out is None:
+                out = dict(data)
+            out[name] = value.tolist()
+    return out if out is not None else data
 
 
 class MemoryTraceStore:
@@ -18,7 +63,7 @@ class MemoryTraceStore:
 
     async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
         now = time.time()
-        self._traces[trace_id] = data
+        self._traces[trace_id] = _pack(data)
         if trace_id not in self._timestamps:
             self._timestamps[trace_id] = now
         idx = self._session_index[session_id]
@@ -26,7 +71,8 @@ class MemoryTraceStore:
             idx.append(trace_id)
 
     async def get_trace(self, trace_id: str) -> dict[str, Any] | None:
-        return self._traces.get(trace_id)
+        data = self._traces.get(trace_id)
+        return _unpack(data) if data is not None else None
 
     async def get_session_traces(
         self,
@@ -45,7 +91,7 @@ class MemoryTraceStore:
                 results.append(data)
         if limit is not None:
             results = results[:limit]
-        return results
+        return [_unpack(d) for d in results]
 
     async def delete_session(self, session_id: str) -> int:
         ids = self._session_index.pop(session_id, [])

--- a/rllm-model-gateway/tests/unit/test_store.py
+++ b/rllm-model-gateway/tests/unit/test_store.py
@@ -1,5 +1,6 @@
 """Tests for MemoryTraceStore and SqliteTraceStore."""
 
+import array
 import os
 import tempfile
 
@@ -115,6 +116,72 @@ class TestFlush:
     @pytest.mark.asyncio
     async def test_flush_no_error(self, store):
         await store.flush()  # should not raise
+
+
+class TestTokenArrayPacking:
+    """The memory store packs token-id/logprob lists into array.array to save
+    RAM, but the packing must be invisible to readers (plain lists back out)."""
+
+    # Ids above CPython's small-int intern cap and a realistic vocab range.
+    _TRACE = {
+        "prompt_token_ids": [1000, 200000, 42, 1000, 151000],
+        "completion_token_ids": [12, 99999],
+        "logprobs": [-0.5, -12.3456, -0.0001],
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    @pytest.mark.asyncio
+    async def test_roundtrip_transparent(self, store):
+        """Both backends return plain lists with identical values."""
+        await store.store_trace("t1", "s1", dict(self._TRACE))
+        for getter in (
+            await store.get_trace("t1"),
+            (await store.get_session_traces("s1"))[0],
+        ):
+            for field in ("prompt_token_ids", "completion_token_ids", "logprobs"):
+                assert isinstance(getter[field], list)
+                assert getter[field] == self._TRACE[field]
+            assert getter["messages"] == self._TRACE["messages"]
+
+    @pytest.mark.asyncio
+    async def test_memory_store_packs_internally(self):
+        mem = MemoryTraceStore()
+        await mem.store_trace("t1", "s1", dict(self._TRACE))
+        stored = mem._traces["t1"]
+        assert isinstance(stored["prompt_token_ids"], array.array)
+        assert isinstance(stored["completion_token_ids"], array.array)
+        assert isinstance(stored["logprobs"], array.array)
+        assert stored["prompt_token_ids"].typecode == "i"
+        assert stored["logprobs"].typecode == "d"
+        # messages and other fields are untouched
+        assert stored["messages"] == self._TRACE["messages"]
+
+    @pytest.mark.asyncio
+    async def test_pack_does_not_mutate_caller_dict(self):
+        mem = MemoryTraceStore()
+        data = dict(self._TRACE)
+        await mem.store_trace("t1", "s1", data)
+        assert isinstance(data["prompt_token_ids"], list)  # caller's copy intact
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_fields_fall_back(self):
+        mem = MemoryTraceStore()
+        # None logprobs, empty ids, and a None element must not raise or corrupt.
+        data = {
+            "prompt_token_ids": [],
+            "completion_token_ids": [1, 2, 3],
+            "logprobs": None,
+        }
+        await mem.store_trace("t1", "s1", data)
+        got = await mem.get_trace("t1")
+        assert got["prompt_token_ids"] == []
+        assert got["completion_token_ids"] == [1, 2, 3]
+        assert got["logprobs"] is None
+
+        data2 = {"logprobs": [-0.1, None, -0.3]}  # ragged -> keep as list
+        await mem.store_trace("t2", "s1", data2)
+        assert isinstance(mem._traces["t2"]["logprobs"], list)
+        assert (await mem.get_trace("t2"))["logprobs"] == [-0.1, None, -0.3]
 
 
 class TestSqliteStoreSpecific:


### PR DESCRIPTION
## Problem

On long-context async RL runs (Fireworks backend), the gateway's in-memory trace store (`--store memory`) dominates RAM — **~50 GB per worker (~194 GB across 4 workers)**, ~85% of the training pod's anonymous memory. Inference is remote, so each worker holds no model weights: it's pure trace storage.

The store keeps token ids as Python `list[int]`. Each token costs **~36 B** — an 8 B list-slot pointer plus a ~28 B boxed `int` object — because Qwen-scale vocab ids (~151k) all exceed CPython's small-int intern cap of 256, so essentially every id is a distinct heap object. `logprobs` has the same problem as `list[float]`. With `--cumulative-token-mode`, every turn re-stores the full growing prompt, so this is also the base of an O(N²) pile.

## Change

Pack the numeric fields into `array.array` (a contiguous C buffer, no per-element object) inside `MemoryTraceStore`:

- `prompt_token_ids`, `completion_token_ids` → `array('i')` (4 B/token)
- `logprobs` → `array('d')` (8 B/elem, lossless)

Pack on `store_trace`, unpack (`.tolist()`) on read. **The external contract is unchanged** — callers still get plain lists; JSON responses are byte-identical. The dict is copied lazily (only when something packs) so the caller's original lists are released. Non-numeric/out-of-range content (e.g. `logprobs=None`, or a ragged list with a `None`) falls back to the original list and can never raise or corrupt. The `sqlite` backend is untouched.

## Impact (measured on this venv, Python 3.12)

| | before | after | |
|---|---|---|---|
| token-id list | 36 B/token | 4 B/token | **9×** |
| numeric fields, one 114688+16384-token trace | 5.24 MB | 0.66 MB | **8×** |
| 200 traces/step/shard | ~1 GB | ~120 MB | **8×** |

Plus a large GC win: a 114k-token prompt goes from 114k tracked objects to **1**.

**Cost:** ~1.5 ms/trace to pack, ~1.6 ms to unpack on read — negligible next to the tokenization and remote-inference round-trip already on the request path, and likely net-positive once reduced GC scanning and smaller serialization are counted.

## Tests

`tests/unit/test_store.py` — new `TestTokenArrayPacking` (roundtrip transparency on **both** backends, internal-packing assertions, caller-dict not mutated, non-numeric fallback). Full store suite: **32 passed**.

## Notes / follow-ups

This is the low-risk 80/20. Remaining gateway RAM after this is dominated by the redundant `messages` text and the O(N²) cumulative duplication — addressed separately by dropping/deduping `messages` and the delta-chain store proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)