### PR TITLE
fix(eval): join dockerfile RUN continuation lines with a space

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -249,9 +249,13 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
 
 
 def _dockerfile_run_commands(task: Task) -> list[str]:
-    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps (joining
-    ``\\``-continuations). Non-``RUN`` directives — ``COPY``/``ADD`` etc. — are
-    skipped; only ``RUN`` is replayable on a live sandbox.
+    """Return a task's ``environment/Dockerfile`` ``RUN`` shell steps.
+
+    ``\\``-continuations are joined into a single logical command with a space
+    (matching shell line-continuation semantics) so multi-line ``RUN`` steps
+    stay valid when re-executed via ``bash -c``. Non-``RUN`` directives —
+    ``COPY``/``ADD`` etc. — are skipped; only ``RUN`` is replayable on a live
+    sandbox.
     """
     dockerfile = task.task_dir / "environment" / "Dockerfile"
     if not dockerfile.exists():
@@ -275,7 +279,7 @@ def _dockerfile_run_commands(task: Task) -> list[str]:
                 if i >= len(lines):
                     break
                 parts.append(lines[i])
-            cmd = "\n".join(parts).strip()
+            cmd = " ".join(part.strip() for part in parts).strip()
             if cmd:
                 commands.append(cmd)
         i += 1

--- a/tests/eval/test_dockerfile_run_continuation.py
+++ b/tests/eval/test_dockerfile_run_continuation.py
@@ -1,0 +1,43 @@
+"""Tests for Dockerfile RUN-continuation joining in :mod:`rllm.eval._resolution`.
+
+``_dockerfile_run_commands`` joins ``\\``-continuations into a single valid
+shell command (so multi-line ``RUN`` steps don't become invalid ``bash``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rllm.eval._resolution import _dockerfile_run_commands
+from rllm.types import Task
+
+
+def _task_with_dockerfile(tmp_path: Path, dockerfile: str) -> Task:
+    env = tmp_path / "environment"
+    env.mkdir(parents=True, exist_ok=True)
+    (env / "Dockerfile").write_text(dockerfile)
+    return Task(id="t", instruction="", metadata={}, dataset_dir=tmp_path)
+
+
+def test_multiline_run_joins_with_space_not_newline(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\nRUN apt-get update && apt-get install -y \\\n    python3-pip \\\n    && rm -rf /var/lib/apt/lists/*\n",
+    )
+    cmds = _dockerfile_run_commands(task)
+    assert cmds == ["apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*"]
+    # The old bug joined with "\n", which bash rejects ("syntax error near '&&'").
+    assert "\n" not in cmds[0]
+
+
+def test_copy_directives_are_skipped(tmp_path):
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\nCOPY input_files/data.json /app/data.json\nRUN echo hi\nADD x.tar /app/\n",
+    )
+    assert _dockerfile_run_commands(task) == ["echo hi"]
+
+
+def test_single_line_run_unchanged(tmp_path):
+    task = _task_with_dockerfile(tmp_path, "FROM ubuntu:24.04\nRUN pip3 install ansible-core==2.16.3\n")
+    assert _dockerfile_run_commands(task) == ["pip3 install ansible-core==2.16.3"]


### PR DESCRIPTION
Multi-line `RUN` steps get rejoined with `\n` instead of a space when replayed on modal/daytona. A backslash continuation in a Dockerfile `RUN` is a shell line continuation, not a literal newline, so it turns a valid multi-line `&&` chain into broken shell:

```
bash: -c: line 2: syntax error near unexpected token '&&'
```

Fixed by joining with a space and stripping each part. Tests cover the multi-line case, single-line (unchanged), and COPY/ADD getting skipped since only RUN is replayable.

Half of #655 — the double-apply issue in the same function is unrelated, split into its own PR (fix/dockerfile-replay-double-apply).

This fix already exists on `terminal-rl` (#656, @signalrush) but never landed on `main`, which still has the bug. Verified it applies clean and passes against current main with no regressions in the snapshot suite.