### PR TITLE
fix(engine): reject extra valid AgentFlow traces

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -150,6 +150,7 @@ def enrich_episode_with_traces(
     # shrink GRPO groups; raise on real mismatches so retries can reissue.
     n_agent_steps = sum(len(t.steps) for t in episode.trajectories)
     agent_populates_steps = any(len(t.steps) > 0 for t in episode.trajectories)
+    all_trajectories_populate_steps = bool(episode.trajectories) and all(t.steps for t in episode.trajectories)
 
     # Common case: vLLM returns an empty body on the final call (e.g. prompt
     # hit max_model_len, or weight-sync disconnect). The agent breaks without
@@ -170,16 +171,16 @@ def enrich_episode_with_traces(
 
     empty_prompt = sum(1 for s in training_steps if not s.model_output.prompt_ids)
     empty_compl = sum(1 for s in training_steps if not s.model_output.completion_ids)
-    # Only enforce step-count parity when the agent actually populates steps.
-    # Trajectories with no agent steps absorb remaining traces wholesale
-    # (see branch below), and trajectories with steps consume traces 1:1.
+    # Enforce exact parity when every trajectory reports steps. A trajectory
+    # without agent steps absorbs remaining traces wholesale (see branch below).
     traces_short = agent_populates_steps and len(training_steps) < n_agent_steps
+    traces_long = all_trajectories_populate_steps and len(training_steps) > n_agent_steps
     # Empty token IDs are a hard error only in strict (training) mode.
     # Eval against external providers (OpenAI/Anthropic via LiteLLM proxy)
     # legitimately has empty token IDs and that's fine — the evaluator
     # reads `model_response` / `chat_completions`, not token IDs.
     token_ids_missing = strict and (empty_prompt or empty_compl)
-    if traces_short or token_ids_missing:
+    if traces_short or traces_long or token_ids_missing:
         raise EnrichMismatchError(f"[{uid}] enrich mismatch: traces={len(training_steps)} agent_steps={n_agent_steps} empty_prompt_ids={empty_prompt} empty_completion_ids={empty_compl}")
 
     # Build enriched trajectories

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -2,9 +2,9 @@ import asyncio
 
 import pytest
 
-from rllm.agents.agent import Episode, Trajectory
+from rllm.agents.agent import Episode, Step, Trajectory
 from rllm.data.utils import task_from_row
-from rllm.engine.agentflow_engine import AgentFlowEngine
+from rllm.engine.agentflow_engine import AgentFlowEngine, EnrichMismatchError, enrich_episode_with_traces
 from rllm.eval.types import EvalOutput
 from rllm.workflows.workflow import TerminationReason
 
@@ -75,21 +75,82 @@ def test_run_single_passes_validation_flag_and_preserves_termination_reason():
     assert episode.termination_reason == TerminationReason.ERROR
 
 
-def _empty_token_trace(session_id: str):
+def _trace(
+    session_id: str,
+    index: int,
+    *,
+    prompt_token_ids: list[int] | None = None,
+    completion_token_ids: list[int] | None = None,
+):
     from rllm_model_gateway.models import TraceRecord
 
+    prompt_ids = [index + 1] if prompt_token_ids is None else prompt_token_ids
+    completion_ids = [index + 11] if completion_token_ids is None else completion_token_ids
     return TraceRecord(
-        trace_id=f"t-{session_id}",
+        trace_id=f"trace-{index}",
         session_id=session_id,
         model="m",
         messages=[{"role": "user", "content": "Q"}],
-        response_message={"role": "assistant", "content": "A"},
-        prompt_token_ids=[],  # empty → corrupts loss math if it reaches training
-        completion_token_ids=[],
-        logprobs=[],
+        response_message={"role": "assistant", "content": f"A{index}"},
+        prompt_token_ids=prompt_ids,
+        completion_token_ids=completion_ids,
+        logprobs=[-0.1] * len(completion_ids),
         finish_reason="stop",
         metadata={},
     )
+
+
+def _empty_token_trace(session_id: str):
+    return _trace(session_id, 0, prompt_token_ids=[], completion_token_ids=[])
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_enrichment_rejects_extra_valid_trace_when_all_trajectories_have_steps(strict):
+    episode = Episode(trajectories=[Trajectory(name="solver", steps=[Step()])])
+
+    with pytest.raises(EnrichMismatchError, match=r"traces=2 agent_steps=1"):
+        enrich_episode_with_traces(
+            episode,
+            [_trace("session", 0), _trace("session", 1)],
+            "session",
+            {},
+            strict=strict,
+        )
+
+
+def test_enrichment_drops_trailing_malformed_trace():
+    episode = Episode(trajectories=[Trajectory(name="solver", steps=[Step()])])
+
+    enriched = enrich_episode_with_traces(
+        episode,
+        [
+            _trace("session", 0),
+            _trace("session", 1, prompt_token_ids=[], completion_token_ids=[]),
+        ],
+        "session",
+        {},
+    )
+
+    assert [step.id for step in enriched.trajectories[0].steps] == ["trace-0"]
+
+
+def test_enrichment_assigns_extra_traces_to_trajectory_without_steps():
+    episode = Episode(
+        trajectories=[
+            Trajectory(name="reported", steps=[Step()]),
+            Trajectory(name="trace-driven"),
+        ]
+    )
+
+    enriched = enrich_episode_with_traces(
+        episode,
+        [_trace("session", 0), _trace("session", 1), _trace("session", 2)],
+        "session",
+        {},
+    )
+
+    assert [step.id for step in enriched.trajectories[0].steps] == ["trace-0"]
+    assert [step.id for step in enriched.trajectories[1].steps] == ["trace-1", "trace-2"]
 
 
 @pytest.mark.parametrize("is_validation", [False, True])
@@ -119,8 +180,6 @@ def test_strict_enrichment_follows_is_validation(is_validation):
             episode = asyncio.run(engine._run_single(task, "task:0", is_validation=True))
             assert episode is not None
         else:
-            from rllm.engine.agentflow_engine import EnrichMismatchError
-
             with pytest.raises(EnrichMismatchError):
                 asyncio.run(engine._run_single(task, "task:0", is_validation=False))
     finally:


### PR DESCRIPTION
## Problem

`enrich_episode_with_traces` matches gateway traces to AgentFlow Steps positionally. The trailing-malformed trace handling added in #511 intentionally keeps an aligned prefix when a failed final model call produced an unusable trace, while valid trailing traces are supposed to remain an alignment error.

The current validation only checks for too few traces. If every trajectory already reports Steps and the gateway returns an additional trace with real token IDs, that trace is never consumed and the rollout is accepted. This silently discards a valid model call even though the trace-to-Step mapping is not one-to-one.

## Fix

- Detect surplus valid traces after the existing malformed-trace cleanup.
- Raise the existing `EnrichMismatchError` when every trajectory reports Steps and usable traces outnumber those Steps.
- Keep structural cardinality checks independent of `strict`, which continues to control only missing token IDs.
- Preserve the existing behavior for trailing malformed traces and trajectories that rely on remaining traces to construct their Steps.

## Testing

- `uv run --extra dev pytest tests/engine/test_agentflow_engine.py -v`
- `uvx pre-commit run --from-ref origin/main --to-ref HEAD --show-diff-on-fail`

