### PR TITLE
feat(opencode): pin session --title to skip title-generation request (terminal-rl)

### DIFF
--- a/rllm/harnesses/opencode.py
+++ b/rllm/harnesses/opencode.py
@@ -79,6 +79,10 @@ class OpenCodeHarness(BaseCliHarness):
     # bypasses that validation.
     _RLLM_PROVIDER_ID = "rllm-gateway"
 
+    # Fixed session title passed via ``opencode run --title`` so opencode
+    # skips its separate title-generation LLM call (see ``build_invocation``).
+    _SESSION_TITLE = "rllm-training"
+
     def install_script(self) -> str:
         return _INSTALL_SCRIPT
 
@@ -159,6 +163,11 @@ class OpenCodeHarness(BaseCliHarness):
         # ``--model`` flag carries.
         _, model_id, _ = self._split_provider(config.model)
         qualified = f"{self._RLLM_PROVIDER_ID}/{model_id}"
+        # ``--title`` pins the session title to a fixed string so opencode
+        # skips its separate async title-generation LLM call. That call is
+        # wasted work during training (titles live only in the sandbox's
+        # local DB; trajectories come from gateway traces), and it forces the
+        # gateway to fork an extra lineage slot for its divergent prefix.
         # ``</dev/null`` is required: Modal's ``sandbox.exec`` leaves
         # stdin connected to a live socket that never receives EOF, and
         # opencode blocks on its initial stdin read forever — the run
@@ -167,6 +176,7 @@ class OpenCodeHarness(BaseCliHarness):
             f"{self._cd_prefix(task)}"
             f". $HOME/.nvm/nvm.sh 2>/dev/null; "
             f"opencode --model={shlex.quote(qualified)} run "
+            f"--title {shlex.quote(self._SESSION_TITLE)} "
             f"--dangerously-skip-permissions "
             f"-- {shlex.quote(instruction)} "
             f"</dev/null 2>&1 | tee {shlex.quote(self.stdout_log_path)}"

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -329,7 +329,10 @@ def test_opencode_writes_config_with_custom_provider_to_bypass_models_dev():
 def test_opencode_invocation_uses_custom_provider_prefix_and_detaches_stdin():
     """--model must carry the custom provider id, not the inferred
     openai/anthropic. And opencode blocks on its initial stdin read on
-    Modal sandboxes — the invocation must redirect stdin from /dev/null."""
+    Modal sandboxes — the invocation must redirect stdin from /dev/null.
+
+    ``--title`` must also be present: it pins the session title so opencode
+    skips its separate title-generation LLM call during training."""
     h = OpenCodeHarness()
     cmd = h.build_invocation(
         instruction="hi",
@@ -337,6 +340,7 @@ def test_opencode_invocation_uses_custom_provider_prefix_and_detaches_stdin():
         config=_make_config(model="gpt-5.4-mini"),
     )
     assert "--model=rllm-gateway/gpt-5.4-mini" in cmd
+    assert "--title " in cmd
     assert "</dev/null" in cmd
 
 


### PR DESCRIPTION
## What

Re-targets the opencode title-generation disable to the `terminal-rl` base branch.

Pins the opencode session title via `opencode run --title rllm-training` so opencode skips its separate async title-generation LLM call.

## Why

opencode's `run` fires a separate LLM request to generate a session title. During RL training that title is never read (session state lives only in the ephemeral sandbox DB; trajectories come from gateway traces), so the request is pure waste — and its divergent (short "You are a title generator…") prefix forces the gateway to **fork an extra lineage slot**. At training time the transform partitions each trajectory by `lineage_id` and emits one row per lineage, so the title-gen lineage inflates `batch/merged_steps_per_traj` above 1 (observed ~1.6) and produces spurious trained rows that get the trajectory reward broadcast to them.

Verified on a live tmax run: ~29% of gateway sessions carried an extra `"You are a title generator. You output ONLY a thread title."` lineage (some carried two, from litellm retries forking the call again).

## History

- Originally merged to `main` in #786, then reverted in #794 — `main` was the wrong base. This PR brings the same commit onto `terminal-rl`, where the opencode/terminal harness work belongs.
- Single cherry-pick of `5148355f`; unrelated commits from the original feature branch are intentionally excluded.

## Test

`tests/harnesses/test_cli_harness.py` opencode cases pass (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
