### PR TITLE
feat(trainer): refill_filtered_uniform_groups — count zero-advantage drops toward the step

### DIFF
--- a/rllm/trainer/algorithms/config.py
+++ b/rllm/trainer/algorithms/config.py
@@ -231,14 +231,12 @@ class RejectionSamplingConfig:
     # Applied at the accumulator level in async training, before groups enter the buffer.
     filter_uniform_groups: bool = False
 
-    # What happens to a whole prompt group's optimizer-step slot when a filter drops it
-    # (uniform-reward, min-trajs, compact-filtering, ...):
-    # - True (default): refill it -- free the slot so generation backfills a fresh group, so
-    #   every step trains on mini_batch_size groups (DAPO-style dynamic sampling).
-    # - False: count it toward mini_batch_size without refilling. The dropped group takes a
-    #   slot but trains nothing; survivors renormalize over their own tokens, so the effective
-    #   batch shrinks (prime-rl's default zero-advantage handling, generalized to all drops).
-    refill_filtered_groups: bool = True
+    # Only when filter_uniform_groups is True. True (default): refill a dropped uniform group
+    # -- backfill a fresh one so the step keeps mini_batch_size signal groups (DAPO). False:
+    # count it toward mini_batch_size without refilling, so the effective batch shrinks
+    # (survivors renormalize over their own tokens; prime-rl default). Uniform drops only --
+    # min-trajs / compact-filtering / empty-group drops always refill.
+    refill_filtered_uniform_groups: bool = True
 
     @classmethod
     def from_config(cls, config: DictConfig) -> "RejectionSamplingConfig":
@@ -250,7 +248,7 @@ class RejectionSamplingConfig:
             min_trajs_per_group=config.get("min_trajs_per_group", 2),
             min_partial_solve_tasks=config.get("min_partial_solve_tasks", 1),
             filter_uniform_groups=config.get("filter_uniform_groups", False),
-            refill_filtered_groups=config.get("refill_filtered_groups", True),
+            refill_filtered_uniform_groups=config.get("refill_filtered_uniform_groups", True),
         )
 
 

--- a/rllm/trainer/algorithms/config.py
+++ b/rllm/trainer/algorithms/config.py
@@ -231,6 +231,15 @@ class RejectionSamplingConfig:
     # Applied at the accumulator level in async training, before groups enter the buffer.
     filter_uniform_groups: bool = False
 
+    # What happens to a whole prompt group's optimizer-step slot when a filter drops it
+    # (uniform-reward, min-trajs, compact-filtering, ...):
+    # - True (default): refill it -- free the slot so generation backfills a fresh group, so
+    #   every step trains on mini_batch_size groups (DAPO-style dynamic sampling).
+    # - False: count it toward mini_batch_size without refilling. The dropped group takes a
+    #   slot but trains nothing; survivors renormalize over their own tokens, so the effective
+    #   batch shrinks (prime-rl's default zero-advantage handling, generalized to all drops).
+    refill_filtered_groups: bool = True
+
     @classmethod
     def from_config(cls, config: DictConfig) -> "RejectionSamplingConfig":
         mode = config.get("mode", None)
@@ -241,6 +250,7 @@ class RejectionSamplingConfig:
             min_trajs_per_group=config.get("min_trajs_per_group", 2),
             min_partial_solve_tasks=config.get("min_partial_solve_tasks", 1),
             filter_uniform_groups=config.get("filter_uniform_groups", False),
+            refill_filtered_groups=config.get("refill_filtered_groups", True),
         )
 
 

--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -53,10 +53,9 @@ class TrajectoryGroupBuffer:
     5. If rejection sampling enabled: drop groups with all-zero advantage
     6. Queue the task batch for training
 
-    A whole group dropped by a filter is either reported to the coordinator so its
-    slot is backfilled (refill_filtered_groups, default) or queued as an empty
-    placeholder that counts toward the step but trains nothing (refill_filtered_groups
-    False). All metrics flow through the shared MetricsAggregator.
+    A dropped group frees its slot for backfill. Exception: a uniform (zero-advantage)
+    group with refill_filtered_uniform_groups False is queued as an empty placeholder
+    that counts toward the step but trains nothing. Metrics flow through the aggregator.
 
     Optionally offloads pending episodes and/or queued task batches to
     disk to reduce memory pressure (disabled by default).
@@ -120,24 +119,6 @@ class TrajectoryGroupBuffer:
         self._refresh_pbar_counters()
         if self._pbar is not None:
             self._pbar.update(1)
-
-    def _finalize_dropped_group(self) -> None:
-        """A whole prompt group was dropped by a filter. Decide its optimizer-step slot.
-
-        refill_filtered_groups=True (default): free the staleness slot so generation
-        backfills a fresh group -- the step keeps mini_batch_size trainable groups.
-        False: count it toward the step by queuing an empty placeholder that occupies a
-        slot but trains nothing; survivors renormalize over their own tokens, so the
-        effective batch shrinks. (reward/*/all already counted these trajectories;
-        reward/*/effective excludes them either way -- nothing was trained on.)"""
-        self._filtered_count += 1
-        if self._rs_config.refill_filtered_groups:
-            self._coordinator.on_group_filtered()
-        else:
-            self._queue.put_nowait(TaskBatch(groups=[], episodes=[]))
-            self._training_queue_size += 1
-            self._queue_update_event.set()
-        self._record_classified_prompt_group()
 
     async def _offload_episode(self, task_id: str, episode: Episode) -> str:
         """Serialize episode to disk, return file path."""
@@ -246,7 +227,10 @@ class TrajectoryGroupBuffer:
                 groups_after_min_trajs=0,
                 groups_after_reward_filter=0,
             )
-            self._finalize_dropped_group()
+            # Missing/broken data (min-trajs / compact-filtered / empty) always refills.
+            self._coordinator.on_group_filtered()
+            self._filtered_count += 1
+            self._record_classified_prompt_group()
             return True
 
         # 4. Compute advantages
@@ -274,7 +258,17 @@ class TrajectoryGroupBuffer:
                 groups_after_min_trajs=before_adv,
                 groups_after_reward_filter=0,
             )
-            self._finalize_dropped_group()
+            self._filtered_count += 1
+            if self._rs_config.refill_filtered_uniform_groups:
+                self._coordinator.on_group_filtered()  # default: free slot, backfill a replacement
+            else:
+                # Count toward the step: queue an empty placeholder (one slot, trains nothing).
+                # Survivors renormalize over their own tokens; effective batch shrinks. `all`
+                # already counted these trajectories; `effective` excludes them.
+                self._queue.put_nowait(TaskBatch(groups=[], episodes=[]))
+                self._training_queue_size += 1
+                self._queue_update_event.set()
+            self._record_classified_prompt_group()
             return True
 
         # reward/{role}/effective: reward per role over only the trajectories

--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -53,9 +53,10 @@ class TrajectoryGroupBuffer:
     5. If rejection sampling enabled: drop groups with all-zero advantage
     6. Queue the task batch for training
 
-    Filtered groups are reported directly to the coordinator (which tracks
-    throttle slots and filter counts). Only non-empty task batches are queued.
-    All metrics flow through the shared MetricsAggregator.
+    A whole group dropped by a filter is either reported to the coordinator so its
+    slot is backfilled (refill_filtered_groups, default) or queued as an empty
+    placeholder that counts toward the step but trains nothing (refill_filtered_groups
+    False). All metrics flow through the shared MetricsAggregator.
 
     Optionally offloads pending episodes and/or queued task batches to
     disk to reduce memory pressure (disabled by default).
@@ -119,6 +120,24 @@ class TrajectoryGroupBuffer:
         self._refresh_pbar_counters()
         if self._pbar is not None:
             self._pbar.update(1)
+
+    def _finalize_dropped_group(self) -> None:
+        """A whole prompt group was dropped by a filter. Decide its optimizer-step slot.
+
+        refill_filtered_groups=True (default): free the staleness slot so generation
+        backfills a fresh group -- the step keeps mini_batch_size trainable groups.
+        False: count it toward the step by queuing an empty placeholder that occupies a
+        slot but trains nothing; survivors renormalize over their own tokens, so the
+        effective batch shrinks. (reward/*/all already counted these trajectories;
+        reward/*/effective excludes them either way -- nothing was trained on.)"""
+        self._filtered_count += 1
+        if self._rs_config.refill_filtered_groups:
+            self._coordinator.on_group_filtered()
+        else:
+            self._queue.put_nowait(TaskBatch(groups=[], episodes=[]))
+            self._training_queue_size += 1
+            self._queue_update_event.set()
+        self._record_classified_prompt_group()
 
     async def _offload_episode(self, task_id: str, episode: Episode) -> str:
         """Serialize episode to disk, return file path."""
@@ -227,9 +246,7 @@ class TrajectoryGroupBuffer:
                 groups_after_min_trajs=0,
                 groups_after_reward_filter=0,
             )
-            self._coordinator.on_group_filtered()
-            self._filtered_count += 1
-            self._record_classified_prompt_group()
+            self._finalize_dropped_group()
             return True
 
         # 4. Compute advantages
@@ -257,9 +274,7 @@ class TrajectoryGroupBuffer:
                 groups_after_min_trajs=before_adv,
                 groups_after_reward_filter=0,
             )
-            self._coordinator.on_group_filtered()
-            self._filtered_count += 1
-            self._record_classified_prompt_group()
+            self._finalize_dropped_group()
             return True
 
         # reward/{role}/effective: reward per role over only the trajectories

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -138,6 +138,12 @@ rejection_sample:
   min_partial_solve_tasks: 1
   min_trajs_per_group: 2
   filter_uniform_groups: false
+  # What a filter-dropped group (uniform-reward, min-trajs, compact-filtering, ...) does to
+  # its optimizer-step slot. true (default): refill it -- backfill a fresh group so every step
+  # trains on mini_batch_size groups (DAPO dynamic sampling). false: count it toward
+  # mini_batch_size without refilling, so the effective batch shrinks (survivors renormalize
+  # over their own tokens; prime-rl default).
+  refill_filtered_groups: true
 
 # Remote Runtime Configuration (for agent-in-container runtimes like AgentCore, Harbor)
 remote_runtime:

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -138,10 +138,6 @@ rejection_sample:
   min_partial_solve_tasks: 1
   min_trajs_per_group: 2
   filter_uniform_groups: false
-  # Only when filter_uniform_groups is true. true (default): refill a dropped uniform group
-  # (backfill so the step keeps mini_batch_size signal groups). false: count it toward
-  # mini_batch_size without refilling, shrinking the effective batch (prime-rl default).
-  # Uniform drops only -- min-trajs / compact-filtering drops always refill.
   refill_filtered_uniform_groups: true
 
 # Remote Runtime Configuration (for agent-in-container runtimes like AgentCore, Harbor)

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -138,12 +138,11 @@ rejection_sample:
   min_partial_solve_tasks: 1
   min_trajs_per_group: 2
   filter_uniform_groups: false
-  # What a filter-dropped group (uniform-reward, min-trajs, compact-filtering, ...) does to
-  # its optimizer-step slot. true (default): refill it -- backfill a fresh group so every step
-  # trains on mini_batch_size groups (DAPO dynamic sampling). false: count it toward
-  # mini_batch_size without refilling, so the effective batch shrinks (survivors renormalize
-  # over their own tokens; prime-rl default).
-  refill_filtered_groups: true
+  # Only when filter_uniform_groups is true. true (default): refill a dropped uniform group
+  # (backfill so the step keeps mini_batch_size signal groups). false: count it toward
+  # mini_batch_size without refilling, shrinking the effective batch (prime-rl default).
+  # Uniform drops only -- min-trajs / compact-filtering drops always refill.
+  refill_filtered_uniform_groups: true
 
 # Remote Runtime Configuration (for agent-in-container runtimes like AgentCore, Harbor)
 remote_runtime:

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -744,9 +744,9 @@ class UnifiedTrainer:
                 if done:
                     break
 
-                # chunk_groups is empty when every batch this pass was a dropped-group
-                # placeholder (refill_filtered_groups=false): it counts toward the step but
-                # trains nothing (the has_trajectory_groups guard below skips fwd-bwd).
+                # chunk_groups empty = this pass was all uniform-group placeholders
+                # (refill_filtered_uniform_groups=false): counts toward the step, trains nothing
+                # (has_trajectory_groups guard below skips fwd-bwd).
                 trainer_state.trajectory_groups = chunk_groups
 
                 if trainer_state.has_trajectory_groups:
@@ -784,7 +784,7 @@ class UnifiedTrainer:
             aggregator.record("async/trained_this_step", float(trained_this_step))
 
             # 3. Capture pre-sync metrics (before weight sync resets coordinator state).
-            #    weight_versions is empty if the whole step was dropped-group placeholders -- np.min([]) raises.
+            #    weight_versions is empty if the whole step was uniform-group placeholders -- np.min([]) raises.
             if weight_versions:
                 staleness_values = [coordinator.weight_version - v for v in weight_versions]
                 aggregator.record("async/staleness_mean", float(np.mean(staleness_values)))

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -741,10 +741,12 @@ class UnifiedTrainer:
                     all_trajectory_groups.extend(task_batch.groups)
                     all_episodes.extend(task_batch.episodes)
 
-                if not chunk_groups or done:
+                if done:
                     break
 
-                # Forward-backward on this chunk
+                # chunk_groups is empty when every batch this pass was a dropped-group
+                # placeholder (refill_filtered_groups=false): it counts toward the step but
+                # trains nothing (the has_trajectory_groups guard below skips fwd-bwd).
                 trainer_state.trajectory_groups = chunk_groups
 
                 if trainer_state.has_trajectory_groups:
@@ -781,11 +783,13 @@ class UnifiedTrainer:
                 logger.warning(f"[TrainingLoop] Step {trainer_state.global_step}: all {groups_consumed} groups dropped (no trainable sequences); skipping optimizer step + weight sync.")
             aggregator.record("async/trained_this_step", float(trained_this_step))
 
-            # 3. Capture pre-sync metrics (before weight sync resets coordinator state)
-            staleness_values = [coordinator.weight_version - v for v in weight_versions]
-            aggregator.record("async/staleness_mean", float(np.mean(staleness_values)))
-            aggregator.record("async/staleness_min", float(np.min(staleness_values)))
-            aggregator.record("async/staleness_max", float(np.max(staleness_values)))
+            # 3. Capture pre-sync metrics (before weight sync resets coordinator state).
+            #    weight_versions is empty if the whole step was dropped-group placeholders -- np.min([]) raises.
+            if weight_versions:
+                staleness_values = [coordinator.weight_version - v for v in weight_versions]
+                aggregator.record("async/staleness_mean", float(np.mean(staleness_values)))
+                aggregator.record("async/staleness_min", float(np.min(staleness_values)))
+                aggregator.record("async/staleness_max", float(np.max(staleness_values)))
             aggregator.record("async/groups_consumed", groups_consumed)
             aggregator.record("time/buffer_wait", buffer_wait_time)
             pre_sync_coordinator_stats = coordinator.stats()

--- a/tests/unified_trainer/test_buffer_refill_filtered.py
+++ b/tests/unified_trainer/test_buffer_refill_filtered.py
@@ -1,0 +1,131 @@
+"""Tests for rejection_sample.refill_filtered_groups in TrajectoryGroupBuffer.
+
+When a whole prompt group is dropped by a filter (uniform-reward, min-trajs, ...),
+refill_filtered_groups decides its optimizer-step slot:
+- True (default): free the staleness slot so generation backfills a fresh group.
+- False: queue an empty placeholder that occupies a mini_batch_size slot but trains
+  nothing (the filtered group "counts toward the step"; the effective batch shrinks).
+
+reward/{role}/all counts every trajectory that ran (pre-filter); reward/{role}/effective
+only the trajectories that survive into the loss -- so a dropped group is in `all` but not
+`effective` regardless of refill mode.
+"""
+
+import pytest
+
+from rllm.agents.agent import Step, Trajectory
+from rllm.trainer.algorithms import (
+    AlgorithmConfig,
+    CompactFilteringConfig,
+    RejectionSamplingConfig,
+    TransformConfig,
+)
+from rllm.trainer.buffer import TaskBatch, TrajectoryGroupBuffer
+from rllm.trainer.metrics_aggregator import MetricsAggregator
+from rllm.trainer.sync_coordinator import SyncCoordinator, SyncCoordinatorConfig
+from rllm.types import Episode, TerminationReason
+
+GROUP_SIZE = 2
+
+
+def _episode(reward: float, idx: int) -> Episode:
+    step = Step(prompt_ids=[1, 2, 3], response_ids=[4, 5], logprobs=[0.0, 0.0], reward=reward)
+    traj = Trajectory(name="agent", steps=[step], reward=reward)
+    return Episode(id=f"task0:{idx}", task={"q": "x"}, termination_reason=TerminationReason.ENV_DONE, is_correct=reward > 0, trajectories=[traj])
+
+
+def _make_buffer(rs_config: RejectionSamplingConfig, *, min_trajs_group_size: int = GROUP_SIZE) -> tuple[TrajectoryGroupBuffer, SyncCoordinator, MetricsAggregator]:
+    coordinator = SyncCoordinator(SyncCoordinatorConfig(mini_batch_size=2, group_size=GROUP_SIZE, staleness_threshold=0.0, trigger_parameter_sync_step=1, max_concurrent_rollouts=8))
+    aggregator = MetricsAggregator()
+    buffer = TrajectoryGroupBuffer(
+        group_size=min_trajs_group_size,
+        coordinator=coordinator,
+        aggregator=aggregator,
+        algorithm_config=AlgorithmConfig(),
+        transform_config=TransformConfig(),
+        cf_config=CompactFilteringConfig(),
+        rs_config=rs_config,
+    )
+    return buffer, coordinator, aggregator
+
+
+async def _feed_group(buffer: TrajectoryGroupBuffer, coordinator: SyncCoordinator, rewards: list[float]) -> None:
+    """Simulate one dispatched task whose group_size rollouts all arrive."""
+    coordinator.on_group_dispatched()  # in_flight -> 1
+    for i, r in enumerate(rewards):
+        await buffer.add_episode("task0", _episode(r, i))
+
+
+@pytest.mark.asyncio
+async def test_uniform_group_refill_true_backfills():
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_groups=True)
+    buffer, coordinator, aggregator = _make_buffer(rs)
+
+    await _feed_group(buffer, coordinator, [1.0, 1.0])  # uniform -> advantage 0 -> dropped
+
+    # Nothing queued; the slot was freed so generation backfills a replacement.
+    assert buffer._queue.qsize() == 0
+    assert buffer._training_queue_size == 0
+    assert buffer._filtered_count == 1
+    assert coordinator.stats()["async/in_flight_groups"] == 0  # on_group_filtered freed it
+
+    m = aggregator.flush()
+    assert any(k.startswith("reward/agent/all/") for k in m)  # it ran
+    assert not any(k.startswith("reward/agent/effective/") for k in m)  # but wasn't trained on
+
+
+@pytest.mark.asyncio
+async def test_uniform_group_refill_false_counts_toward_step():
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_groups=False)
+    buffer, coordinator, aggregator = _make_buffer(rs)
+
+    await _feed_group(buffer, coordinator, [1.0, 1.0])  # uniform -> dropped, but counted
+
+    # An empty placeholder occupies a step slot; the slot is NOT backfilled.
+    assert buffer._queue.qsize() == 1
+    assert buffer._training_queue_size == 1
+    assert buffer._filtered_count == 1
+    assert coordinator.stats()["async/in_flight_groups"] == 1  # on_group_filtered NOT called
+
+    item = buffer._queue.get_nowait()
+    assert isinstance(item, TaskBatch)
+    assert item.groups == []  # trains nothing
+
+    m = aggregator.flush()
+    assert any(k.startswith("reward/agent/all/") for k in m)
+    assert not any(k.startswith("reward/agent/effective/") for k in m)
+
+
+@pytest.mark.asyncio
+async def test_min_trajs_drop_honors_refill_false():
+    # The flag is generic: a min-trajs drop (not a uniform drop) is also counted toward the
+    # step under refill_filtered_groups=False. group has 2 trajs < min_trajs_per_group=3.
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=3, filter_uniform_groups=False, refill_filtered_groups=False)
+    buffer, coordinator, aggregator = _make_buffer(rs)
+
+    await _feed_group(buffer, coordinator, [1.0, 0.0])
+
+    assert buffer._queue.qsize() == 1
+    assert coordinator.stats()["async/in_flight_groups"] == 1
+    item = buffer._queue.get_nowait()
+    assert item.groups == []
+
+
+@pytest.mark.asyncio
+async def test_nonuniform_group_queued_normally():
+    # Positive control: a group with real signal is queued with its groups regardless of the
+    # refill flag, and contributes to reward/*/effective.
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_groups=False)
+    buffer, coordinator, aggregator = _make_buffer(rs)
+
+    await _feed_group(buffer, coordinator, [1.0, 0.0])  # mixed -> nonzero advantage -> survives
+
+    assert buffer._queue.qsize() == 1
+    assert buffer._filtered_count == 0
+    item = buffer._queue.get_nowait()
+    assert len(item.groups) == 1
+    assert len(item.groups[0].trajectories) == 2
+
+    m = aggregator.flush()
+    assert any(k.startswith("reward/agent/all/") for k in m)
+    assert any(k.startswith("reward/agent/effective/") for k in m)

--- a/tests/unified_trainer/test_buffer_refill_filtered.py
+++ b/tests/unified_trainer/test_buffer_refill_filtered.py
@@ -1,14 +1,9 @@
-"""Tests for rejection_sample.refill_filtered_groups in TrajectoryGroupBuffer.
+"""Tests for rejection_sample.refill_filtered_uniform_groups in TrajectoryGroupBuffer.
 
-When a whole prompt group is dropped by a filter (uniform-reward, min-trajs, ...),
-refill_filtered_groups decides its optimizer-step slot:
-- True (default): free the staleness slot so generation backfills a fresh group.
-- False: queue an empty placeholder that occupies a mini_batch_size slot but trains
-  nothing (the filtered group "counts toward the step"; the effective batch shrinks).
-
-reward/{role}/all counts every trajectory that ran (pre-filter); reward/{role}/effective
-only the trajectories that survive into the loss -- so a dropped group is in `all` but not
-`effective` regardless of refill mode.
+When a uniform (zero-advantage) group is dropped: True (default) refills it (backfill);
+False queues an empty placeholder that counts toward the step but trains nothing. Scoped to
+uniform drops only -- min-trajs / compact-filtering drops always refill. reward/{role}/all
+counts trajectories that ran; reward/{role}/effective only those trained on.
 """
 
 import pytest
@@ -58,7 +53,7 @@ async def _feed_group(buffer: TrajectoryGroupBuffer, coordinator: SyncCoordinato
 
 @pytest.mark.asyncio
 async def test_uniform_group_refill_true_backfills():
-    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_groups=True)
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_uniform_groups=True)
     buffer, coordinator, aggregator = _make_buffer(rs)
 
     await _feed_group(buffer, coordinator, [1.0, 1.0])  # uniform -> advantage 0 -> dropped
@@ -76,7 +71,7 @@ async def test_uniform_group_refill_true_backfills():
 
 @pytest.mark.asyncio
 async def test_uniform_group_refill_false_counts_toward_step():
-    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_groups=False)
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_uniform_groups=False)
     buffer, coordinator, aggregator = _make_buffer(rs)
 
     await _feed_group(buffer, coordinator, [1.0, 1.0])  # uniform -> dropped, but counted
@@ -97,25 +92,25 @@ async def test_uniform_group_refill_false_counts_toward_step():
 
 
 @pytest.mark.asyncio
-async def test_min_trajs_drop_honors_refill_false():
-    # The flag is generic: a min-trajs drop (not a uniform drop) is also counted toward the
-    # step under refill_filtered_groups=False. group has 2 trajs < min_trajs_per_group=3.
-    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=3, filter_uniform_groups=False, refill_filtered_groups=False)
+async def test_min_trajs_drop_always_refills_even_in_count_mode():
+    # Scoping guarantee: a min-trajs drop (missing data, NOT a uniform drop) always refills,
+    # even with refill_filtered_uniform_groups=False. group has 2 trajs < min_trajs_per_group=3.
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=3, filter_uniform_groups=True, refill_filtered_uniform_groups=False)
     buffer, coordinator, aggregator = _make_buffer(rs)
 
     await _feed_group(buffer, coordinator, [1.0, 0.0])
 
-    assert buffer._queue.qsize() == 1
-    assert coordinator.stats()["async/in_flight_groups"] == 1
-    item = buffer._queue.get_nowait()
-    assert item.groups == []
+    assert buffer._queue.qsize() == 0  # no placeholder -- refilled, not counted
+    assert buffer._training_queue_size == 0
+    assert buffer._filtered_count == 1
+    assert coordinator.stats()["async/in_flight_groups"] == 0  # slot freed for backfill
 
 
 @pytest.mark.asyncio
 async def test_nonuniform_group_queued_normally():
     # Positive control: a group with real signal is queued with its groups regardless of the
     # refill flag, and contributes to reward/*/effective.
-    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_groups=False)
+    rs = RejectionSamplingConfig(mode="group", min_trajs_per_group=2, filter_uniform_groups=True, refill_filtered_uniform_groups=False)
     buffer, coordinator, aggregator = _make_buffer(rs)
 
     await _feed_group(buffer, coordinator, [1.0, 0.0])  # mixed -> nonzero advantage -> survives


### PR DESCRIPTION
## What

Adds `rejection_sample.refill_filtered_uniform_groups` (default `true`) to the async training buffer. When a **uniform (zero-advantage) group** is dropped by `filter_uniform_groups`:

- **`true` (default, unchanged):** free the staleness slot so generation **backfills** a fresh group — every step trains on `mini_batch_size` signal-bearing groups (DAPO-style dynamic sampling).
- **`false`:** **count** the dropped group toward `mini_batch_size` without backfilling. The buffer queues an empty placeholder that occupies a step slot but trains nothing; surviving groups renormalize over their own tokens (not diluted), so the *effective* batch shrinks. Mirrors **prime-rl's default** zero-advantage handling (`ZeroAdvantageFilter` in `post_batch_filters`: drop the tokens, renormalize, no resample).

## Scope — uniform drops only

The flag governs **only** the `uniform_reward` drop. The other whole-group drops — `min_trajs`, `compact_filtering`, `no_trajectory_groups` — are *missing/broken data* (too few samples, infra/grading errors, empty rollouts) and **always refill**, regardless of the flag.

This matches prime-rl exactly. Its sink has two removal points and no regeneration anywhere:
- **zero-advantage** → removed *post-batch* → shrink + renormalize (the one default "count toward batch" filter).
- **infra/tool/env errors, empty trajectories, group-scored partials, sub-survivor groups** → removed *pre-batch* → the batch stays full by draining the continuous rollout stream (their analog of "refill").
- **truncation / gibberish / repetition** → not dropped by default (kept & trained).

Letting infra-failure slots count toward the step (shrinking the batch on sandbox/verifier noise) is exactly what we want to avoid, so the count behavior is scoped to genuine zero-signal groups.

## Why / the math

A uniform-reward group is an **advantage-0 group** exactly (`(r − mean)/(std+1e-6) = 0`). Under rLLM's default `loss_agg_mode` (`token-mean`), **dropping a zero-adv group is *not* gradient-equivalent to keeping it with advantage 0** — dropping renormalizes over survivors (they keep full weight); keeping would dilute them. prime-rl drops precisely to avoid that dilution, and the placeholder here reproduces it: the placeholder contributes no tokens, so survivors renormalize over their own tokens.

## Metrics

`reward/{role}/all` still counts dropped trajectories (they ran); `reward/{role}/effective` still excludes them (not trained on) — the `{all, effective}` gap is the filtered mass, in both modes.

## Changes

- `algorithms/config.py` — new `refill_filtered_uniform_groups` field (default `true`) + `from_config`.
- `buffer.py` — the uniform-drop path branches on the flag (queue an empty placeholder when `false`); min-trajs/compact/empty drops always refill.
- `unified_trainer.py` — an all-placeholder fwd-bwd pass is a no-op instead of ending the step early; guard `async/staleness_*` against an all-placeholder step (empty `weight_versions`).
- `config/rllm/base.yaml` — expose the key.
- `tests/unified_trainer/test_buffer_refill_filtered.py` — end-to-end `add_episode` tests: uniform-drop refill vs count, **min-trajs drop always refills even in count mode** (scoping guarantee), non-uniform positive control, and `all`/`effective` behavior.

## Tests

`tests/unified_trainer/test_buffer_refill_filtered.py` (4) + existing `test_buffer_reward_metrics.py` / `test_sync_coordinator.py` (14) all pass. Default (`true`) preserves current behavior everywhere — no cookbook/script changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)