### PR TITLE
feat(tinker): surface optim-step metrics (e.g. grad norm) from the Tinker server

### DIFF
--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -358,8 +358,15 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
                 beta2=self.beta2,
                 eps=self.eps,
             )
-            await optim_step_future.result_async()
+            optim_result = await optim_step_future.result_async()
             trainer_state.extra_info["scheduled_learning_rate"] = scheduled_learning_rate
+
+        # Surface optimizer-step metrics (e.g. grad norm) emitted by the Tinker server.
+        if optim_result.metrics:
+            for k, v in optim_result.metrics.items():
+                if k.startswith("clock_cycle"):
+                    continue
+                trainer_state.metrics[f"train/{k.replace(':', '/')}"] = v
 
     # =========================================================================
     # Async hook methods

--- a/rllm/trainer/tinker/tinker_policy_trainer.py
+++ b/rllm/trainer/tinker/tinker_policy_trainer.py
@@ -316,7 +316,7 @@ class TinkerPolicyTrainer:
         )
         # Retrieve the results together
         fwd_bwd_results = await asyncio.gather(*fwd_bwd_futures)
-        await optim_step_future.result_async()
+        optim_result = await optim_step_future.result_async()
 
         training_logprobs = []
         for fwd_bwd_result in fwd_bwd_results:
@@ -328,6 +328,13 @@ class TinkerPolicyTrainer:
                     if k.startswith("clock_cycle"):
                         continue
                     adv_metrics[f"train/{k.replace(':', '/')}"] = v
+
+        # Surface optimizer-step metrics (e.g. grad norm) emitted by the Tinker server.
+        if optim_result.metrics:
+            for k, v in optim_result.metrics.items():
+                if k.startswith("clock_cycle"):
+                    continue
+                adv_metrics[f"train/{k.replace(':', '/')}"] = v
 
         return training_datums, training_logprobs, adv_metrics, scheduled_learning_rate
 


### PR DESCRIPTION
## Problem

The Tinker trainer awaited the `optim_step` future but **discarded** its `OptimStepResponse`, so any optimizer-step metrics the Tinker server emits (grad norm, etc.) never reached the metrics logger.

- We already forward `forward_backward` metrics (`fwd_bwd_result.metrics`), but not the optim-step ones.
- `tinker-cookbook` surfaces these: every training loop does `if optim_result.metrics: metrics.update(optim_result.metrics)` (`rl/train.py`, `recipes/rl_loop.py`, `recipes/sl_loop.py`, `supervised/train.py`).
- Note: Tinker's `AdamParams` has **no** `emit_grad_norm_metrics` flag (unlike Fireworks) — only `grad_clip_norm`. Whatever the server chooses to populate in the opaque `OptimStepResponse.metrics` dict is the only channel, and we were dropping it.

## Change

Capture `optim_result.metrics` and merge it under the `train/` prefix in **both** optim paths, mirroring the existing `forward_backward` metric handling (skip `clock_cycle:*` keys, `':' -> '/'`):

- `tinker_policy_trainer.py` — fused path (`fused_forward_backward_and_optim_step`): merge into `adv_metrics` (returned → merged into `trainer_state.metrics`).
- `tinker_backend.py` — non-fused path (`update_policy`): merge directly into `trainer_state.metrics`.

Strictly additive: if the server emits nothing, behavior is unchanged. If it emits grad norm (or any optim metric), it now shows up in logs.

## Verification

- Both files byte-compile.
- Metric-ordering traced in `unified_trainer.py`: in the sync flow (`_train_batch_async`) `update_policy` runs at stage 7, before stage-8 logging; in the async flow (`_training_loop`) the merge (line 710) lands after the per-step reset (701) and before the log (762), with no intervening reset. Fused metrics flow through `adv_metrics` → `trainer_state.metrics.update(...)`.
- Not yet validated against a live run — the exact metric keys the Tinker server emits are opaque in the SDK types, so the first logged step will reveal whether a `grad_norm` key is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)