### PR TITLE
config: default filter_uniform_groups=true, refill_filtered_uniform_groups=false

### DIFF
--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -137,8 +137,8 @@ rejection_sample:
   multiplier: 1
   min_partial_solve_tasks: 1
   min_trajs_per_group: 2
-  filter_uniform_groups: false
-  refill_filtered_uniform_groups: true
+  filter_uniform_groups: true
+  refill_filtered_uniform_groups: false
 
 # Remote Runtime Configuration (for agent-in-container runtimes like AgentCore, Harbor)
 remote_runtime:


### PR DESCRIPTION
Flip the `rejection_sample` defaults in `rllm/trainer/config/rllm/base.yaml`:

```diff
-  filter_uniform_groups: false
-  refill_filtered_uniform_groups: true
+  filter_uniform_groups: true
+  refill_filtered_uniform_groups: false
```

So uniform (zero-advantage) groups are **filtered out and not refilled** by default — dropped from the step rather than kept as zero-advantage placeholders.

`base.yaml` is the only config that sets these keys (every backend/cookbook config inherits it via `rllm: base`), so this is the single source for the default.

Based on `terminal-rl` because `refill_filtered_uniform_groups` (PR #799) exists only there, not on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)