### PR TITLE
feat(cli): config-file-driven `rllm train` / `rllm eval`

### DIFF
--- a/design/config-file-driven-train-eval.md
+++ b/design/config-file-driven-train-eval.md
@@ -1,0 +1,376 @@
+# Design: Config-file-driven `rllm train` / `rllm eval`
+
+- **Status:** Proposed. One deliverable: a single self-contained config file (`.toml`, `.yaml` also accepted) that fully specifies a run, launched as `rllm train run.toml` / `rllm eval run.toml`. Two design forks resolved with a recommendation below (schema = **hybrid**; custom code = **import-path + optional entrypoint hook**); alternatives recorded in *Alternatives considered*.
+- **Scope:** Make the config file the positional, self-contained source of truth for a run — carrying the *run definition* (agent, datasets, evaluator, sandbox) that today lives as **code** in each cookbook's `train.py`, plus every config knob that today lives as **Hydra dotlist args** in a `train_*.sh`. CLI flags/dotlist become optional overrides on top. A design goal is **cross-backend portability** — one file where flipping `backend` reuses the common config and only the backend-specific section changes (see [Backend selection & cross-backend portability](#backend-selection--cross-backend-portability)); reaching it fully depends on a schema-normalization workstream this feature motivates. Otherwise no change to the trainer, backends, or config semantics — this is a new front-end over the existing `AgentTrainer` facade.
+- **Non-goals:** Replacing Hydra for power users who prefer `python train.py <overrides>` (that path stays). Changing the config schema/tree. A new resolver for agents/datasets/evaluators (we reuse `load_agent` / `load_evaluator` / `DatasetRegistry` / `BenchmarkLoader`).
+- **Related:** extends the existing `--config file.yaml` merge in `rllm/cli/train.py` and `rllm/cli/sft.py`; reuses the Hydra-free merge in `build_train_config` and the resolution logic in `_run_train` / `_run_eval`.
+
+## Summary
+
+Today a real training run is a **pair**: a cookbook `train.py` (Python — loads datasets, constructs the `AgentFlow`, reads env vars, calls `AgentTrainer(...).train()`) plus a `train_*.sh` shell script carrying ~40 Hydra dotlist overrides. The quick path (`rllm train <benchmark>`) is a Click command with fixed flags, tinker-only, resolving everything from the catalog. Neither lets you point at *one file* and go.
+
+This design adds a **config-file mode** to `rllm train` / `rllm eval`: `rllm train run.toml`. The file has a small curated **`[run]`** section that captures exactly what the `train.py` *code* does (which agent, which datasets, which evaluator, which sandbox), and everything else **mirrors the existing config tree 1:1** (`[model]`, `[training]`, `[rllm.async_training]`, …) — i.e. your shell-script overrides, as a file. CLI dotlist/flags still apply on top. The same file drives eval, so `rllm eval run.toml` re-runs the exact agent/dataset/sandbox config you trained with.
+
+The whole `terminal-rl` a35b run — `train.py` (110 lines) + `train_fireworks_a35b.sh` (~110 lines of env + Hydra) — collapses to a single ~40-line `run.toml`.
+
+## Motivation
+
+There are two launch surfaces today and they don't overlap:
+
+1. **Power path (every serious run).** `cookbooks/<x>/train.py` under `@hydra.main(config_name="unified")` + a `train_*.sh`. The `.py` holds *code*: dataset loading, `agent_flow = Terminus2Harness(sandbox_backend=…, max_turns=…, enable_summarize=…)`, a dozen `os.environ.get(...)` reads, then `AgentTrainer(...).train()`. The `.sh` holds the config as Hydra dotlist (`rllm/backend=fireworks model.name=… training.group_size=16 rllm.async_training.enable=true …`). Pain: the run definition is split across a `.py` + a `.sh`; config is opaque positional args; env vars silently steer behavior; the three `train_fireworks_{,_a35b,_glm5p2}.sh` scripts are 90% duplicated.
+
+2. **Quick path (`rllm train <benchmark>`).** Click flags + optional `--config file.yaml` merged on top; backend hardcoded to tinker; agent/evaluator/dataset resolved from the catalog + local `dataset.toml` dirs. Good for one-liners, can't express a real MoE-on-Fireworks async run.
+
+We already have most of the machinery: `build_train_config` reproduces the Hydra compose (`base.yaml` + `backend/<backend>.yaml`) **without the Hydra runtime**; `--config` already merges a user file over templates; `load_agent("mod:Class")` / `load_evaluator("mod:Class")` resolve code by import path; `DatasetRegistry` / `BenchmarkLoader` / harbor resolution already back `_run_train`. The gap is only that the file (a) isn't the positional arg, (b) isn't *self-contained* (carries neither the run definition nor the backend), and (c) is YAML-over-flags rather than the source of truth.
+
+## Current state (what we build on)
+
+**Config composition (Hydra).** `unified.yaml` composes `rllm/base.yaml` (backend-agnostic, under the `rllm.*` namespace) + `rllm/backend/<backend>.yaml`. Backend templates use `# @package _global_`: a top-level block (`model`, `training`, `data`, `fireworks_config`, …) *and* a nested `rllm:` block that overrides into the `rllm.*` namespace. There are `${oc.select:…}` / `${rllm.…}` interpolations. `build_train_config` (in `rllm/cli/train.py`) already merges this by hand: load `base.yaml` under `{"rllm": …}`, split the backend template's top-level vs `rllm:` block, merge in order.
+
+**Trainer facade.** `rllm.trainer.AgentTrainer` (the `unified_trainer.py:1052` class) is the public API:
+
+```python
+AgentTrainer(
+    config,                       # OmegaConf DictConfig
+    backend="verl"|"tinker"|"fireworks",
+    agent_flow=..., evaluator=..., hooks=...,   # OR workflow_class=...
+    train_dataset=..., val_dataset=...,
+    sandbox_backend=..., sandbox_concurrency=...,
+).train()
+```
+
+It already auto-wires `SandboxTaskHooks` + gateway loopback/tunnel when the flow/data needs a sandbox, and dispatches to the per-backend launcher by the `backend` string. **This is the single call the config-file loader ultimately makes** — no trainer changes.
+
+**Resolution logic.** `_run_train` / `_run_eval` in the CLI already resolve: local benchmark dirs (`BenchmarkLoader.is_local_benchmark`), catalog datasets (auto-pull), harbor datasets (`harbor:` prefix, row-wrapping), agents (`load_agent`), evaluators (explicit → dataset.toml `[verifier]` → catalog `reward_fn` → per-task). The config-file `[run]` resolver reuses these — factored into shared helpers.
+
+## Design
+
+### File detection
+
+`rllm train <arg>` / `rllm eval <arg>`: if `<arg>` is an existing regular file whose suffix is `.toml` / `.yaml` / `.yml` → **config-file mode**. Otherwise the current behavior (benchmark name, `harbor:` prefix, or local benchmark *directory*). No collision: benchmarks are names or directories, configs are files.
+
+### Schema (hybrid: curated `[run]` + config-tree mirror)
+
+TOML is primary (the ask); YAML accepted via `OmegaConf.load`. The file has three tiers:
+
+**1. Top level — run identity.**
+
+| key | meaning |
+|---|---|
+| `backend` | `"tinker"` \| `"fireworks"` \| `"verl"`. Selects the backend template. Default `"tinker"`. |
+| `extends` | *(optional)* path to another config file merged **underneath** this one. Lets `a35b`/`9b`/`glm5p2` share a base and override only what differs. |
+
+**2. `[run]` — the run definition (what `train.py` code does today).** The only *new* schema surface: the declarative form of "construct these objects". Grouped into sub-tables so the agent / dataset / sandbox concerns stay separate and scannable.
+
+`[run.agent]`
+
+| key | meaning |
+|---|---|
+| `name` | built-in catalog name (`terminus2`, `mini-swe-agent`, `react`, `claude-code`, `aider`, `codex`, `opencode`, `oracle`, …), a user-registered name (`~/.rllm/agents.json`), a `harbor:<scaffold>` prefix, **or** a `module:Class` import path for anything unregistered. Bare names are the normal case; the import path is the escape hatch. Resolved by `load_agent` (order: user registry → import path → built-in catalog → entry-point plugin). |
+| `[run.agent.args]` | table → constructor kwargs for the flow (`max_turns`, `enable_summarize`, …). Absorbs the per-cookbook `TERMINUS_*` env reads. |
+| `evaluator` | *(optional)* registry name / import path; **omit** → per-task verifier from `dataset.toml`/`task.toml` (`SandboxTaskHooks`). |
+
+`[run.dataset]`
+
+| key | meaning |
+|---|---|
+| `train` / `train_split` | registry name, local benchmark dir, or `harbor:<name>`; split resolved as `_run_train` does. |
+| `val` / `val_split` | same; omit `val` to reuse the train tasks for validation. |
+| `max_examples` | cap the train set. |
+
+`[run.sandbox]`
+
+| key | meaning |
+|---|---|
+| `backend` | `docker`\|`local`\|`modal`\|`daytona`\|…; forwarded to the auto-wired `SandboxTaskHooks`. Omit → the `dataset.toml` `default_sandbox` / per-task default. |
+| `concurrency` | override the flow's `max_concurrent`. |
+
+Directly under `[run]`: `entrypoint` (escape hatch, `"module:function"` — see [Custom code](#custom-code-import-path--optional-entrypoint-hook)) and `env` (a table of env vars exported before the run — see below).
+
+**Why nested under `[run.*]`, not bare `[agent]`/`[sandbox]`/`[dataset]`.** The config tree already owns those names with *different* meanings, and the tier-3 mirror rule maps a bare section straight onto the tree: `[data]` = batch sizes & sequence lengths (read across every backend), `[agent]` = the *workflow-path* agent (`agent.name`/`max_steps`, resolved via `env_agent_mappings`), `[env]` = the *workflow-path* environment. A bare `[agent]` would merge into `config.agent` — silently ignored by the AgentFlow path but overwriting the workflow default — and a `[dataset]` next to `[data]` reads as a typo. Nesting under `[run.*]` gives the split-out readability while staying collision-free.
+
+> **Resolver note.** Built-in/registered names today instantiate the flow with *no* constructor args (`load_agent` calls `Cls()`), so `[run.agent.args]` requires a small resolver change: instantiate the catalog class *with* those kwargs, so `agent.args` behaves as constructor kwargs uniformly whether the agent was named or imported. (Alternative for flows that only expose knobs via `configure()`: route `args` through `configure()` — but constructor kwargs are the cleaner default.)
+
+**3. Config-tree mirror — everything else, 1:1 with the Hydra tree.** Any section the trainer config already has: `[model]`, `[training]`, `[validation]`, `[data]`, `[fireworks_config]`, `[rollout_engine]`, `[concurrency]`, and the `rllm.*` namespace as `[rllm.trainer]`, `[rllm.algorithm]`, `[rllm.async_training]`, `[rllm.gateway]`, `[rllm.workflow]`, `[rllm.rollout.train]`, `[rllm.rollout.val]`, `[rllm.compact_filtering]`, `[rllm.rejection_sample]`, … These merge directly onto the composed config — no translation, so they never drift from the schema. **For a file you intend to flip across backends, author common knobs in the canonical `rllm.*` namespace (or its normalized aliases) rather than the backend-flavored top-level `model`/`training` sections — see [Backend selection & cross-backend portability](#backend-selection--cross-backend-portability).**
+
+**Convenience the loader applies** (so the file stays DRY vs. today's shell scripts):
+- `[data]` is auto-mirrored into `[rllm.data]` (today's scripts write both `data.*` and `rllm.data.*`; `sync_config` keeps parity, but the file should require it once).
+- `[run.env]` *(optional)* — a table of environment variables exported before the run, capturing the `export RLLM_HARNESS_RUN_TIMEOUT_S=… / RLLM_SANDBOX_TIMEOUT_S=… / RLLM_SANDBOX_LOG_CAPTURE_DIR=…` lines from the shell scripts. Keeps infra knobs in the file instead of the shell. (Under `[run.*]` for the same reason as above — bare `[env]` is the workflow-path environment.)
+
+### Worked example — the terminal-rl a35b run, as one file
+
+`cookbooks/terminal-rl/train.py` + `train_fireworks_a35b.sh` → `run.toml`:
+
+```toml
+backend = "fireworks"
+
+[run.agent]                                            # ← was train.py code
+name = "terminus2"                                     # built-in catalog name
+# evaluator omitted → per-task sandbox-shell verifier (tests/test.sh)
+[run.agent.args]                                       # ← was TERMINUS_* env vars
+max_turns        = 75
+enable_summarize = false
+
+[run.dataset]
+train = "tb-opus-pass"
+val   = "terminal-bench@2.0"
+
+[run.sandbox]
+backend = "modal"
+
+[run.env]                                              # ← was `export ...` lines
+RLLM_HARNESS_RUN_TIMEOUT_S   = "2400"
+RLLM_SANDBOX_TIMEOUT_S       = "3200"
+RLLM_SANDBOX_LOG_CAPTURE_DIR = "sandbox_logs/qwen3p5-35b-a3b"
+
+[model]
+name            = "accounts/fireworks/models/qwen3p5-35b-a3b"
+tokenizer_model = "Qwen/Qwen3.5-35B-A3B"
+lora_rank       = 32
+
+[training]
+group_size    = 16
+learning_rate = 2e-5
+max_length    = 139264
+
+[data]                                                 # auto-mirrored to [rllm.data]
+max_prompt_length   = 122880
+max_response_length = 16384
+train_batch_size    = 1
+val_batch_size      = -1
+
+[fireworks_config]
+policy_trainer_shape_id          = "accounts/fireworks/trainingShapes/qwen3p5-35b-a3b-256k-lora"
+policy_trainer_replica_count     = 2
+rollout_deployment_replica_count = 6
+
+[rllm.async_training]
+enable                     = true
+mini_batch_size            = 12
+fwd_bwd_group_size         = 1
+staleness_threshold        = 3.0
+trigger_parameter_sync_step = 1
+partial_rollout            = true
+
+[rllm.gateway]
+port                 = 9090
+tunnel               = "https://rllm.ngrok.dev"
+num_workers          = 4
+cumulative_token_mode = true
+renderer_family      = "qwen3.5"
+
+[rllm.workflow]
+n_parallel_tasks = 256
+raise_on_error   = false
+
+[rllm.algorithm]
+adv_estimator          = "grpo"
+norm_adv_by_std_in_grpo = true
+
+[rllm.rejection_sample]
+filter_uniform_groups = true
+
+[rllm.rollout.train]
+temperature = 1.0
+top_p       = 0.95
+
+[rllm.rollout.val]
+temperature = 1.0
+top_p       = 0.95
+
+[rllm.trainer]
+total_epochs    = 1
+logger          = ["wandb"]
+project_name    = "terminal-rl"
+experiment_name = "terminal-rl-terminus2-qwen3p5-35b-a3b-fireworks"
+val_before_train = false
+test_freq       = 100
+save_freq       = 10
+```
+
+Launch: `rllm train run.toml`. Override for a sweep without editing the file:
+`rllm train run.toml training.learning_rate=1e-5 rllm.trainer.experiment_name=lr1e5`.
+
+The `9b` / `glm5p2` variants become tiny files with `extends = "run.toml"` overriding only `model.*` + `fireworks_config.*` — killing the shell-script duplication.
+
+> This example authors common knobs in fireworks' native sections (`[training]`, `[model]`, `[fireworks_config]`) — fine for a single-backend file. For a file you intend to flip across backends, author them in the canonical namespace instead (see [Backend selection & cross-backend portability](#backend-selection--cross-backend-portability)).
+
+### Resolution & precedence
+
+Merge order (lowest → highest; standard OmegaConf merge, matching Hydra intuition and today's `--config < flags` rule):
+
+```
+base.yaml + backend/<backend>.yaml          # composed template (build_train_config path)
+  ← extends chain (if any), file underneath file
+  ← the config file's mirror sections        # [model], [training], [rllm.*], ...
+  ← [data] → [rllm.data] auto-mirror
+  ← CLI dotlist overrides (key=value)         # `training.learning_rate=1e-5`
+  ← CLI named flags (--lr, --experiment, …)   # when explicitly passed
+```
+
+`backend` is read first (file, overridable by a `backend=` dotlist / `--backend`) to pick the template. Named flags keep their current defaults but only override when the user actually passed them (so a flag's default never clobbers a file value — implemented by treating unset flags as absent, as `train.py` already does for `--ui`).
+
+### Loading pipeline
+
+New module `rllm/config/run_config.py` (importable outside the CLI too):
+
+```python
+def load_run_config(path, *, overrides=None, cli_flags=None) -> tuple[DictConfig, RunSpec]:
+    raw   = _parse(path)                     # tomllib for .toml, OmegaConf for .yaml
+    chain = _resolve_extends(raw, path)      # merge `extends` bases underneath
+    backend = _pick_backend(chain, overrides)
+    cfg   = merge_backend_config(backend, user_cfg=chain)   # ← extracted from build_train_config
+    cfg   = _mirror_data(cfg)                # [data] → [rllm.data]
+    cfg   = _apply_overrides(cfg, overrides, cli_flags)
+    run   = RunSpec.from_config(chain)       # the [run] section (+ [env], backend)
+    return cfg, run
+```
+
+`RunSpec` is a small dataclass of the `[run]` keys. Then a thin driver (shared by train and eval):
+
+```python
+cfg, run = load_run_config(path, overrides=dotlist, cli_flags=flags)
+_export_env(run.env)                      # run.env  == [run.env]
+objs = resolve_run(run, cfg)   # ← extracted from _run_train / _run_eval resolution
+AgentTrainer(cfg, backend=run.backend, **objs,
+             sandbox_backend=run.sandbox.backend,        # [run.sandbox]
+             sandbox_concurrency=run.sandbox.concurrency).train()
+```
+
+`resolve_run` returns `{agent_flow, evaluator, train_dataset, val_dataset}` (or `{hooks, ...}`), reusing the exact catalog/local/harbor logic in `_run_train`. **Refactor:** lift that resolution out of `_run_train`/`_run_eval` into shared functions so flag-mode and file-mode share one implementation (they're near-duplicates already).
+
+### Custom code (import-path + optional entrypoint hook)
+
+Most cookbooks are pure "construct this harness with these kwargs + load these datasets" — fully expressible by `[run]` (agent import path + `agent_args`, dataset names, sandbox). `terminal-rl`'s `train.py` is exactly this shape and needs **no** Python file under the new scheme.
+
+For runs that genuinely need Python (dataset built dynamically, a custom evaluator wired at runtime, conditional logic), `[run].entrypoint = "module:function"` is the escape hatch:
+
+```python
+# my_cookbook/setup.py
+def build(cfg):                       # receives the fully-merged DictConfig
+    return {
+        "agent_flow":   MyFlow(temperature=cfg.rollout.train.temperature),
+        "evaluator":    MyEvaluator(...),
+        "train_dataset": make_dataset(...),
+        "val_dataset":   make_dataset(...),
+    }
+```
+
+```toml
+[run]
+entrypoint = "my_cookbook.setup:build"
+```
+
+When `entrypoint` is set, its returned dict supersedes the declarative `agent`/`dataset`/`evaluator` keys (which may then be omitted). This keeps the common case file-only while never boxing out arbitrary setup — the cookbook shrinks from "a `train.py` with a Hydra `main()` + a shell script" to "a `build()` function + a TOML".
+
+### Backend selection & cross-backend portability
+
+`backend` selects both the composed template (`merge_backend_config`) and the launcher (`AgentTrainer(backend=...)`) — all three already dispatch through the facade, so file-mode just lifts the tinker-only hardcode in `rllm/cli/train.py` (verl rides the same facade; its launcher handles Ray init).
+
+**Goal: one file, flip `backend`, common config carries over.** This is already the architecture's intent. `rllm.*` is the canonical backend-agnostic namespace, and each backend ships a `sync_config` (`rllm/trainer/<backend>/utils.py`) whose `_SHARED_KEYS` table fans a common `rllm.*` key out to that backend's native path (verl → `actor_rollout_ref.*` / `data.*` / `trainer.*`; tinker/fireworks → top-level `data.*` / `training.*`), with an explicit `rllm.*` value always winning. So the file authors common config **once in the canonical namespace**, and the loader runs the active backend's `sync_config` to populate its native keys.
+
+**What's portable today vs. the gap** — coverage is uneven:
+
+| knob | canonical `rllm.*` home | ports across backends today |
+|---|---|---|
+| adv_estimator, loss_fn/agg, kl_beta, eps_clip, warmup, sampling | ✅ `rllm.algorithm.*` / `rllm.rollout.*` | ✅ |
+| batch sizes, seq lengths | ✅ `rllm.data.*` | ✅ |
+| trainer freqs, epochs, logger, project/exp | ✅ `rllm.trainer.*` | ✅ |
+| group size | ✅ `rllm.rollout.n` | ⚠️ verl syncs it; tinker/fireworks interpolate from `training.group_size` |
+| **model name / tokenizer** | ❌ `model.name` vs verl `actor_rollout_ref.model.path` | ❌ |
+| **learning rate / optimizer** | ❌ `training.learning_rate` vs verl `actor_rollout_ref.actor.optim.lr` (not in `_SHARED_KEYS`) | ❌ |
+| **LoRA rank / targets** | ❌ `model.lora_rank` + per-backend target flags | ❌ |
+
+~Half the common surface already ports; the rest (model identity, LR/optimizer, LoRA, group-size) has no single home, so flipping `backend` today means re-stating those in the new backend's native paths.
+
+**Closing the gap** — a schema-normalization workstream this feature motivates; each step is a small, independently-landable addition to the sync tables (same pattern as the ~35 verl entries): promote the un-canonicalized knobs into `rllm.*` and extend each `_SHARED_KEYS` — `rllm.model.{name, tokenizer, lora.*}`, `rllm.optim.{lr, betas, eps, weight_decay, grad_clip}`, and finish `rllm.rollout.n` as the sole group-size home (deprecate `training.group_size`). The **file schema doesn't change** as this lands; knobs just migrate from a `[<backend>]` section into the common block.
+
+**Backend-specific config stays backend-scoped**, read only when that backend is active — no cross-backend meaning: verl resources (`nnodes` / `n_gpus_per_node`) / Megatron / critic / placement; fireworks shapes / replicas / provisioning (`fireworks_config.*`, `fireworks_infra.*`, `concurrency.*`); tinker `num_minibatches` / LoRA-target flags / `tinker_base_url`.
+
+**File shape** — backend-agnostic common block + one section per backend; flip the top line to switch:
+
+```toml
+backend = "fireworks"        # ← the only line that changes to switch backend
+
+[model]                      # common (canonical rllm.model.* after normalization)
+name = "…/qwen3p5-35b-a3b"
+tokenizer_model = "Qwen/Qwen3.5-35B-A3B"
+[model.lora]
+rank = 32
+[optim]                      # common (canonical rllm.optim.*)
+lr = 2e-5
+[algorithm]                  # common (rllm.algorithm)
+adv_estimator = "grpo"
+[data]                       # common (rllm.data)
+max_prompt_length = 122880
+
+[fireworks]                  # backend-specific — read only when backend="fireworks"
+policy_trainer_shape_id = "…/qwen3p5-35b-a3b-256k-lora"
+rollout_deployment_replica_count = 6
+[tinker]                     # ignored unless backend="tinker"
+num_minibatches = 1
+[verl]                       # ignored unless backend="verl"
+nnodes = 1
+n_gpus_per_node = 8
+```
+
+The loader routes common sections to the canonical namespace (then `sync_config` fans them native) and the active `[<backend>]` section to that backend's native tree; inactive backend sections are ignored but kept for one-flip switching. **MVP vs. north star:** file-mode ships *now* against today's uneven canonicalization — portable for the already-shared half, with the rest expressed in the `[<backend>]` sections — and becomes fully portable as the normalization lands incrementally.
+
+### Eval path
+
+The **same file** drives eval. `rllm eval run.toml` reads `[run]` (agent, evaluator, dataset/split, sandbox) + the model source, and an optional `[eval]` section for eval-only knobs:
+
+```toml
+[eval]
+model       = "accounts/fireworks/models/qwen3p5-35b-a3b"  # or base_url / provider from `rllm setup`
+split       = "default"
+concurrency = 64
+attempts    = 1
+# max_examples, task_indices, sampling, snapshot, warm_queue_size, output — as CLI flags today
+```
+
+`_run_eval` already does all the resolution; file-mode just populates its arguments from `[run]` + `[eval]` instead of Click flags. Model source precedence: `[eval].base_url` (direct) → `[eval].model`/`[eval].provider` → `rllm setup` config, mirroring `eval_cmd` today. **Payoff:** train and eval read one file, so eval is guaranteed to use the same agent/sandbox/dataset config as training — no drift between a `train.py` and a separate eval invocation.
+
+## Implementation plan
+
+Phased, each independently landable:
+
+1. **Extract shared helpers (no behavior change).**
+   - `merge_backend_config(backend, user_cfg)` ← the compose logic in `build_train_config` (`rllm/cli/train.py:32`).
+   - `resolve_run_objects(...)` ← the agent/evaluator/dataset resolution in `_run_train` (`:146`) and `_run_eval` (`:117`). Land as refactor; existing flag paths call the extracted fns.
+2. **`rllm/config/run_config.py`.** `RunSpec`, `load_run_config`, `_parse` (tomllib/YAML), `_resolve_extends`, `_mirror_data`, `_apply_overrides`, `_export_env`. Unit-tested against the a35b example → expected merged `DictConfig`.
+3. **Wire `train_cmd`.** File detection on the positional arg; on match, call the file driver (dotlist from remaining args, named flags as overrides). Non-file arg → unchanged.
+4. **Wire `eval_cmd`.** Same detection; `[eval]` + `[run]` → `_run_eval` args.
+5. **Entrypoint hook.** `[run].entrypoint` import + `build(cfg)` contract; supersede declarative keys.
+6. **Docs + reference migration.** Convert `cookbooks/terminal-rl` to `run.toml` (+ `run_eval.toml` or shared) as the worked example; keep `train.py`/`.sh` temporarily for A/B. Doc page under `rllm-docs`.
+
+**Files touched:** `rllm/config/run_config.py` (new), `rllm/cli/train.py` (detect + driver + extract), `rllm/cli/eval.py` (detect + driver + extract), `rllm/cli/_run_resolve.py` (new, shared resolution), tests under `tests/`, one cookbook + docs. No trainer/backend changes.
+
+**Dependencies:** `tomllib` (stdlib ≥3.11; repo is Python ≤3.12 — fine). YAML already supported by OmegaConf.
+
+## Migration
+
+- Cookbook shell + `train.py` pairs → one `run.toml` (pure-declarative cookbooks) or `run.toml` + a small `build()` (custom ones). Old `python train.py <hydra args>` keeps working — the file mode is additive.
+- The near-duplicate `train_fireworks_{,_a35b,_glm5p2}.sh` collapse to a base `run.toml` + tiny `extends` variants.
+- `rllm train <benchmark> --flags` (quick path) is unchanged.
+
+## Alternatives considered
+
+**Schema shape.**
+- **Strict mirror** (every section is a Hydra node, no curated layer): zero new schema to maintain, but agent/dataset/evaluator/sandbox have *no home in the config tree today*, so they'd be bolted on as ad-hoc raw keys anyway — you invent a `[run]`-equivalent regardless, with less clarity. Rejected.
+- **Curated/friendly flat schema** (friendly names, loader expands to nested): nicest for newcomers, but it's a translation layer that must track the schema as it evolves, and every advanced knob needs an `[overrides]` escape hatch — which is most of a real run. High maintenance for marginal gain over hybrid. Rejected.
+- **Hybrid (chosen):** curated `[run]` (the genuinely-new run-definition surface) + 1:1 mirror for everything else. The mirror never drifts (it *is* the tree); the curated part is tiny and stable. Lowest total maintenance, self-contained, and the mirror keys already match muscle memory from the shell-script dotlists.
+
+**Custom code.**
+- **Import-path only** (no `entrypoint`): smaller surface, but any dynamic dataset/evaluator forces a separate `.py` you run directly — so those runs can't use `rllm train file.toml` at all, undercutting the feature for exactly the complex runs that most want one entry point. Rejected as the *only* mechanism.
+- **TOML = config only, keep `train.py`:** minimal change, but doesn't deliver a real `rllm train file.toml` for the power path — the run definition stays split across `.py` + file. Rejected.
+- **Import-path + optional entrypoint hook (chosen):** declarative for the common case (no `.py`), `build(cfg)` escape hatch for arbitrary setup. Covers both ends of the spectrum with one loader.
+
+## Open questions
+
+- **`extends` semantics:** single base or a list? Relative to the file or CWD? (Lean: single path or list, resolved relative to the file.)
+- **Named-flag surface in file mode:** which Click flags remain meaningful as overrides (e.g. `--experiment`, `--max-examples`, `--sandbox-backend`) vs. file-only? (Lean: keep the run-shaping flags as overrides; drop redundant ones.)
+- **One file for both, or `[train]`/`[eval]` split?** A shared `[run]` + separate `[eval]` reads cleanest and keeps train/eval parity; confirm we don't want fully separate files.
+- **Validation & errors:** unknown top-level keys → hard error (typo protection) vs. warn? Schema-validate `[run]` against `RunSpec`; mirror sections pass through to OmegaConf (which already errors on struct violations at merge if we enable struct mode).
+- **Backend-section grouping:** clean aliases (`[fireworks]`/`[tinker]`/`[verl]`, `[optim]`, `[model.lora]`) that need a thin routing map, vs. native section names (`[fireworks_config]`, `[actor_rollout_ref]`, …) that mirror 1:1 but leak each backend's native layout into the file? (Lean: alias sugar for the handful of backend + normalized-common blocks; 1:1 mirror for everything else.)
+- **Normalization sequencing:** ship file-mode against today's uneven `_SHARED_KEYS` first (backend sections cover the un-shared knobs), then promote model/optimizer/LoRA/group-size into `rllm.*` incrementally — or block file-mode on the normalization landing? (Lean: ship first, normalize incrementally; the file schema is stable across it.)

--- a/rllm/cli/_run_resolve.py
+++ b/rllm/cli/_run_resolve.py
@@ -1,0 +1,147 @@
+"""Resolve a :class:`RunSpec` into the objects the trainer / eval runner need.
+
+Shared by the config-file ``rllm train`` / ``rllm eval`` drivers. Reuses the
+same primitives as the flag-based paths (``load_agent`` / ``load_evaluator`` /
+``DatasetRegistry`` / ``BenchmarkLoader``) so behavior matches.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ResolvedRun:
+    """Objects resolved from a :class:`RunSpec`, ready for ``AgentTrainer``."""
+
+    agent_flow: Any = None
+    evaluator: Any = None
+    train_dataset: Any = None
+    val_dataset: Any = None
+    hooks: Any = None
+    # Human-readable summaries for the CLI header.
+    agent_display: str = ""
+    evaluator_display: str = ""
+
+
+def load_agent_with_args(name_or_path: str, agent_args: dict | None) -> Any:
+    """Load an AgentFlow, applying ``agent_args``.
+
+    Delegates to :func:`rllm.eval.agent_loader.load_agent`, which resolves the
+    name/path and applies ``agent_args`` as constructor kwargs (class) or via
+    the instance's ``configure()`` (already-instantiated flows).
+    """
+    from rllm.eval.agent_loader import load_agent
+
+    return load_agent(name_or_path, dict(agent_args or {}))
+
+
+def _resolve_dataset(name: str | None, split: str | None, *, default_split: str):
+    """Load a dataset by registry name / local benchmark dir / harbor name.
+
+    Reuses the flag-path helpers in ``rllm.cli.train`` so resolution matches.
+    Returns ``(dataset, resolved_split)`` or ``(None, split)``.
+    """
+    if not name:
+        return None, split
+
+    from rllm.tasks.loader import BenchmarkLoader
+
+    # Local benchmark directory (dataset.toml / task.toml).
+    if BenchmarkLoader.is_local_benchmark(name):
+        from rllm.data.dataset import Dataset
+
+        bench = BenchmarkLoader.load(name)
+        resolved_split = split or bench.split or default_split
+        return Dataset(data=list(bench.tasks), name=bench.name, split=resolved_split), resolved_split
+
+    # Registry / catalog / harbor name (auto-pull if needed).
+    from rllm.cli._pull import load_dataset_catalog
+    from rllm.cli.train import _load_or_pull_dataset, _resolve_dataset_entry
+
+    catalog = load_dataset_catalog()
+    entry = _resolve_dataset_entry(name, catalog)
+    resolved_split = split
+    if resolved_split is None:
+        if entry and "train_split" in entry and default_split == "train":
+            resolved_split = entry["train_split"]
+        elif entry:
+            resolved_split = entry.get("eval_split", default_split)
+        else:
+            resolved_split = default_split
+
+    dataset = _load_or_pull_dataset(name, resolved_split, catalog, entry)
+
+    # Wrap harbor rows as Tasks rooted at their task dir (per-task verifiers).
+    if dataset is not None and entry and entry.get("source", "").startswith("harbor:"):
+        from rllm.data.dataset import Dataset, _wrap_rows_as_tasks
+
+        dataset = Dataset(data=_wrap_rows_as_tasks(list(dataset.data)), name=name, split=resolved_split)
+    return dataset, resolved_split
+
+
+def resolve_run(run, *, for_eval: bool = False) -> ResolvedRun:
+    """Resolve a :class:`RunSpec` into a :class:`ResolvedRun`.
+
+    Order of resolution mirrors the flag-based paths:
+
+    * ``entrypoint`` (escape hatch) wins — import ``module:function``, call with
+      no args, and take ``agent_flow`` / ``evaluator`` / ``train_dataset`` /
+      ``val_dataset`` / ``hooks`` from its returned dict.
+    * otherwise resolve ``[run.agent]`` via :func:`load_agent_with_args`,
+      ``[run.agent].evaluator`` via ``load_evaluator`` (omit -> per-task
+      verifier), and the datasets via :func:`_resolve_dataset`.
+    """
+    from rllm.config.run_config import RunSpec  # noqa: F401  (type hint only)
+
+    resolved = ResolvedRun()
+
+    if run.entrypoint:
+        from rllm.eval.agent_loader import _import_from_path
+
+        fn = _import_from_path(run.entrypoint)
+        out = fn() if callable(fn) else fn
+        if not isinstance(out, dict):
+            raise TypeError(f"entrypoint {run.entrypoint!r} must return a dict of {{agent_flow, evaluator, train_dataset, val_dataset, hooks}}, got {type(out).__name__}")
+        resolved.agent_flow = out.get("agent_flow")
+        resolved.evaluator = out.get("evaluator")
+        resolved.train_dataset = out.get("train_dataset")
+        resolved.val_dataset = out.get("val_dataset")
+        resolved.hooks = out.get("hooks")
+        resolved.agent_display = f"entrypoint:{run.entrypoint}"
+        resolved.evaluator_display = "from entrypoint" if resolved.evaluator is not None else "per-task / entrypoint"
+        return resolved
+
+    # ---- Agent ----
+    if not run.agent:
+        raise ValueError("config [run.agent].name (or [run].entrypoint) is required")
+    resolved.agent_flow = load_agent_with_args(run.agent, run.agent_args)
+    resolved.agent_display = run.agent
+
+    # ---- Evaluator (optional; omit -> per-task verifier) ----
+    if run.evaluator:
+        from rllm.eval.evaluator_loader import load_evaluator
+
+        resolved.evaluator = load_evaluator(run.evaluator)
+        resolved.evaluator_display = f"{run.evaluator} (overrides per-task verifier)"
+    else:
+        resolved.evaluator_display = "per-task (from dataset.toml / task.toml)"
+
+    # ---- Datasets ----
+    resolved.train_dataset, _ = _resolve_dataset(run.train_dataset, run.train_split, default_split="train")
+
+    if run.max_examples is not None and resolved.train_dataset is not None and run.max_examples < len(resolved.train_dataset):
+        resolved.train_dataset = resolved.train_dataset.select(range(run.max_examples))
+
+    if run.val_dataset:
+        resolved.val_dataset, _ = _resolve_dataset(run.val_dataset, run.val_split, default_split="test")
+    elif not for_eval:
+        # No explicit val dataset: reuse the train tasks for validation
+        # (matches the flag-based ``_run_train`` fallback).
+        resolved.val_dataset = resolved.train_dataset
+
+    return resolved

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -133,8 +133,14 @@ def _run_eval(
     warm_queue_size: int = 0,
     sampling_config=None,
     attempts: int = 1,
+    agent_args: dict | None = None,
 ):
-    """Core eval logic, extracted for clean proxy lifecycle management."""
+    """Core eval logic, extracted for clean proxy lifecycle management.
+
+    ``agent_args`` (config-file mode) are applied to the loaded flow —
+    constructor kwargs for a class, else via ``configure()``. Flag mode passes
+    ``None`` (unchanged behavior).
+    """
     from rllm.data import DatasetRegistry
     from rllm.eval.agent_loader import load_agent
     from rllm.eval.evaluator_loader import load_evaluator, resolve_evaluator_from_catalog
@@ -203,7 +209,7 @@ def _run_eval(
         # Construct the AgentFlow: catalog covers built-in harnesses
         # (react/bash/claude-code) and any user-registered or plugin agents.
         try:
-            agent = load_agent(agent_name)
+            agent = load_agent(agent_name, agent_args)
         except (KeyError, ImportError, AttributeError, TypeError) as e:
             fail(f"Cannot load agent '{agent_name}': {e}")
 
@@ -288,7 +294,7 @@ def _run_eval(
         # plus user-registered + plugin agents; ``harbor:<scaffold>`` resolves
         # to a HarborRuntime via the harbor: prefix branch in load_agent.
         try:
-            agent = load_agent(agent_name)
+            agent = load_agent(agent_name, agent_args)
         except (KeyError, ImportError, AttributeError, TypeError) as e:
             fail(f"Error loading agent '{agent_name}': {e}")
 
@@ -583,8 +589,188 @@ def _run_eval(
     console.print()
 
 
+def _resolve_eval_model_source(base_url: str | None, model: str | None, proxy_port: int | None = None):
+    """Resolve the OpenAI-compatible endpoint + model for an eval run.
+
+    Direct mode (``base_url`` given) requires ``model``. Otherwise: a
+    ``tinker://`` checkpoint routes to the Tinker OAI endpoint; a ``custom``
+    provider uses its ``base_url`` directly; any other provider auto-starts a
+    LiteLLM proxy. Returns ``(base_url, model, proxy_manager)`` — the caller
+    must call ``proxy_manager.shutdown_proxy()`` when done (it may be ``None``).
+
+    Shared by flag mode (``eval_cmd``) and config-file mode
+    (``_run_eval_from_config``).
+    """
+    if base_url is not None:
+        if model is None:
+            fail("--model is required when --base-url is provided.")
+        return base_url, model, None
+
+    import os as _os
+
+    from rllm.eval.config import load_config
+
+    config = load_config()
+
+    # A ``tinker://`` sampler-checkpoint path is served by the Tinker OAI
+    # endpoint; the checkpoint path alone determines where it can run.
+    resolved_model = model if model is not None else config.model
+    is_tinker_checkpoint = bool(resolved_model) and resolved_model.startswith("tinker://")
+
+    if is_tinker_checkpoint:
+        api_key = _os.environ.get("TINKER_API_KEY", "")
+        if not api_key:
+            fail("tinker:// checkpoint models require TINKER_API_KEY in the environment.\n\n  Export your Tinker key and re-run, e.g.:\n    export TINKER_API_KEY=<your-tinker-key>")
+        provider = "tinker"
+        model = resolved_model
+        console.print("  [success]tinker:// checkpoint detected[/] → routing through the Tinker OAI endpoint")
+    else:
+        if not config.is_configured():
+            fail("No configuration found. Run `rllm setup` first to configure your provider and API key.")
+        provider = config.provider
+        api_key = config.api_key
+        if model is None:
+            model = config.model
+
+    if provider == "custom":
+        base_url = config.base_url
+        if api_key:
+            _os.environ.setdefault("OPENAI_API_KEY", api_key)
+        console.print(f"  [success]Using custom endpoint[/] at [dim]{base_url}[/]")
+        return base_url, model, None
+
+    from rllm.eval.proxy import EvalProxyManager
+
+    proxy_manager = EvalProxyManager(
+        provider=provider,
+        model_name=model,
+        api_key=api_key,
+        proxy_port=proxy_port,
+    )
+    with Status(f"[dim]Starting LiteLLM proxy for [bold]{provider}/{model}[/bold]...[/]", console=console):
+        try:
+            proxy_manager.start_proxy_subprocess(proxy_manager.build_proxy_config())
+        except (RuntimeError, TimeoutError) as e:
+            console.print("\n  [dim]Make sure litellm is installed:[/] [bold]pip install litellm\\[proxy][/]")
+            console.print()
+            fail(f"Failed to start LiteLLM proxy.\n\n  {e}")
+    base_url = proxy_manager.get_proxy_url()
+    console.print(f"  [success]Proxy ready[/] at [dim]{base_url}[/]")
+    return base_url, model, proxy_manager
+
+
+def _run_eval_from_config(config_path: str, overrides: tuple[str, ...], *, dry_run: bool = False):
+    """Evaluate from a self-contained config file: ``rllm eval run.toml [key=value ...]``.
+
+    Reuses the ``[run]`` definition (agent / evaluator / dataset / sandbox) and
+    an optional ``[eval]`` block for eval-only knobs. Funnels into the same
+    ``_run_eval`` core the flag path uses, so resolution behavior matches.
+    """
+    from rllm.cli._sampling import resolve_eval_sampling
+    from rllm.config.run_config import export_env, load_run_config
+
+    try:
+        _config, run = load_run_config(config_path, overrides=list(overrides) or None)
+    except (FileNotFoundError, ValueError, TypeError) as exc:
+        fail(f"Invalid config file '{config_path}': {exc}")
+
+    export_env(run.env)
+
+    if run.entrypoint:
+        fail("[run].entrypoint is not yet supported for `rllm eval`; use declarative [run.agent] / [run.dataset]. (Tracked as a follow-up.)")
+
+    e = run.eval  # the [eval] block
+
+    # Dataset to evaluate on: [eval].dataset > [run.dataset].val > [run.dataset].train
+    benchmark = e.get("dataset") or run.val_dataset or run.train_dataset
+    if not benchmark:
+        fail("No eval dataset. Set [eval].dataset, [run.dataset].val, or [run.dataset].train.")
+    if not run.agent:
+        fail("config [run.agent].name is required for eval.")
+
+    split = e.get("split") or run.val_split
+    concurrency = int(e.get("concurrency", 64))
+    attempts = int(e.get("attempts", 1))
+    if attempts < 1:
+        fail("[eval].attempts must be >= 1.")
+    max_examples = e.get("max_examples")
+    task_indices = parse_index_spec(str(e["task_indices"])) if e.get("task_indices") is not None else None
+    output_path = e.get("output")
+    use_snapshot = bool(e.get("snapshot", True))
+    warm_queue_size = int(e.get("warm_queue_size", 0))
+    save_episodes = bool(e.get("save_episodes", True))
+    episodes_dir = e.get("episodes_dir")
+
+    try:
+        sampling_config = resolve_eval_sampling(e.get("sampling_params"), e.get("temperature"), e.get("top_p"), e.get("max_tokens"))
+    except (ValueError, FileNotFoundError, TypeError) as exc:
+        fail(f"Invalid [eval] sampling params: {exc}")
+
+    # UI: [eval].ui if set, else auto-detect from login (mirrors eval_cmd).
+    enable_ui = e.get("ui")
+    if enable_ui is None:
+        from rllm.eval.config import load_ui_config
+
+        enable_ui = bool(os.environ.get("RLLM_API_KEY") or load_ui_config().get("ui_api_key"))
+
+    # Header
+    rows = [
+        ("Config", f"[val]{config_path}[/]"),
+        ("Benchmark", f"[val]{benchmark}[/]" + (f"  [dim]({split})[/]" if split else "")),
+        ("Agent", f"[val]{run.agent}[/]"),
+        ("Evaluator", f"[dim]{run.evaluator or 'per-task (from dataset.toml / task.toml)'}[/]"),
+        ("Model", f"[val]{e.get('model') or '(from rllm setup)'}[/]"),
+    ]
+    if run.sandbox_backend:
+        rows.append(("Sandbox", f"[val]{run.sandbox_backend}[/]"))
+    if overrides:
+        rows.append(("Overrides", f"[dim]{' '.join(overrides)}[/]"))
+    console.print()
+    console.print(info_panel(rows, title="[bold]rLLM Eval (config)[/]", border="brand"))
+    console.print()
+
+    if dry_run:
+        console.print("[dim]--dry-run: resolved above; not evaluating.[/]\n")
+        return
+
+    base_url, model, proxy_manager = _resolve_eval_model_source(e.get("base_url"), e.get("model"), e.get("proxy_port"))
+
+    agent_metadata = {}
+    if run.sandbox_backend:
+        agent_metadata["sandbox_backend"] = run.sandbox_backend
+    if run.sandbox_concurrency is not None:
+        agent_metadata["sandbox_concurrency"] = run.sandbox_concurrency
+
+    try:
+        _run_eval(
+            benchmark,
+            run.agent,
+            run.evaluator,
+            base_url,
+            model,
+            split,
+            concurrency,
+            max_examples,
+            task_indices,
+            output_path,
+            agent_metadata=agent_metadata,
+            enable_ui=enable_ui,
+            save_episodes=save_episodes,
+            episodes_dir=episodes_dir,
+            use_snapshot=use_snapshot,
+            warm_queue_size=warm_queue_size,
+            sampling_config=sampling_config,
+            attempts=attempts,
+            agent_args=run.agent_args,
+        )
+    finally:
+        if proxy_manager is not None:
+            proxy_manager.shutdown_proxy()
+
+
 @click.command("eval")
 @click.argument("benchmark")
+@click.argument("overrides", nargs=-1)
 @click.option("--agent", "agent_name", default=None, help="Agent scaffold: registry name or module:object path.")
 @click.option("--evaluator", "evaluator_name", default=None, help="Evaluator: registry name or module:class path.")
 @click.option("--base-url", default=None, help="OpenAI-compatible API endpoint URL. If omitted, a proxy is auto-started using 'rllm setup' config.")
@@ -637,8 +823,11 @@ def _run_eval(
         "Default 3600. Sandbox lifetimes are sized to outlast this, so the environment isn't torn down mid-rollout."
     ),
 )
+@click.option("--dry-run", "dry_run", is_flag=True, default=False, help="Config-file mode only: resolve the run and print it, then exit without evaluating.")
 def eval_cmd(
     benchmark: str,
+    overrides: tuple[str, ...],
+    dry_run: bool,
     agent_name: str | None,
     evaluator_name: str | None,
     base_url: str | None,
@@ -663,7 +852,18 @@ def eval_cmd(
     max_tokens: int | None,
     agent_timeout: int | None,
 ):
-    """Evaluate a model on a benchmark dataset."""
+    """Evaluate a model on a benchmark dataset.
+
+    ``rllm eval run.toml [key=value ...]`` — config-file mode: the ``[run]``
+    definition + optional ``[eval]`` block specify the run. Otherwise flag mode
+    (``rllm eval <benchmark> --agent ...``).
+    """
+    from rllm.config.run_config import is_config_file
+
+    if is_config_file(benchmark):
+        _run_eval_from_config(benchmark, overrides, dry_run=dry_run)
+        return
+
     from rllm.cli._sampling import resolve_eval_sampling
 
     try:
@@ -685,68 +885,7 @@ def eval_cmd(
     if not enable_ui and not _ui_explicit:
         console.print("  [blue]Tip: Try rllm UI for live monitoring! Run [bold]rllm login[/bold] to get started.[/]")
 
-    proxy_manager = None
-
-    if base_url is not None:
-        # Direct mode: user provided --base-url, require --model too
-        if model is None:
-            fail("--model is required when --base-url is provided.")
-    else:
-        # Proxy mode: auto-start LiteLLM proxy from config
-        import os as _os
-
-        from rllm.eval.config import load_config
-
-        config = load_config()
-
-        # A ``tinker://`` sampler-checkpoint path (produced by ``rllm sft`` on the
-        # tinker backend) is served by the Tinker OAI endpoint, which the built-in
-        # "tinker" provider is pinned to. Route it there automatically no matter
-        # which provider the local config selects — or whether a config exists at
-        # all — since the checkpoint path alone determines where it can run.
-        resolved_model = model if model is not None else config.model
-        is_tinker_checkpoint = bool(resolved_model) and resolved_model.startswith("tinker://")
-
-        if is_tinker_checkpoint:
-            api_key = _os.environ.get("TINKER_API_KEY", "")
-            if not api_key:
-                fail("tinker:// checkpoint models require TINKER_API_KEY in the environment.\n\n  Export your Tinker key and re-run, e.g.:\n    export TINKER_API_KEY=<your-tinker-key>")
-            provider = "tinker"
-            model = resolved_model
-            console.print("  [success]tinker:// checkpoint detected[/] → routing through the Tinker OAI endpoint")
-        else:
-            if not config.is_configured():
-                fail("No configuration found. Run `rllm setup` first to configure your provider and API key.")
-            provider = config.provider
-            api_key = config.api_key
-            # --model overrides configured model
-            if model is None:
-                model = config.model
-
-        if provider == "custom":
-            # Custom provider: skip LiteLLM proxy, use base_url directly
-            base_url = config.base_url
-            if api_key:
-                _os.environ.setdefault("OPENAI_API_KEY", api_key)
-            console.print(f"  [success]Using custom endpoint[/] at [dim]{base_url}[/]")
-        else:
-            from rllm.eval.proxy import EvalProxyManager
-
-            proxy_manager = EvalProxyManager(
-                provider=provider,
-                model_name=model,
-                api_key=api_key,
-                proxy_port=proxy_port,
-            )
-            with Status(f"[dim]Starting LiteLLM proxy for [bold]{provider}/{model}[/bold]...[/]", console=console):
-                try:
-                    proxy_manager.start_proxy_subprocess(proxy_manager.build_proxy_config())
-                except (RuntimeError, TimeoutError) as e:
-                    console.print("\n  [dim]Make sure litellm is installed:[/] [bold]pip install litellm\\[proxy][/]")
-                    console.print()
-                    fail(f"Failed to start LiteLLM proxy.\n\n  {e}")
-            base_url = proxy_manager.get_proxy_url()
-            console.print(f"  [success]Proxy ready[/] at [dim]{base_url}[/]")
+    base_url, model, proxy_manager = _resolve_eval_model_source(base_url, model, proxy_port)
 
     # Build agent metadata from CLI options
     agent_metadata = {}

--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -552,12 +552,99 @@ def _load_or_pull_dataset(name: str, split: str, catalog: dict, catalog_entry_ov
 
 
 # ---------------------------------------------------------------------------
+# 2b. _run_train_from_config  — config-file training path
+# ---------------------------------------------------------------------------
+
+
+def _run_train_from_config(config_path: str, overrides: tuple[str, ...], *, dry_run: bool = False):
+    """Launch training from a self-contained config file.
+
+    ``rllm train run.toml [key=value ...]``. Composes the full trainer config
+    for the file's ``backend``, resolves the ``[run]`` definition into
+    agent/evaluator/datasets, and hands them to ``AgentTrainer`` — the same
+    facade the flag path uses.
+    """
+    from omegaconf import OmegaConf
+
+    from rllm.cli._run_resolve import resolve_run
+    from rllm.config.run_config import export_env, load_run_config
+
+    try:
+        config, run = load_run_config(config_path, overrides=list(overrides) or None)
+    except (FileNotFoundError, ValueError, TypeError) as e:
+        fail(f"Invalid config file '{config_path}': {e}")
+
+    export_env(run.env)
+
+    try:
+        resolved = resolve_run(run, for_eval=False)
+    except (KeyError, ImportError, AttributeError, TypeError, ValueError) as e:
+        fail(f"Could not resolve run definition in '{config_path}': {e}")
+
+    # ---- Header ----
+    project = OmegaConf.select(config, "rllm.trainer.project_name")
+    experiment = OmegaConf.select(config, "rllm.trainer.experiment_name")
+    model_name = OmegaConf.select(config, "model.name") or OmegaConf.select(config, "actor_rollout_ref.model.path")
+    train_n = len(resolved.train_dataset) if resolved.train_dataset is not None else 0
+    val_info = "[dim]None[/]"
+    if resolved.val_dataset is not None:
+        val_name = run.val_dataset or run.train_dataset
+        val_info = f"[val]{val_name}[/]  [dim]({len(resolved.val_dataset)} examples)[/]"
+    rows = [
+        ("Config", f"[val]{config_path}[/]"),
+        ("Backend", f"[val]{run.backend}[/]"),
+        ("Model", f"[val]{model_name}[/]"),
+        ("Agent", f"[val]{resolved.agent_display}[/]"),
+        ("Evaluator", f"[dim]{resolved.evaluator_display}[/]"),
+        ("Train data", f"[val]{run.train_dataset}[/]  [dim]({train_n} examples)[/]"),
+        ("Val data", val_info),
+        ("Project", f"[dim]{project} / {experiment}[/]"),
+    ]
+    if run.sandbox_backend:
+        rows.append(("Sandbox", f"[val]{run.sandbox_backend}[/]"))
+    if overrides:
+        rows.append(("Overrides", f"[dim]{' '.join(overrides)}[/]"))
+    console.print()
+    console.print(info_panel(rows, title="[bold]rLLM Train (config)[/]", label_width=14))
+    console.print()
+
+    if dry_run:
+        console.print("[dim]--dry-run: composed config below; not launching.[/]\n")
+        console.print(OmegaConf.to_yaml(config))
+        return
+
+    try:
+        from rllm.trainer import AgentTrainer
+    except ImportError as e:
+        fail(f"Missing training dependencies: {e}\n  Install with: pip install 'rllm[train]'")
+
+    trainer_kwargs = dict(
+        config=config,
+        backend=run.backend,
+        agent_flow=resolved.agent_flow,
+        train_dataset=resolved.train_dataset,
+        val_dataset=resolved.val_dataset,
+        sandbox_backend=run.sandbox_backend,
+        sandbox_concurrency=run.sandbox_concurrency,
+    )
+    # entrypoint may supply explicit hooks; otherwise pass the evaluator and let
+    # AgentTrainer auto-wire SandboxTaskHooks when the flow needs a sandbox.
+    if resolved.hooks is not None:
+        trainer_kwargs["hooks"] = resolved.hooks
+    else:
+        trainer_kwargs["evaluator"] = resolved.evaluator
+
+    AgentTrainer(**trainer_kwargs).train()
+
+
+# ---------------------------------------------------------------------------
 # 3. train_cmd  — Click command
 # ---------------------------------------------------------------------------
 
 
 @click.command("train")
 @click.argument("benchmark")
+@click.argument("overrides", nargs=-1)
 # Dataset options
 @click.option("--train-dataset", default=None, help="Training dataset name (default: same as <benchmark>).")
 @click.option("--train-split", default=None, help="Training split (default: catalog train_split, then 'train' if available, else eval_split).")
@@ -582,6 +669,7 @@ def _load_or_pull_dataset(name: str, split: str, catalog: dict, catalog_entry_ov
 @click.option("--experiment", default=None, help="Experiment name (default: <benchmark>).")
 @click.option("--output", "output_dir", default=None, help="Checkpoint directory.")
 @click.option("--config", "config_file", default=None, type=click.Path(exists=True), help="YAML config file merged on top of base templates. CLI flags override it.")
+@click.option("--dry-run", "dry_run", is_flag=True, default=False, help="Config-file mode only: compose the config, resolve the run, print both, then exit without training.")
 # UI logging options
 @click.option("--ui/--no-ui", "enable_ui", default=None, help="Enable/disable live UI logging. Default: auto-enabled when logged in (see 'rllm login').")
 # Sandbox options
@@ -600,6 +688,8 @@ def _load_or_pull_dataset(name: str, split: str, catalog: dict, catalog_entry_ov
 @click.option("--max-tokens", "max_tokens", default=None, type=int, help="Max generated tokens per call for train+val (shortcut).")
 def train_cmd(
     benchmark: str,
+    overrides: tuple[str, ...],
+    dry_run: bool,
     train_dataset: str | None,
     train_split: str | None,
     val_dataset: str | None,
@@ -628,7 +718,22 @@ def train_cmd(
     top_p: float | None,
     max_tokens: int | None,
 ):
-    """Train a model on a benchmark dataset using RL."""
+    """Train a model on a benchmark dataset using RL.
+
+    Two modes:
+
+    * ``rllm train run.toml [key=value ...]`` — config-file mode: a single
+      self-contained TOML/YAML fully specifies the run (see
+      ``design/config-file-driven-train-eval.md``). Trailing ``key=value`` args
+      are Hydra-style dotlist overrides merged last.
+    * ``rllm train <benchmark> --model ... [OPTIONS]`` — flag mode (tinker).
+    """
+    from rllm.config.run_config import is_config_file
+
+    if is_config_file(benchmark):
+        _run_train_from_config(benchmark, overrides, dry_run=dry_run)
+        return
+
     # Auto-detect UI logging: enable if user is logged in (has ui_api_key or RLLM_API_KEY)
     _ui_explicit = enable_ui is not None
     if enable_ui is None:

--- a/rllm/config/__init__.py
+++ b/rllm/config/__init__.py
@@ -1,0 +1,23 @@
+"""Config-file-driven run loading for ``rllm train`` / ``rllm eval``."""
+
+from __future__ import annotations
+
+from rllm.config.run_config import (
+    CONFIG_SUFFIXES,
+    VALID_BACKENDS,
+    RunSpec,
+    export_env,
+    is_config_file,
+    load_run_config,
+    merge_backend_config,
+)
+
+__all__ = [
+    "CONFIG_SUFFIXES",
+    "VALID_BACKENDS",
+    "RunSpec",
+    "export_env",
+    "is_config_file",
+    "load_run_config",
+    "merge_backend_config",
+]

--- a/rllm/config/run_config.py
+++ b/rllm/config/run_config.py
@@ -1,0 +1,300 @@
+"""Config-file-driven run loading for ``rllm train`` / ``rllm eval``.
+
+Parses a single self-contained ``.toml`` (or ``.yaml``) config file into:
+
+1. the full OmegaConf ``DictConfig`` the trainer expects — composed from
+   ``rllm/trainer/config/unified.yaml`` for the file's ``backend`` (same result
+   as ``@hydra.main(config_name="unified")``), with the file's config-tree
+   sections merged on top; and
+2. a :class:`RunSpec` describing the *run definition* (agent, datasets,
+   evaluator, sandbox, env, entrypoint) that today lives as code in each
+   cookbook's ``train.py``.
+
+Schema (see ``design/config-file-driven-train-eval.md``):
+
+    backend = "fireworks"          # tinker | fireworks | verl
+    extends = "base.toml"          # optional; merged underneath this file
+
+    [run.agent]                    # run definition
+    name = "terminus2"             # catalog name | module:Class import path
+    evaluator = "..."              # optional; omit -> per-task verifier
+    [run.agent.args]               # constructor kwargs / configure() overrides
+    max_turns = 75
+    [run.dataset]
+    train = "tb-opus-pass"
+    val   = "terminal-bench@2.0"
+    [run.sandbox]
+    backend = "modal"
+    [run.env]                      # env vars exported before the run
+    RLLM_HARNESS_RUN_TIMEOUT_S = "2400"
+
+    [model]                        # everything else mirrors the config tree 1:1
+    name = "..."
+    [training]
+    group_size = 16
+    [rllm.async_training]
+    enable = true
+
+    [eval]                         # eval-only knobs (rllm eval)
+    concurrency = 64
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from omegaconf import DictConfig, OmegaConf
+
+# Bundled Hydra config root (holds unified.yaml + rllm/ + rllm/backend/).
+_CONFIG_DIR = Path(__file__).resolve().parent.parent / "trainer" / "config"
+
+VALID_BACKENDS = ("tinker", "fireworks", "verl")
+CONFIG_SUFFIXES = (".toml", ".yaml", ".yml")
+
+# Top-level file keys consumed by the loader itself (not config-tree overrides).
+_META_KEYS = frozenset({"backend", "extends", "run", "eval"})
+
+
+def is_config_file(arg: str) -> bool:
+    """True if ``arg`` names an existing regular file with a config suffix.
+
+    This is the discriminator ``rllm train`` / ``rllm eval`` use to choose
+    config-file mode over the benchmark-name / benchmark-directory behavior.
+    Benchmarks are names or directories, so a suffixed regular file is
+    unambiguous.
+    """
+    p = Path(os.path.expanduser(arg))
+    return p.is_file() and p.suffix.lower() in CONFIG_SUFFIXES
+
+
+# ---------------------------------------------------------------------------
+# RunSpec — the run definition (the [run] / [eval] blocks)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunSpec:
+    """The declarative run definition parsed from ``[run]`` (+ ``[eval]``)."""
+
+    backend: str = "tinker"
+
+    # agent ([run.agent])
+    agent: str | None = None
+    agent_args: dict = field(default_factory=dict)
+    evaluator: str | None = None
+    entrypoint: str | None = None
+
+    # dataset ([run.dataset])
+    train_dataset: str | None = None
+    train_split: str | None = None
+    val_dataset: str | None = None
+    val_split: str | None = None
+    max_examples: int | None = None
+
+    # sandbox ([run.sandbox])
+    sandbox_backend: str | None = None
+    sandbox_concurrency: int | None = None
+
+    # env ([run.env]) — exported before the run
+    env: dict = field(default_factory=dict)
+
+    # eval-only knobs ([eval]) — kept raw, consumed by the eval driver
+    eval: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_raw(cls, raw: dict) -> RunSpec:
+        run = dict(raw.get("run") or {})
+        agent = run.get("agent")
+        if isinstance(agent, str):
+            agent_name, agent_block = agent, {}
+        else:
+            agent_block = dict(agent or {})
+            agent_name = agent_block.get("name")
+
+        dataset = dict(run.get("dataset") or {})
+
+        sandbox = run.get("sandbox")
+        if isinstance(sandbox, str):
+            sandbox_backend, sandbox_block = sandbox, {}
+        else:
+            sandbox_block = dict(sandbox or {})
+            sandbox_backend = sandbox_block.get("backend")
+
+        return cls(
+            backend=raw.get("backend", "tinker"),
+            agent=agent_name,
+            agent_args=dict(agent_block.get("args") or {}),
+            # evaluator may sit under [run.agent] or directly under [run].
+            evaluator=agent_block.get("evaluator") or run.get("evaluator"),
+            entrypoint=run.get("entrypoint"),
+            train_dataset=dataset.get("train"),
+            train_split=dataset.get("train_split"),
+            val_dataset=dataset.get("val"),
+            val_split=dataset.get("val_split"),
+            max_examples=dataset.get("max_examples"),
+            sandbox_backend=sandbox_backend,
+            sandbox_concurrency=sandbox_block.get("concurrency"),
+            env=dict(run.get("env") or {}),
+            eval=dict(raw.get("eval") or {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parsing + extends resolution
+# ---------------------------------------------------------------------------
+
+
+def _parse(path: Path) -> dict:
+    """Parse a single config file to a plain dict (no extends resolution)."""
+    suffix = path.suffix.lower()
+    if suffix == ".toml":
+        import tomllib
+
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    if suffix in (".yaml", ".yml"):
+        loaded = OmegaConf.load(str(path))
+        return OmegaConf.to_container(loaded, resolve=False)  # type: ignore[return-value]
+    raise ValueError(f"Unsupported config suffix {suffix!r} (expected one of {CONFIG_SUFFIXES})")
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Deep-merge ``override`` onto ``base`` (override wins), via OmegaConf."""
+    merged = OmegaConf.merge(OmegaConf.create(base), OmegaConf.create(override))
+    return OmegaConf.to_container(merged, resolve=False)  # type: ignore[return-value]
+
+
+def _load_with_extends(path: Path, _seen: set[Path] | None = None) -> dict:
+    """Parse ``path``, resolving its ``extends`` chain underneath it.
+
+    ``extends`` is a path or list of paths (relative to the file), merged in
+    order with each base *under* the file that names it (child wins).
+    """
+    _seen = _seen if _seen is not None else set()
+    if path in _seen:
+        chain = " -> ".join(str(p) for p in (*_seen, path))
+        raise ValueError(f"Circular extends chain: {chain}")
+    _seen.add(path)
+
+    raw = _parse(path)
+    extends = raw.pop("extends", None)
+    if not extends:
+        return raw
+
+    bases = [extends] if isinstance(extends, str) else list(extends)
+    merged: dict = {}
+    for base in bases:
+        base_expanded = os.path.expanduser(str(base))
+        base_path = Path(base_expanded) if os.path.isabs(base_expanded) else (path.parent / base_expanded)
+        merged = _deep_merge(merged, _load_with_extends(base_path.resolve(), set(_seen)))
+    return _deep_merge(merged, raw)
+
+
+# ---------------------------------------------------------------------------
+# Config composition
+# ---------------------------------------------------------------------------
+
+
+def merge_backend_config(backend: str, user_cfg: dict | DictConfig | None = None) -> DictConfig:
+    """Compose the full trainer config for ``backend`` and merge user overrides.
+
+    Uses Hydra's ``compose`` API against ``unified.yaml`` with
+    ``rllm/backend=<backend>`` — reproducing ``@hydra.main(config_name="unified")``
+    including the ``@package _global_`` split and ``${...}`` interpolations, and
+    (for verl) the ``defaults: - /ppo_trainer`` composition that a plain
+    ``OmegaConf.load`` cannot do. ``user_cfg`` (the file's config-tree sections)
+    is merged on top.
+    """
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    if backend not in VALID_BACKENDS:
+        raise ValueError(f"Unknown backend {backend!r}; must be one of {VALID_BACKENDS}")
+
+    GlobalHydra.instance().clear()
+    try:
+        with initialize_config_dir(config_dir=str(_CONFIG_DIR), version_base=None):
+            cfg = compose(config_name="unified", overrides=[f"rllm/backend={backend}"])
+    finally:
+        GlobalHydra.instance().clear()
+
+    # compose() omits the ``hydra`` node; guard in case that changes.
+    OmegaConf.set_struct(cfg, False)
+    if "hydra" in cfg:
+        del cfg["hydra"]
+
+    if user_cfg:
+        # Permissive merge (additive keys allowed) — matches build_train_config.
+        cfg = OmegaConf.merge(cfg, OmegaConf.create(user_cfg))
+    return cfg  # type: ignore[return-value]
+
+
+def _mirror_data(tree: dict) -> dict:
+    """Copy a top-level ``[data]`` section into ``[rllm.data]`` (explicit ``rllm.data`` wins).
+
+    The scripts historically set both ``data.*`` and ``rllm.data.*``; the file
+    should declare ``[data]`` once. ``sync_config`` keeps the two in parity at
+    runtime, but the loader-writes ensure the loader-visible config is already
+    consistent.
+    """
+    data = tree.get("data")
+    if not isinstance(data, dict):
+        return tree
+    tree = dict(tree)
+    rllm = dict(tree.get("rllm") or {})
+    rllm_data = dict(rllm.get("data") or {})
+    for k, v in data.items():
+        rllm_data.setdefault(k, v)  # explicit rllm.data.* takes precedence
+    rllm["data"] = rllm_data
+    tree["rllm"] = rllm
+    return tree
+
+
+def _tree_overrides(raw: dict) -> dict:
+    """The config-tree sections of the file (everything but the meta keys)."""
+    return {k: v for k, v in raw.items() if k not in _META_KEYS}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def load_run_config(
+    path: str | os.PathLike,
+    *,
+    overrides: list[str] | None = None,
+) -> tuple[DictConfig, RunSpec]:
+    """Load a run config file into ``(DictConfig, RunSpec)``.
+
+    Args:
+        path: ``.toml`` / ``.yaml`` config file.
+        overrides: Hydra-style ``key=value`` dotlist merged last (highest
+            precedence), e.g. ``["training.learning_rate=1e-5"]``.
+    """
+    path = Path(os.path.expanduser(str(path))).resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    raw = _load_with_extends(path)
+    run = RunSpec.from_raw(raw)
+    if run.backend not in VALID_BACKENDS:
+        raise ValueError(f"Unknown backend {run.backend!r} in {path.name}; must be one of {VALID_BACKENDS}")
+
+    tree = _mirror_data(_tree_overrides(raw))
+    cfg = merge_backend_config(run.backend, tree)
+
+    if overrides:
+        OmegaConf.set_struct(cfg, False)
+        cfg = OmegaConf.merge(cfg, OmegaConf.from_dotlist(list(overrides)))
+
+    return cfg, run
+
+
+def export_env(env: dict[str, Any]) -> None:
+    """Export ``[run.env]`` variables into ``os.environ`` (values stringified)."""
+    for key, value in (env or {}).items():
+        os.environ[str(key)] = str(value)

--- a/rllm/eval/agent_loader.py
+++ b/rllm/eval/agent_loader.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import os
 from importlib.metadata import entry_points
 
 from rllm import paths
 from rllm.types import AgentFlow
+
+logger = logging.getLogger(__name__)
 
 _USER_AGENTS_FILE = paths.rllm_path("agents.json")
 
@@ -104,16 +107,40 @@ def _validate_agent_class(cls: type, name: str) -> None:
         raise TypeError(f"Agent '{name}' must be an AgentFlow class with a .run() method, got {cls.__name__}")
 
 
-def _load_and_instantiate(import_path: str, name: str) -> AgentFlow:
-    """Import an agent from a path, auto-instantiate classes, and validate."""
-    obj = _import_from_path(import_path)
+def _finalize_agent(obj: object, name: str, agent_args: dict | None = None) -> AgentFlow:
+    """Instantiate a resolved agent object and apply ``agent_args``.
+
+    A class is constructed with ``agent_args`` as keyword arguments. An
+    already-instantiated object receives ``agent_args`` through its
+    ``configure()`` method when it exposes one (unconsumed keys warn); with no
+    ``configure()`` and ``agent_args`` given, they are ignored with a warning.
+    """
+    args = dict(agent_args or {})
     if isinstance(obj, type):
-        obj = obj()
+        obj = obj(**args)
+        args = {}
     _validate_agent(obj, name)
+    if args:
+        configure = getattr(obj, "configure", None)
+        if callable(configure):
+            leftovers = dict(configure(dict(args)) or {})
+            for key in leftovers:
+                logger.warning("agent_args %r had no effect for agent %s", key, type(obj).__name__)
+        else:
+            logger.warning(
+                "agent %s exposes no configure(); ignoring agent_args %s (use a module:Class import path to pass constructor kwargs)",
+                type(obj).__name__,
+                sorted(args),
+            )
     return obj
 
 
-def load_agent(name_or_path: str) -> AgentFlow:
+def _load_and_instantiate(import_path: str, name: str, agent_args: dict | None = None) -> AgentFlow:
+    """Import an agent from a path, instantiate (with ``agent_args``), and validate."""
+    return _finalize_agent(_import_from_path(import_path), name, agent_args)
+
+
+def load_agent(name_or_path: str, agent_args: dict | None = None) -> AgentFlow:
     """Load an agent by registry name, import path, or entry point.
 
     Lookup order: user registry (``~/.rllm/agents.json``) → colon import path
@@ -124,6 +151,9 @@ def load_agent(name_or_path: str) -> AgentFlow:
         name_or_path: A registry name (e.g., ``"math"``), a colon-separated
             import path (e.g., ``"my_module:my_agent"``), or a plugin name
             registered via the ``rllm.agents`` entry-point group.
+        agent_args: Optional kwargs applied to the resolved flow — constructor
+            kwargs when it resolves to a class, else forwarded to the instance's
+            ``configure()``. Defaults to no args (unchanged behavior).
 
     Returns:
         An AgentFlow instance with a ``.run()`` method.
@@ -133,16 +163,16 @@ def load_agent(name_or_path: str) -> AgentFlow:
         harbor_agent_name = name_or_path.removeprefix("harbor:")
         from rllm.integrations.harbor.runtime import HarborRuntime
 
-        return HarborRuntime(agent_name=harbor_agent_name)
+        return HarborRuntime(agent_name=harbor_agent_name, **(agent_args or {}))
 
     # 1. User-registered agents (persistent, from register_agent())
     user_agents = _load_user_agents()
     if name_or_path in user_agents:
-        return _load_and_instantiate(user_agents[name_or_path]["import_path"], name_or_path)
+        return _load_and_instantiate(user_agents[name_or_path]["import_path"], name_or_path, agent_args)
 
     # 2. Explicit import path: "my_module:my_agent"
     if ":" in name_or_path:
-        return _load_and_instantiate(name_or_path, name_or_path)
+        return _load_and_instantiate(name_or_path, name_or_path, agent_args)
 
     # 3. Built-in catalog
     catalog = _load_agent_catalog()
@@ -151,20 +181,14 @@ def load_agent(name_or_path: str) -> AgentFlow:
         entry = agents[name_or_path]
         module = importlib.import_module(entry["module"])
         obj = getattr(module, entry["function"])
-        if isinstance(obj, type):
-            obj = obj()
-        _validate_agent(obj, name_or_path)
-        return obj
+        return _finalize_agent(obj, name_or_path, agent_args)
 
     # 4. Plugin discovery via entry points
     eps = entry_points(group="rllm.agents")
     for ep in eps:
         if ep.name == name_or_path:
             obj = ep.load()
-            if isinstance(obj, type):
-                obj = obj()
-            _validate_agent(obj, name_or_path)
-            return obj
+            return _finalize_agent(obj, name_or_path, agent_args)
 
     available = ", ".join(sorted(agents.keys()))
     raise KeyError(f"Agent '{name_or_path}' not found in registry. Available built-in: {available}")

--- a/tests/cli/test_eval_command.py
+++ b/tests/cli/test_eval_command.py
@@ -310,3 +310,59 @@ def test_eval_tinker_checkpoint_requires_api_key(runner, tmp_rllm_home, monkeypa
     assert "TINKER_API_KEY" in result.output
     mock_pm_cls.assert_not_called()
     mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Config-file mode: `rllm eval run.toml`
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_eval_model_source_direct():
+    """Direct mode (base_url + model) returns them with no proxy."""
+    from rllm.cli.eval import _resolve_eval_model_source
+
+    base_url, model, proxy = _resolve_eval_model_source("http://localhost:8000/v1", "my-model")
+    assert base_url == "http://localhost:8000/v1"
+    assert model == "my-model"
+    assert proxy is None
+
+
+def test_resolve_eval_model_source_direct_requires_model():
+    """Direct mode without a model fails."""
+    from rllm.cli._ui import CliError
+    from rllm.cli.eval import _resolve_eval_model_source
+
+    with pytest.raises(CliError):
+        _resolve_eval_model_source("http://localhost:8000/v1", None)
+
+
+def test_eval_config_dry_run(runner, tmp_path):
+    """`rllm eval run.toml --dry-run` composes + resolves the run without evaluating."""
+    cfg = tmp_path / "run.toml"
+    cfg.write_text(
+        """
+backend = "fireworks"
+[run.agent]
+name = "react"
+[run.dataset]
+val = "some-benchmark"
+[eval]
+split = "test"
+base_url = "http://localhost:8000/v1"
+model = "m"
+""".strip()
+    )
+    result = runner.invoke(cli, ["eval", str(cfg), "--dry-run", "rllm.trainer.project_name=x"])
+    assert result.exit_code == 0, result.output
+    assert "rLLM Eval (config)" in result.output
+    assert "some-benchmark" in result.output
+    assert "react" in result.output
+
+
+def test_eval_config_requires_dataset(runner, tmp_path):
+    """A config with no eval dataset fails clearly."""
+    cfg = tmp_path / "run.toml"
+    cfg.write_text('backend = "fireworks"\n[run.agent]\nname = "react"\n')
+    result = runner.invoke(cli, ["eval", str(cfg), "--dry-run"])
+    assert result.exit_code != 0
+    assert "eval dataset" in result.output.lower()

--- a/tests/config/test_run_config.py
+++ b/tests/config/test_run_config.py
@@ -1,0 +1,234 @@
+"""Tests for the config-file loader (``rllm.config.run_config``)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from omegaconf import OmegaConf
+
+from rllm.config.run_config import (
+    RunSpec,
+    _mirror_data,
+    export_env,
+    is_config_file,
+    load_run_config,
+    merge_backend_config,
+)
+
+
+def _write(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# is_config_file
+# ---------------------------------------------------------------------------
+
+
+def test_is_config_file(tmp_path):
+    toml = _write(tmp_path, "run.toml", "backend = 'tinker'\n")
+    assert is_config_file(str(toml))
+    assert is_config_file(str(_write(tmp_path, "run.yaml", "backend: tinker\n")))
+    # A bare benchmark name is not a file.
+    assert not is_config_file("aime2024")
+    # A directory is not a config file.
+    assert not is_config_file(str(tmp_path))
+    # A non-config suffix is not a config file.
+    assert not is_config_file(str(_write(tmp_path, "notes.txt", "x")))
+
+
+# ---------------------------------------------------------------------------
+# RunSpec.from_raw
+# ---------------------------------------------------------------------------
+
+
+def test_runspec_nested_blocks():
+    raw = {
+        "backend": "fireworks",
+        "run": {
+            "agent": {"name": "terminus2", "args": {"max_turns": 75, "enable_summarize": False}},
+            "dataset": {"train": "tb-opus-pass", "val": "terminal-bench@2.0", "val_split": "default", "max_examples": 10},
+            "sandbox": {"backend": "modal", "concurrency": 8},
+            "env": {"RLLM_HARNESS_RUN_TIMEOUT_S": "2400"},
+        },
+    }
+    spec = RunSpec.from_raw(raw)
+    assert spec.backend == "fireworks"
+    assert spec.agent == "terminus2"
+    assert spec.agent_args == {"max_turns": 75, "enable_summarize": False}
+    assert spec.train_dataset == "tb-opus-pass"
+    assert spec.val_dataset == "terminal-bench@2.0"
+    assert spec.val_split == "default"
+    assert spec.max_examples == 10
+    assert spec.sandbox_backend == "modal"
+    assert spec.sandbox_concurrency == 8
+    assert spec.env == {"RLLM_HARNESS_RUN_TIMEOUT_S": "2400"}
+
+
+def test_runspec_scalar_shorthands():
+    # agent / sandbox may be given as bare strings.
+    spec = RunSpec.from_raw({"run": {"agent": "react", "sandbox": "docker"}})
+    assert spec.agent == "react"
+    assert spec.agent_args == {}
+    assert spec.sandbox_backend == "docker"
+    assert spec.backend == "tinker"  # default
+
+
+def test_runspec_evaluator_locations():
+    # evaluator under [run.agent]
+    a = RunSpec.from_raw({"run": {"agent": {"name": "react", "evaluator": "math"}}})
+    assert a.evaluator == "math"
+    # evaluator directly under [run]
+    b = RunSpec.from_raw({"run": {"agent": "react", "evaluator": "math"}})
+    assert b.evaluator == "math"
+
+
+def test_runspec_entrypoint():
+    spec = RunSpec.from_raw({"run": {"entrypoint": "my_pkg.setup:build"}})
+    assert spec.entrypoint == "my_pkg.setup:build"
+
+
+# ---------------------------------------------------------------------------
+# merge_backend_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["tinker", "fireworks"])
+def test_merge_backend_config_base(backend):
+    cfg = merge_backend_config(backend)
+    assert cfg.rllm.backend == backend
+    assert cfg.rllm.algorithm.adv_estimator == "grpo"
+    assert cfg.rllm.data.train_batch_size == 64
+
+
+def test_merge_backend_config_user_override():
+    cfg = merge_backend_config("tinker", {"rllm": {"trainer": {"project_name": "myproj"}}, "training": {"group_size": 16}})
+    assert cfg.rllm.trainer.project_name == "myproj"
+    # group_size flows into rllm.rollout.n via the template interpolation.
+    assert OmegaConf.select(cfg, "rllm.rollout.n") == 16
+
+
+def test_merge_backend_config_bad_backend():
+    with pytest.raises(ValueError):
+        merge_backend_config("nope")
+
+
+# ---------------------------------------------------------------------------
+# _mirror_data
+# ---------------------------------------------------------------------------
+
+
+def test_mirror_data_copies_into_rllm():
+    tree = {"data": {"train_batch_size": 4, "max_prompt_length": 100}}
+    out = _mirror_data(tree)
+    assert out["rllm"]["data"]["train_batch_size"] == 4
+    assert out["rllm"]["data"]["max_prompt_length"] == 100
+    # original untouched
+    assert out["data"]["train_batch_size"] == 4
+
+
+def test_mirror_data_explicit_rllm_wins():
+    tree = {"data": {"train_batch_size": 4}, "rllm": {"data": {"train_batch_size": 8}}}
+    out = _mirror_data(tree)
+    assert out["rllm"]["data"]["train_batch_size"] == 8  # explicit rllm.data.* wins
+
+
+# ---------------------------------------------------------------------------
+# load_run_config — end to end
+# ---------------------------------------------------------------------------
+
+
+def test_load_run_config_end_to_end(tmp_path):
+    toml = _write(
+        tmp_path,
+        "run.toml",
+        """
+backend = "tinker"
+
+[run.agent]
+name = "react"
+[run.agent.args]
+max_turns = 5
+
+[run.dataset]
+train = "some-train"
+val = "some-val"
+
+[run.sandbox]
+backend = "docker"
+
+[model]
+name = "Qwen/Qwen3-4B"
+
+[data]
+train_batch_size = 4
+
+[rllm.trainer]
+project_name = "cfg-test"
+experiment_name = "exp1"
+""",
+    )
+    cfg, run = load_run_config(str(toml))
+    # RunSpec
+    assert run.backend == "tinker"
+    assert run.agent == "react"
+    assert run.agent_args == {"max_turns": 5}
+    assert run.train_dataset == "some-train"
+    assert run.sandbox_backend == "docker"
+    # Config tree
+    assert cfg.model.name == "Qwen/Qwen3-4B"
+    assert cfg.rllm.trainer.project_name == "cfg-test"
+    assert cfg.rllm.trainer.experiment_name == "exp1"
+    # [data] mirrored into [rllm.data]
+    assert cfg.rllm.data.train_batch_size == 4
+    assert cfg.data.train_batch_size == 4
+
+
+def test_load_run_config_dotlist_overrides(tmp_path):
+    toml = _write(tmp_path, "run.toml", 'backend = "tinker"\n[rllm.trainer]\nproject_name = "base"\n')
+    cfg, _ = load_run_config(str(toml), overrides=["rllm.trainer.project_name=overridden", "training.group_size=32"])
+    assert cfg.rllm.trainer.project_name == "overridden"
+    assert OmegaConf.select(cfg, "rllm.rollout.n") == 32
+
+
+def test_load_run_config_extends(tmp_path):
+    _write(
+        tmp_path,
+        "base.toml",
+        'backend = "tinker"\n[model]\nname = "base-model"\n[rllm.trainer]\nproject_name = "base-proj"\nsave_freq = 20\n',
+    )
+    child = _write(
+        tmp_path,
+        "child.toml",
+        'extends = "base.toml"\n[model]\nname = "child-model"\n[rllm.trainer]\nsave_freq = 5\n',
+    )
+    cfg, run = load_run_config(str(child))
+    assert run.backend == "tinker"  # inherited
+    assert cfg.model.name == "child-model"  # child wins
+    assert cfg.rllm.trainer.project_name == "base-proj"  # inherited
+    assert cfg.rllm.trainer.save_freq == 5  # child wins
+
+
+def test_load_run_config_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_run_config(str(tmp_path / "nope.toml"))
+
+
+def test_load_run_config_bad_backend(tmp_path):
+    toml = _write(tmp_path, "run.toml", 'backend = "wat"\n')
+    with pytest.raises(ValueError):
+        load_run_config(str(toml))
+
+
+# ---------------------------------------------------------------------------
+# export_env
+# ---------------------------------------------------------------------------
+
+
+def test_export_env(monkeypatch):
+    monkeypatch.delenv("RLLM_TEST_ENV_KEY", raising=False)
+    export_env({"RLLM_TEST_ENV_KEY": 123})
+    assert os.environ["RLLM_TEST_ENV_KEY"] == "123"  # stringified

--- a/tests/eval/test_agent_loader.py
+++ b/tests/eval/test_agent_loader.py
@@ -27,6 +27,20 @@ class TestLoadAgent:
         assert isinstance(agent, ReActHarness)
         assert not isinstance(agent, type)
 
+    def test_agent_args_as_constructor_kwargs_import_path(self):
+        """agent_args are passed to the class constructor (import-path form)."""
+        agent = load_agent("rllm.harnesses.react:ReActHarness", {"system_prompt": "custom-sp"})
+        assert agent.system_prompt == "custom-sp"
+
+    def test_agent_args_as_constructor_kwargs_catalog_name(self):
+        """agent_args reach the constructor for a catalog-resolved name too."""
+        agent = load_agent("react", {"system_prompt": "sp2"})
+        assert agent.system_prompt == "sp2"
+
+    def test_agent_args_none_is_unchanged_behavior(self):
+        agent = load_agent("rllm.harnesses.react:ReActHarness")
+        assert agent.system_prompt is not None  # default applied, no kwargs
+
     def test_load_bad_import_path_raises(self):
         with pytest.raises(ImportError):
             load_agent("nonexistent.module:my_agent")


### PR DESCRIPTION
Rebased onto **terminal-rl** (supersedes #803, which targeted main). One self-contained TOML/YAML specifies a whole run: `rllm train run.toml [key=value ...]` / `rllm eval run.toml [key=value ...]`. Implements phases 1–2 of `design/config-file-driven-train-eval.md` (included).

## Schema
```toml
backend = "fireworks"                     # tinker | fireworks | verl
[run.agent]
name = "terminus2"                        # catalog name | module:Class
[run.agent.args]
max_turns = 75
[run.dataset]
train = "tmax-15k"
val   = "terminal-bench@2.0"
[run.sandbox]
backend = "modal"
[run.env]
RLLM_HARNESS_RUN_TIMEOUT_S = "2400"
[model]                                   # everything else mirrors the config tree 1:1
name = "accounts/fireworks/models/qwen3p5-9b"
[training]
group_size = 16
[eval]                                    # eval-only knobs
split = "default"
concurrency = 64
```

## Components
- `rllm/config/run_config.py` — parse `.toml`/`.yaml` → `(DictConfig, RunSpec)`; composes the backend config via Hydra `compose` (handles `@package _global_`, interpolations, verl's `/ppo_trainer`), merges config-tree sections, mirrors `[data]`→`[rllm.data]`, resolves `extends`, applies dotlist overrides.
- `rllm/cli/_run_resolve.py` — `RunSpec` → agent/evaluator/datasets (+ `entrypoint` hook for train).
- `rllm/cli/train.py` / `eval.py` — config-file positional → config driver; `--dry-run`. Flag mode unchanged.
- `rllm/eval/agent_loader.py` — `load_agent(name, agent_args=...)`.

## Consolidation
- Extracted `_resolve_eval_model_source` (shared by flag + config eval; preserves terminal-rl's `tinker://` + `--proxy-port` behavior byte-identical).
- Config-eval funnels into the same `_run_eval` core (single resolution path); `_run_eval` gained `agent_args`.

## Testing
145 passing (`tests/cli` + `tests/config` + `tests/eval/test_agent_loader.py`); ruff clean; `--dry-run` smoke-tested for both `train` and `eval` on the terminal-rl base.

## Deferred
verl file-mode verification; entrypoint-for-eval; flag-path `_run_train`/`build_train_config` unification; cross-backend `rllm.*` canonicalization; docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)