### PR TITLE
fix(sandbox): skip dockerfile RUN replay for prebuilt task images

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -196,15 +196,37 @@ def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, 
     return create_sandbox(backend, name=name, image=image, **_sandbox_resource_kwargs(task, backend), **backend_kwargs)
 
 
+def _should_replay_dockerfile(task: Task) -> bool:
+    """Whether to replay the Dockerfile's ``RUN`` steps on non-docker backends.
+
+    Two task conventions are supported via ``[environment].replay_dockerfile``:
+
+    * **SWE-bench style** (default, ``true``): the configured ``docker_image``
+      is a *base*; the Dockerfile's ``RUN`` steps (e.g. ``uv``, needed by the
+      grader) are not in that image and must be replayed on top.
+    * **Terminal-bench / Harbor style** (``false``): the configured
+      ``docker_image`` is the *fully built* task image, so replaying its ``RUN``
+      steps double-applies the build (``git clone ... already exists``, missing
+      ``COPY``'d files, etc.). These tasks set
+      ``[environment]\nreplay_dockerfile = false`` to boot the image as-is.
+    """
+    env = task.metadata.get("environment", {}) or {}
+    return bool(env.get("replay_dockerfile", True))
+
+
 def _replay_dockerfile(task: Task, sandbox: Sandbox, backend: str) -> None:
     """Replay the Dockerfile RUN steps on a live sandbox (stage C).
 
     Non-docker backends pull the Dockerfile's FROM base instead of building
     it, so the RUN steps (e.g. swebench's ``uv``, needed by the grader) must
     be replayed. Best-effort: a failed step shouldn't abort the task. Docker
-    builds the image, so its RUN steps already ran — skip.
+    builds the image, so its RUN steps already ran — skip. Tasks that boot a
+    fully-built image opt out via ``[environment].replay_dockerfile = false``
+    (see :func:`_should_replay_dockerfile`).
     """
     if backend == "docker":
+        return
+    if not _should_replay_dockerfile(task):
         return
     for cmd in _dockerfile_run_commands(task):
         _safe_exec(sandbox, cmd, timeout=900)

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -327,7 +327,13 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
     """
     from daytona import CreateSnapshotParams, Daytona, DaytonaNotFoundError, Image, Resources
 
-    from rllm.eval._resolution import _as_single_run_line, _dockerfile_run_commands, _resolve_image, _sandbox_resource_kwargs
+    from rllm.eval._resolution import (
+        _as_single_run_line,
+        _dockerfile_run_commands,
+        _resolve_image,
+        _sandbox_resource_kwargs,
+        _should_replay_dockerfile,
+    )
 
     client = Daytona()
     try:
@@ -341,7 +347,9 @@ def build_daytona_snapshot(task, key: str, *, force: bool = False, install_scrip
         pass
 
     img = Image.base(_resolve_image(task, "daytona"))
-    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)]
+    # Honor [environment].replay_dockerfile: fully-built task images opt out so
+    # their RUN steps aren't double-applied on top of the prebuilt image.
+    run_commands = [_as_single_run_line(c) for c in _dockerfile_run_commands(task)] if _should_replay_dockerfile(task) else []
     if install_script:
         run_commands.append(_as_single_run_line(install_script))
     if run_commands:

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -322,7 +322,12 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     (stored as a diff from the base). A failed install fails the build — a
     snapshot keyed on the install must actually contain it.
     """
-    from rllm.eval._resolution import _create_base_sandbox, _dockerfile_run_commands, _replay_dockerfile
+    from rllm.eval._resolution import (
+        _create_base_sandbox,
+        _dockerfile_run_commands,
+        _replay_dockerfile,
+        _should_replay_dockerfile,
+    )
 
     if prior_ref and not force and _modal_ref_alive(prior_ref):
         logger.info("modal snapshot %s already live (%s) — reusing", key, prior_ref)
@@ -333,7 +338,8 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     # full bound), plus the install bound and pull/capture slack. With the
     # 30-min default, two hung steps killed the sandbox mid-build.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
-    build_timeout = max(_DEFAULT_TIMEOUT, 900 * len(_dockerfile_run_commands(task)) + install_budget + 600)
+    n_replay = len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0
+    build_timeout = max(_DEFAULT_TIMEOUT, 900 * n_replay + install_budget + 600)
     sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
     try:
         _replay_dockerfile(task, sb, "modal")

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -70,9 +70,10 @@ def env_key(backend: str, base_image: str, run_commands: list[str], install_scri
 
 def env_key_for(task: Task, backend: str, install_script: str = "") -> str:
     """Fingerprint a task's environment via the shared image/RUN resolution."""
-    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image
+    from rllm.eval._resolution import _dockerfile_run_commands, _resolve_image, _should_replay_dockerfile
 
-    return env_key(backend, _resolve_image(task, backend), _dockerfile_run_commands(task), install_script)
+    run_commands = _dockerfile_run_commands(task) if _should_replay_dockerfile(task) else []
+    return env_key(backend, _resolve_image(task, backend), run_commands, install_script)
 
 
 def install_script_for(agent_flow: object) -> str:

--- a/tests/eval/test_dockerfile_replay_toggle.py
+++ b/tests/eval/test_dockerfile_replay_toggle.py
@@ -1,0 +1,40 @@
+"""Tests for the ``[environment].replay_dockerfile`` toggle in :mod:`rllm.eval._resolution`.
+
+Terminal-bench / Harbor tasks boot a fully-built image, so replaying the
+Dockerfile's RUN steps on top double-applies the build (e.g. a `git clone`
+failing because the destination already exists from the built image).
+``_should_replay_dockerfile`` lets those tasks opt out and boot as-is.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rllm.eval._resolution import _should_replay_dockerfile
+from rllm.tasks.loader import _load_task_from_dir
+from rllm.types import Task
+
+
+def test_replay_defaults_true_when_unset():
+    assert _should_replay_dockerfile(Task(id="t", instruction="", metadata={}, dataset_dir=Path("."))) is True
+    task = Task(id="t", instruction="", metadata={"environment": {"docker_image": "base"}}, dataset_dir=Path("."))
+    assert _should_replay_dockerfile(task) is True
+
+
+def test_replay_disabled_when_flag_false():
+    task = Task(
+        id="t",
+        instruction="",
+        metadata={"environment": {"docker_image": "prebuilt", "replay_dockerfile": False}},
+        dataset_dir=Path("."),
+    )
+    assert _should_replay_dockerfile(task) is False
+
+
+def test_replay_flag_read_from_task_toml(tmp_path):
+    """End-to-end: [environment].replay_dockerfile in task.toml reaches metadata."""
+    (tmp_path / "environment").mkdir()
+    (tmp_path / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\nRUN echo hi\n")
+    (tmp_path / "task.toml").write_text('[environment]\ndocker_image = "org/img:t"\nreplay_dockerfile = false\n')
+    task = _load_task_from_dir(tmp_path, dataset_dir=tmp_path)
+    assert _should_replay_dockerfile(task) is False


### PR DESCRIPTION
modal/daytona boot a base image and replay the Dockerfile's RUN steps on top, since neither builds the Dockerfile like docker does. Fine when the configured image is actually a base. Terminal-bench/Harbor tasks configure the fully built image instead, so replay runs on top of something that already has everything:

```
Command failed in sandbox rllm-hector-carbon-budget: git clone https://github.com/JGCRI/hector.git /app/hector
stderr: fatal: destination path '/app/hector' already exists
```

Added `[environment].replay_dockerfile` (default true) so those tasks opt out and boot as-is. Threaded through both snapshot builders and the env-key fingerprint too.

Other half of #655. Same story as the companion PR — this was already fixed on `terminal-rl` (#656) but sitting unmerged, so `main` never got it.