### PR TITLE
fix(gateway): tombstone deleted sessions to stop trace-store leak

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -53,33 +53,36 @@ def _unpack(data: dict[str, Any]) -> dict[str, Any]:
 class MemoryTraceStore:
     """Ephemeral in-memory store.  Useful for tests and short-lived processes."""
 
-    #: A session deleted within this many seconds is "tombstoned": a late
-    #: ``store_trace`` for it is dropped instead of resurrecting the session.
-    #: Traces persist fire-and-forget, so a completion still in flight when the
-    #: rollout ended can land *after* the trainer's ``delete_session``; without a
-    #: tombstone ``store_trace`` re-creates a ``defaultdict`` entry that nothing
-    #: ever deletes again, leaking the session for the process lifetime. Must
-    #: exceed the longest possible in-flight request. Set to 0 to disable.
-    _DEFAULT_TOMBSTONE_TTL_S = 1800.0
+    #: Cap on remembered tombstones. A deleted session is tombstoned
+    #: *permanently* — session ids are unique uuids that are never legitimately
+    #: reused, so any later write is a straggler that must never resurrect the
+    #: session. Traces persist fire-and-forget, so a completion still in flight
+    #: when the rollout ended can land *after* the trainer's ``delete_session``;
+    #: without a tombstone ``store_trace`` re-creates a ``defaultdict`` entry that
+    #: nothing ever deletes again, leaking the session for the process lifetime.
+    #: The cap is only a memory backstop for long-lived multi-run gateways: it is
+    #: far larger than the number of sessions deletable while any request is still
+    #: in flight, so FIFO eviction never exposes a live straggler. 0 disables.
+    _DEFAULT_MAX_TOMBSTONES = 1_000_000
 
-    def __init__(self, tombstone_ttl_s: float = _DEFAULT_TOMBSTONE_TTL_S) -> None:
+    def __init__(self, max_tombstones: int = _DEFAULT_MAX_TOMBSTONES) -> None:
         # trace_id -> data dict
         self._traces: dict[str, dict[str, Any]] = {}
         # trace_id -> created_at
         self._timestamps: dict[str, float] = {}
         # session_id -> list[trace_id]  (insertion order)
         self._session_index: dict[str, list[str]] = defaultdict(list)
-        # session_id -> deletion time; blocks post-delete resurrection
-        self._tombstones: dict[str, float] = {}
-        self._tombstone_ttl_s = tombstone_ttl_s
+        # deleted session ids (insertion-ordered, FIFO-evicted at the cap);
+        # blocks post-delete resurrection by a straggler trace
+        self._tombstones: dict[str, None] = {}
+        self._max_tombstones = max_tombstones
 
     async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
-        now = time.time()
-        # Drop a straggler write that lands after the session was deleted; letting
-        # it through would resurrect a session no reader will ever delete again.
-        deleted_at = self._tombstones.get(session_id)
-        if deleted_at is not None and (now - deleted_at) <= self._tombstone_ttl_s:
+        # A session id is deleted at most once and never reused, so any write to
+        # a tombstoned session is a straggler that must not resurrect it.
+        if session_id in self._tombstones:
             return
+        now = time.time()
         self._traces[trace_id] = _pack(data)
         if trace_id not in self._timestamps:
             self._timestamps[trace_id] = now
@@ -111,14 +114,12 @@ class MemoryTraceStore:
         return [_unpack(d) for d in results]
 
     async def delete_session(self, session_id: str) -> int:
-        if self._tombstone_ttl_s > 0:
-            now = time.time()
-            self._tombstones[session_id] = now
-            # Purge expired tombstones on this cold path so the map stays bounded
-            # to roughly one TTL window of recently-deleted sessions.
-            cutoff = now - self._tombstone_ttl_s
-            for sid in [s for s, t in self._tombstones.items() if t < cutoff]:
-                del self._tombstones[sid]
+        if self._max_tombstones != 0:
+            # Tombstone permanently; evict oldest (FIFO) only to honour the cap.
+            self._tombstones.pop(session_id, None)
+            self._tombstones[session_id] = None
+            while len(self._tombstones) > self._max_tombstones:
+                self._tombstones.pop(next(iter(self._tombstones)))
         ids = self._session_index.pop(session_id, [])
         # Collect trace_ids referenced by other sessions
         referenced: set[str] = set()

--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -53,16 +53,33 @@ def _unpack(data: dict[str, Any]) -> dict[str, Any]:
 class MemoryTraceStore:
     """Ephemeral in-memory store.  Useful for tests and short-lived processes."""
 
-    def __init__(self) -> None:
+    #: A session deleted within this many seconds is "tombstoned": a late
+    #: ``store_trace`` for it is dropped instead of resurrecting the session.
+    #: Traces persist fire-and-forget, so a completion still in flight when the
+    #: rollout ended can land *after* the trainer's ``delete_session``; without a
+    #: tombstone ``store_trace`` re-creates a ``defaultdict`` entry that nothing
+    #: ever deletes again, leaking the session for the process lifetime. Must
+    #: exceed the longest possible in-flight request. Set to 0 to disable.
+    _DEFAULT_TOMBSTONE_TTL_S = 1800.0
+
+    def __init__(self, tombstone_ttl_s: float = _DEFAULT_TOMBSTONE_TTL_S) -> None:
         # trace_id -> data dict
         self._traces: dict[str, dict[str, Any]] = {}
         # trace_id -> created_at
         self._timestamps: dict[str, float] = {}
         # session_id -> list[trace_id]  (insertion order)
         self._session_index: dict[str, list[str]] = defaultdict(list)
+        # session_id -> deletion time; blocks post-delete resurrection
+        self._tombstones: dict[str, float] = {}
+        self._tombstone_ttl_s = tombstone_ttl_s
 
     async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
         now = time.time()
+        # Drop a straggler write that lands after the session was deleted; letting
+        # it through would resurrect a session no reader will ever delete again.
+        deleted_at = self._tombstones.get(session_id)
+        if deleted_at is not None and (now - deleted_at) <= self._tombstone_ttl_s:
+            return
         self._traces[trace_id] = _pack(data)
         if trace_id not in self._timestamps:
             self._timestamps[trace_id] = now
@@ -94,6 +111,14 @@ class MemoryTraceStore:
         return [_unpack(d) for d in results]
 
     async def delete_session(self, session_id: str) -> int:
+        if self._tombstone_ttl_s > 0:
+            now = time.time()
+            self._tombstones[session_id] = now
+            # Purge expired tombstones on this cold path so the map stays bounded
+            # to roughly one TTL window of recently-deleted sessions.
+            cutoff = now - self._tombstone_ttl_s
+            for sid in [s for s, t in self._tombstones.items() if t < cutoff]:
+                del self._tombstones[sid]
         ids = self._session_index.pop(session_id, [])
         # Collect trace_ids referenced by other sessions
         referenced: set[str] = set()

--- a/rllm-model-gateway/tests/unit/test_store.py
+++ b/rllm-model-gateway/tests/unit/test_store.py
@@ -3,7 +3,6 @@
 import array
 import os
 import tempfile
-import time
 
 import pytest
 from rllm_model_gateway.store.memory_store import MemoryTraceStore
@@ -187,7 +186,8 @@ class TestTokenArrayPacking:
 
 class TestTombstone:
     """A trace that lands after its session was deleted must NOT resurrect the
-    session (the fire-and-forget persist race that leaked orphaned sessions)."""
+    session (the fire-and-forget persist race that leaked orphaned sessions).
+    Session ids are unique and never reused, so the block is permanent."""
 
     @pytest.mark.asyncio
     async def test_straggler_write_after_delete_is_dropped(self):
@@ -201,43 +201,40 @@ class TestTombstone:
         assert all(s["session_id"] != "s1" for s in await mem.list_sessions())
 
     @pytest.mark.asyncio
+    async def test_block_is_permanent(self):
+        mem = MemoryTraceStore()
+        await mem.delete_session("s1")
+        for tid in ("t1", "t2", "t3"):                            # repeated late writes
+            await mem.store_trace(tid, "s1", {})
+        assert await mem.get_session_traces("s1") == []
+
+    @pytest.mark.asyncio
     async def test_delete_does_not_block_other_sessions(self):
         mem = MemoryTraceStore()
         await mem.store_trace("t1", "s1", {})
         await mem.delete_session("s1")
         await mem.store_trace("t2", "s2", {})                     # unrelated session
-        traces = await mem.get_session_traces("s2")
-        assert len(traces) == 1
+        assert len(await mem.get_session_traces("s2")) == 1
 
     @pytest.mark.asyncio
-    async def test_tombstone_expiry_allows_reuse(self):
-        mem = MemoryTraceStore(tombstone_ttl_s=1000.0)
-        await mem.store_trace("t1", "s1", {})
-        await mem.delete_session("s1")
-        # simulate the tombstone aging past the TTL
-        mem._tombstones["s1"] = time.time() - 2000.0
-        await mem.store_trace("t2", "s1", {})                     # now allowed again
+    async def test_cap_evicts_oldest_tombstone(self):
+        mem = MemoryTraceStore(max_tombstones=2)
+        for sid in ("s1", "s2", "s3"):                            # s1 evicted (FIFO)
+            await mem.delete_session(sid)
+        assert list(mem._tombstones) == ["s2", "s3"]
+        await mem.store_trace("t2", "s2", {})                     # still blocked
+        assert await mem.get_session_traces("s2") == []
+        await mem.store_trace("t1", "s1", {})                     # evicted past cap -> allowed
         assert len(await mem.get_session_traces("s1")) == 1
 
     @pytest.mark.asyncio
-    async def test_ttl_zero_disables_tombstone(self):
-        mem = MemoryTraceStore(tombstone_ttl_s=0.0)
+    async def test_zero_cap_disables_tombstone(self):
+        mem = MemoryTraceStore(max_tombstones=0)
         await mem.store_trace("t1", "s1", {})
         await mem.delete_session("s1")
-        assert mem._tombstones == {}                             # no tombstone recorded
+        assert mem._tombstones == {}                             # nothing remembered
         await mem.store_trace("t2", "s1", {})                     # legacy resurrection behaviour
         assert len(await mem.get_session_traces("s1")) == 1
-
-    @pytest.mark.asyncio
-    async def test_expired_tombstones_are_purged(self):
-        mem = MemoryTraceStore(tombstone_ttl_s=1000.0)
-        await mem.store_trace("t1", "s1", {})
-        await mem.delete_session("s1")
-        mem._tombstones["s1"] = time.time() - 2000.0             # stale entry
-        await mem.store_trace("t2", "s2", {})
-        await mem.delete_session("s2")                            # cold-path purge runs here
-        assert "s1" not in mem._tombstones                        # stale entry reaped
-        assert "s2" in mem._tombstones
 
 
 class TestSqliteStoreSpecific:

--- a/rllm-model-gateway/tests/unit/test_store.py
+++ b/rllm-model-gateway/tests/unit/test_store.py
@@ -3,6 +3,7 @@
 import array
 import os
 import tempfile
+import time
 
 import pytest
 from rllm_model_gateway.store.memory_store import MemoryTraceStore
@@ -182,6 +183,61 @@ class TestTokenArrayPacking:
         await mem.store_trace("t2", "s1", data2)
         assert isinstance(mem._traces["t2"]["logprobs"], list)
         assert (await mem.get_trace("t2"))["logprobs"] == [-0.1, None, -0.3]
+
+
+class TestTombstone:
+    """A trace that lands after its session was deleted must NOT resurrect the
+    session (the fire-and-forget persist race that leaked orphaned sessions)."""
+
+    @pytest.mark.asyncio
+    async def test_straggler_write_after_delete_is_dropped(self):
+        mem = MemoryTraceStore()
+        await mem.store_trace("t1", "s1", {"prompt_token_ids": [1, 2, 3]})
+        assert await mem.delete_session("s1") == 1
+        # straggler completion for the same session lands after the delete
+        await mem.store_trace("t2", "s1", {"prompt_token_ids": [4, 5, 6]})
+        assert await mem.get_session_traces("s1") == []          # not resurrected
+        assert await mem.get_trace("t2") is None
+        assert all(s["session_id"] != "s1" for s in await mem.list_sessions())
+
+    @pytest.mark.asyncio
+    async def test_delete_does_not_block_other_sessions(self):
+        mem = MemoryTraceStore()
+        await mem.store_trace("t1", "s1", {})
+        await mem.delete_session("s1")
+        await mem.store_trace("t2", "s2", {})                     # unrelated session
+        traces = await mem.get_session_traces("s2")
+        assert len(traces) == 1
+
+    @pytest.mark.asyncio
+    async def test_tombstone_expiry_allows_reuse(self):
+        mem = MemoryTraceStore(tombstone_ttl_s=1000.0)
+        await mem.store_trace("t1", "s1", {})
+        await mem.delete_session("s1")
+        # simulate the tombstone aging past the TTL
+        mem._tombstones["s1"] = time.time() - 2000.0
+        await mem.store_trace("t2", "s1", {})                     # now allowed again
+        assert len(await mem.get_session_traces("s1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_ttl_zero_disables_tombstone(self):
+        mem = MemoryTraceStore(tombstone_ttl_s=0.0)
+        await mem.store_trace("t1", "s1", {})
+        await mem.delete_session("s1")
+        assert mem._tombstones == {}                             # no tombstone recorded
+        await mem.store_trace("t2", "s1", {})                     # legacy resurrection behaviour
+        assert len(await mem.get_session_traces("s1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_tombstones_are_purged(self):
+        mem = MemoryTraceStore(tombstone_ttl_s=1000.0)
+        await mem.store_trace("t1", "s1", {})
+        await mem.delete_session("s1")
+        mem._tombstones["s1"] = time.time() - 2000.0             # stale entry
+        await mem.store_trace("t2", "s2", {})
+        await mem.delete_session("s2")                            # cold-path purge runs here
+        assert "s1" not in mem._tombstones                        # stale entry reaped
+        assert "s2" in mem._tombstones
 
 
 class TestSqliteStoreSpecific:


### PR DESCRIPTION
## Problem

The gateway's in-memory trace store (`--store memory`) leaks sessions during async RL training. Observed live on a Fireworks run: **~157 orphaned sessions/hr**, each exactly **1 trace**, at old weight versions, with large mid-episode prompts — accumulating unbounded (the store has no TTL/eviction).

## Root cause — a persist-after-delete race

Every rollout correctly deletes its own gateway session in a `finally` (so filtering, staleness, and errors are all cleaned up — those were *not* the leak). The leak is a lifecycle race:

1. Traces persist **fire-and-forget** (`sync_traces=False`): the proxy does `asyncio.create_task(store_trace(...))` after each completion returns.
2. When a rollout ends it calls `flush()` then `delete_session(uid)`. `flush()` only drains persist tasks that *already exist* — an LLM call still in flight at the provider hasn't reached the persist line yet, so it can't be flushed.
3. That straggler returns **after** the delete → `store_trace` runs → and `MemoryTraceStore` **resurrects the session** because `self._session_index[session_id]` is a `defaultdict(list)` with no tombstone. Nothing deletes that `uid` again → permanent orphan with exactly 1 trace.

Signature match: single trace (the lone straggler), large prompt (slow `_build_trace_data` widens the window under high concurrency), grouped by task-uuid (a hard prompt makes several group members straggle together), early weight version (early policy aborts right after big tool-call turns).

## Fix — a permanent tombstone

Session ids are unique uuids (`uid = f"{uuid4()}:{rollout_idx}"`) that are **never reused**, so a deleted session must be rejected **permanently**, not for a time window:

- `delete_session` records the `session_id` in a tombstone set.
- `store_trace` drops any write for a tombstoned session instead of resurrecting it — always correct, since a deleted `uid` is never legitimately written again.
- The tombstone set is FIFO-capped (`max_tombstones`, default **1,000,000**) purely as a memory backstop for long-lived multi-run gateways. The cap is far larger than the number of sessions deletable while any request is still in flight, so eviction never exposes a live straggler. `max_tombstones=0` disables the guard (legacy behaviour).

Why not require pre-creation instead? Sessions are **implicitly created on first request** (a documented gateway feature for captured/external sessions), and the persist path (`ReverseProxy`) doesn't hold the `SessionManager`'s liveness state — so remembering *deletions* (a tombstone) is the correct store-level mechanism.

Why not a TTL? A time window has a real failure mode — if a request outlives it (the heartbeat budget allows up to 3600s), a very-late straggler could still resurrect the session. A permanent block has no such edge.

Cost: one interned `session_id` per deleted session (~tens of MB worst-case for an entire multi-day run, hard-capped); no change to the read/serialization path.

## Tests

`tests/unit/test_store.py` — new `TestTombstone`: straggler-after-delete is dropped (not resurrected), the block is permanent across repeated late writes, unrelated sessions unaffected, FIFO cap evicts the oldest tombstone, and `max_tombstones=0` restores legacy behaviour. Full store suite: **37 passed**.

## Scope / follow-up

`SqliteTraceStore` shares the same resurrection pattern (`INSERT OR REPLACE`/`IGNORE` on write, plain `DELETE`) and would take the identical guard — left as a follow-up since the observed leak is on the in-use `memory` backend.

This is a separate fix from the array-packing perf change (#787, already merged into this branch); the leak is a distinct, slower, unbounded issue on top of the O(N²) working-set growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)