### PR TITLE
feat(fireworks): make grad clipping opt-in (default grad_clip_norm 0.0)

### DIFF
--- a/rllm/trainer/config/rllm/backend/fireworks.yaml
+++ b/rllm/trainer/config/rllm/backend/fireworks.yaml
@@ -28,7 +28,7 @@ training:
   beta2: 0.95
   eps: 1e-8
   weight_decay: 0.01
-  grad_clip_norm: 1.0
+  grad_clip_norm: 0.0  # 0.0 = disabled (opt-in). Set >0 to clip global grad norm; avoid low values (e.g. 1.0) with token-sum loss.
   max_length: null  # Auto-derived from training shape if null
   resume_from_fireworks_job_id: null  # Source trainer job id for loading a DCP checkpoint
   resume_from_dcp_checkpoint: null  # Explicit DCP name to load; null uses latest on the source/current job

--- a/rllm/trainer/fireworks/fireworks_backend.py
+++ b/rllm/trainer/fireworks/fireworks_backend.py
@@ -97,7 +97,7 @@ class FireworksBackend(TinkerBackend):
         self.beta2 = config.training.get("beta2", 0.95)
         self.eps = config.training.get("eps", 1e-8)
         self.weight_decay = config.training.get("weight_decay", 0.01)
-        self.grad_clip_norm = config.training.get("grad_clip_norm", 1.0)
+        self.grad_clip_norm = config.training.get("grad_clip_norm", 0.0)  # 0.0 = disabled; opt in explicitly (1.0 is too aggressive for token-sum loss)
 
         # Fireworks-specific handles (populated in _init_fireworks_infra)
         self.weight_syncer: WeightSyncer | None = None

--- a/rllm/trainer/fireworks/fireworks_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_policy_trainer.py
@@ -631,7 +631,7 @@ class FireworksPolicyTrainer:
         beta2: float = 0.999,
         eps: float = 1e-8,
         weight_decay: float = 0.01,
-        grad_clip_norm: float = 1.0,
+        grad_clip_norm: float = 0.0,  # 0.0 = no clipping (opt-in); see AdamParams grad_clip_norm semantics
     ) -> tuple[float, dict]:
         """Run optimizer step. Returns (scheduled_lr, metrics)."""
         scheduled_lr = learning_rate * compute_schedule_lr_multiplier(


### PR DESCRIPTION
Makes Fireworks gradient clipping **opt-in**: default `grad_clip_norm` 1.0 → 0.0 (disabled).

## Why

Fireworks defaulted to `grad_clip_norm=1.0`, but its loss kernel is **raw token-sum**, so the gradient norm scales with the batch's token count (observed ~a couple thousand). A max-norm clip of 1.0 therefore binds on essentially every step — degenerating Adam's update to unit-norm/near-sign descent and discarding all the magnitude token-sum was accumulating. That's far too aggressive for token-sum.

The clip value is not comparable across backends because it depends on the loss reduction:

| Backend | Default loss reduction | Default grad clip | Effect |
|---|---|---|---|
| **Fireworks** (before) | raw token-sum (server kernel) | `grad_clip_norm=1.0` | grad norm ~thousands → clip **always binds**, very aggressive |
| **verl 0.8.0** | `token-mean` | `clip_grad=1.0` | grad norm O(1) → **mild, standard** clip |
| **Tinker** | — | `grad_clip_norm=0.0` | **no clipping** |

verl (checked at `verl/workers/engine/fsdp/transformer_impl.py:665` + `core_algos.py:1168`) defaults to `clip_grad=1.0` **but** with `token-mean` aggregation, so the same `1.0` is gentle there. verl never pairs a raw token-sum loss with a low clip.

## Change

Default `grad_clip_norm` to `0.0` (= no clipping, per the `tinker.types.AdamParams` semantics Fireworks reuses: *"0.0 means no clipping"*) in all three places, so clipping is opt-in:

- `fireworks_backend.py` — `config.training.get("grad_clip_norm", 0.0)`
- `fireworks_policy_trainer.py` — `optim_step(..., grad_clip_norm: float = 0.0)`
- `config/rllm/backend/fireworks.yaml` — `grad_clip_norm: 0.0`

Users who want clipping set a value explicitly. `weight_decay` (0.01) is unchanged. Verified: both modules byte-compile, yaml parses, and `grad_clip_norm=0.0` is confirmed = "no clipping" in the shared `AdamParams` type (not "clip to zero").

Pairs with #790 (surfacing the Tinker/Fireworks optim-step grad-norm metric), which lets you actually observe the pre-clip norm this addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)