### PR TITLE
feat(tinker): surface optim-step metrics (e.g. grad norm) from the Tinker server

### DIFF
--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -368,8 +368,15 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
                 beta2=self.beta2,
                 eps=self.eps,
             )
-            await optim_step_future.result_async()
+            optim_result = await optim_step_future.result_async()
             trainer_state.extra_info["scheduled_learning_rate"] = scheduled_learning_rate
+
+        # Surface optimizer-step metrics (e.g. grad norm) emitted by the Tinker server.
+        if optim_result.metrics:
+            for k, v in optim_result.metrics.items():
+                if k.startswith("clock_cycle"):
+                    continue
+                trainer_state.metrics[f"train/{k.replace(':', '/')}"] = v
 
     # =========================================================================
     # Async hook methods

--- a/rllm/trainer/tinker/tinker_policy_trainer.py
+++ b/rllm/trainer/tinker/tinker_policy_trainer.py
@@ -358,7 +358,7 @@ class TinkerPolicyTrainer:
         )
         # Retrieve the results together
         fwd_bwd_results = await asyncio.gather(*fwd_bwd_futures)
-        await optim_step_future.result_async()
+        optim_result = await optim_step_future.result_async()
 
         training_logprobs = []
         for fwd_bwd_result in fwd_bwd_results:
@@ -375,6 +375,13 @@ class TinkerPolicyTrainer:
                     if k.startswith("clock_cycle"):
                         continue
                     adv_metrics[f"train/{k.replace(':', '/')}"] = v
+
+        # Surface optimizer-step metrics (e.g. grad norm) emitted by the Tinker server.
+        if optim_result.metrics:
+            for k, v in optim_result.metrics.items():
+                if k.startswith("clock_cycle"):
+                    continue
+                adv_metrics[f"train/{k.replace(':', '/')}"] = v
 
         return training_datums, training_logprobs, adv_metrics, scheduled_learning_rate
 


### PR DESCRIPTION
Re-targets the change from #788 (which was merged into `main` by mistake) onto `terminal-rl`.

## Problem

The Tinker trainer awaited the `optim_step` future but **discarded** its `OptimStepResponse`, so any optimizer-step metrics the Tinker server emits (grad norm, etc.) never reached the metrics logger.

- We already forward `forward_backward` metrics (`fwd_bwd_result.metrics`), but not the optim-step ones.
- `tinker-cookbook` surfaces these: every training loop does `if optim_result.metrics: metrics.update(optim_result.metrics)`.
- Tinker's `AdamParams` has **no** `emit_grad_norm_metrics` flag (unlike Fireworks) — only `grad_clip_norm`. Whatever the server populates in the opaque `OptimStepResponse.metrics` dict is the only channel, and we were dropping it.

## Change

Capture `optim_result.metrics` and merge under the `train/` prefix in **both** optim paths, mirroring the existing `forward_backward` handling (skip `clock_cycle:*`, `':' -> '/'`):

- `tinker_policy_trainer.py` — fused path (`fused_forward_backward_and_optim_step`): merge into `adv_metrics`.
- `tinker_backend.py` — non-fused path (`update_policy`): merge into `trainer_state.metrics`.

Strictly additive. Both files compile; metric ordering verified in `unified_trainer.py` for sync and async flows. Actual server metric keys are opaque in the SDK types, so whether a `grad_norm` key appears will be confirmed on the first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)