### PR TITLE
feat(data): support pinned revisions in the SWE-Smith builder

### DIFF
--- a/rllm/data/swesmith_builder.py
+++ b/rllm/data/swesmith_builder.py
@@ -65,7 +65,7 @@ def bug_in_test_file(task_dir: Path) -> bool:
     return any(t in f2p_files for t in targets)
 
 
-def list_task_ids() -> list[str]:
+def list_task_ids(revision: str | None = None) -> list[str]:
     """List every task-dir name in the HF repo from one tree listing.
 
     A repo-tree listing is a handful of paginated API calls — unlike the
@@ -74,7 +74,11 @@ def list_task_ids() -> list[str]:
     """
     from huggingface_hub import HfApi
 
-    files = HfApi().list_repo_files(REPO_ID, repo_type="dataset")
+    files = HfApi().list_repo_files(
+        REPO_ID,
+        repo_type="dataset",
+        revision=revision,
+    )
     return sorted({f.split("/", 1)[0] for f in files if "/" in f})
 
 

--- a/rllm/data/swesmith_builder.py
+++ b/rllm/data/swesmith_builder.py
@@ -178,6 +178,7 @@ def build_benchmark(
     out_dir: str | Path,
     catalog_entry: dict | None = None,
     task_ids: list[str] | None = None,
+    revision: str | None = None,
     limit: int | None = None,
     default_agent: str = "mini-swe-agent",
     clean: bool = False,
@@ -193,6 +194,8 @@ def build_benchmark(
             ``default_agent``/``limit`` are read from it when present.
         task_ids: Build only these instance ids (downloads just their files).
             Default: derived from ``limit`` when given, else the full repo.
+        revision: Hugging Face dataset revision used for task discovery and
+            snapshot download.
         limit: Keep only N solvable tasks. Without explicit ``task_ids`` the
             download itself is capped to ``limit`` (+screen margin) ids picked
             round-robin across repos — not first-N-alphabetical.
@@ -217,7 +220,10 @@ def build_benchmark(
     # With a limit but no explicit ids, select the download set up front from
     # one repo-tree listing so a capped build never fetches all ~33K files.
     if task_ids is None and limit is not None:
-        task_ids = spread_task_ids(list_task_ids(), int(limit * _SCREEN_MARGIN) + 10)
+        task_ids = spread_task_ids(
+            list_task_ids(revision=revision),
+            int(limit * _SCREEN_MARGIN) + 10,
+        )
         print(f"[swesmith] selected {len(task_ids)} candidate tasks across repos for limit={limit}", flush=True)
 
     patterns = [f"{t}/*" for t in task_ids] if task_ids else None
@@ -228,7 +234,10 @@ def build_benchmark(
             f"[swesmith] downloading the FULL {REPO_ID} repo (~4.8K tasks, ~33K files).\n[swesmith] HF free-tier rate limits make this take ~35-40 min; progress resumes from cache if interrupted.",
             flush=True,
         )
-    cache = _snapshot_download_with_retry(patterns)
+    cache = _snapshot_download_with_retry(
+        patterns,
+        revision=revision,
+    )
 
     candidates = sorted(d for d in cache.iterdir() if d.is_dir() and (d / "task.toml").exists())
     if task_ids:

--- a/rllm/data/swesmith_builder.py
+++ b/rllm/data/swesmith_builder.py
@@ -102,7 +102,10 @@ def spread_task_ids(ids: list[str], n: int) -> list[str]:
     return sorted(picked)
 
 
-def _snapshot_download_with_retry(patterns: list[str] | None) -> Path:
+def _snapshot_download_with_retry(
+    patterns: list[str] | None,
+    revision: str | None = None,
+) -> Path:
     """``snapshot_download`` that sleeps out HF 429 rate-limit windows.
 
     The free tier allows 5000 resolver requests per 5 minutes and every file
@@ -115,7 +118,14 @@ def _snapshot_download_with_retry(patterns: list[str] | None) -> Path:
 
     while True:
         try:
-            return Path(snapshot_download(REPO_ID, repo_type="dataset", allow_patterns=patterns))
+            return Path(
+                snapshot_download(
+                    REPO_ID,
+                    repo_type="dataset",
+                    revision=revision,
+                    allow_patterns=patterns,
+                )
+            )
         except HfHubHTTPError as e:
             status = getattr(getattr(e, "response", None), "status_code", None)
             if status != 429:

--- a/tests/data/test_swesmith_builder.py
+++ b/tests/data/test_swesmith_builder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import tomllib
 
@@ -72,6 +72,61 @@ def test_list_task_ids_forwards_revision(monkeypatch):
             "revision": "dataset-sha",
         }
     ]
+
+
+def test_snapshot_download_preserves_revision_across_retry(
+    monkeypatch,
+    tmp_path,
+):
+    calls = []
+
+    class FakeHfHubHTTPError(Exception):
+        def __init__(self):
+            self.response = SimpleNamespace(
+                status_code=429,
+                headers={"Retry-After": "0"},
+            )
+
+    def fake_snapshot_download(
+        repo_id,
+        *,
+        repo_type,
+        revision,
+        allow_patterns,
+    ):
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "repo_type": repo_type,
+                "revision": revision,
+                "allow_patterns": allow_patterns,
+            }
+        )
+        if len(calls) == 1:
+            raise FakeHfHubHTTPError
+        return str(tmp_path)
+
+    hub = ModuleType("huggingface_hub")
+    hub.snapshot_download = fake_snapshot_download
+    errors = ModuleType("huggingface_hub.errors")
+    errors.HfHubHTTPError = FakeHfHubHTTPError
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.errors", errors)
+    monkeypatch.setattr(swesmith_builder.time, "sleep", lambda _wait: None)
+
+    result = swesmith_builder._snapshot_download_with_retry(
+        ["repo_a/*"],
+        revision="dataset-sha",
+    )
+
+    expected_call = {
+        "repo_id": swesmith_builder.REPO_ID,
+        "repo_type": "dataset",
+        "revision": "dataset-sha",
+        "allow_patterns": ["repo_a/*"],
+    }
+    assert result == tmp_path
+    assert calls == [expected_call, expected_call]
 
 
 class TestBugInTestFile:

--- a/tests/data/test_swesmith_builder.py
+++ b/tests/data/test_swesmith_builder.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import tomllib
 
+import rllm.data.swesmith_builder as swesmith_builder
 from rllm.data.swesmith_builder import _write_dataset_toml, bug_in_test_file, patch_task_toml
 
 _TASK_TOML = """\
@@ -34,6 +37,41 @@ def _make_task(tmp_path: Path, *, patch_target: str, f2p_file: str) -> Path:
     }
     (task_dir / "tests" / "config.json").write_text(json.dumps(cfg))
     return task_dir
+
+
+def test_list_task_ids_forwards_revision(monkeypatch):
+    calls = []
+
+    class FakeHfApi:
+        def list_repo_files(self, repo_id, *, repo_type, revision):
+            calls.append(
+                {
+                    "repo_id": repo_id,
+                    "repo_type": repo_type,
+                    "revision": revision,
+                }
+            )
+            return [
+                "repo_b/task.toml",
+                "repo_a/instruction.md",
+                "README.md",
+            ]
+
+    hub = ModuleType("huggingface_hub")
+    hub.HfApi = FakeHfApi
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    assert swesmith_builder.list_task_ids(revision="dataset-sha") == [
+        "repo_a",
+        "repo_b",
+    ]
+    assert calls == [
+        {
+            "repo_id": swesmith_builder.REPO_ID,
+            "repo_type": "dataset",
+            "revision": "dataset-sha",
+        }
+    ]
 
 
 class TestBugInTestFile:

--- a/tests/data/test_swesmith_builder.py
+++ b/tests/data/test_swesmith_builder.py
@@ -129,6 +129,80 @@ def test_snapshot_download_preserves_revision_across_retry(
     assert calls == [expected_call, expected_call]
 
 
+def test_build_benchmark_uses_one_revision_for_discovery_and_download(
+    monkeypatch,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    task = _make_task(
+        cache,
+        patch_target="src/a.py",
+        f2p_file="tests/test_a.py",
+    )
+    calls = []
+
+    class FakeHfApi:
+        def list_repo_files(self, repo_id, *, repo_type, revision):
+            calls.append(("list", repo_id, repo_type, revision))
+            return [
+                f"{task.name}/task.toml",
+                f"{task.name}/tests/config.json",
+            ]
+
+    class FakeHfHubHTTPError(Exception):
+        pass
+
+    def fake_snapshot_download(
+        repo_id,
+        *,
+        repo_type,
+        revision,
+        allow_patterns,
+    ):
+        calls.append(
+            (
+                "download",
+                repo_id,
+                repo_type,
+                revision,
+                allow_patterns,
+            )
+        )
+        return str(cache)
+
+    hub = ModuleType("huggingface_hub")
+    hub.HfApi = FakeHfApi
+    hub.snapshot_download = fake_snapshot_download
+    errors = ModuleType("huggingface_hub.errors")
+    errors.HfHubHTTPError = FakeHfHubHTTPError
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.errors", errors)
+
+    out = swesmith_builder.build_benchmark(
+        out_dir=tmp_path / "out",
+        revision="dataset-sha",
+        limit=1,
+        register=False,
+    )
+
+    assert (out / task.name / "task.toml").is_file()
+    assert calls == [
+        (
+            "list",
+            swesmith_builder.REPO_ID,
+            "dataset",
+            "dataset-sha",
+        ),
+        (
+            "download",
+            swesmith_builder.REPO_ID,
+            "dataset",
+            "dataset-sha",
+            [f"{task.name}/*"],
+        ),
+    ]
+
+
 class TestBugInTestFile:
     def test_source_bug_is_solvable(self, tmp_path):
         task = _make_task(tmp_path, patch_target="src/repo/core.py", f2p_file="tests/test_core.py")


### PR DESCRIPTION
## Summary

Adds an optional `revision` argument to the programmatic SWE-Smith benchmark builder. The same Hugging Face dataset revision is used for task discovery and snapshot download, including retries, so callers can materialize an internally consistent dataset snapshot. Existing behavior is unchanged when `revision` is omitted.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- Forward `revision` to `HfApi.list_repo_files` during task discovery.
- Forward the same `revision` to `snapshot_download` and preserve it across HTTP 429 retries.
- Add offline tests for discovery, retry, and end-to-end builder propagation.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `PYTHONPATH=. pytest tests/data/test_swesmith_builder.py -q`
- [ ] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Targeted tests: 8 passed.
- `uvx pre-commit run --files rllm/data/swesmith_builder.py tests/data/test_swesmith_builder.py`: Ruff and Ruff format passed.
- The full suite was not collected locally because the lightweight environment does not include optional backend packages such as rllm-model-gateway, OmegaConf, Tinker, Ray, and telemetry; the affected data-builder tests have no dependency on those packages.

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- None

## Screenshots / logs

- Not applicable
