### PR TITLE
feat(sft,tinker): harden multi-turn SFT training

### DIFF
--- a/cookbooks/swe-rl/nemotron_fireworks_sft.yaml
+++ b/cookbooks/swe-rl/nemotron_fireworks_sft.yaml
@@ -1,0 +1,57 @@
+# Fireworks port of the measured Nemotron 3 Nano SWE-agent SFT run.
+#
+# This file is merged over rllm/trainer/sft/config/fireworks.yaml.  Keep the
+# Fireworks model, Hugging Face tokenizer, and training shape in lockstep.
+
+model:
+  name: accounts/fireworks/models/nemotron-nano-3-30b-a3b
+  tokenizer_model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  lora_rank: 32
+  # fireworks-ai 1.2.1 defaults all three targets to true.  The pinned rLLM
+  # backend does not forward these fields, so the preflight verifies the SDK
+  # defaults before any paid trainer is provisioned.
+  train_unembed: true
+  train_attn: true
+  train_mlp: true
+
+fireworks_config:
+  policy_trainer_shape_id: accounts/fireworks/trainingShapes/nemotron-nano-3-30b-a3b-262k-b200-lora
+  policy_trainer_replica_count: 1
+
+data:
+  train_batch_size: 9
+  micro_batch_size_per_gpu: 9
+  train_max_samples: -1
+  val_max_samples: -1
+  max_length: 65536
+  renderer_name: nemotron3
+  rllm:
+    tokenize_and_mask_method: cumulative
+    group_by_length: false
+    length_group_factor: 50
+    overlength_policy: error
+    # Match the measured run: one cross-entropy mean over all supervised
+    # assistant tokens in the nine-trajectory optimizer batch.
+    loss_reduction: token_mean
+    strip_thinking_from_history: false
+
+optim:
+  lr: 1.0e-4
+  betas: [0.9, 0.999]
+  eps: 1.0e-8
+  lr_scheduler: cosine
+  warmup_steps_ratio: 0.0
+  warmup_steps: 50
+  min_lr: 1.0e-5
+  weight_decay: 0.01
+  grad_clip_norm: 1.0
+
+trainer:
+  total_epochs: 1
+  max_steps: 1000
+  logger: [console]
+  project_name: rllm-nemotron3-swe-sft
+  experiment_name: nemotron3-nano-30b-a3b-lora32-fireworks
+  save_freq: 250
+  test_freq: 100
+  default_local_dir: /tmp/rllm-nemotron3-fireworks-sft-checkpoints

--- a/cookbooks/swe-rl/nemotron_fireworks_sft.yaml
+++ b/cookbooks/swe-rl/nemotron_fireworks_sft.yaml
@@ -54,4 +54,3 @@ trainer:
   experiment_name: nemotron3-nano-30b-a3b-lora32-fireworks
   save_freq: 250
   test_freq: 100
-  default_local_dir: /tmp/rllm-nemotron3-fireworks-sft-checkpoints

--- a/cookbooks/swe-rl/nemotron_fireworks_sft_runtime.txt
+++ b/cookbooks/swe-rl/nemotron_fireworks_sft_runtime.txt
@@ -1,0 +1,10 @@
+# Measured runtime overlay. Install after the repository's fireworks extra.
+fireworks-ai==1.2.1
+fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@6b1232504fdacd1149895acf63b388ae792cb062#subdirectory=training
+huggingface-hub==0.36.2
+tinker==0.22.7
+tinker-cookbook==0.4.2
+transformers==4.57.6
+datasets==5.0.1
+pyarrow==23.0.1
+tokenizers==0.22.2

--- a/cookbooks/swe-rl/setup_nemotron_fireworks_sft.sh
+++ b/cookbooks/swe-rl/setup_nemotron_fireworks_sft.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Create an isolated environment matching the measured Nemotron Fireworks run.
+# This intentionally overlays older measured SDK versions after installing the
+# current rLLM Fireworks extra; it does not modify the repository's main venv.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+RUNTIME_PATH="${SCRIPT_DIR}/nemotron_fireworks_sft_runtime.txt"
+ENV_DIR="${NEMOTRON_SFT_ENV_DIR:-${REPO_ROOT}/.venv-nemotron-fireworks-sft}"
+
+if [[ $# -gt 0 ]]; then
+    echo "usage: $0" >&2
+    exit 2
+fi
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv is required: https://docs.astral.sh/uv/getting-started/installation/" >&2
+    exit 1
+fi
+if [[ ! -f "${RUNTIME_PATH}" ]]; then
+    echo "missing measured runtime overlay: ${RUNTIME_PATH}" >&2
+    exit 1
+fi
+
+if [[ ! -x "${ENV_DIR}/bin/python" ]]; then
+    if [[ -e "${ENV_DIR}" ]]; then
+        echo "${ENV_DIR} exists but is not a usable virtual environment" >&2
+        echo "move it aside or set NEMOTRON_SFT_ENV_DIR to a new path" >&2
+        exit 1
+    fi
+    uv venv --python 3.12.3 "${ENV_DIR}"
+fi
+
+actual_python="$(${ENV_DIR}/bin/python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
+if [[ "${actual_python}" != "3.12.3" ]]; then
+    echo "${ENV_DIR} uses Python ${actual_python}; expected 3.12.3" >&2
+    echo "move it aside or set NEMOTRON_SFT_ENV_DIR to a new path" >&2
+    exit 1
+fi
+
+uv pip install --python "${ENV_DIR}/bin/python" -e "${REPO_ROOT}[fireworks]"
+uv pip install --python "${ENV_DIR}/bin/python" --no-deps --requirement "${RUNTIME_PATH}"
+
+printf 'environment ready: %s\n' "${ENV_DIR}"
+printf 'activate with: source %q\n' "${ENV_DIR}/bin/activate"

--- a/cookbooks/swe-rl/train_nemotron_fireworks_sft.sh
+++ b/cookbooks/swe-rl/train_nemotron_fireworks_sft.sh
@@ -3,6 +3,9 @@
 # prepared train/validation Parquet files.
 #
 # Usage:
+#   bash cookbooks/swe-rl/setup_nemotron_fireworks_sft.sh
+#   source .venv-nemotron-fireworks-sft/bin/activate
+#   hf auth login
 #   export FIREWORKS_API_KEY=...
 #   bash cookbooks/swe-rl/train_nemotron_fireworks_sft.sh [DATASET_DIR]
 #
@@ -22,16 +25,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 CONFIG_PATH="${SCRIPT_DIR}/nemotron_fireworks_sft.yaml"
-DEFAULT_DATASET_DIR="${REPO_ROOT}/artifacts/nemotron-swe/approx-a/migrated"
+DEFAULT_ENV_DIR="${NEMOTRON_SFT_ENV_DIR:-${REPO_ROOT}/.venv-nemotron-fireworks-sft}"
+DEFAULT_DATASET_DIR="${REPO_ROOT}/artifacts/nemotron-swe/approx-a/hf-download"
 DATASET_DIR="${1:-${NEMOTRON_SFT_DATASET_DIR:-${DEFAULT_DATASET_DIR}}}"
 TRAIN_PATH="${DATASET_DIR}/train.parquet"
 VALIDATION_PATH="${DATASET_DIR}/validation.parquet"
 MANIFEST_PATH="${DATASET_DIR}/manifest.json"
 EXPECTED_TRAIN_SHA256="da467b1937cc3f2e7ce8687b8b6ea122090984faa3080becf3a3b37eb0900e16"
 EXPECTED_VALIDATION_SHA256="76a18380d127d2c65716ec1c063667dfc91577280366e39702b71aa9cd9aa9e9"
-EXPECTED_CONFIG_SHA256="0ad7b8a439397d725d187d10aeb9672488b7836a7edfe9141cf9c239dcebab2c"
+EXPECTED_CONFIG_SHA256="2ce851d7b27c12be8e09914d3e72e31d85f0c4e51a17830f6596fe535908ad40"
 REQUIRED_RLLM_BASE_REVISION="079c65d4237da01de0334735f3684f475c4d976f"
 TOKENIZER_REVISION="2d59de1cbd51c0adf384eb906b766d1aee0e0517"
+TOKENIZER_REPO="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
 DEFAULT_DATASET_REPO="mobius-lab/nemotron-swe-v3-rllm-sft-surrogate-a"
 DEFAULT_DATASET_REVISION="e775ddc45209d327afd8e26d9571c9761ca3d7ae"
 
@@ -40,15 +45,20 @@ if [[ $# -gt 1 ]]; then
     exit 2
 fi
 
+HF_BIN="${HF_BIN:-${DEFAULT_ENV_DIR}/bin/hf}"
+if [[ ! -x "${HF_BIN}" ]]; then
+    HF_BIN="$(command -v hf || true)"
+fi
+
 if [[ ! -f "${TRAIN_PATH}" || ! -f "${VALIDATION_PATH}" ]]; then
     DATASET_REPO="${NEMOTRON_SFT_DATASET_REPO:-${DEFAULT_DATASET_REPO}}"
     DATASET_REVISION="${NEMOTRON_SFT_DATASET_REVISION:-${DEFAULT_DATASET_REVISION}}"
-    if ! command -v hf >/dev/null 2>&1; then
+    if [[ -z "${HF_BIN}" || ! -x "${HF_BIN}" ]]; then
         echo "the Hugging Face 'hf' CLI is required to download ${DATASET_REPO}" >&2
         exit 1
     fi
     mkdir -p "${DATASET_DIR}"
-    hf download "${DATASET_REPO}" \
+    "${HF_BIN}" download "${DATASET_REPO}" \
         train.parquet validation.parquet manifest.json README.md \
         --repo-type dataset \
         --revision "${DATASET_REVISION}" \
@@ -94,7 +104,10 @@ else
     echo "warning: ${MANIFEST_PATH} is absent; Parquet hashes still match" >&2
 fi
 
-RLLM_BIN="${RLLM_BIN:-${REPO_ROOT}/.venv/bin/rllm}"
+RLLM_BIN="${RLLM_BIN:-${DEFAULT_ENV_DIR}/bin/rllm}"
+if [[ ! -x "${RLLM_BIN}" ]]; then
+    RLLM_BIN="${REPO_ROOT}/.venv/bin/rllm"
+fi
 if [[ ! -x "${RLLM_BIN}" ]]; then
     RLLM_BIN="$(command -v rllm || true)"
 fi
@@ -123,6 +136,7 @@ expected = {
     "rllm": "0.3.0rc0",
     "fireworks-ai": "1.2.1",
     "fireworks-training-cookbook": "0.1.0",
+    "huggingface-hub": "0.36.2",
     "tinker": "0.22.7",
     "tinker-cookbook": "0.4.2",
     "transformers": "4.57.6",
@@ -158,17 +172,58 @@ if problems:
     raise SystemExit("runtime mismatch:\n- " + "\n- ".join(problems))
 PY
 
-export HF_HUB_CACHE="${HF_HUB_CACHE:-${REPO_ROOT}/../.hf-tokenizer-cache}"
-if [[ "${NEMOTRON_SFT_OFFLINE:-1}" == "1" ]]; then
-    TOKENIZER_REF="${HF_HUB_CACHE}/models--nvidia--NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/refs/main"
-    if [[ ! -f "${TOKENIZER_REF}" || "$(<"${TOKENIZER_REF}")" != "${TOKENIZER_REVISION}" ]]; then
-        echo "the pinned Nemotron tokenizer revision is not cached under ${HF_HUB_CACHE}" >&2
-        echo "populate the cache first or set NEMOTRON_SFT_OFFLINE=0 for a non-identical online resolution" >&2
+TOKENIZER_CACHE="${NEMOTRON_SFT_TOKENIZER_CACHE:-${REPO_ROOT}/artifacts/nemotron-swe/tokenizer-cache}"
+TOKENIZER_REPO_CACHE="${TOKENIZER_CACHE}/models--nvidia--NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+TOKENIZER_SNAPSHOT="${TOKENIZER_REPO_CACHE}/snapshots/${TOKENIZER_REVISION}"
+TOKENIZER_FILES=(
+    chat_template.jinja
+    config.json
+    special_tokens_map.json
+    tokenizer.json
+    tokenizer_config.json
+)
+TOKENIZER_SHA256=(
+    ab7813c3abdd9cb655905a410728b26c7884eca45ddfab8d9f931553485a7862
+    dd9fa380ac107b0477db5a26108db9febe6378e7bb3966a107944853ec4f76f8
+    e3a4f63da745f02317a45e00e6476c17fc66ac41faf14bb1b0be1f3211b0ca53
+    c6021eb6847e682f89aa52d5eb6e8c7d902a23acfc8137e25211cf84828f1592
+    3d568e506d0905285ae90a3fdd1482be7b6d0bf0b8ca9514d75dad4257b0827a
+)
+
+tokenizer_missing=0
+for filename in "${TOKENIZER_FILES[@]}"; do
+    if [[ ! -f "${TOKENIZER_SNAPSHOT}/${filename}" ]]; then
+        tokenizer_missing=1
+    fi
+done
+if [[ "${tokenizer_missing}" == "1" ]]; then
+    if [[ "${NEMOTRON_SFT_OFFLINE:-0}" == "1" ]]; then
+        echo "the pinned Nemotron tokenizer is absent and NEMOTRON_SFT_OFFLINE=1" >&2
         exit 1
     fi
-    export HF_HUB_OFFLINE=1
-    export TRANSFORMERS_OFFLINE=1
+    if [[ -z "${HF_BIN}" || ! -x "${HF_BIN}" ]]; then
+        echo "the Hugging Face 'hf' CLI is required to download ${TOKENIZER_REPO}" >&2
+        exit 1
+    fi
+    "${HF_BIN}" download "${TOKENIZER_REPO}" "${TOKENIZER_FILES[@]}" \
+        --revision "${TOKENIZER_REVISION}" \
+        --cache-dir "${TOKENIZER_CACHE}"
 fi
+
+for index in "${!TOKENIZER_FILES[@]}"; do
+    verify_sha256 \
+        "${TOKENIZER_SNAPSHOT}/${TOKENIZER_FILES[index]}" \
+        "${TOKENIZER_SHA256[index]}"
+done
+
+# Use a recipe-owned cache so resolving the model ID offline is pinned without
+# mutating the user's general Hugging Face cache or the remote tokenizer ID
+# passed to Fireworks provisioning.
+mkdir -p "${TOKENIZER_REPO_CACHE}/refs"
+printf '%s\n' "${TOKENIZER_REVISION}" > "${TOKENIZER_REPO_CACHE}/refs/main"
+export HF_HUB_CACHE="${TOKENIZER_CACHE}"
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
 export TOKENIZERS_PARALLELISM=false
 export PYTHONUNBUFFERED=1
 

--- a/cookbooks/swe-rl/train_nemotron_fireworks_sft.sh
+++ b/cookbooks/swe-rl/train_nemotron_fireworks_sft.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Launch the measured Nemotron 3 Nano Fireworks SFT recipe on the already
+# prepared train/validation Parquet files.
+#
+# Usage:
+#   export FIREWORKS_API_KEY=...
+#   bash cookbooks/swe-rl/train_nemotron_fireworks_sft.sh [DATASET_DIR]
+#
+# DATASET_DIR must contain train.parquet, validation.parquet, and preferably
+# manifest.json. When the files are absent, this script downloads the pinned
+# private Hugging Face dataset. You may override that source explicitly:
+#
+#   NEMOTRON_SFT_DATASET_REPO=org/repo \
+#   NEMOTRON_SFT_DATASET_REVISION=<immutable-commit> \
+#   bash cookbooks/swe-rl/train_nemotron_fireworks_sft.sh /path/to/cache
+#
+# Set NEMOTRON_SFT_DRY_RUN=1 to verify inputs and print the command without
+# provisioning a paid trainer.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+CONFIG_PATH="${SCRIPT_DIR}/nemotron_fireworks_sft.yaml"
+DEFAULT_DATASET_DIR="${REPO_ROOT}/artifacts/nemotron-swe/approx-a/migrated"
+DATASET_DIR="${1:-${NEMOTRON_SFT_DATASET_DIR:-${DEFAULT_DATASET_DIR}}}"
+TRAIN_PATH="${DATASET_DIR}/train.parquet"
+VALIDATION_PATH="${DATASET_DIR}/validation.parquet"
+MANIFEST_PATH="${DATASET_DIR}/manifest.json"
+EXPECTED_TRAIN_SHA256="da467b1937cc3f2e7ce8687b8b6ea122090984faa3080becf3a3b37eb0900e16"
+EXPECTED_VALIDATION_SHA256="76a18380d127d2c65716ec1c063667dfc91577280366e39702b71aa9cd9aa9e9"
+EXPECTED_CONFIG_SHA256="0ad7b8a439397d725d187d10aeb9672488b7836a7edfe9141cf9c239dcebab2c"
+REQUIRED_RLLM_BASE_REVISION="079c65d4237da01de0334735f3684f475c4d976f"
+TOKENIZER_REVISION="2d59de1cbd51c0adf384eb906b766d1aee0e0517"
+DEFAULT_DATASET_REPO="mobius-lab/nemotron-swe-v3-rllm-sft-surrogate-a"
+DEFAULT_DATASET_REVISION="e775ddc45209d327afd8e26d9571c9761ca3d7ae"
+
+if [[ $# -gt 1 ]]; then
+    echo "usage: $0 [DATASET_DIR]" >&2
+    exit 2
+fi
+
+if [[ ! -f "${TRAIN_PATH}" || ! -f "${VALIDATION_PATH}" ]]; then
+    DATASET_REPO="${NEMOTRON_SFT_DATASET_REPO:-${DEFAULT_DATASET_REPO}}"
+    DATASET_REVISION="${NEMOTRON_SFT_DATASET_REVISION:-${DEFAULT_DATASET_REVISION}}"
+    if ! command -v hf >/dev/null 2>&1; then
+        echo "the Hugging Face 'hf' CLI is required to download ${DATASET_REPO}" >&2
+        exit 1
+    fi
+    mkdir -p "${DATASET_DIR}"
+    hf download "${DATASET_REPO}" \
+        train.parquet validation.parquet manifest.json README.md \
+        --repo-type dataset \
+        --revision "${DATASET_REVISION}" \
+        --local-dir "${DATASET_DIR}"
+fi
+
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+    echo "missing SFT recipe: ${CONFIG_PATH}" >&2
+    exit 1
+fi
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        echo "neither sha256sum nor shasum is installed" >&2
+        return 1
+    fi
+}
+
+verify_sha256() {
+    local path="$1"
+    local expected="$2"
+    local actual
+    actual="$(sha256_file "${path}")"
+    if [[ "${actual}" != "${expected}" ]]; then
+        echo "dataset hash mismatch for ${path}" >&2
+        echo "expected ${expected}" >&2
+        echo "actual   ${actual}" >&2
+        exit 1
+    fi
+}
+
+verify_sha256 "${TRAIN_PATH}" "${EXPECTED_TRAIN_SHA256}"
+verify_sha256 "${VALIDATION_PATH}" "${EXPECTED_VALIDATION_SHA256}"
+verify_sha256 "${CONFIG_PATH}" "${EXPECTED_CONFIG_SHA256}"
+
+if [[ -f "${MANIFEST_PATH}" ]]; then
+    echo "dataset manifest: ${MANIFEST_PATH}"
+else
+    echo "warning: ${MANIFEST_PATH} is absent; Parquet hashes still match" >&2
+fi
+
+RLLM_BIN="${RLLM_BIN:-${REPO_ROOT}/.venv/bin/rllm}"
+if [[ ! -x "${RLLM_BIN}" ]]; then
+    RLLM_BIN="$(command -v rllm || true)"
+fi
+if [[ -z "${RLLM_BIN}" || ! -x "${RLLM_BIN}" ]]; then
+    echo "rllm executable not found; set RLLM_BIN or install the repository environment" >&2
+    exit 1
+fi
+
+RLLM_PYTHON="${RLLM_PYTHON:-$(dirname -- "${RLLM_BIN}")/python}"
+if [[ ! -x "${RLLM_PYTHON}" ]]; then
+    echo "Python next to rllm was not found; set RLLM_PYTHON explicitly" >&2
+    exit 1
+fi
+
+if ! git -C "${REPO_ROOT}" merge-base --is-ancestor "${REQUIRED_RLLM_BASE_REVISION}" HEAD; then
+    echo "rLLM HEAD does not contain the required SFT base ${REQUIRED_RLLM_BASE_REVISION}" >&2
+    exit 1
+fi
+
+"${RLLM_PYTHON}" - <<'PY'
+import importlib.metadata
+import json
+import sys
+
+expected = {
+    "rllm": "0.3.0rc0",
+    "fireworks-ai": "1.2.1",
+    "fireworks-training-cookbook": "0.1.0",
+    "tinker": "0.22.7",
+    "tinker-cookbook": "0.4.2",
+    "transformers": "4.57.6",
+    "datasets": "5.0.1",
+    "pyarrow": "23.0.1",
+    "tokenizers": "0.22.2",
+}
+problems = []
+actual_python = ".".join(str(part) for part in sys.version_info[:3])
+if actual_python != "3.12.3":
+    problems.append(f"Python {actual_python} != 3.12.3")
+for package, wanted in expected.items():
+    try:
+        actual = importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        problems.append(f"{package} is not installed")
+        continue
+    if actual != wanted:
+        problems.append(f"{package} {actual} != {wanted}")
+
+dist = importlib.metadata.distribution("fireworks-training-cookbook")
+direct_url_raw = dist.read_text("direct_url.json")
+direct_url = json.loads(direct_url_raw) if direct_url_raw else {}
+actual_commit = direct_url.get("vcs_info", {}).get("commit_id")
+expected_commit = "6b1232504fdacd1149895acf63b388ae792cb062"
+if actual_commit != expected_commit:
+    problems.append(
+        "fireworks-training-cookbook commit "
+        f"{actual_commit!r} != {expected_commit}"
+    )
+
+if problems:
+    raise SystemExit("runtime mismatch:\n- " + "\n- ".join(problems))
+PY
+
+export HF_HUB_CACHE="${HF_HUB_CACHE:-${REPO_ROOT}/../.hf-tokenizer-cache}"
+if [[ "${NEMOTRON_SFT_OFFLINE:-1}" == "1" ]]; then
+    TOKENIZER_REF="${HF_HUB_CACHE}/models--nvidia--NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/refs/main"
+    if [[ ! -f "${TOKENIZER_REF}" || "$(<"${TOKENIZER_REF}")" != "${TOKENIZER_REVISION}" ]]; then
+        echo "the pinned Nemotron tokenizer revision is not cached under ${HF_HUB_CACHE}" >&2
+        echo "populate the cache first or set NEMOTRON_SFT_OFFLINE=0 for a non-identical online resolution" >&2
+        exit 1
+    fi
+    export HF_HUB_OFFLINE=1
+    export TRANSFORMERS_OFFLINE=1
+fi
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+
+if [[ "${NEMOTRON_SFT_DRY_RUN:-0}" != "1" && -z "${FIREWORKS_API_KEY:-}" ]]; then
+    echo "FIREWORKS_API_KEY is required for Fireworks SFT" >&2
+    exit 1
+fi
+
+RUNS_DIR="${NEMOTRON_SFT_RUNS_DIR:-${REPO_ROOT}/artifacts/nemotron-swe/approx-a/runs}"
+mkdir -p "${RUNS_DIR}"
+RUN_STAMP="$(date -u +%Y%m%d-%H%M%S)"
+LOG_PATH="${NEMOTRON_SFT_LOG_PATH:-${RUNS_DIR}/fireworks-sft-${RUN_STAMP}.log}"
+
+COMMAND=(
+    "${RLLM_BIN}" sft
+    --backend fireworks
+    --train-file "${TRAIN_PATH}"
+    --val-file "${VALIDATION_PATH}"
+    --model accounts/fireworks/models/nemotron-nano-3-30b-a3b
+    --lora-rank 32
+    --lr 1.0e-4
+    --batch-size 9
+    --epochs 1
+    --max-length 65536
+    --tokenize-method cumulative
+    --lr-schedule cosine
+    --val-freq 100
+    --save-freq 250
+    --project rllm-nemotron3-swe-sft
+    --experiment nemotron3-nano-30b-a3b-lora32-fireworks
+    --logger console
+    --output "${RUNS_DIR}"
+    --no-ui
+    --config "${CONFIG_PATH}"
+)
+
+printf 'launch command:'
+printf ' %q' "${COMMAND[@]}"
+printf '\nlog: %s\n' "${LOG_PATH}"
+
+if [[ "${NEMOTRON_SFT_DRY_RUN:-0}" == "1" ]]; then
+    exit 0
+fi
+
+"${COMMAND[@]}" 2>&1 | tee "${LOG_PATH}"

--- a/docs/guides/sft-distillation.mdx
+++ b/docs/guides/sft-distillation.mdx
@@ -94,7 +94,7 @@ If an attempt produces many trained steps but zero merges, curation logs a **deg
 
 ### `rllm dataset import` — external trace files
 
-`import` bridges a local file of `{"messages": [...]}` rows into the canonical schema and registers it. Choose the source shape with `--format` (`rllm/cli/dataset.py`, bridges in `rllm/data/sft_bridges.py`):
+Choose the format that matches your source:
 
 ```bash
 rllm dataset import data.jsonl --name my-sft                             # --format messages (default)
@@ -102,30 +102,83 @@ rllm dataset import data.jsonl --name my-sft --train-on last             # only 
 rllm dataset import traces.jsonl --name distill-traces --format think-tags  # split <think>...</think> into a thinking part
 ```
 
-- **`messages`** — plain OpenAI rows. The loss mask is derived from `--train-on` (`all` assistant turns, default, or only the `last`).
-- **`think-tags`** — rows whose assistant turns start with a `<think>...</think>` block (a common convention for distilled reasoning traces). The bridge splits that block into a `thinking` part and carries every non-`messages` top-level key through verbatim as row metadata.
+- **`messages`** accepts OpenAI-style rows, including sibling `reasoning_content` and tool calls. `--train-on` selects all assistant turns or only the last one.
+- **`think-tags`** parses a leading assistant `<think>...</think>` block into a `thinking` part.
+
+rLLM preserves source whitespace. If a `messages` row starts assistant text with a structural `<think>` block, import it with `--format think-tags`; rLLM rejects the ambiguous plain form instead of training the tags as visible text.
 
 #### `--explode` (think-tags only, default ON)
 
-This is the most important knob for `think-tags`, so spell out the tradeoff before choosing:
-
-- **Exploded (default)** — the conversation is split into one row per assistant turn. History turns keep only their visible text (CoT stripped), and the row's single final assistant turn is the trained target with its CoT kept. This is exactly what a next-token SFT loss wants, and it's **inference-faithful**: thinking-family renderers strip prior-turn reasoning at render time, so training every CoT block requires giving each its own row. The cost is duplicated history tokens.
-- **`--no-explode`** — one compact row per full conversation, every assistant turn trainable. But because thinking-family renderers strip history CoT at render time, only the **final** turn's CoT is actually trained; earlier turns contribute their visible text only. You save history-token duplication but train fewer CoT blocks.
-
-Rule of thumb: keep the default `--explode` when you want every reasoning block trained; use `--no-explode` for compact conversations where only the last turn's reasoning matters.
+- **Exploded (default)** creates one row per assistant turn. It duplicates history, but trains every reasoning block.
+- **`--no-explode`** keeps one compact conversation. Existing per-message masks are preserved; otherwise assistant turns are trained.
 
 ## Training with `rllm sft`
 
+<Steps>
+  <Step title="Inspect the registered rows">
+
+    ```bash
+    rllm dataset inspect my-sft --split train
+    ```
+
+    Confirm that reasoning uses `thinking` parts and the intended assistant messages have `trainable: true`.
+  </Step>
+
+  <Step title="Start with a short hosted run">
+
+    ```bash
+    rllm sft my-sft \
+      --model Qwen/Qwen3.5-4B \
+      --backend tinker \
+      --batch-size 2 \
+      --epochs 1 \
+      --save-freq 2 \
+      --val-freq 2
+    ```
+
+    Tinker and Fireworks render every train and validation row before creating a paid training client. Schema, renderer, masking, and length failures therefore stop locally.
+  </Step>
+
+  <Step title="Scale the verified configuration">
+
+    Increase the batch size, epochs, or step cap only after the short run succeeds. Use `--config` for backend-native controls:
+
+    ```yaml hosted-sft.yaml
+    data:
+      rllm:
+        overlength_policy: error
+        group_by_length: true
+        length_group_factor: 50
+        loss_reduction: token_mean
+    optim:
+      warmup_steps: 10
+      min_lr: 0.000001
+      weight_decay: 0.01
+    trainer:
+      max_steps: 100
+    ```
+
+    ```bash
+    rllm sft my-sft --backend tinker --config hosted-sft.yaml
+    ```
+  </Step>
+</Steps>
+
+The hosted backends use each message's `trainable` flag as the loss mask. Flag-less rows train assistant turns; `--tokenize-method stepwise` limits that derived default to the final assistant turn.
+
+### Checkpoints and resume
+
+Without `--output`, each Tinker launch creates an isolated run directory. To resume intentionally, pass the same explicit directory:
+
 ```bash
-rllm sft my-sft --model Qwen/Qwen3.5-4B --backend tinker --epochs 3
-rllm sft --train-file data.parquet --lr 1e-5 --backend fireworks
+rllm sft my-sft --backend tinker --output runs/my-sft
 ```
 
-Masking is always tinker's `CUSTOMIZED` mode, driven by each message's `trainable` flag — the data decides the loss mask (`rllm/trainer/sft/tinker_backend.py`, `build_sft_data`).
+On a later launch, rLLM resumes only when the local run contract and provider checkpoint match the model, LoRA settings, renderer, dataset, optimizer, and step horizon. A legacy or mismatched checkpoint fails before a resumed training client is created; use a new output directory.
 
 ### Logging training progress
 
-Per-step training metrics (loss, learning rate, progress) route through rLLM's unified tracking layer (`rllm.utils.tracking.Tracking`). `console` logging is always on; add more backends with `--logger`:
+Console logging is always on. Add another tracker with `--logger`:
 
 ```bash
 rllm sft my-sft --logger wandb                    # needs WANDB_API_KEY or `wandb login`
@@ -133,7 +186,7 @@ rllm sft my-sft --logger wandb --logger tensorboard   # repeatable
 rllm sft my-sft --ui                              # live rLLM UI (see `rllm login`)
 ```
 
-`--logger` accepts `console | wandb | mlflow | swanlab | tensorboard | file | ui`. `--project`/`--experiment` name the run in whichever backend you pick (default `rllm-sft` / the dataset name). `--ui` is auto-enabled when you're logged in; pass `--no-ui` to opt out.
+`--logger` accepts `console | wandb | mlflow | swanlab | tensorboard | file | ui`. `--project` and `--experiment` name the run. Pass `--no-ui` to disable automatic UI logging when you are logged in.
 
 <Note>
   Live rLLM UI logging (`--ui`) is supported on the **tinker** and **fireworks** backends only; on `--backend verl` it is dropped with a warning.
@@ -141,21 +194,14 @@ rllm sft my-sft --ui                              # live rLLM UI (see `rllm logi
 
 ### Renderer auto-detection and `--renderer`
 
-The tinker/fireworks path renders rows through a tinker-cookbook renderer. rLLM auto-detects it from the model in this order (`_resolve_renderer_name`, `rllm/trainer/sft/tinker_backend.py`):
-
-1. An explicit `--renderer` wins (an advisory warning fires if it looks mismatched — never fatal).
-2. Otherwise tinker-cookbook's recommendation map (`get_recommended_renderer_name`).
-3. Otherwise a family heuristic on the model basename (`qwen3.5 → qwen3_5`, `qwen3 → qwen3`, `deepseek → deepseekv3`, `llama-3 → llama3`).
-4. Otherwise fall back to `role_colon` with a warning.
-
-Pass `--renderer` when auto-detection can't place your model (e.g. a small or renamed checkpoint tinker's map doesn't cover). Valid names:
+Tinker and Fireworks auto-detect a renderer from the model. Pin one when using a renamed or unsupported model:
 
 ```text
 qwen3 | qwen3_5 | deepseekv3 | llama3 | role_colon
 ```
 
 <Warning>
-  `role_colon` and `llama3` are **text-only** renderers — they cannot represent reasoning (`thinking` parts) or tool calls. If your data contains either, the tinker backend **fails fast** with an `SFTConfigError` rather than silently dropping the reasoning. Pin a capable renderer (`qwen3` / `qwen3_5` / `deepseekv3`) or use a chat model whose default renderer supports structured content.
+  `role_colon` and `llama3` cannot represent reasoning or tool calls. Pin `qwen3`, `qwen3_5`, or `deepseekv3` for structured rows.
 </Warning>
 
 ## Backend support matrix
@@ -166,7 +212,7 @@ qwen3 | qwen3_5 | deepseekv3 | llama3 | role_colon
 | **fireworks** | ✓ (same data path) | ✓ |
 | **verl** | ✗ (rejected today) | ✓ |
 
-Fireworks subclasses the tinker backend and reuses the same rendering pipeline, so structured rows behave identically. The verl backend rejects structured rows — parts-list content or per-message `trainable` flags — with an actionable `SFTConfigError` (`_reject_structured_rows`, `rllm/trainer/sft/verl_backend.py`); plain `{role, content: str}` rows still train fine on verl. Structured SFT support on verl is planned.
+Fireworks reuses the Tinker rendering path. verl currently accepts only plain `{role, content: str}` rows. It also rejects hosted-only `--config` keys with the closest verl-native alternative instead of ignoring them.
 
 ## Worked example: importing think-tagged teacher traces
 
@@ -202,7 +248,11 @@ Common `SFTConfigError` messages and what to do:
 | `train dataset is empty` | The dataset/split resolved to zero rows. Check the name and `--split`; run `rllm dataset list --local`. |
 | `train dataset is missing a 'messages' column` | The file isn't in SFT shape. Import it first with `rllm dataset import` (or point at the right file). |
 | `... row 0 does not match the SFT schema` | A malformed message (bad part type, missing `role`/`content`). The error names the failing field. |
+| `assistant text begins with a structural <think>...` | Import the source with `--format think-tags`, or provide canonical `thinking` parts. |
+| `... renders to ... > data.max_length` | Raise `--max-length`, filter the row, or explicitly select the lossy `overlength_policy: truncate`. |
 | `The 'role_colon' renderer cannot represent reasoning (<think>) or tool-calls` | A text-only renderer met structured data. Pass `--renderer qwen3` (or `qwen3_5` / `deepseekv3`). |
+| `Cannot resume ... run identity mismatch` | The explicit Tinker output directory belongs to different training inputs. Choose a new directory. |
+| `verl cannot use hosted-backend SFT override keys` | Replace each rejected key with the alternative listed in the error. |
 | `... has structured SFT rows ... not supported on the verl backend yet` | Structured rows on verl. Use `--backend tinker` (or `fireworks`). |
 | `Unsupported lr_schedule ... for verl` | verl ships `constant` / `cosine` only; `linear` maps to `cosine` with a warning. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ tinker = [
 ]
 
 fireworks = [
-    "fireworks-ai[training]==1.2.1 ; python_version >= '3.11'",
-    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
+    "fireworks-ai[training]==1.2.8 ; python_version >= '3.11'",
+    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@f2696f25152b8d4e10589248f1c99d977a5238dc#subdirectory=training ; python_version >= '3.11'",
 ]
 
 opentelemetry = [

--- a/rllm/cli/dataset.py
+++ b/rllm/cli/dataset.py
@@ -292,22 +292,16 @@ def register(name: str, file_path: str, split: str, category: str | None, descri
 @click.option("--split", default="train", help="Split name to register the rows under (default: train).")
 @click.option("--train-on", type=click.Choice(["all", "last"]), default="all", help="[messages] Derive the loss mask over 'all' assistant turns (default) or only the 'last'.")
 @click.option("--no-explode", is_flag=True, help="[think-tags] Emit one row per conversation instead of one row per assistant turn.")
-@click.option(
-    "--trim-whitespace/--no-trim-whitespace",
-    default=False,
-    help="Strip leading/trailing message whitespace for templates known to do the same (default: preserve source text).",
-)
 @click.option("--description", default=None, help="Short description of the dataset.")
 @click.pass_context
-def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: str, train_on: str, no_explode: bool, trim_whitespace: bool, description: str | None):
+def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: str, train_on: str, no_explode: bool, description: str | None):
     """Import a local SFT data file, bridging it to the canonical row schema.
 
     FILE is a JSON/JSONL/CSV/Parquet file of ``{"messages": [...]}`` rows. The
     chosen --format bridge normalizes each row (deriving ``trainable`` masks,
     lifting ``reasoning_content`` into thinking parts, decoding JSON-string
-    ``tool_calls``, trimming template-trimmed whitespace and, for think-tags,
-    splitting the ``<think>`` chain-of-thought) before the rows are registered
-    ready for ``rllm sft``.
+    ``tool_calls`` and, for think-tags, splitting the ``<think>``
+    chain-of-thought) before the rows are registered ready for ``rllm sft``.
 
     \b
     Examples:
@@ -327,7 +321,6 @@ def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: 
         console.print("  [yellow]--no-explode is ignored for --format messages[/] [dim](explosion only applies to think-tags).[/]")
 
     bridge_opts = {"train_on": train_on} if fmt == "messages" else {"explode": not no_explode}
-    bridge_opts["trim_whitespace"] = trim_whitespace
 
     ds = Dataset.load_data(file_path)
     try:
@@ -340,7 +333,7 @@ def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: 
         name,
         records,
         split=split,
-        source=f"import:{fmt}:trim" if trim_whitespace else f"import:{fmt}",
+        source=f"import:{fmt}",
         description=description or "",
     )
 

--- a/rllm/cli/dataset.py
+++ b/rllm/cli/dataset.py
@@ -292,15 +292,22 @@ def register(name: str, file_path: str, split: str, category: str | None, descri
 @click.option("--split", default="train", help="Split name to register the rows under (default: train).")
 @click.option("--train-on", type=click.Choice(["all", "last"]), default="all", help="[messages] Derive the loss mask over 'all' assistant turns (default) or only the 'last'.")
 @click.option("--no-explode", is_flag=True, help="[think-tags] Emit one row per conversation instead of one row per assistant turn.")
+@click.option(
+    "--trim-whitespace/--no-trim-whitespace",
+    default=False,
+    help="Strip leading/trailing message whitespace for templates known to do the same (default: preserve source text).",
+)
 @click.option("--description", default=None, help="Short description of the dataset.")
 @click.pass_context
-def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: str, train_on: str, no_explode: bool, description: str | None):
+def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: str, train_on: str, no_explode: bool, trim_whitespace: bool, description: str | None):
     """Import a local SFT data file, bridging it to the canonical row schema.
 
     FILE is a JSON/JSONL/CSV/Parquet file of ``{"messages": [...]}`` rows. The
-    chosen --format bridge normalizes each row (deriving ``trainable`` masks and,
-    for think-tags, splitting the ``<think>`` chain-of-thought) before the rows
-    are registered ready for ``rllm sft``.
+    chosen --format bridge normalizes each row (deriving ``trainable`` masks,
+    lifting ``reasoning_content`` into thinking parts, decoding JSON-string
+    ``tool_calls``, trimming template-trimmed whitespace and, for think-tags,
+    splitting the ``<think>`` chain-of-thought) before the rows are registered
+    ready for ``rllm sft``.
 
     \b
     Examples:
@@ -320,6 +327,7 @@ def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: 
         console.print("  [yellow]--no-explode is ignored for --format messages[/] [dim](explosion only applies to think-tags).[/]")
 
     bridge_opts = {"train_on": train_on} if fmt == "messages" else {"explode": not no_explode}
+    bridge_opts["trim_whitespace"] = trim_whitespace
 
     ds = Dataset.load_data(file_path)
     try:
@@ -332,7 +340,7 @@ def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: 
         name,
         records,
         split=split,
-        source=f"import:{fmt}",
+        source=f"import:{fmt}:trim" if trim_whitespace else f"import:{fmt}",
         description=description or "",
     )
 

--- a/rllm/data/dataset.py
+++ b/rllm/data/dataset.py
@@ -163,9 +163,12 @@ class Dataset:
 
             data = pd.read_csv(path).to_dict("records")
         elif file_ext == ".parquet":
-            import pandas as pd
+            import pyarrow.parquet as pq
 
-            data = pd.read_parquet(path).to_dict("records")
+            # pandas materializes nested list columns as ``numpy.ndarray``
+            # objects. Conversation and tool schemas require ordinary Python
+            # lists, and PyArrow preserves that shape directly.
+            data = pq.read_table(path).to_pylist()
         elif file_ext == ".arrow":
             data = DatasetRegistry._load_arrow_ipc(path)
         else:

--- a/rllm/data/sft_bridges.py
+++ b/rllm/data/sft_bridges.py
@@ -22,9 +22,8 @@ variance is absorbed — once, at dataset-build time — rather than in renderer
 trainers that would otherwise each have to cope with every export's quirks. Both
 bridges therefore apply the same source-shape normalization before validation
 (``reasoning_content`` lifted to a thinking part, JSON-string ``tool_calls``
-decoded, already-parsed ``arguments`` re-encoded). ``trim_whitespace=True`` is
-an explicit compatibility option for serving templates known to strip message
-boundaries; source text is otherwise preserved verbatim.
+decoded, already-parsed ``arguments`` re-encoded). Source text is preserved
+verbatim; model-aware normalization belongs with the resolved renderer.
 
 Both bridges return ``list[SFTRow]``; callers persist ``[r.to_record() for r in
 rows]``. Malformed rows raise :class:`SFTSchemaError` naming the failing row
@@ -46,6 +45,7 @@ from rllm.data.sft_schema import (
     SFTMessage,
     SFTRow,
     SFTSchemaError,
+    _has_structural_inline_thinking,
     normalize_message_dict,
     normalize_rows,
 )
@@ -116,12 +116,12 @@ def _normalize_source_message(msg: Any) -> Any:
     if isinstance(out.get("tool_calls"), list):
         out["tool_calls"] = [_normalize_tool_call(c) for c in out["tool_calls"]]
 
-    # Only an assistant turn can reason. Reject prompt-side or conflicting
-    # provider fields rather than silently deleting source data.
+    # Empty provider fields are absent. Non-empty reasoning belongs only on an
+    # assistant turn; reject prompt-side or conflicting data rather than drop it.
     reasoning_values: list[tuple[str, str]] = []
     for key in _REASONING_KEYS:
         value = out.pop(key, None)
-        if value is None:
+        if value is None or (isinstance(value, str) and value == ""):
             continue
         if not isinstance(value, str):
             raise SFTSchemaError(f"{key} must be a string, got {type(value).__name__}.")
@@ -135,10 +135,13 @@ def _normalize_source_message(msg: Any) -> Any:
         raise SFTSchemaError(f"conflicting reasoning aliases ({fields}) carry different values.")
     reasoning = reasoning_values[0][1] if reasoning_values else ""
     if reasoning:
+        content = out.get("content")
+        if _has_structural_inline_thinking(content):
+            fields = ", ".join(key for key, _ in reasoning_values)
+            raise SFTSchemaError(f"sibling reasoning field ({fields}) conflicts with structural inline <think>...</think> content; choose one reasoning representation.")
         # Lifted ahead of ``content`` so the turn keeps the think-then-speak
         # order every reasoning renderer expects.
         parts: list = [{"type": "thinking", "thinking": reasoning}]
-        content = out.get("content")
         if isinstance(content, str):
             if content:
                 parts.append({"type": "text", "text": content})
@@ -162,31 +165,6 @@ def _payload_of(part: Any, kind: str | None = None) -> str | None:
     return value if isinstance(value, str) else None
 
 
-def _trim_parts(parts: list) -> list:
-    """Strip boundary whitespace from each content stream.
-
-    Serving chat templates ``|trim`` a message's ``content`` and
-    ``reasoning_content`` before rendering, so whenever the training renderer
-    does not (the tinker-cookbook renderers encode content verbatim), boundary
-    whitespace in the data is a pure train/serve mismatch: the model is trained
-    to emit padding the template deletes from every context it ever sees.
-    Trimming is per *stream* (all text parts together, all thinking parts
-    together) rather than per part, so whitespace between two parts of the same
-    stream — which the template does render — survives.
-
-    Only parts the trim itself emptied are dropped, so a row with nothing to trim
-    comes out byte-identical, its already-empty parts included.
-    """
-    out = [dict(p) if isinstance(p, dict) else p for p in parts]
-    for kind, key in _PART_PAYLOAD.items():
-        stream = [i for i, p in enumerate(out) if _payload_of(p, kind) is not None]
-        if not stream:
-            continue
-        out[stream[0]][key] = out[stream[0]][key].lstrip()
-        out[stream[-1]][key] = out[stream[-1]][key].rstrip()
-    return [p for p, before in zip(out, parts, strict=True) if _payload_of(p) != "" or _payload_of(before) == ""]
-
-
 # --- shared helpers ----------------------------------------------------------
 
 
@@ -204,10 +182,9 @@ def _content_to_parts(role: str, content: Any) -> list[dict]:
     An assistant leading ``<think>...</think>`` block is split into a
     ``thinking`` part (CoT ``strip``ed) plus a ``text`` part (remainder
     left-stripped) — whether the CoT arrives inside a raw ``str`` or inside the
-    first text part of an already-structured list, so a source that carries both
-    a sibling reasoning field and an inline tag loses neither. Any other ``str``
-    becomes a single ``text`` part; ``None`` and ``list`` content are coerced the
-    same way the schema does.
+    first text part of an already-structured list. Any other ``str`` becomes a
+    single ``text`` part; ``None`` and ``list`` content are coerced the same way
+    the schema does.
     """
     if isinstance(content, str):
         return _split_think_tag(content) if role == "assistant" else [{"type": "text", "text": content}]
@@ -248,17 +225,6 @@ def _make_message(raw_msg: dict, parts: list[dict], trainable: bool, idx: int) -
         raise SFTSchemaError(f"message {idx}: {e}") from e
 
 
-def _prepare_message(msg: Any, *, trim_whitespace: bool) -> Any:
-    """Source-shape normalization plus the optional trim, for one raw turn."""
-    out = _normalize_source_message(msg)
-    if not trim_whitespace or not isinstance(out, dict):
-        return out
-    cleaned = normalize_message_dict(out)
-    if isinstance(cleaned.get("content"), list):
-        cleaned["content"] = _trim_parts(cleaned["content"])
-    return cleaned
-
-
 def _row_fields(row: dict) -> dict:
     """Carry every non-``messages`` top-level key through as row-level metadata.
 
@@ -270,7 +236,7 @@ def _row_fields(row: dict) -> dict:
     return {key: value for key, value in row.items() if key != "messages"}
 
 
-def _bridge_think_row(row: dict, explode: bool, trim_whitespace: bool = False) -> list[SFTRow]:
+def _bridge_think_row(row: dict, explode: bool) -> list[SFTRow]:
     """Bridge one think-tagged row into one (no-explode) or many (explode) rows."""
     if not isinstance(row, dict):
         raise SFTSchemaError(f"row must be a dict with a 'messages' field, got {type(row).__name__}.")
@@ -283,19 +249,24 @@ def _bridge_think_row(row: dict, explode: bool, trim_whitespace: bool = False) -
         if not isinstance(m, dict):
             raise SFTSchemaError(f"message {j}: expected a dict, got {type(m).__name__}.")
 
-    # Source shape first, then ``<think>`` extraction, then the trim: trimming
-    # before extraction would strip the padding the tag's remainder is measured
-    # against.
+    # Source-shape normalization precedes the format-specific tag extraction.
     messages = [_normalize_source_message(m) for m in messages]
     roles = [m.get("role") for m in messages]
     full_parts = [_content_to_parts(role, m.get("content")) for role, m in zip(roles, messages, strict=True)]
-    if trim_whitespace:
-        full_parts = [_trim_parts(p) for p in full_parts]
     hist_parts = [_strip_thinking(p) for p in full_parts]
     fields = _row_fields(row)
+    all_flagged = all(isinstance(m.get("trainable"), bool) for m in messages)
 
     if not explode:
-        msgs = [_make_message(messages[j], full_parts[j], roles[j] == "assistant", j) for j in range(len(messages))]
+        msgs = [
+            _make_message(
+                messages[j],
+                full_parts[j],
+                bool(messages[j]["trainable"]) if all_flagged else roles[j] == "assistant",
+                j,
+            )
+            for j in range(len(messages))
+        ]
         return [SFTRow(messages=msgs, **fields)]
 
     # Target selection honours a pre-masked conversation. When every message
@@ -305,8 +276,6 @@ def _bridge_think_row(row: dict, explode: bool, trim_whitespace: bool = False) -
     # appears in later history (thinking stripped) but is never emitted as a
     # target to imitate. A flag-less row (the common raw-``<think>`` export)
     # explodes every assistant turn, matching the schema's all-or-nothing policy.
-    all_flagged = all(isinstance(m.get("trainable"), bool) for m in messages)
-
     def _is_target(j: int) -> bool:
         if roles[j] != "assistant":
             return False
@@ -323,15 +292,13 @@ def _bridge_think_row(row: dict, explode: bool, trim_whitespace: bool = False) -
 # --- bridges -----------------------------------------------------------------
 
 
-def bridge_messages(rows: Sequence[dict], *, train_on: str = "all", trim_whitespace: bool = False) -> list[SFTRow]:
+def bridge_messages(rows: Sequence[dict], *, train_on: str = "all") -> list[SFTRow]:
     """Bridge plain OpenAI ``{"messages": [...]}`` rows via the schema.
 
     ``train_on`` picks the derived loss mask: ``"all"`` trains every assistant
     turn, ``"last"`` only the final one. Explicit per-message ``trainable`` flags
     (when *every* message carries one) are preserved by the schema. Source-shape
     normalization (reasoning lifting, tool-call decoding) always applies.
-    ``trim_whitespace`` explicitly opts into stripping message boundaries for a
-    serving template known to do the same.
     """
     prepared: list = []
     for i, row in enumerate(rows):
@@ -339,13 +306,13 @@ def bridge_messages(rows: Sequence[dict], *, train_on: str = "all", trim_whitesp
             prepared.append(row)  # let the schema raise the row-level error
             continue
         try:
-            prepared.append({**row, "messages": [_prepare_message(m, trim_whitespace=trim_whitespace) for m in row["messages"]]})
+            prepared.append({**row, "messages": [_normalize_source_message(m) for m in row["messages"]]})
         except SFTSchemaError as e:
             raise SFTSchemaError(f"row {i}: {e}") from e
     return normalize_rows(prepared, default_trainable=train_on)
 
 
-def bridge_think_tags(rows: Sequence[dict], *, explode: bool = True, trim_whitespace: bool = False) -> list[SFTRow]:
+def bridge_think_tags(rows: Sequence[dict], *, explode: bool = True) -> list[SFTRow]:
     """Bridge ``<think>``-tagged rows into schema rows.
 
     ``explode=True`` (default) emits one row per assistant *target*: history
@@ -354,12 +321,13 @@ def bridge_think_tags(rows: Sequence[dict], *, explode: bool = True, trim_whites
     assistant turn, unless the source rows already carry explicit per-message
     ``trainable`` flags, in which case only flagged-trainable assistant turns
     are exploded (masked-out steps stay in history). ``explode=False`` emits one
-    row per conversation with every assistant turn trainable and CoT kept.
+    row per conversation with CoT kept; a fully explicit mask is preserved,
+    otherwise assistant targets are derived.
     """
     out: list[SFTRow] = []
     for i, row in enumerate(rows):
         try:
-            out.extend(_bridge_think_row(row, explode, trim_whitespace))
+            out.extend(_bridge_think_row(row, explode))
         except SFTSchemaError as e:
             raise SFTSchemaError(f"row {i}: {e}") from e
     return out

--- a/rllm/data/sft_bridges.py
+++ b/rllm/data/sft_bridges.py
@@ -5,9 +5,10 @@ A *bridge* is the ingestion boundary in front of the SFT schema
 each bridge knows how to turn one of them into schema ``SFTRow`` objects that the
 tinker loader can render with ``CUSTOMIZED`` masking:
 
-- ``messages`` — plain OpenAI ``{"messages": [...]}`` rows. Delegates straight to
-  :func:`rllm.data.sft_schema.normalize_rows`, deriving the ``trainable`` mask
-  from ``train_on`` (``"all"`` assistant turns, or only the ``"last"`` one).
+- ``messages`` — plain OpenAI ``{"messages": [...]}`` rows, including the
+  reasoning-model flavour where chain-of-thought rides in a sibling
+  ``reasoning_content`` field. Derives the ``trainable`` mask from ``train_on``
+  (``"all"`` assistant turns, or only the ``"last"`` one).
 - ``think-tags`` — rows whose assistant turns carry a leading
   ``<think>...</think>`` block, a common convention for distilled reasoning
   traces (R1-style exports, many HF distill datasets). The chain-of-thought is
@@ -15,6 +16,15 @@ tinker loader can render with ``CUSTOMIZED`` masking:
   carried through verbatim as row-level metadata. By default the conversation is
   *exploded* into one row per assistant turn (history CoT stripped, single
   trainable target), which is the shape a next-token SFT loss wants.
+
+Source shape varies far more than the schema does, so the *bridge* is where that
+variance is absorbed — once, at dataset-build time — rather than in renderers and
+trainers that would otherwise each have to cope with every export's quirks. Both
+bridges therefore apply the same source-shape normalization before validation
+(``reasoning_content`` lifted to a thinking part, JSON-string ``tool_calls``
+decoded, already-parsed ``arguments`` re-encoded). ``trim_whitespace=True`` is
+an explicit compatibility option for serving templates known to strip message
+boundaries; source text is otherwise preserved verbatim.
 
 Both bridges return ``list[SFTRow]``; callers persist ``[r.to_record() for r in
 rows]``. Malformed rows raise :class:`SFTSchemaError` naming the failing row
@@ -25,6 +35,7 @@ the file first.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -45,33 +56,174 @@ from rllm.data.sft_schema import (
 # plain text.
 _THINK_RE = re.compile(r"\s*<think>(.*?)</think>(.*)", re.DOTALL)
 
+# Sibling fields carrying chain-of-thought next to ``content`` in the
+# OpenAI-compatible reasoning-model wire shape, in precedence order.
+_REASONING_KEYS = ("reasoning_content", "reasoning")
+# Content part type -> the key holding its string payload.
+_PART_PAYLOAD = {"text": "text", "thinking": "thinking"}
+
+
+# --- source-shape normalization ----------------------------------------------
+
+
+def _normalize_tool_call(call: Any) -> Any:
+    """Canonicalize one ``tool_calls`` element to the OpenAI wire shape.
+
+    ``arguments`` is a JSON *string* in the canonical schema, but exports that
+    round-trip through a JSON/parquet writer often store it already parsed. Both
+    shapes describe the same call, so re-encode the parsed one rather than
+    rejecting the row.
+    """
+    if not isinstance(call, dict):
+        return call
+    fn = call.get("function")
+    if not isinstance(fn, dict) or not isinstance(fn.get("arguments"), dict | list):
+        return call
+    try:
+        arguments = json.dumps(fn["arguments"], ensure_ascii=False)
+    except TypeError as e:
+        raise SFTSchemaError(f"tool call arguments are not JSON-serializable: {e}") from e
+    return {**call, "function": {**fn, "arguments": arguments}}
+
+
+def _normalize_source_message(msg: Any) -> Any:
+    """Coerce one raw turn into the shapes the schema accepts.
+
+    Three variations show up across real exports and are not schema-legal as
+    they stand: ``tool_calls`` serialized as a JSON string (HF/parquet columns
+    cannot hold the heterogeneous struct, so producers stringify it), tool-call
+    ``arguments`` stored already-parsed, and reasoning carried in a sibling
+    ``reasoning_content``/``reasoning`` field where the schema wants a
+    ``thinking`` content part. Non-dict turns pass through untouched so the
+    schema raises the message-level error.
+    """
+    if not isinstance(msg, dict):
+        return msg
+    out = dict(msg)
+
+    tool_calls = out.get("tool_calls")
+    if isinstance(tool_calls, str):
+        if not tool_calls.strip():
+            out.pop("tool_calls")
+        else:
+            try:
+                tool_calls = json.loads(tool_calls)
+            except ValueError as e:
+                raise SFTSchemaError(f"tool_calls is a string but not valid JSON: {e}") from e
+            if not isinstance(tool_calls, list):
+                raise SFTSchemaError(f"tool_calls JSON must decode to a list, got {type(tool_calls).__name__}.")
+            out["tool_calls"] = tool_calls
+    if isinstance(out.get("tool_calls"), list):
+        out["tool_calls"] = [_normalize_tool_call(c) for c in out["tool_calls"]]
+
+    # Only an assistant turn can reason. Reject prompt-side or conflicting
+    # provider fields rather than silently deleting source data.
+    reasoning_values: list[tuple[str, str]] = []
+    for key in _REASONING_KEYS:
+        value = out.pop(key, None)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise SFTSchemaError(f"{key} must be a string, got {type(value).__name__}.")
+        if out.get("role") != "assistant":
+            raise SFTSchemaError(f"{key} is supported only on assistant messages, got role {out.get('role')!r}.")
+        if value:
+            reasoning_values.append((key, value))
+    distinct_reasoning = {value for _, value in reasoning_values}
+    if len(distinct_reasoning) > 1:
+        fields = ", ".join(key for key, _ in reasoning_values)
+        raise SFTSchemaError(f"conflicting reasoning aliases ({fields}) carry different values.")
+    reasoning = reasoning_values[0][1] if reasoning_values else ""
+    if reasoning:
+        # Lifted ahead of ``content`` so the turn keeps the think-then-speak
+        # order every reasoning renderer expects.
+        parts: list = [{"type": "thinking", "thinking": reasoning}]
+        content = out.get("content")
+        if isinstance(content, str):
+            if content:
+                parts.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            parts.extend(normalize_message_dict({"role": out.get("role"), "content": content}).get("content", []))
+        elif content is not None:
+            raise SFTSchemaError(f"assistant content must be a string, list, or null when reasoning is present, got {type(content).__name__}.")
+        out["content"] = parts
+    return out
+
+
+def _payload_of(part: Any, kind: str | None = None) -> str | None:
+    """The string payload of a content part, or ``None`` if it has none."""
+    if not isinstance(part, dict):
+        return None
+    part_type = part.get("type")
+    if kind is not None and part_type != kind:
+        return None
+    key = _PART_PAYLOAD.get(part_type) if isinstance(part_type, str) else None
+    value = part.get(key) if key else None
+    return value if isinstance(value, str) else None
+
+
+def _trim_parts(parts: list) -> list:
+    """Strip boundary whitespace from each content stream.
+
+    Serving chat templates ``|trim`` a message's ``content`` and
+    ``reasoning_content`` before rendering, so whenever the training renderer
+    does not (the tinker-cookbook renderers encode content verbatim), boundary
+    whitespace in the data is a pure train/serve mismatch: the model is trained
+    to emit padding the template deletes from every context it ever sees.
+    Trimming is per *stream* (all text parts together, all thinking parts
+    together) rather than per part, so whitespace between two parts of the same
+    stream — which the template does render — survives.
+
+    Only parts the trim itself emptied are dropped, so a row with nothing to trim
+    comes out byte-identical, its already-empty parts included.
+    """
+    out = [dict(p) if isinstance(p, dict) else p for p in parts]
+    for kind, key in _PART_PAYLOAD.items():
+        stream = [i for i, p in enumerate(out) if _payload_of(p, kind) is not None]
+        if not stream:
+            continue
+        out[stream[0]][key] = out[stream[0]][key].lstrip()
+        out[stream[-1]][key] = out[stream[-1]][key].rstrip()
+    return [p for p, before in zip(out, parts, strict=True) if _payload_of(p) != "" or _payload_of(before) == ""]
+
 
 # --- shared helpers ----------------------------------------------------------
+
+
+def _split_think_tag(text: str) -> list[dict]:
+    """``<think>COT</think>REST`` -> thinking + text parts; plain text -> one part."""
+    m = _THINK_RE.match(text)
+    if not m:
+        return [{"type": "text", "text": text}]
+    return [{"type": "thinking", "thinking": m.group(1).strip()}, {"type": "text", "text": m.group(2).lstrip()}]
 
 
 def _content_to_parts(role: str, content: Any) -> list[dict]:
     """Turn a raw message ``content`` into a schema parts-list (list of dicts).
 
-    An assistant ``str`` with a leading ``<think>...</think>`` block is split
-    into a ``thinking`` part (CoT ``strip``ed) plus a ``text`` part (remainder
-    left-stripped). Any other ``str`` becomes a single ``text`` part. ``None``
-    and already-structured ``list`` content are coerced the same way the schema
-    does, so this bridge tolerates partially-structured inputs too.
+    An assistant leading ``<think>...</think>`` block is split into a
+    ``thinking`` part (CoT ``strip``ed) plus a ``text`` part (remainder
+    left-stripped) — whether the CoT arrives inside a raw ``str`` or inside the
+    first text part of an already-structured list, so a source that carries both
+    a sibling reasoning field and an inline tag loses neither. Any other ``str``
+    becomes a single ``text`` part; ``None`` and ``list`` content are coerced the
+    same way the schema does.
     """
     if isinstance(content, str):
-        if role == "assistant":
-            m = _THINK_RE.match(content)
-            if m:
-                return [
-                    {"type": "thinking", "thinking": m.group(1).strip()},
-                    {"type": "text", "text": m.group(2).lstrip()},
-                ]
-        return [{"type": "text", "text": content}]
+        return _split_think_tag(content) if role == "assistant" else [{"type": "text", "text": content}]
     if content is None:
         return [{"type": "text", "text": ""}]
     if isinstance(content, list):
         # Reuse the schema's part cleanup (drops ``None`` cross-keys).
-        return list(normalize_message_dict({"role": role, "content": content}).get("content", []))
+        parts = list(normalize_message_dict({"role": role, "content": content}).get("content", []))
+        if role != "assistant":
+            return parts
+        for i, part in enumerate(parts):
+            if _payload_of(part, "text") is None:
+                continue
+            split = _split_think_tag(part["text"])
+            return parts[:i] + split + parts[i + 1 :] if len(split) > 1 else parts
+        return parts
     raise SFTSchemaError(f"unsupported content type {type(content).__name__} for role {role!r}.")
 
 
@@ -96,6 +248,17 @@ def _make_message(raw_msg: dict, parts: list[dict], trainable: bool, idx: int) -
         raise SFTSchemaError(f"message {idx}: {e}") from e
 
 
+def _prepare_message(msg: Any, *, trim_whitespace: bool) -> Any:
+    """Source-shape normalization plus the optional trim, for one raw turn."""
+    out = _normalize_source_message(msg)
+    if not trim_whitespace or not isinstance(out, dict):
+        return out
+    cleaned = normalize_message_dict(out)
+    if isinstance(cleaned.get("content"), list):
+        cleaned["content"] = _trim_parts(cleaned["content"])
+    return cleaned
+
+
 def _row_fields(row: dict) -> dict:
     """Carry every non-``messages`` top-level key through as row-level metadata.
 
@@ -107,7 +270,7 @@ def _row_fields(row: dict) -> dict:
     return {key: value for key, value in row.items() if key != "messages"}
 
 
-def _bridge_think_row(row: dict, explode: bool) -> list[SFTRow]:
+def _bridge_think_row(row: dict, explode: bool, trim_whitespace: bool = False) -> list[SFTRow]:
     """Bridge one think-tagged row into one (no-explode) or many (explode) rows."""
     if not isinstance(row, dict):
         raise SFTSchemaError(f"row must be a dict with a 'messages' field, got {type(row).__name__}.")
@@ -120,8 +283,14 @@ def _bridge_think_row(row: dict, explode: bool) -> list[SFTRow]:
         if not isinstance(m, dict):
             raise SFTSchemaError(f"message {j}: expected a dict, got {type(m).__name__}.")
 
+    # Source shape first, then ``<think>`` extraction, then the trim: trimming
+    # before extraction would strip the padding the tag's remainder is measured
+    # against.
+    messages = [_normalize_source_message(m) for m in messages]
     roles = [m.get("role") for m in messages]
     full_parts = [_content_to_parts(role, m.get("content")) for role, m in zip(roles, messages, strict=True)]
+    if trim_whitespace:
+        full_parts = [_trim_parts(p) for p in full_parts]
     hist_parts = [_strip_thinking(p) for p in full_parts]
     fields = _row_fields(row)
 
@@ -129,8 +298,22 @@ def _bridge_think_row(row: dict, explode: bool) -> list[SFTRow]:
         msgs = [_make_message(messages[j], full_parts[j], roles[j] == "assistant", j) for j in range(len(messages))]
         return [SFTRow(messages=msgs, **fields)]
 
+    # Target selection honours a pre-masked conversation. When every message
+    # already carries an explicit bool ``trainable`` (a curated trajectory whose
+    # parse-error/recovery steps are deliberately masked out), only the
+    # flagged-trainable assistant turns become targets — a masked-out turn still
+    # appears in later history (thinking stripped) but is never emitted as a
+    # target to imitate. A flag-less row (the common raw-``<think>`` export)
+    # explodes every assistant turn, matching the schema's all-or-nothing policy.
+    all_flagged = all(isinstance(m.get("trainable"), bool) for m in messages)
+
+    def _is_target(j: int) -> bool:
+        if roles[j] != "assistant":
+            return False
+        return bool(messages[j].get("trainable")) if all_flagged else True
+
     rows: list[SFTRow] = []
-    for target in (j for j, role in enumerate(roles) if role == "assistant"):
+    for target in (j for j in range(len(messages)) if _is_target(j)):
         history = [_make_message(messages[j], hist_parts[j], False, j) for j in range(target)]
         history.append(_make_message(messages[target], full_parts[target], True, target))
         rows.append(SFTRow(messages=history, **fields))
@@ -140,28 +323,43 @@ def _bridge_think_row(row: dict, explode: bool) -> list[SFTRow]:
 # --- bridges -----------------------------------------------------------------
 
 
-def bridge_messages(rows: Sequence[dict], *, train_on: str = "all") -> list[SFTRow]:
+def bridge_messages(rows: Sequence[dict], *, train_on: str = "all", trim_whitespace: bool = False) -> list[SFTRow]:
     """Bridge plain OpenAI ``{"messages": [...]}`` rows via the schema.
 
     ``train_on`` picks the derived loss mask: ``"all"`` trains every assistant
     turn, ``"last"`` only the final one. Explicit per-message ``trainable`` flags
-    (when *every* message carries one) are preserved by the schema.
+    (when *every* message carries one) are preserved by the schema. Source-shape
+    normalization (reasoning lifting, tool-call decoding) always applies.
+    ``trim_whitespace`` explicitly opts into stripping message boundaries for a
+    serving template known to do the same.
     """
-    return normalize_rows(rows, default_trainable=train_on)
+    prepared: list = []
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict) or not isinstance(row.get("messages"), list):
+            prepared.append(row)  # let the schema raise the row-level error
+            continue
+        try:
+            prepared.append({**row, "messages": [_prepare_message(m, trim_whitespace=trim_whitespace) for m in row["messages"]]})
+        except SFTSchemaError as e:
+            raise SFTSchemaError(f"row {i}: {e}") from e
+    return normalize_rows(prepared, default_trainable=train_on)
 
 
-def bridge_think_tags(rows: Sequence[dict], *, explode: bool = True) -> list[SFTRow]:
+def bridge_think_tags(rows: Sequence[dict], *, explode: bool = True, trim_whitespace: bool = False) -> list[SFTRow]:
     """Bridge ``<think>``-tagged rows into schema rows.
 
-    ``explode=True`` (default) emits one row per assistant turn: history turns
-    are non-trainable with their CoT stripped, and the single final assistant
-    turn is the trainable target (CoT kept). ``explode=False`` emits one row per
-    conversation with every assistant turn trainable and CoT kept.
+    ``explode=True`` (default) emits one row per assistant *target*: history
+    turns are non-trainable with their CoT stripped, and the single final
+    assistant turn is the trainable target (CoT kept). Targets are every
+    assistant turn, unless the source rows already carry explicit per-message
+    ``trainable`` flags, in which case only flagged-trainable assistant turns
+    are exploded (masked-out steps stay in history). ``explode=False`` emits one
+    row per conversation with every assistant turn trainable and CoT kept.
     """
     out: list[SFTRow] = []
     for i, row in enumerate(rows):
         try:
-            out.extend(_bridge_think_row(row, explode))
+            out.extend(_bridge_think_row(row, explode, trim_whitespace))
         except SFTSchemaError as e:
             raise SFTSchemaError(f"row {i}: {e}") from e
     return out

--- a/rllm/data/sft_schema.py
+++ b/rllm/data/sft_schema.py
@@ -217,6 +217,20 @@ def normalize_messages(messages, default_trainable: str = "all") -> list[SFTMess
     if not isinstance(messages, list) or len(messages) == 0:
         raise SFTSchemaError("'messages' must be a non-empty list of conversation turns.")
 
+    # Provider-style reasoning siblings are source fields, not disposable
+    # metadata. The messages bridge is the ingestion boundary that lifts them
+    # into canonical thinking parts; reaching core normalization with one still
+    # present means that boundary was skipped.
+    for i, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        reasoning_key = next(
+            (key for key in ("reasoning_content", "reasoning") if message.get(key) is not None),
+            None,
+        )
+        if reasoning_key is not None:
+            raise SFTSchemaError(f"message {i} contains source field {reasoning_key!r}; import it through `rllm dataset import --format messages` so reasoning is preserved as a thinking part.")
+
     cleaned = [normalize_message_dict(m) for m in messages]
 
     all_flagged = all(isinstance(m, dict) and isinstance(m.get("trainable"), bool) for m in cleaned)

--- a/rllm/data/sft_schema.py
+++ b/rllm/data/sft_schema.py
@@ -16,15 +16,17 @@ which builds tinker's structured ``ToolCall`` objects for the renderer.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+import re
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, ValidationInfo, model_validator
 
 # Message-level keys we recognize; everything else is dropped during cleanup.
 _MESSAGE_KEYS = ("role", "content", "trainable", "tool_calls", "tool_call_id", "name")
 # Optional keys that arrive as ``None`` from a parquet struct-unification round
 # trip; a ``None`` here means "absent", so we drop the key entirely.
 _OPTIONAL_NONE_KEYS = ("tool_calls", "tool_call_id", "name")
+_STRUCTURAL_THINK_RE = re.compile(r"\s*<think>.*?</think>", re.DOTALL)
 
 
 class SFTSchemaError(ValueError):
@@ -58,6 +60,23 @@ class ThinkingPart(BaseModel):
 
 # Discriminated on ``type`` so an unknown part type is a clean validation error.
 ContentPart = Annotated[TextPart | ThinkingPart, Field(discriminator="type")]
+
+
+def _has_structural_inline_thinking(content: Any) -> bool:
+    """Whether an assistant text stream starts with a complete think block."""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        chunks: list[str] = []
+        for part in content:
+            if isinstance(part, TextPart):
+                chunks.append(part.text)
+            elif isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str):
+                chunks.append(part["text"])
+        text = "".join(chunks)
+    else:
+        return False
+    return _STRUCTURAL_THINK_RE.match(text) is not None
 
 
 # --- tool calls --------------------------------------------------------------
@@ -98,6 +117,15 @@ class SFTMessage(BaseModel):
     tool_calls: list[SFTToolCall] | None = None
     tool_call_id: str | None = None
     name: str | None = None
+
+    @model_validator(mode="after")
+    def reject_structural_inline_thinking(self, info: ValidationInfo):
+        allow_inline = bool((info.context or {}).get("allow_structural_inline_thinking_text"))
+        if not allow_inline and self.role == "assistant" and _has_structural_inline_thinking(self.content):
+            raise ValueError(
+                "assistant text begins with a structural <think>...</think> block; import wire-format text with `rllm dataset import --format think-tags` or provide canonical thinking parts."
+            )
+        return self
 
     def text(self) -> str:
         """Concatenated visible text across the message's ``TextPart``s."""
@@ -205,7 +233,12 @@ def normalize_message_dict(msg: dict) -> dict:
     return out
 
 
-def normalize_messages(messages, default_trainable: str = "all") -> list[SFTMessage]:
+def normalize_messages(
+    messages,
+    default_trainable: str = "all",
+    *,
+    allow_structural_inline_thinking_text: bool = False,
+) -> list[SFTMessage]:
     """Clean and validate a conversation into ``SFTMessage`` objects.
 
     Trainable-flag policy: if ANY message lacks a real bool ``trainable`` (missing
@@ -217,18 +250,19 @@ def normalize_messages(messages, default_trainable: str = "all") -> list[SFTMess
     if not isinstance(messages, list) or len(messages) == 0:
         raise SFTSchemaError("'messages' must be a non-empty list of conversation turns.")
 
-    # Provider-style reasoning siblings are source fields, not disposable
-    # metadata. The messages bridge is the ingestion boundary that lifts them
-    # into canonical thinking parts; reaching core normalization with one still
-    # present means that boundary was skipped.
+    # Empty provider fields are serialization artifacts. Non-empty siblings are
+    # source data that must be lifted by the messages bridge rather than dropped.
     for i, message in enumerate(messages):
         if not isinstance(message, dict):
             continue
-        reasoning_key = next(
-            (key for key in ("reasoning_content", "reasoning") if message.get(key) is not None),
-            None,
-        )
-        if reasoning_key is not None:
+        for reasoning_key in ("reasoning_content", "reasoning"):
+            if reasoning_key not in message:
+                continue
+            value = message[reasoning_key]
+            if value is None or (isinstance(value, str) and value == ""):
+                continue
+            if not isinstance(value, str):
+                raise SFTSchemaError(f"message {i} field {reasoning_key!r} must be a string, got {type(value).__name__}.")
             raise SFTSchemaError(f"message {i} contains source field {reasoning_key!r}; import it through `rllm dataset import --format messages` so reasoning is preserved as a thinking part.")
 
     cleaned = [normalize_message_dict(m) for m in messages]
@@ -247,13 +281,23 @@ def normalize_messages(messages, default_trainable: str = "all") -> list[SFTMess
     out: list[SFTMessage] = []
     for i, m in enumerate(cleaned):
         try:
-            out.append(SFTMessage.model_validate(m))
+            out.append(
+                SFTMessage.model_validate(
+                    m,
+                    context={"allow_structural_inline_thinking_text": allow_structural_inline_thinking_text},
+                )
+            )
         except ValidationError as e:
             raise SFTSchemaError(f"message {i}: {e}") from e
     return out
 
 
-def normalize_row(row: dict, default_trainable: str = "all") -> SFTRow:
+def normalize_row(
+    row: dict,
+    default_trainable: str = "all",
+    *,
+    allow_structural_inline_thinking_text: bool = False,
+) -> SFTRow:
     """Normalize a single ``{"messages": [...], **extra}`` row into an ``SFTRow``.
 
     Raises :class:`SFTSchemaError` for a non-dict row, a missing/empty
@@ -265,10 +309,17 @@ def normalize_row(row: dict, default_trainable: str = "all") -> SFTRow:
     if "messages" not in row:
         raise SFTSchemaError("row is missing a 'messages' field.")
 
-    messages = normalize_messages(row["messages"], default_trainable=default_trainable)
+    messages = normalize_messages(
+        row["messages"],
+        default_trainable=default_trainable,
+        allow_structural_inline_thinking_text=allow_structural_inline_thinking_text,
+    )
     extra = {k: v for k, v in row.items() if k != "messages"}
     try:
-        return SFTRow(messages=messages, **extra)
+        return SFTRow.model_validate(
+            {"messages": messages, **extra},
+            context={"allow_structural_inline_thinking_text": allow_structural_inline_thinking_text},
+        )
     except ValidationError as e:  # pragma: no cover - extra="allow" makes this rare
         raise SFTSchemaError(str(e)) from e
 

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -25,24 +25,29 @@ logger = logging.getLogger(__name__)
 def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
     """Convert tool calls from any producer shape to the OpenAI wire format.
 
-    ``ModelOutput.tool_calls`` arrives in one of three shapes depending on which parser
+    ``ModelOutput.tool_calls`` arrives in one of four shapes depending on which parser
     ``assemble_model_output`` used:
 
     * prime-rl ``renderers`` (the unified renderer, e.g. ``parse_qwen35``): a **nested**
       dict ``{"function": {"name", "arguments"}}`` — the OpenAI-ish shape.
+    * tinker/Fireworks-cookbook ``ToolCall``: the same nesting as a pydantic
+      **object**, ``.function.name`` / ``.function.arguments``.
     * rLLM ``ToolCall`` object: ``.name`` / ``.arguments`` attributes.
     * flat dict: ``{"name", "arguments"}``.
 
-    The nested form is easy to mis-read: pulling top-level ``name``/``arguments`` off it
-    yields empty tool calls (name=""), which is exactly what broke OpenAI function-calling
-    clients like opencode — they received a structurally-present but empty tool call and
-    took no action. Extract ``function`` first, then object attrs, then flat keys.
+    Every nested form is easy to mis-read: pulling top-level ``name``/``arguments`` off
+    one yields empty tool calls (name=""), which is exactly what broke OpenAI
+    function-calling clients like opencode — they received a structurally-present but
+    empty tool call and took no action. Unwrap ``function`` first, in both dict and
+    attribute form, then fall back to the flat shapes.
     """
     result = []
     for i, tc in enumerate(tool_calls):
-        fn = tc.get("function") if isinstance(tc, dict) else None
+        fn = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
         if isinstance(fn, dict):  # prime-rl nested shape
             name, args = fn.get("name", ""), fn.get("arguments", {})
+        elif fn is not None:  # cookbook ToolCall: nested pydantic model
+            name, args = getattr(fn, "name", ""), getattr(fn, "arguments", {})
         elif isinstance(tc, dict):  # flat dict
             name, args = tc.get("name", ""), tc.get("arguments", {})
         else:  # rLLM ToolCall object

--- a/rllm/renderers/adapters.py
+++ b/rllm/renderers/adapters.py
@@ -67,10 +67,24 @@ def _is_qwen_history_renderer(renderer: Any) -> bool:
     return any(cls.__module__.startswith("tinker_cookbook.renderers.qwen3") for cls in type(renderer).__mro__)
 
 
+def _text_content(content: Any) -> str | None:
+    """Read wire text without mistaking multimodal content for a tool result."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    text: list[str] = []
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") != "text" or not isinstance(part.get("text"), str):
+            return None
+        text.append(part["text"])
+    return "".join(text)
+
+
 def _is_tool_response_user(message: dict) -> bool:
     """Recognize the legacy Qwen wire shape where a tool result has user role."""
-    content = message.get("content")
-    return message.get("role") == "user" and isinstance(content, str) and content.startswith("<tool_response>") and content.endswith("</tool_response>")
+    content = _text_content(message.get("content"))
+    return message.get("role") == "user" and content is not None and content.startswith("<tool_response>") and content.endswith("</tool_response>")
 
 
 def _last_real_user_index(messages: list[dict]) -> int:

--- a/rllm/renderers/adapters.py
+++ b/rllm/renderers/adapters.py
@@ -17,7 +17,33 @@ from .bridging import BridgingRendererMixin
 from .types import ParsedResponse, RenderedTokens
 
 
-def _to_parsed(content: str, reasoning: str | None, tool_calls: Any) -> ParsedResponse:
+def _flatten_parts(content: Any) -> tuple[str, str]:
+    """Split a renderer's content into ``(text, thinking)``.
+
+    Parts concatenate without a separator — each carries its own whitespace.
+    Ordering between text and thinking is lost, which the flat
+    ``ParsedResponse`` shape cannot express; for the one-thinking-block-then-text
+    turn every renderer here produces, the join is exact.
+    """
+    if not isinstance(content, list):
+        return content or "", ""
+    text = "".join(p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text")
+    thinking = "".join(p.get("thinking", "") for p in content if isinstance(p, dict) and p.get("type") == "thinking")
+    return text, thinking
+
+
+def _to_parsed(content: Any, reasoning: str | None, tool_calls: Any) -> ParsedResponse:
+    """Build a ``ParsedResponse``, flattening structured content.
+
+    Tinker-style renderers return a turn's content as a parts list whenever the
+    model emitted thinking, with the reasoning inside it rather than on
+    ``reasoning_content``. ``ParsedResponse.content`` is a ``str`` and its
+    consumers (``ModelOutput`` -> ``Step.model_response``) enforce that, so the
+    parts are split here rather than left for every consumer to handle.
+    """
+    if isinstance(content, list):
+        content, thinking = _flatten_parts(content)
+        reasoning = reasoning or thinking
     return ParsedResponse(
         content=content or "",
         reasoning_content=reasoning or None,
@@ -25,28 +51,181 @@ def _to_parsed(content: str, reasoning: str | None, tool_calls: Any) -> ParsedRe
     )
 
 
+def _sibling_reasoning(message: dict) -> str:
+    """A turn's reasoning as harnesses echo it back, in wire-preference order."""
+    for key in ("reasoning_content", "reasoning"):
+        value = message.get(key)
+        if isinstance(value, str) and value:
+            return value
+    provider = message.get("provider_specific_fields")
+    value = provider.get("reasoning") if isinstance(provider, dict) else None
+    return value if isinstance(value, str) else ""
+
+
+def _is_qwen_history_renderer(renderer: Any) -> bool:
+    """Whether ``renderer`` uses Qwen's last-real-user reasoning boundary."""
+    return any(cls.__module__.startswith("tinker_cookbook.renderers.qwen3") for cls in type(renderer).__mro__)
+
+
+def _is_tool_response_user(message: dict) -> bool:
+    """Recognize the legacy Qwen wire shape where a tool result has user role."""
+    content = message.get("content")
+    return message.get("role") == "user" and isinstance(content, str) and content.startswith("<tool_response>") and content.endswith("</tool_response>")
+
+
+def _last_real_user_index(messages: list[dict]) -> int:
+    """The boundary used by Qwen chat templates to retain recent thinking."""
+    return max(
+        (index for index, message in enumerate(messages) if message.get("role") == "user" and not _is_tool_response_user(message)),
+        default=-1,
+    )
+
+
+def to_tinker_messages(
+    messages: list[dict],
+    *,
+    lift_reasoning: bool = False,
+    keep_reasoning_after: int | None = None,
+) -> list[dict]:
+    """Translate OpenAI wire messages into tinker-cookbook ``Message``s.
+
+    Tinker-style renderers read a turn's tool calls only as pydantic
+    ``ToolCall`` objects; harnesses send plain dicts, which raise on the first
+    tool call in history.
+
+    ``lift_reasoning`` additionally moves a turn's sibling ``reasoning_content``
+    / ``reasoning`` into a structured ``thinking`` part, the only form a
+    renderer reads it in. ``keep_reasoning_after`` applies Qwen's history rule:
+    assistant thinking at or before that message index is removed, while later
+    thinking is retained. It is off by default because lifting is only sound
+    when the wrapped renderer keeps the supplied thinking parts.
+
+    Messages already in cookbook form (parts-list content, ``ToolCall``
+    objects) keep it; every other key rides along untouched, so cookbook-only
+    fields (``trainable``, ``tools``, ``response_format``) survive the trip.
+    """
+    from tinker_cookbook.renderers.base import ToolCall
+
+    modelled_tool_call_fields = set(ToolCall.model_fields)
+    out: list[dict] = []
+    for index, message in enumerate(messages):
+        converted = {**message, "content": message.get("content") or ""}
+        keep_reasoning = keep_reasoning_after is None or index > keep_reasoning_after
+        content = converted["content"]
+        if not keep_reasoning and message.get("role") == "assistant" and isinstance(content, list):
+            converted["content"] = [part for part in content if not (isinstance(part, dict) and part.get("type") == "thinking")]
+        reasoning = _sibling_reasoning(message) if lift_reasoning and keep_reasoning and message.get("role") == "assistant" else ""
+        if reasoning:
+            thinking = {"type": "thinking", "thinking": reasoning}
+            content = converted["content"]
+            if isinstance(content, str):
+                converted["content"] = [thinking, {"type": "text", "text": content}]
+            elif not any(isinstance(p, dict) and p.get("type") == "thinking" for p in content):
+                converted["content"] = [thinking, *content]
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            # Wire tool calls carry fields the cookbook model forbids (e.g. the
+            # streaming ``index``), so keep only what it declares.
+            converted["tool_calls"] = [ToolCall.model_validate({k: v for k, v in tc.items() if k in modelled_tool_call_fields}) if isinstance(tc, dict) else tc for tc in tool_calls]
+        out.append(converted)
+    return out
+
+
+def prepare_tinker_messages_for_history(
+    renderer: Any,
+    messages: list[dict],
+    *,
+    lift_reasoning: bool,
+) -> list[dict]:
+    """Apply the wrapped renderer's history policy while translating messages."""
+    boundary = _last_real_user_index(messages) if _is_qwen_history_renderer(renderer) and not getattr(renderer, "strip_thinking_from_history", False) else None
+    return to_tinker_messages(
+        messages,
+        lift_reasoning=lift_reasoning,
+        keep_reasoning_after=boundary,
+    )
+
+
+def to_tinker_tool_specs(tools: list[dict] | None) -> list:
+    """Translate OpenAI function declarations into cookbook ``ToolSpec``s."""
+    from tinker_cookbook.renderers.base import ToolSpec
+
+    specs: list[ToolSpec] = []
+    for index, tool in enumerate(tools or []):
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            raise ValueError(f"Tool declaration {index} must be an OpenAI function tool.")
+        function = tool.get("function")
+        if not isinstance(function, dict) or not function.get("name"):
+            raise ValueError(f"Tool declaration {index} needs a non-empty function.name.")
+        parameters = function.get("parameters") or {}
+        if not isinstance(parameters, dict):
+            raise ValueError(f"Tool declaration {index} function.parameters must be an object.")
+        specs.append(
+            ToolSpec(
+                name=function["name"],
+                description=function.get("description") or "",
+                parameters=parameters,
+            )
+        )
+    return specs
+
+
+def prepare_tinker_messages_with_tools(
+    renderer: Any,
+    messages: list[dict],
+    tools: list[dict] | None,
+) -> list[dict]:
+    """Inject declarations exactly as the cookbook serving renderer does."""
+    if not tools:
+        return list(messages)
+
+    remaining = list(messages)
+    system_prompt = ""
+    if remaining and remaining[0].get("role") == "system":
+        content = remaining[0].get("content") or ""
+        if isinstance(content, str):
+            system_prompt = content
+        elif isinstance(content, list):
+            system_prompt = "".join(part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text")
+        remaining = remaining[1:]
+
+    prefix = renderer.create_conversation_prefix_with_tools(
+        to_tinker_tool_specs(tools),
+        system_prompt=system_prompt,
+    )
+    return list(prefix) + remaining
+
+
 class TinkerRendererAdapter(BridgingRendererMixin):
     """Wrap a tinker-style renderer (tinker_cookbook / Fireworks cookbook)."""
 
     def __init__(self, inner: Any, *, close_token_ids: set[int] | None = None, synthesize_close: int | None = None):
         self._inner = inner
+        # Cookbook Qwen strips thinking from every historical assistant turn,
+        # while the HF template strips only at/before the last genuine user
+        # query. Disable the coarse renderer behavior and apply the precise
+        # boundary while translating messages. Tool-role observations therefore
+        # preserve the current agent trace; a new user query clears earlier CoT.
+        self._qwen_history_boundary = _is_qwen_history_renderer(inner)
+        if self._qwen_history_boundary and getattr(inner, "strip_thinking_from_history", False):
+            inner.strip_thinking_from_history = False
+        self._lift_reasoning = not getattr(inner, "strip_thinking_from_history", False)
         stops = [int(t) for t in inner.get_stop_sequences()]
         self.close_token_ids = set(close_token_ids) if close_token_ids is not None else set(stops)
         self.synthesize_close = synthesize_close if synthesize_close is not None else (stops[0] if stops else None)
 
     def _with_tools(self, messages: list[dict], tools) -> list[dict]:
-        if not tools:
-            return list(messages)
-        msgs = list(messages)
-        system = ""
-        if msgs and msgs[0].get("role") == "system":
-            system = msgs[0].get("content") or ""
-            msgs = msgs[1:]
-        prefix = self._inner.create_conversation_prefix_with_tools(tools, system_prompt=system)
-        return list(prefix) + msgs
+        return prepare_tinker_messages_with_tools(self._inner, messages, tools)
 
     def render_ids(self, messages, *, tools=None, add_generation_prompt: bool = False) -> list[int]:
-        msgs = self._with_tools(list(messages), tools)
+        msgs = self._with_tools(
+            prepare_tinker_messages_for_history(
+                self._inner,
+                messages,
+                lift_reasoning=self._lift_reasoning,
+            ),
+            tools,
+        )
         if add_generation_prompt:
             model_input = self._inner.build_generation_prompt(msgs)
         else:
@@ -64,7 +243,11 @@ class TinkerRendererAdapter(BridgingRendererMixin):
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
         msg, _term = self._inner.parse_response(list(token_ids))
         get = msg.get if isinstance(msg, dict) else (lambda k, d=None: getattr(msg, k, d))
-        return _to_parsed(get("content", ""), get("reasoning_content"), get("tool_calls"))
+        return _to_parsed(
+            get("content", ""),
+            get("reasoning_content"),
+            get("tool_calls"),
+        )
 
 
 class ChatTemplateAdapter(BridgingRendererMixin):

--- a/rllm/trainer/sft/backend.py
+++ b/rllm/trainer/sft/backend.py
@@ -24,7 +24,12 @@ class SFTConfigError(Exception):
     """Raised for invalid SFT specs/config or unsupported backends."""
 
 
-def validate_messages_dataset(dataset, label: str = "train") -> None:
+def validate_messages_dataset(
+    dataset,
+    label: str = "train",
+    *,
+    allow_structural_inline_thinking_text: bool = False,
+) -> None:
     """Validate that *dataset* has the SFT ``messages`` schema.
 
     Mirrors the check the old experimental SFT CLI did, raising
@@ -49,7 +54,10 @@ def validate_messages_dataset(dataset, label: str = "train") -> None:
     from rllm.data.sft_schema import SFTSchemaError, normalize_row
 
     try:
-        normalize_row(row)
+        normalize_row(
+            row,
+            allow_structural_inline_thinking_text=allow_structural_inline_thinking_text,
+        )
     except SFTSchemaError as e:
         raise SFTConfigError(f"{label} dataset: row 0 does not match the SFT schema: {e}") from e
 

--- a/rllm/trainer/sft/config/fireworks.yaml
+++ b/rllm/trainer/sft/config/fireworks.yaml
@@ -40,16 +40,26 @@ data:
   renderer_name: null   # null = auto-detect from the model; set explicitly to override, e.g. qwen3 / qwen3_5 / deepseekv3 / role_colon
   rllm:
     tokenize_and_mask_method: cumulative
+    group_by_length: false      # bucket similarly-sized rows into a batch (cuts padding waste + context-parallel degree on high-variance sets); batch count/resume unchanged
+    length_group_factor: 50     # mega-window = train_batch_size * this; larger -> tighter length grouping, weaker shuffle
+    overlength_policy: error
+    loss_reduction: none
+    strip_thinking_from_history: false
 
 optim:
   lr: 1e-5
   betas: [0.9, 0.95]
   eps: 1e-8
   lr_scheduler: constant
-  warmup_steps_ratio: 0.1
+  warmup_steps_ratio: 0.0     # linear LR warmup as a fraction of total steps (0 = off)
+  warmup_steps: -1            # absolute warmup steps; <=0 falls back to warmup_steps_ratio
+  min_lr: 0.0
+  weight_decay: 0.0
+  grad_clip_norm: 0.0
 
 trainer:
   total_epochs: 1
+  max_steps: null
   logger: ['console']
   project_name: 'rllm-fireworks-sft'
   experiment_name: 'default'

--- a/rllm/trainer/sft/config/tinker.yaml
+++ b/rllm/trainer/sft/config/tinker.yaml
@@ -22,16 +22,26 @@ data:
   renderer_name: null   # null = auto-detect from the model; set explicitly to override, e.g. qwen3 / qwen3_5 / deepseekv3 / role_colon
   rllm:
     tokenize_and_mask_method: cumulative  # cumulative -> ALL_ASSISTANT_MESSAGES; stepwise -> LAST_ASSISTANT_MESSAGE
+    group_by_length: false      # bucket similarly-sized rows into a batch (cuts padding waste on high-variance sets like exploded SFT); batch count/resume unchanged
+    length_group_factor: 50     # mega-window = train_batch_size * this; larger -> tighter length grouping, weaker shuffle
+    overlength_policy: error    # preserve whole trajectories; truncate is a lossy compatibility escape hatch
+    loss_reduction: none       # none preserves legacy token-sum behavior; token_mean and sequence_mean are explicit choices
+    strip_thinking_from_history: false  # preserve multi-turn CoT; matches the unified serving adapter
 
 optim:
   lr: 1e-5
   betas: [0.9, 0.95]
   eps: 1e-8
   lr_scheduler: constant  # constant | linear | cosine
-  warmup_steps_ratio: 0.1
+  warmup_steps_ratio: 0.0     # linear LR warmup as a fraction of total steps (0 = off)
+  warmup_steps: -1            # absolute warmup steps; <=0 falls back to warmup_steps_ratio
+  min_lr: 0.0                 # cosine/linear floor; e.g. 1e-5 with lr=1e-4
+  weight_decay: 0.0
+  grad_clip_norm: 0.0
 
 trainer:
   total_epochs: 1
+  max_steps: null             # cap optimizer steps even when stopping within an epoch
   logger: ['console']
   project_name: 'rllm-tinker-sft'
   experiment_name: 'default'

--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -25,22 +25,37 @@ import os
 import re
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from omegaconf import DictConfig, OmegaConf
 
 from rllm.trainer.sft.backend import SFTConfigError
 from rllm.trainer.sft.tinker_backend import (
     TinkerSFTBackend,
+    _is_step_boundary,
     build_adam_params,
     build_sft_data,
+    iter_training_batches_from_step,
     resolve_sft_optimizer_settings,
+    resolve_sft_training_plan,
     sft_lr_multiplier,
 )
 
 logger = logging.getLogger(__name__)
 
 _CONFIG_FILE = Path(__file__).resolve().parent / "config" / "fireworks.yaml"
+
+
+@dataclass
+class _SubmittedFireworksBatch:
+    step: int
+    data: list[Any]
+    learning_rate: float
+    started_at: float
+    fb_future: Any
+    opt_future: Any
 
 
 class FireworksSFTBackend(TinkerSFTBackend):
@@ -236,22 +251,30 @@ class FireworksSFTBackend(TinkerSFTBackend):
             _tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
 
             # Validate the complete loop before provisioning a paid trainer.
-            n_batches = len(train_dataset)
-            if n_batches <= 0:
-                raise SFTConfigError("The SFT training dataset contains no batches.")
-            total_epochs = int(config.trainer.get("total_epochs", 1))
-            if total_epochs <= 0:
-                raise SFTConfigError(f"trainer.total_epochs must be positive, got {total_epochs}.")
-            max_steps_value = config.trainer.get("max_steps")
-            max_steps = int(max_steps_value) if max_steps_value is not None else None
-            if max_steps is not None and max_steps <= 0:
-                raise SFTConfigError(f"trainer.max_steps must be positive when set, got {max_steps}.")
-            available_steps = n_batches * total_epochs
-            total_steps = min(available_steps, max_steps) if max_steps is not None else available_steps
+            plan = resolve_sft_training_plan(config, len(train_dataset))
+            n_batches = plan.n_batches
+            total_epochs = plan.total_epochs
+            max_steps = plan.max_steps
+            available_steps = plan.available_steps
+            total_steps = plan.total_steps
+            save_every = plan.save_every
+            eval_every = plan.eval_every
             optimizer = resolve_sft_optimizer_settings(
                 config.get("optim", {}),
                 total_steps=total_steps,
             )
+            planned_batches = (
+                (epoch_idx, batch_idx)
+                for _, epoch_idx, batch_idx in iter_training_batches_from_step(
+                    n_batches=n_batches,
+                    total_epochs=total_epochs,
+                    start_step=0,
+                    max_steps=max_steps,
+                )
+            )
+            train_dataset.preflight("train", planned_batches=planned_batches)
+            if val_dataset is not None:
+                val_dataset.preflight("validation")
 
             infra = self._provision(config, api_key, base_url)
             try:
@@ -266,16 +289,22 @@ class FireworksSFTBackend(TinkerSFTBackend):
 
                 # Auto-resume from the newest resumable checkpoint, if any.
                 resume = ckpt.resume()
-                if resume and resume.data_consumed:
+                if resume is not None:
+                    data_consumed = getattr(resume, "data_consumed", None)
+                    if isinstance(data_consumed, bool) or not isinstance(data_consumed, int) or data_consumed <= 0:
+                        raise SFTConfigError(
+                            "Fireworks found a resumable checkpoint without a positive persisted dataset cursor; "
+                            "refusing to replay training data. Use a new trainer job or restore its dataloader.json."
+                        )
                     # The service can rename a requested checkpoint (e.g.
                     # step-42 -> step-0), so its name-derived ``step`` is not a
                     # reliable data cursor. TrainingCheckpoints persists the
                     # raw-row cursor separately under the actual server name.
-                    start_step = train_dataset.step_for_data_cursor(resume.data_consumed)
+                    start_step = train_dataset.step_for_data_cursor(data_consumed)
                 else:
-                    # Legacy checkpoints lack dataloader.json; fall back to the
-                    # logical name's completed-step cursor.
-                    start_step = resume.step if resume else 0
+                    start_step = 0
+                if isinstance(start_step, bool) or not isinstance(start_step, int) or not 0 <= start_step <= total_steps:
+                    raise SFTConfigError(f"Fireworks checkpoint step {start_step!r} is outside the resolved SFT horizon 0..{total_steps}; use a new trainer job or an intact rLLM checkpoint.")
 
                 progress_denominator = total_steps if total_steps > 0 else 1
                 logger.info(
@@ -286,9 +315,6 @@ class FireworksSFTBackend(TinkerSFTBackend):
                     total_steps,
                 )
 
-                save_every = config.trainer.get("save_freq", 20)
-                eval_every = config.trainer.get("test_freq", 10)
-
                 if val_dataset is not None and start_step == 0:
                     tracking_logger.log(
                         data=self._validate(client, val_dataset),
@@ -296,14 +322,16 @@ class FireworksSFTBackend(TinkerSFTBackend):
                     )
 
                 current_epoch: int | None = None
-                for step in range(start_step, total_steps):
-                    epoch_idx, batch_idx = divmod(step, n_batches)
+                pending: _SubmittedFireworksBatch | None = None
+
+                def submit_batch(step, epoch_idx, batch_idx):
+                    nonlocal current_epoch
                     if epoch_idx != current_epoch:
                         logger.info("Starting epoch %d", epoch_idx)
                         train_dataset.set_epoch(seed=epoch_idx)
                         current_epoch = epoch_idx
 
-                    t0 = time.time()
+                    started_at = time.time()
                     lr = optimizer.learning_rate * sft_lr_multiplier(
                         optimizer.lr_schedule,
                         step,
@@ -322,22 +350,32 @@ class FireworksSFTBackend(TinkerSFTBackend):
                     data = train_dataset.get_batch(batch_idx)
                     fb_fut = client.submit_forward_backward(data, loss_fn="cross_entropy")
                     opt_fut = client.submit_optim_step(adam)
-                    fb_result = fb_fut.result(timeout=DEFAULT_TIMEOUT_S)
-                    opt_fut.result(timeout=DEFAULT_TIMEOUT_S)
+                    return _SubmittedFireworksBatch(
+                        step=step,
+                        data=data,
+                        learning_rate=lr,
+                        started_at=started_at,
+                        fb_future=fb_fut,
+                        opt_future=opt_fut,
+                    )
+
+                def finish_batch(submitted):
+                    fb_result = submitted.fb_future.result(timeout=DEFAULT_TIMEOUT_S)
+                    submitted.opt_future.result(timeout=DEFAULT_TIMEOUT_S)
                     # Fireworks' cross_entropy forward_backward returns aggregate
                     # metrics (loss:sum / response_tokens), not per-token logprobs.
                     fb_metrics = getattr(fb_result, "metrics", {}) or {}
                     n_loss_tokens = fb_metrics.get("response_tokens") or 0
                     train_loss = (fb_metrics.get("loss:sum", 0.0) / n_loss_tokens) if n_loss_tokens else 0.0
+                    completed_steps = submitted.step + 1
                     metrics = {
-                        "learning_rate": lr,
-                        "progress": min((step + 1) / progress_denominator, 1.0),
-                        "num_sequences": len(data),
+                        "learning_rate": submitted.learning_rate,
+                        "progress": min(completed_steps / progress_denominator, 1.0),
+                        "num_sequences": len(submitted.data),
                         "num_loss_tokens": n_loss_tokens,
                         "train_loss": train_loss,
-                        "time/total": time.time() - t0,
+                        "time/total": time.time() - submitted.started_at,
                     }
-                    completed_steps = step + 1
                     if val_dataset is not None and eval_every > 0 and completed_steps % eval_every == 0:
                         metrics.update(self._validate(client, val_dataset))
                     if save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps:
@@ -349,7 +387,40 @@ class FireworksSFTBackend(TinkerSFTBackend):
                             data_consumed=train_dataset.data_cursor_for_step(completed_steps),
                         )
                     tracking_logger.log(data=metrics, step=completed_steps)
-                    logger.info("Step %d: train_loss=%.4f, lr=%.2e", completed_steps, train_loss, lr)
+                    logger.info(
+                        "Step %d: train_loss=%.4f, lr=%.2e",
+                        completed_steps,
+                        train_loss,
+                        submitted.learning_rate,
+                    )
+
+                for step, epoch_idx, batch_idx in iter_training_batches_from_step(
+                    n_batches=n_batches,
+                    total_epochs=total_epochs,
+                    start_step=start_step,
+                    max_steps=max_steps,
+                ):
+                    if pending is None:
+                        pending = submit_batch(step, epoch_idx, batch_idx)
+                        continue
+
+                    pending_completed = pending.step + 1
+                    if _is_step_boundary(
+                        pending_completed,
+                        total_steps,
+                        save_every=save_every,
+                        eval_every=eval_every,
+                        has_validation=val_dataset is not None,
+                    ):
+                        finish_batch(pending)
+                        pending = submit_batch(step, epoch_idx, batch_idx)
+                    else:
+                        following = submit_batch(step, epoch_idx, batch_idx)
+                        finish_batch(pending)
+                        pending = following
+
+                if pending is not None:
+                    finish_batch(pending)
 
                 if total_steps > start_step:
                     logger.info(f"Saving final checkpoint at step {total_steps}")

--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -25,13 +25,18 @@ import os
 import re
 import tempfile
 import time
-from collections import deque
 from pathlib import Path
 
 from omegaconf import DictConfig, OmegaConf
 
 from rllm.trainer.sft.backend import SFTConfigError
-from rllm.trainer.sft.tinker_backend import TinkerSFTBackend, build_sft_data
+from rllm.trainer.sft.tinker_backend import (
+    TinkerSFTBackend,
+    build_adam_params,
+    build_sft_data,
+    resolve_sft_optimizer_settings,
+    sft_lr_multiplier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -190,8 +195,6 @@ class FireworksSFTBackend(TinkerSFTBackend):
         config = self._config
 
         try:
-            import tinker
-            from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier
             from training.utils.checkpoints import TrainingCheckpoints
             from training.utils.client import DEFAULT_TIMEOUT_S
         except ImportError as e:
@@ -232,6 +235,24 @@ class FireworksSFTBackend(TinkerSFTBackend):
         try:
             _tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
 
+            # Validate the complete loop before provisioning a paid trainer.
+            n_batches = len(train_dataset)
+            if n_batches <= 0:
+                raise SFTConfigError("The SFT training dataset contains no batches.")
+            total_epochs = int(config.trainer.get("total_epochs", 1))
+            if total_epochs <= 0:
+                raise SFTConfigError(f"trainer.total_epochs must be positive, got {total_epochs}.")
+            max_steps_value = config.trainer.get("max_steps")
+            max_steps = int(max_steps_value) if max_steps_value is not None else None
+            if max_steps is not None and max_steps <= 0:
+                raise SFTConfigError(f"trainer.max_steps must be positive when set, got {max_steps}.")
+            available_steps = n_batches * total_epochs
+            total_steps = min(available_steps, max_steps) if max_steps is not None else available_steps
+            optimizer = resolve_sft_optimizer_settings(
+                config.get("optim", {}),
+                total_steps=total_steps,
+            )
+
             infra = self._provision(config, api_key, base_url)
             try:
                 client = infra.policy
@@ -245,36 +266,62 @@ class FireworksSFTBackend(TinkerSFTBackend):
 
                 # Auto-resume from the newest resumable checkpoint, if any.
                 resume = ckpt.resume()
-                start_step = resume.step if resume else 0
+                if resume and resume.data_consumed:
+                    # The service can rename a requested checkpoint (e.g.
+                    # step-42 -> step-0), so its name-derived ``step`` is not a
+                    # reliable data cursor. TrainingCheckpoints persists the
+                    # raw-row cursor separately under the actual server name.
+                    start_step = train_dataset.step_for_data_cursor(resume.data_consumed)
+                else:
+                    # Legacy checkpoints lack dataloader.json; fall back to the
+                    # logical name's completed-step cursor.
+                    start_step = resume.step if resume else 0
 
-                # len(dataset) floors examples//batch_size; keep the final partial
-                # batch when the dataset is smaller than one batch (else 0 steps).
-                n_batches = max(1, len(train_dataset))
-                total_epochs = config.trainer.get("total_epochs", 1)
-                total_steps = n_batches * total_epochs
                 progress_denominator = total_steps if total_steps > 0 else 1
-                logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
+                logger.info(
+                    "Training for %d batches x %d epochs = %d available steps; effective steps=%d",
+                    n_batches,
+                    total_epochs,
+                    available_steps,
+                    total_steps,
+                )
 
-                base_lr = config.optim.lr
-                lr_schedule = config.optim.get("lr_scheduler", "constant")
-                betas = config.optim.get("betas", [0.9, 0.95])
-                eps = config.optim.get("eps", 1e-8)
                 save_every = config.trainer.get("save_freq", 20)
                 eval_every = config.trainer.get("test_freq", 10)
 
-                # Pipelined sync loop: keep one (fwd_bwd, optim) pair in flight.
-                in_flight: deque = deque()
+                if val_dataset is not None and start_step == 0:
+                    tracking_logger.log(
+                        data=self._validate(client, val_dataset),
+                        step=0,
+                    )
 
-                def submit(step: int):
-                    lr = base_lr * compute_schedule_lr_multiplier(lr_schedule=lr_schedule, step=step, total_steps=total_steps)
-                    adam = tinker.AdamParams(learning_rate=lr, beta1=betas[0], beta2=betas[1], eps=eps)
-                    data = train_dataset.get_batch(step % n_batches)
+                current_epoch: int | None = None
+                for step in range(start_step, total_steps):
+                    epoch_idx, batch_idx = divmod(step, n_batches)
+                    if epoch_idx != current_epoch:
+                        logger.info("Starting epoch %d", epoch_idx)
+                        train_dataset.set_epoch(seed=epoch_idx)
+                        current_epoch = epoch_idx
+
+                    t0 = time.time()
+                    lr = optimizer.learning_rate * sft_lr_multiplier(
+                        optimizer.lr_schedule,
+                        step,
+                        total_steps,
+                        optimizer.warmup_steps_ratio,
+                        optimizer.warmup_steps,
+                        optimizer.min_lr_ratio,
+                    )
+                    adam = build_adam_params(
+                        learning_rate=lr,
+                        betas=optimizer.betas,
+                        eps=optimizer.eps,
+                        weight_decay=optimizer.weight_decay,
+                        grad_clip_norm=optimizer.grad_clip_norm,
+                    )
+                    data = train_dataset.get_batch(batch_idx)
                     fb_fut = client.submit_forward_backward(data, loss_fn="cross_entropy")
                     opt_fut = client.submit_optim_step(adam)
-                    in_flight.append((step, lr, data, fb_fut, opt_fut, time.time()))
-
-                def collect():
-                    step, lr, data, fb_fut, opt_fut, t0 = in_flight.popleft()
                     fb_result = fb_fut.result(timeout=DEFAULT_TIMEOUT_S)
                     opt_fut.result(timeout=DEFAULT_TIMEOUT_S)
                     # Fireworks' cross_entropy forward_backward returns aggregate
@@ -290,22 +337,19 @@ class FireworksSFTBackend(TinkerSFTBackend):
                         "train_loss": train_loss,
                         "time/total": time.time() - t0,
                     }
-                    if val_dataset and eval_every > 0 and step % eval_every == 0 and step > 0:
-                        metrics.update(self._validate(client, val_dataset, DEFAULT_TIMEOUT_S))
-                    tracking_logger.log(data=metrics, step=step)
-                    logger.info(f"Step {step}: train_loss={train_loss:.4f}, lr={lr:.2e}")
-                    if save_every > 0 and step % save_every == 0 and step > 0:
-                        logger.info(f"Saving checkpoint at step {step}")
-                        ckpt.save(f"step-{step}", resumable=True, promotable=False)
-
-                for step in range(start_step, total_steps):
-                    if step % n_batches == 0:
-                        train_dataset.set_epoch(seed=step // n_batches)
-                    submit(step)
-                    if len(in_flight) > 1:
-                        collect()
-                while in_flight:
-                    collect()
+                    completed_steps = step + 1
+                    if val_dataset is not None and eval_every > 0 and completed_steps % eval_every == 0:
+                        metrics.update(self._validate(client, val_dataset))
+                    if save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps:
+                        logger.info("Saving checkpoint at step %d", completed_steps)
+                        ckpt.save(
+                            f"step-{completed_steps}",
+                            resumable=True,
+                            promotable=False,
+                            data_consumed=train_dataset.data_cursor_for_step(completed_steps),
+                        )
+                    tracking_logger.log(data=metrics, step=completed_steps)
+                    logger.info("Step %d: train_loss=%.4f, lr=%.2e", completed_steps, train_loss, lr)
 
                 if total_steps > start_step:
                     logger.info(f"Saving final checkpoint at step {total_steps}")
@@ -314,7 +358,12 @@ class FireworksSFTBackend(TinkerSFTBackend):
                     # resumable-only DCP blob, GC'd after the job's ~30-day retention
                     # window — so promote BEFORE ``finally: infra.close()`` deletes the
                     # trainer job. Mirrors the RL path and the SDK sft recipe.
-                    ckpt.save(f"step-{total_steps}", resumable=True, promotable=True)
+                    ckpt.save(
+                        f"step-{total_steps}",
+                        resumable=True,
+                        promotable=True,
+                        data_consumed=train_dataset.data_cursor_for_step(total_steps),
+                    )
                     artifact = "LoRA adapter" if lora_rank else "full-weight model"
                     experiment = config.trainer.get("experiment_name") or "default"
                     output_model_id = re.sub(r"[^a-z0-9-]+", "-", f"{config.trainer.get('project_name', 'rllm-sft')}-{experiment}".lower()).strip("-")[:63]
@@ -344,16 +393,38 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 pass
 
     @staticmethod
-    def _validate(client, val_dataset, timeout) -> dict[str, float]:
+    def _validate(client, val_dataset) -> dict[str, float]:
+        """Token-weighted held-out NLL over the val set — same quantity as the
+        tinker path's ``test/mean_nll``, and as the ``loss:sum``/``response_tokens``
+        ratio the server reports for training batches.
+
+        Must stay forward-only: the trainer accumulates gradients server-side
+        across ``forward_backward`` calls until the next ``optim_step``, so a
+        backward pass here folds the val set into the following update — the
+        model would train on its own validation data. ``ReconnectableClient``
+        exposes no non-blocking ``forward``; the blocking one carries the
+        provision document's ``step_timeout``.
+        """
+        from tinker_cookbook.supervised.common import compute_mean_nll
+
         logger.info("Running validation...")
-        total_loss = 0.0
+        total_nll = 0.0
         total_tokens = 0
         for batch_idx in range(len(val_dataset)):
             data = val_dataset.get_batch(batch_idx)
-            fb_result = client.submit_forward_backward(data, loss_fn="cross_entropy").result(timeout=timeout)
-            m = getattr(fb_result, "metrics", {}) or {}
-            total_loss += m.get("loss:sum", 0.0)
-            total_tokens += m.get("response_tokens") or 0
-        val_loss = total_loss / total_tokens if total_tokens > 0 else 0.0
+            forward_result = client.forward(data, "cross_entropy")
+            weights = [datum.loss_fn_inputs["weights"] for datum in data]
+            batch_tokens = sum(sum(w.data) for w in weights)
+            # A batch whose rows are all loss-masked (e.g. every row truncated
+            # past its trainable tail) scores nan; skip it rather than let one
+            # such batch poison the whole metric.
+            if not batch_tokens:
+                continue
+            logprobs = [x["logprobs"] for x in forward_result.loss_fn_outputs]
+            total_nll += compute_mean_nll(logprobs, weights) * batch_tokens
+            total_tokens += batch_tokens
+        if total_tokens <= 0:
+            raise SFTConfigError("The validation dataset has no trainable tokens after rendering and masking.")
+        val_loss = total_nll / total_tokens
         logger.info(f"Validation loss: {val_loss:.4f}")
         return {"test/loss": val_loss}

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -9,10 +9,14 @@ imports it — stay importable without the tinker stack installed.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
+import re
+import secrets
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +27,9 @@ from rllm.trainer.sft.backend import SFTBackend, SFTConfigError, validate_messag
 logger = logging.getLogger(__name__)
 
 _CONFIG_FILE = Path(__file__).resolve().parent / "config" / "tinker.yaml"
+_RESUME_CONTRACT_VERSION = 1
+_LOOP_SEMANTICS_VERSION = "ordered-ceil-batches-v1"
+_RUN_MANIFEST_NAME = "sft-run.json"
 
 # Plain-text renderers that cannot represent reasoning (``<think>``) or tool-calls.
 _PLAIN_RENDERERS = {"role_colon", "llama3"}
@@ -232,6 +239,24 @@ def iter_training_batches(
         yield step, epoch_idx, batch_idx
 
 
+def iter_training_batches_from_step(
+    *,
+    n_batches: int,
+    total_epochs: int,
+    start_step: int,
+    max_steps: int | None = None,
+):
+    """Yield a training plan from a completed-step cursor."""
+    start_epoch, start_batch = divmod(start_step, n_batches)
+    return iter_training_batches(
+        n_batches=n_batches,
+        total_epochs=total_epochs,
+        start_epoch=start_epoch,
+        start_batch=start_batch,
+        max_steps=max_steps,
+    )
+
+
 def build_adam_params(
     *,
     learning_rate: float,
@@ -264,6 +289,262 @@ class SFTOptimizerSettings:
     eps: float
     weight_decay: float
     grad_clip_norm: float
+
+
+@dataclass(frozen=True)
+class SFTTrainingPlan:
+    n_batches: int
+    total_epochs: int
+    max_steps: int | None
+    available_steps: int
+    total_steps: int
+    save_every: int
+    eval_every: int
+
+
+@dataclass(frozen=True)
+class SFTResumeContract:
+    """Versioned identity required for a Tinker optimizer-state resume."""
+
+    payload: dict[str, Any]
+    digest: str
+
+
+@dataclass
+class SubmittedTinkerBatch:
+    step: int
+    epoch: int
+    batch: int
+    data: list[Any]
+    learning_rate: float
+    started_at: float
+    metrics: dict[str, Any]
+    fwd_bwd_future: Any
+    optim_step_future: Any
+
+
+def _stable_digest(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _coerce_integer_setting(value: Any, path: str) -> int:
+    if isinstance(value, bool):
+        raise SFTConfigError(f"{path} must be an integer, got {value!r}.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and re.fullmatch(r"[+-]?\d+", value.strip()):
+        return int(value)
+    raise SFTConfigError(f"{path} must be an integer, got {value!r}.")
+
+
+def resolve_sft_training_plan(config, n_batches: int) -> SFTTrainingPlan:
+    """Resolve and validate loop/cadence values before provider creation."""
+    if n_batches <= 0:
+        raise SFTConfigError("The SFT training dataset contains no batches.")
+    total_epochs = _coerce_integer_setting(config.trainer.get("total_epochs", 1), "trainer.total_epochs")
+    if total_epochs <= 0:
+        raise SFTConfigError(f"trainer.total_epochs must be positive, got {total_epochs}.")
+    max_steps_value = config.trainer.get("max_steps")
+    max_steps = _coerce_integer_setting(max_steps_value, "trainer.max_steps") if max_steps_value is not None else None
+    if max_steps is not None and max_steps <= 0:
+        raise SFTConfigError(f"trainer.max_steps must be positive when set, got {max_steps}.")
+    save_every = _coerce_integer_setting(config.trainer.get("save_freq", 20), "trainer.save_freq")
+    eval_every = _coerce_integer_setting(config.trainer.get("test_freq", 10), "trainer.test_freq")
+    available_steps = n_batches * total_epochs
+    total_steps = min(available_steps, max_steps) if max_steps is not None else available_steps
+    return SFTTrainingPlan(
+        n_batches=n_batches,
+        total_epochs=total_epochs,
+        max_steps=max_steps,
+        available_steps=available_steps,
+        total_steps=total_steps,
+        save_every=save_every,
+        eval_every=eval_every,
+    )
+
+
+def build_tinker_resume_contract(
+    config,
+    train_dataset,
+    optimizer: SFTOptimizerSettings,
+    *,
+    n_batches: int,
+    total_epochs: int,
+    total_steps: int,
+) -> SFTResumeContract:
+    """Capture all local inputs that can change resumed training semantics."""
+    rllm_data = config.data.get("rllm", {})
+    optimizer_payload = asdict(optimizer)
+    optimizer_payload["betas"] = list(optimizer_payload["betas"])
+    payload: dict[str, Any] = {
+        "contract_version": _RESUME_CONTRACT_VERSION,
+        "loop_semantics": _LOOP_SEMANTICS_VERSION,
+        "model": {
+            "base_model": str(config.model.name),
+            "lora_rank": int(config.model.get("lora_rank", 32)),
+            "train_unembed": bool(OmegaConf.select(config, "model.train_unembed", default=True)),
+            "train_attn": bool(OmegaConf.select(config, "model.train_attn", default=True)),
+            "train_mlp": bool(OmegaConf.select(config, "model.train_mlp", default=True)),
+        },
+        "rendering": {
+            "renderer": str(config.data.get("resolved_renderer_name")),
+            "tokenizer_model": str(config.model.get("tokenizer_model") or config.model.name),
+            "tokenize_and_mask_method": str(rllm_data.get("tokenize_and_mask_method", "cumulative")),
+            "strip_thinking_from_history": bool(rllm_data.get("strip_thinking_from_history", False)),
+            "max_length": config.data.get("max_length"),
+            "overlength_policy": str(rllm_data.get("overlength_policy", "error")),
+            "loss_reduction": str(rllm_data.get("loss_reduction", "none")),
+            "group_by_length": bool(rllm_data.get("group_by_length", False)),
+            "length_group_factor": int(rllm_data.get("length_group_factor", 50)),
+        },
+        "dataset": {
+            "fingerprint": train_dataset.content_fingerprint(),
+            "row_count": len(train_dataset.dataset),
+            "batch_size": int(train_dataset.batch_size),
+        },
+        "optimizer": optimizer_payload,
+        "horizon": {
+            "batches_per_epoch": n_batches,
+            "total_epochs": total_epochs,
+            "total_steps": total_steps,
+        },
+    }
+    return SFTResumeContract(payload=payload, digest=_stable_digest(payload))
+
+
+def _is_step_boundary(
+    completed_steps: int,
+    total_steps: int,
+    *,
+    save_every: int,
+    eval_every: int,
+    has_validation: bool,
+) -> bool:
+    return (
+        completed_steps >= total_steps
+        or (has_validation and eval_every > 0 and completed_steps % eval_every == 0)
+        or (save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps)
+    )
+
+
+def _contract_differences(expected: Any, actual: Any, prefix: str = "") -> list[str]:
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        differences: list[str] = []
+        for key in sorted(set(expected) | set(actual)):
+            path = f"{prefix}.{key}" if prefix else key
+            if key not in expected or key not in actual:
+                differences.append(path)
+            else:
+                differences.extend(_contract_differences(expected[key], actual[key], path))
+        return differences
+    return [] if expected == actual else [prefix or "contract"]
+
+
+def prepare_tinker_resume_contract(
+    checkpoint_dir: str,
+    contract: SFTResumeContract,
+    resume_info,
+) -> None:
+    """Validate or create the local manifest before any resumed client exists."""
+    manifest_path = Path(checkpoint_dir) / _RUN_MANIFEST_NAME
+    expected_manifest = {
+        "contract_version": _RESUME_CONTRACT_VERSION,
+        "contract_hash": contract.digest,
+        "contract": contract.payload,
+    }
+    existing = None
+    if manifest_path.exists():
+        try:
+            existing = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            raise SFTConfigError(f"Cannot resume from {checkpoint_dir!r}: {_RUN_MANIFEST_NAME} is unreadable ({e}). Use a new output directory.") from e
+
+    if existing is not None:
+        differences = _contract_differences(
+            expected_manifest.get("contract"),
+            existing.get("contract") if isinstance(existing, dict) else None,
+        )
+        if not isinstance(existing, dict) or existing.get("contract_version") != _RESUME_CONTRACT_VERSION or existing.get("contract_hash") != contract.digest or differences:
+            fields = ", ".join(differences[:8]) or "contract version/hash"
+            raise SFTConfigError(f"Cannot resume from {checkpoint_dir!r}: run identity mismatch in {fields}. Use a new output directory.")
+
+    if resume_info is not None:
+        if existing is None:
+            raise SFTConfigError(f"Cannot resume the legacy checkpoint in {checkpoint_dir!r}: {_RUN_MANIFEST_NAME} is missing. Use a new output directory.")
+        checkpoint_version = resume_info.get("contract_version")
+        checkpoint_hash = resume_info.get("contract_hash")
+        if checkpoint_version != _RESUME_CONTRACT_VERSION or checkpoint_hash != contract.digest:
+            raise SFTConfigError(
+                f"Cannot resume from {checkpoint_dir!r}: checkpoint contract "
+                f"version/hash is {checkpoint_version!r}/{checkpoint_hash!r}, expected "
+                f"{_RESUME_CONTRACT_VERSION!r}/{contract.digest!r}. Use a new output directory."
+            )
+    elif existing is None:
+        try:
+            manifest_path.write_text(json.dumps(expected_manifest, indent=2, sort_keys=True) + "\n")
+        except OSError as e:
+            raise SFTConfigError(f"Could not write Tinker run identity to {manifest_path}: {e}") from e
+
+
+def validate_tinker_resume_cursor(
+    resume_info,
+    *,
+    n_batches: int,
+    total_steps: int,
+) -> int:
+    """Require a complete, internally consistent completed-step cursor."""
+    values = {}
+    for field in ("epoch", "batch", "step"):
+        value = resume_info.get(field)
+        values[field] = _coerce_integer_setting(value, f"checkpoint loop_state.{field}")
+        if values[field] < 0:
+            raise SFTConfigError(f"checkpoint loop_state.{field} must be non-negative, got {values[field]}.")
+    expected_step = values["epoch"] * n_batches + values["batch"]
+    if values["batch"] >= n_batches or values["step"] != expected_step or values["step"] > total_steps:
+        raise SFTConfigError(
+            "Tinker checkpoint cursor is inconsistent with the resolved SFT batch plan "
+            f"(epoch={values['epoch']}, batch={values['batch']}, step={values['step']}, "
+            f"batches_per_epoch={n_batches}, total_steps={total_steps}). Use a new output directory."
+        )
+    return values["step"]
+
+
+async def validate_tinker_checkpoint_identity(
+    service_client,
+    checkpoint_path: str,
+    config,
+) -> None:
+    """Hard-compare provider checkpoint metadata with the resolved run config."""
+    from tinker_cookbook import checkpoint_utils
+
+    rest_client = service_client.create_rest_client()
+    weights = await rest_client.get_weights_info_by_tinker_path(checkpoint_path)
+    training_run = await rest_client.get_training_run_by_tinker_path_async(checkpoint_path)
+    expected = {
+        "base_model": str(config.model.name),
+        "lora_rank": int(config.model.get("lora_rank", 32)),
+        "train_unembed": bool(OmegaConf.select(config, "model.train_unembed", default=True)),
+        "train_attn": bool(OmegaConf.select(config, "model.train_attn", default=True)),
+        "train_mlp": bool(OmegaConf.select(config, "model.train_mlp", default=True)),
+        "renderer": str(config.data.get("resolved_renderer_name")),
+    }
+    actual = {
+        "base_model": weights.base_model,
+        "lora_rank": weights.lora_rank,
+        "train_unembed": (weights.train_unembed if weights.train_unembed is not None else True),
+        "train_attn": weights.train_attn if weights.train_attn is not None else True,
+        "train_mlp": weights.train_mlp if weights.train_mlp is not None else True,
+        "renderer": (training_run.user_metadata or {}).get(checkpoint_utils.RENDERER_NAME_METADATA_KEY),
+    }
+    mismatches = [f"{field}={actual[field]!r} (expected {value!r})" for field, value in expected.items() if actual[field] != value]
+    if mismatches:
+        raise SFTConfigError("Tinker checkpoint identity mismatch: " + "; ".join(mismatches) + ". Use a new output directory.")
 
 
 def resolve_sft_optimizer_settings(
@@ -328,6 +609,8 @@ class TinkerSFTBackend(SFTBackend):
     def __init__(self, spec):
         super().__init__(spec)
         self._config: DictConfig | None = None
+        self._run_leaf = f"{time.strftime('%Y%m%d_%H%M%S', time.gmtime())}-{secrets.token_hex(4)}"
+        self._resume_requested = False
 
     # -- contract -----------------------------------------------------------
 
@@ -392,6 +675,24 @@ class TinkerSFTBackend(SFTBackend):
             cfg = OmegaConf.merge(cfg, OmegaConf.create({"trainer": {"default_local_dir": spec.output_dir}}))
         if spec.overrides:
             cfg = OmegaConf.merge(cfg, OmegaConf.create(spec.overrides))
+        user = OmegaConf.to_container(OmegaConf.create(spec.overrides), resolve=False) if spec.overrides else {}
+        user_trainer = user.get("trainer") if isinstance(user, dict) else None
+        explicit_override = isinstance(user_trainer, dict) and user_trainer.get("default_local_dir") is not None
+        self._resume_requested = bool(spec.output_dir) or explicit_override
+        if not self._resume_requested:
+            experiment = (
+                re.sub(
+                    r"[^A-Za-z0-9._-]+",
+                    "-",
+                    str(cfg.trainer.get("experiment_name") or "default"),
+                ).strip("-._")
+                or "default"
+            )
+            cfg.trainer.default_local_dir = os.path.join(
+                str(cfg.trainer.default_local_dir),
+                experiment,
+                self._run_leaf,
+            )
         self._config = cfg
         return cfg
 
@@ -422,6 +723,8 @@ class TinkerSFTBackend(SFTBackend):
         from rllm.utils.tracking import Tracking
 
         config = self._config
+        if not self._resume_requested and os.path.exists(config.trainer.default_local_dir):
+            raise SFTConfigError("The generated Tinker run directory already exists; create a new backend instance so a fresh isolated directory can be selected.")
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
 
         tokenizer, train_dataset, val_dataset = build_sft_data(
@@ -433,25 +736,60 @@ class TinkerSFTBackend(SFTBackend):
         # Reject an invalid run before opening a paid training client. These
         # values also define checkpoint progress, so coercion happens once and
         # the exact same plan is used throughout the loop.
-        n_batches = len(train_dataset)
-        if n_batches <= 0:
-            raise SFTConfigError("The SFT training dataset contains no batches.")
-        total_epochs = int(config.trainer.get("total_epochs", 1))
-        if total_epochs <= 0:
-            raise SFTConfigError(f"trainer.total_epochs must be positive, got {total_epochs}.")
-        max_steps_value = config.trainer.get("max_steps")
-        max_steps = int(max_steps_value) if max_steps_value is not None else None
-        if max_steps is not None and max_steps <= 0:
-            raise SFTConfigError(f"trainer.max_steps must be positive when set, got {max_steps}.")
-        available_steps = n_batches * total_epochs
-        total_steps = min(available_steps, max_steps) if max_steps is not None else available_steps
+        plan = resolve_sft_training_plan(config, len(train_dataset))
+        n_batches = plan.n_batches
+        total_epochs = plan.total_epochs
+        max_steps = plan.max_steps
+        available_steps = plan.available_steps
+        total_steps = plan.total_steps
 
         optimizer = resolve_sft_optimizer_settings(
             config.get("optim", {}),
             total_steps=total_steps,
         )
-        save_every = int(config.trainer.get("save_freq", 20))
-        eval_every = int(config.trainer.get("test_freq", 10))
+        save_every = plan.save_every
+        eval_every = plan.eval_every
+
+        planned_batches = (
+            (epoch_idx, batch_idx)
+            for _, epoch_idx, batch_idx in iter_training_batches_from_step(
+                n_batches=n_batches,
+                total_epochs=total_epochs,
+                start_step=0,
+                max_steps=max_steps,
+            )
+        )
+        train_dataset.preflight("train", planned_batches=planned_batches)
+        if val_dataset is not None:
+            val_dataset.preflight("validation")
+
+        resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir) if self._resume_requested else None
+        resume_contract = build_tinker_resume_contract(
+            config,
+            train_dataset,
+            optimizer,
+            n_batches=n_batches,
+            total_epochs=total_epochs,
+            total_steps=total_steps,
+        )
+        prepare_tinker_resume_contract(
+            config.trainer.default_local_dir,
+            resume_contract,
+            resume_info,
+        )
+        resume_start_step = (
+            validate_tinker_resume_cursor(
+                resume_info,
+                n_batches=n_batches,
+                total_steps=total_steps,
+            )
+            if resume_info is not None
+            else 0
+        )
+        checkpoint_contract = {
+            "contract_version": _RESUME_CONTRACT_VERSION,
+            "contract_hash": resume_contract.digest,
+        }
 
         logger_backend = config.trainer.logger
         if isinstance(logger_backend, str):
@@ -472,21 +810,17 @@ class TinkerSFTBackend(SFTBackend):
                 resolved_renderer,
             )
 
-            resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
             if resume_info:
                 logger.info(f"Resuming from checkpoint: {resume_info}")
-                if resolved_renderer:
-                    await checkpoint_utils.check_renderer_name_for_checkpoint_async(
-                        service_client,
-                        resume_info.state_path,
-                        resolved_renderer,
-                    )
+                await validate_tinker_checkpoint_identity(
+                    service_client,
+                    resume_info.state_path,
+                    config,
+                )
                 training_client = await service_client.create_training_client_from_state_with_optimizer_async(
                     resume_info.state_path,
                     user_metadata=user_metadata,
                 )
-                start_epoch = resume_info.get("epoch", 0) or 0
-                start_batch = resume_info.get("batch", 0) or 0
             else:
                 logger.info("Starting training from scratch")
                 training_client = await service_client.create_lora_training_client_async(
@@ -497,10 +831,7 @@ class TinkerSFTBackend(SFTBackend):
                     train_mlp=OmegaConf.select(config, "model.train_mlp", default=True),
                     user_metadata=user_metadata,
                 )
-                start_epoch = 0
-                start_batch = 0
-
-            start_step = start_epoch * n_batches + start_batch
+            start_step = resume_start_step
             logger.info(
                 "Training for %d batches x %d epochs = %d available steps; effective steps=%d",
                 n_batches,
@@ -522,19 +853,20 @@ class TinkerSFTBackend(SFTBackend):
                 tracking_logger.log(data=initial_metrics, step=0)
 
             current_epoch: int | None = None
-            for step, epoch_idx, batch_idx in iter_training_batches(
-                n_batches=n_batches,
-                total_epochs=total_epochs,
-                start_epoch=start_epoch,
-                start_batch=start_batch,
-                max_steps=max_steps,
-            ):
+            pending: SubmittedTinkerBatch | None = None
+
+            async def submit_batch(
+                step: int,
+                epoch_idx: int,
+                batch_idx: int,
+            ) -> SubmittedTinkerBatch:
+                nonlocal current_epoch
                 if epoch_idx != current_epoch:
                     logger.info("Starting epoch %d", epoch_idx)
                     train_dataset.set_epoch(seed=epoch_idx)
                     current_epoch = epoch_idx
 
-                batch_start_time = time.time()
+                started_at = time.time()
                 metrics: dict[str, Any] = {
                     "epoch": epoch_idx,
                     "progress": step / max(total_steps, 1),
@@ -561,27 +893,41 @@ class TinkerSFTBackend(SFTBackend):
                 if data:
                     logger.info(colorize_example(data[0], tokenizer))
 
+                fwd_bwd_future = await training_client.forward_backward_async(
+                    data,
+                    loss_fn="cross_entropy",
+                )
+                optim_step_future = await training_client.optim_step_async(adam_params)
+                return SubmittedTinkerBatch(
+                    step=step,
+                    epoch=epoch_idx,
+                    batch=batch_idx,
+                    data=data,
+                    learning_rate=learning_rate,
+                    started_at=started_at,
+                    metrics=metrics,
+                    fwd_bwd_future=fwd_bwd_future,
+                    optim_step_future=optim_step_future,
+                )
+
+            async def finish_batch(submitted: SubmittedTinkerBatch) -> None:
+                metrics = submitted.metrics
                 with timed("step", metrics):
-                    fwd_bwd_future = await training_client.forward_backward_async(
-                        data,
-                        loss_fn="cross_entropy",
-                    )
-                    optim_step_future = await training_client.optim_step_async(adam_params)
-                    fwd_bwd_result = await fwd_bwd_future.result_async()
-                    optim_result = await optim_step_future.result_async()
+                    fwd_bwd_result = await submitted.fwd_bwd_future.result_async()
+                    optim_result = await submitted.optim_step_future.result_async()
                 if optim_result.metrics:
                     metrics.update(optim_result.metrics)
 
                 logprobs = [x["logprobs"] for x in fwd_bwd_result.loss_fn_outputs]
-                weights = [datum.loss_fn_inputs["weights"] for datum in data]
+                weights = [datum.loss_fn_inputs["weights"] for datum in submitted.data]
                 train_nll = compute_mean_nll(logprobs, weights)
                 metrics.update(
-                    num_sequences=len(data),
-                    num_tokens=sum(datum.model_input.length for datum in data),
-                    num_loss_tokens=count_loss_tokens(data),
+                    num_sequences=len(submitted.data),
+                    num_tokens=sum(datum.model_input.length for datum in submitted.data),
+                    num_loss_tokens=count_loss_tokens(submitted.data),
                     train_mean_nll=train_nll,
                 )
-                completed_steps = step + 1
+                completed_steps = submitted.step + 1
                 metrics["progress"] = min(completed_steps / max(total_steps, 1), 1.0)
 
                 if val_dataset is not None and eval_every > 0 and completed_steps % eval_every == 0:
@@ -605,18 +951,47 @@ class TinkerSFTBackend(SFTBackend):
                                 "epoch": next_epoch,
                                 "batch": next_batch,
                                 "step": completed_steps,
+                                **checkpoint_contract,
                             },
                             kind="both",
                         )
 
-                metrics["time/total"] = time.time() - batch_start_time
+                metrics["time/total"] = time.time() - submitted.started_at
                 tracking_logger.log(data=metrics, step=completed_steps)
                 logger.info(
                     "Step %d: train_nll=%.4f, lr=%.2e",
                     completed_steps,
                     train_nll,
-                    learning_rate,
+                    submitted.learning_rate,
                 )
+
+            for step, epoch_idx, batch_idx in iter_training_batches_from_step(
+                n_batches=n_batches,
+                total_epochs=total_epochs,
+                start_step=start_step,
+                max_steps=max_steps,
+            ):
+                if pending is None:
+                    pending = await submit_batch(step, epoch_idx, batch_idx)
+                    continue
+
+                pending_completed = pending.step + 1
+                if _is_step_boundary(
+                    pending_completed,
+                    total_steps,
+                    save_every=save_every,
+                    eval_every=eval_every,
+                    has_validation=val_dataset is not None,
+                ):
+                    await finish_batch(pending)
+                    pending = await submit_batch(step, epoch_idx, batch_idx)
+                else:
+                    following = await submit_batch(step, epoch_idx, batch_idx)
+                    await finish_batch(pending)
+                    pending = following
+
+            if pending is not None:
+                await finish_batch(pending)
 
             if start_step < total_steps:
                 final_epoch, final_batch = divmod(total_steps, n_batches)
@@ -630,6 +1005,7 @@ class TinkerSFTBackend(SFTBackend):
                         "batch": final_batch,
                         "step": total_steps,
                         "final": True,
+                        **checkpoint_contract,
                     },
                 )
             else:

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -14,15 +14,11 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from omegaconf import DictConfig, OmegaConf
 
 from rllm.trainer.sft.backend import SFTBackend, SFTConfigError, validate_messages_dataset
-
-if TYPE_CHECKING:
-    import tinker
-    from tinker.lib.public_interfaces import APIFuture
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +26,12 @@ _CONFIG_FILE = Path(__file__).resolve().parent / "config" / "tinker.yaml"
 
 # Plain-text renderers that cannot represent reasoning (``<think>``) or tool-calls.
 _PLAIN_RENDERERS = {"role_colon", "llama3"}
+_HF_TEMPLATE_UNSUPPORTED = (
+    "--tokenize-method hf_template is not supported by the Tinker/Fireworks SFT path: "
+    "their native sampler checkpoints are served through tinker_cookbook renderers, so "
+    "training with a different HF template would create an untracked train/serve mismatch. "
+    "Use cumulative/stepwise here, or use the verl backend for hf_template tokenization."
+)
 
 
 def _resolve_renderer_name(model_source: str, explicit: str | None) -> str:
@@ -131,23 +133,35 @@ def build_sft_data(config, train_data, val_data):
     # Fireworks' model.name is a FW model path (accounts/fireworks/models/...),
     # not HF-resolvable, so render/tokenize from the HF tokenizer_model when set.
     tokenizer_name = config.model.get("tokenizer_model") or config.model.name
-    tokenizer = get_tokenizer(tokenizer_name)
+    tokenize_method = config.data.get("rllm", {}).get("tokenize_and_mask_method", "cumulative")
+    if tokenize_method == "hf_template":
+        raise SFTConfigError(_HF_TEMPLATE_UNSUPPORTED)
     # renderer_name=null (yaml default) -> auto-detect from the model; an explicit
     # value (e.g. from --renderer) overrides. A plain renderer that would drop
     # reasoning/tool-calls fails fast before we render.
     renderer_name = _resolve_renderer_name(tokenizer_name, config.data.get("renderer_name", None))
+    tokenizer = get_tokenizer(tokenizer_name)
     _guard_plain_renderer(renderer_name, train_data)
-    renderer = get_renderer(renderer_name, tokenizer)
+    renderer = get_renderer(renderer_name, tokenizer, model_name=tokenizer_name)
+    if hasattr(renderer, "strip_thinking_from_history"):
+        renderer.strip_thinking_from_history = bool(
+            config.data.get("rllm", {}).get(
+                "strip_thinking_from_history",
+                False,
+            )
+        )
+    logger.info(f"Using renderer: {renderer_name}, masking: CUSTOMIZED")
+    config.data.resolved_renderer_name = renderer_name
     # Masking is always CUSTOMIZED, driven by each message's ``trainable`` flag:
     # rows from ``from-eval``'s automerge carry the flags directly; flag-less rows
     # (e.g. an external ``--train-file``) get a derived default in the dataset
     # loader. ``tokenize_and_mask_method=stepwise`` only selects that default
     # (train just the last assistant turn) rather than the all-assistant default.
-    last_only = config.data.get("rllm", {}).get("tokenize_and_mask_method", "cumulative") == "stepwise"
-    logger.info(f"Using renderer: {renderer_name}, masking: CUSTOMIZED (last_only={last_only})")
+    last_only = tokenize_method == "stepwise"
 
     train_batch_size = config.data.get("train_batch_size", 32)
     val_batch_size = config.data.get("micro_batch_size_per_gpu", train_batch_size)
+    rllm_data = config.data.get("rllm", {})
     train_dataset, val_dataset = create_tinker_sft_datasets(
         train_data=train_data,
         val_data=val_data,
@@ -158,22 +172,148 @@ def build_sft_data(config, train_data, val_data):
         last_only=last_only,
         max_train_samples=config.data.get("train_max_samples", -1),
         max_val_samples=config.data.get("val_max_samples", -1),
+        group_by_length=bool(rllm_data.get("group_by_length", False)),
+        length_group_factor=int(rllm_data.get("length_group_factor", 50)),
+        overlength_policy=str(rllm_data.get("overlength_policy", "error")),
+        loss_reduction=str(rllm_data.get("loss_reduction", "none")),
     )
     return tokenizer, train_dataset, val_dataset
 
 
-@dataclass
-class _SubmittedBatch:
-    """A batch submitted to Tinker (forward-backward + optim step in flight)."""
+def sft_lr_multiplier(
+    lr_schedule: str,
+    step: int,
+    total_steps: int,
+    warmup_steps_ratio: float = 0.0,
+    warmup_steps: int | None = -1,
+    min_lr_ratio: float = 0.0,
+) -> float:
+    """LR-schedule multiplier with a linear warmup ramp, shared by both SFT fits.
 
-    fwd_bwd_future: APIFuture[tinker.ForwardBackwardOutput]
-    optim_step_future: APIFuture[tinker.OptimStepResponse]
-    metrics: dict[str, Any]
-    data: list
-    step: int
-    epoch_idx: int
-    batch_idx: int
-    batch_start_time: float
+    A linear ramp over the first ``warmup_steps`` steps (derived from
+    ``warmup_steps_ratio`` when not given absolutely), then the tinker_cookbook
+    decay (constant/linear/cosine) over the remaining horizon — the warmup
+    convention the RL policy trainer already uses. ``warmup_steps_ratio=0`` is a
+    no-op ramp, so the value reduces exactly to the cookbook multiplier.
+    """
+    from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier
+
+    if not 0 <= min_lr_ratio <= 1:
+        raise SFTConfigError(f"optim.min_lr / optim.lr must be in [0, 1], got {min_lr_ratio}.")
+    ws = -1 if warmup_steps is None else int(warmup_steps)
+    if ws <= 0:
+        ws = int(total_steps * (warmup_steps_ratio or 0.0))
+    if ws > 0 and step < ws:
+        return step / ws
+    decay = compute_schedule_lr_multiplier(
+        lr_schedule=lr_schedule,
+        step=step - ws,
+        total_steps=max(total_steps - ws, 1),
+    )
+    return min_lr_ratio + (1 - min_lr_ratio) * decay
+
+
+def iter_training_batches(
+    *,
+    n_batches: int,
+    total_epochs: int,
+    start_epoch: int = 0,
+    start_batch: int = 0,
+    max_steps: int | None = None,
+):
+    """Yield ``(global_step, epoch, batch)`` up to an exact optional cap."""
+    if n_batches <= 0:
+        raise SFTConfigError("The SFT training dataset contains no batches.")
+    available_steps = n_batches * total_epochs
+    total_steps = min(available_steps, int(max_steps)) if max_steps is not None and int(max_steps) >= 0 else available_steps
+    start_step = start_epoch * n_batches + start_batch
+    for step in range(start_step, total_steps):
+        epoch_idx, batch_idx = divmod(step, n_batches)
+        yield step, epoch_idx, batch_idx
+
+
+def build_adam_params(
+    *,
+    learning_rate: float,
+    betas: list[float] | tuple[float, float],
+    eps: float,
+    weight_decay: float,
+    grad_clip_norm: float,
+):
+    """Build the complete AdamW request sent to Tinker."""
+    import tinker
+
+    return tinker.AdamParams(
+        learning_rate=learning_rate,
+        beta1=betas[0],
+        beta2=betas[1],
+        eps=eps,
+        weight_decay=weight_decay,
+        grad_clip_norm=grad_clip_norm,
+    )
+
+
+@dataclass(frozen=True)
+class SFTOptimizerSettings:
+    learning_rate: float
+    lr_schedule: str
+    warmup_steps_ratio: float
+    warmup_steps: int
+    min_lr_ratio: float
+    betas: tuple[float, float]
+    eps: float
+    weight_decay: float
+    grad_clip_norm: float
+
+
+def resolve_sft_optimizer_settings(
+    optim_cfg,
+    *,
+    total_steps: int,
+) -> SFTOptimizerSettings:
+    """Validate optimizer settings before opening a paid training client."""
+    learning_rate = float(optim_cfg.get("lr", 1e-5))
+    min_learning_rate = float(optim_cfg.get("min_lr", 0.0))
+    if learning_rate <= 0:
+        raise SFTConfigError(f"optim.lr must be positive, got {learning_rate}.")
+    if not 0 <= min_learning_rate <= learning_rate:
+        raise SFTConfigError(f"optim.min_lr must be between zero and optim.lr, got {min_learning_rate} with lr={learning_rate}.")
+
+    lr_schedule = str(optim_cfg.get("lr_scheduler", "constant"))
+    if lr_schedule not in {"constant", "linear", "cosine"}:
+        raise SFTConfigError(f"optim.lr_scheduler must be constant, linear, or cosine, got {lr_schedule!r}.")
+    warmup_steps_ratio = float(optim_cfg.get("warmup_steps_ratio", 0.0) or 0.0)
+    if not 0 <= warmup_steps_ratio <= 1:
+        raise SFTConfigError(f"optim.warmup_steps_ratio must be in [0, 1], got {warmup_steps_ratio}.")
+    warmup_steps = int(optim_cfg.get("warmup_steps", -1) or -1)
+    if warmup_steps > total_steps:
+        raise SFTConfigError(f"optim.warmup_steps cannot exceed total training steps ({total_steps}), got {warmup_steps}.")
+
+    raw_betas = optim_cfg.get("betas", [0.9, 0.95])
+    if len(raw_betas) != 2:
+        raise SFTConfigError(f"optim.betas must contain beta1 and beta2, got {raw_betas}.")
+    betas = (float(raw_betas[0]), float(raw_betas[1]))
+    if any(not 0 <= beta < 1 for beta in betas):
+        raise SFTConfigError(f"optim.betas must each be in [0, 1), got {betas}.")
+    eps = float(optim_cfg.get("eps", 1e-8))
+    weight_decay = float(optim_cfg.get("weight_decay", 0.0))
+    grad_clip_norm = float(optim_cfg.get("grad_clip_norm", 0.0))
+    if eps <= 0:
+        raise SFTConfigError(f"optim.eps must be positive, got {eps}.")
+    if weight_decay < 0 or grad_clip_norm < 0:
+        raise SFTConfigError("optim.weight_decay and optim.grad_clip_norm must be non-negative.")
+
+    return SFTOptimizerSettings(
+        learning_rate=learning_rate,
+        lr_schedule=lr_schedule,
+        warmup_steps_ratio=warmup_steps_ratio,
+        warmup_steps=warmup_steps,
+        min_lr_ratio=min_learning_rate / learning_rate,
+        betas=betas,
+        eps=eps,
+        weight_decay=weight_decay,
+        grad_clip_norm=grad_clip_norm,
+    )
 
 
 class TinkerSFTBackend(SFTBackend):
@@ -192,6 +332,8 @@ class TinkerSFTBackend(SFTBackend):
     # -- contract -----------------------------------------------------------
 
     def validate_spec(self) -> None:
+        if self.spec.tokenize_method == "hf_template":
+            raise SFTConfigError(_HF_TEMPLATE_UNSUPPORTED)
         if self._effective_lora_rank() == 0 and not self.supports_full_finetune:
             raise SFTConfigError(
                 f"--lora-rank 0 (full-parameter fine-tuning) is not supported by the {self.name!r} SFT backend: "
@@ -274,14 +416,42 @@ class TinkerSFTBackend(SFTBackend):
         from tinker_cookbook import checkpoint_utils
         from tinker_cookbook.display import colorize_example
         from tinker_cookbook.supervised.common import compute_mean_nll
-        from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier
         from tinker_cookbook.utils.misc_utils import timed
 
+        from rllm.trainer.sft.tinker_dataset import count_loss_tokens
         from rllm.utils.tracking import Tracking
 
         config = self._config
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
-        service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
+
+        tokenizer, train_dataset, val_dataset = build_sft_data(
+            config,
+            self.spec.train_dataset,
+            self.spec.val_dataset,
+        )
+
+        # Reject an invalid run before opening a paid training client. These
+        # values also define checkpoint progress, so coercion happens once and
+        # the exact same plan is used throughout the loop.
+        n_batches = len(train_dataset)
+        if n_batches <= 0:
+            raise SFTConfigError("The SFT training dataset contains no batches.")
+        total_epochs = int(config.trainer.get("total_epochs", 1))
+        if total_epochs <= 0:
+            raise SFTConfigError(f"trainer.total_epochs must be positive, got {total_epochs}.")
+        max_steps_value = config.trainer.get("max_steps")
+        max_steps = int(max_steps_value) if max_steps_value is not None else None
+        if max_steps is not None and max_steps <= 0:
+            raise SFTConfigError(f"trainer.max_steps must be positive when set, got {max_steps}.")
+        available_steps = n_batches * total_epochs
+        total_steps = min(available_steps, max_steps) if max_steps is not None else available_steps
+
+        optimizer = resolve_sft_optimizer_settings(
+            config.get("optim", {}),
+            total_steps=total_steps,
+        )
+        save_every = int(config.trainer.get("save_freq", 20))
+        eval_every = int(config.trainer.get("test_freq", 10))
 
         logger_backend = config.trainer.logger
         if isinstance(logger_backend, str):
@@ -293,17 +463,30 @@ class TinkerSFTBackend(SFTBackend):
             config=OmegaConf.to_container(config, resolve=True),
         )
 
-        # Wrap the loop so tracking_logger.finish() runs even on failure: the 'ui'
-        # backend tees stdout/stderr and holds an open session until finish().
         try:
-            tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
+            service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
+            resolved_renderer = config.data.get("resolved_renderer_name")
+            user_metadata: dict[str, str] = {}
+            checkpoint_utils.add_renderer_name_to_user_metadata(
+                user_metadata,
+                resolved_renderer,
+            )
 
             resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
             if resume_info:
                 logger.info(f"Resuming from checkpoint: {resume_info}")
-                training_client = await service_client.create_training_client_from_state_async(resume_info["state_path"])
-                start_epoch = resume_info.get("epoch", 0)
-                start_batch = resume_info.get("batch", 0)
+                if resolved_renderer:
+                    await checkpoint_utils.check_renderer_name_for_checkpoint_async(
+                        service_client,
+                        resume_info.state_path,
+                        resolved_renderer,
+                    )
+                training_client = await service_client.create_training_client_from_state_with_optimizer_async(
+                    resume_info.state_path,
+                    user_metadata=user_metadata,
+                )
+                start_epoch = resume_info.get("epoch", 0) or 0
+                start_batch = resume_info.get("batch", 0) or 0
             else:
                 logger.info("Starting training from scratch")
                 training_client = await service_client.create_lora_training_client_async(
@@ -312,97 +495,142 @@ class TinkerSFTBackend(SFTBackend):
                     train_unembed=OmegaConf.select(config, "model.train_unembed", default=True),
                     train_attn=OmegaConf.select(config, "model.train_attn", default=True),
                     train_mlp=OmegaConf.select(config, "model.train_mlp", default=True),
+                    user_metadata=user_metadata,
                 )
                 start_epoch = 0
                 start_batch = 0
 
-            # len(dataset) floors examples//batch_size; keep the final partial batch
-            # when the dataset is smaller than one batch (else 0 steps).
-            n_batches = max(1, len(train_dataset))
-            total_epochs = config.trainer.get("total_epochs", 1)
-            total_steps = n_batches * total_epochs
-            progress_denominator = total_steps if total_steps > 0 else 1
-            logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
+            start_step = start_epoch * n_batches + start_batch
+            logger.info(
+                "Training for %d batches x %d epochs = %d available steps; effective steps=%d",
+                n_batches,
+                total_epochs,
+                available_steps,
+                total_steps,
+            )
 
-            base_learning_rate = config.get("optim", {}).get("lr", 1e-5)
-            lr_schedule = config.get("optim", {}).get("lr_scheduler", "constant")
-            adam_betas = config.get("optim", {}).get("betas", [0.9, 0.95])
-            adam_eps = config.get("optim", {}).get("eps", 1e-8)
-            save_every = config.trainer.get("save_freq", 20)
-            eval_every = config.trainer.get("test_freq", 10)
+            if val_dataset is not None and start_step == 0:
+                initial_metrics: dict[str, Any] = {}
+                with timed("validation", initial_metrics):
+                    initial_metrics.update(
+                        await self._validate(
+                            training_client,
+                            val_dataset,
+                            compute_mean_nll,
+                        )
+                    )
+                tracking_logger.log(data=initial_metrics, step=0)
 
-            async def submit_batch(epoch_idx: int, batch_idx: int) -> _SubmittedBatch:
-                step = epoch_idx * n_batches + batch_idx
+            current_epoch: int | None = None
+            for step, epoch_idx, batch_idx in iter_training_batches(
+                n_batches=n_batches,
+                total_epochs=total_epochs,
+                start_epoch=start_epoch,
+                start_batch=start_batch,
+                max_steps=max_steps,
+            ):
+                if epoch_idx != current_epoch:
+                    logger.info("Starting epoch %d", epoch_idx)
+                    train_dataset.set_epoch(seed=epoch_idx)
+                    current_epoch = epoch_idx
+
                 batch_start_time = time.time()
-                metrics: dict[str, Any] = {"epoch": epoch_idx, "progress": step / progress_denominator}
-                learning_rate = base_learning_rate * compute_schedule_lr_multiplier(lr_schedule=lr_schedule, step=step, total_steps=total_steps)
+                metrics: dict[str, Any] = {
+                    "epoch": epoch_idx,
+                    "progress": step / max(total_steps, 1),
+                }
+                learning_rate = optimizer.learning_rate * sft_lr_multiplier(
+                    optimizer.lr_schedule,
+                    step,
+                    total_steps,
+                    optimizer.warmup_steps_ratio,
+                    optimizer.warmup_steps,
+                    optimizer.min_lr_ratio,
+                )
                 metrics["learning_rate"] = learning_rate
-                adam_params = tinker.AdamParams(learning_rate=learning_rate, beta1=adam_betas[0], beta2=adam_betas[1], eps=adam_eps)
+                adam_params = build_adam_params(
+                    learning_rate=learning_rate,
+                    betas=optimizer.betas,
+                    eps=optimizer.eps,
+                    weight_decay=optimizer.weight_decay,
+                    grad_clip_norm=optimizer.grad_clip_norm,
+                )
 
                 with timed("get_batch", metrics):
                     data = train_dataset.get_batch(batch_idx)
                 if data:
                     logger.info(colorize_example(data[0], tokenizer))
 
-                fwd_bwd_future = await training_client.forward_backward_async(data, loss_fn="cross_entropy")
-                optim_step_future = await training_client.optim_step_async(adam_params)
-                return _SubmittedBatch(fwd_bwd_future, optim_step_future, metrics, data, step, epoch_idx, batch_idx, batch_start_time)
+                with timed("step", metrics):
+                    fwd_bwd_future = await training_client.forward_backward_async(
+                        data,
+                        loss_fn="cross_entropy",
+                    )
+                    optim_step_future = await training_client.optim_step_async(adam_params)
+                    fwd_bwd_result = await fwd_bwd_future.result_async()
+                    optim_result = await optim_step_future.result_async()
+                if optim_result.metrics:
+                    metrics.update(optim_result.metrics)
 
-            async def finish_batch(submitted: _SubmittedBatch) -> None:
-                metrics = submitted.metrics
-                metrics["progress"] = min((submitted.step + 1) / progress_denominator, 1.0)
-                if save_every > 0 and submitted.step % save_every == 0 and submitted.step > 0:
+                logprobs = [x["logprobs"] for x in fwd_bwd_result.loss_fn_outputs]
+                weights = [datum.loss_fn_inputs["weights"] for datum in data]
+                train_nll = compute_mean_nll(logprobs, weights)
+                metrics.update(
+                    num_sequences=len(data),
+                    num_tokens=sum(datum.model_input.length for datum in data),
+                    num_loss_tokens=count_loss_tokens(data),
+                    train_mean_nll=train_nll,
+                )
+                completed_steps = step + 1
+                metrics["progress"] = min(completed_steps / max(total_steps, 1), 1.0)
+
+                if val_dataset is not None and eval_every > 0 and completed_steps % eval_every == 0:
+                    with timed("validation", metrics):
+                        metrics.update(
+                            await self._validate(
+                                training_client,
+                                val_dataset,
+                                compute_mean_nll,
+                            )
+                        )
+
+                if save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps:
+                    next_epoch, next_batch = divmod(completed_steps, n_batches)
                     with timed("save_checkpoint", metrics):
                         await checkpoint_utils.save_checkpoint_async(
                             training_client=training_client,
-                            name=f"{submitted.step:06d}",
+                            name=f"{completed_steps:06d}",
                             log_path=config.trainer.default_local_dir,
-                            loop_state={"epoch": submitted.epoch_idx, "batch": submitted.batch_idx},
+                            loop_state={
+                                "epoch": next_epoch,
+                                "batch": next_batch,
+                                "step": completed_steps,
+                            },
                             kind="both",
                         )
-                with timed("step", metrics):
-                    fwd_bwd_result = await submitted.fwd_bwd_future.result_async()
-                    await submitted.optim_step_future.result_async()
 
-                logprobs = [x["logprobs"] for x in fwd_bwd_result.loss_fn_outputs]
-                weights = [datum.loss_fn_inputs["weights"] for datum in submitted.data]
-                train_nll = compute_mean_nll(logprobs, weights)
-                metrics.update(
-                    num_sequences=len(submitted.data),
-                    num_tokens=sum(datum.model_input.length for datum in submitted.data),
-                    num_loss_tokens=sum(sum(datum.loss_fn_inputs["weights"].data) for datum in submitted.data),
-                    train_mean_nll=train_nll,
+                metrics["time/total"] = time.time() - batch_start_time
+                tracking_logger.log(data=metrics, step=completed_steps)
+                logger.info(
+                    "Step %d: train_nll=%.4f, lr=%.2e",
+                    completed_steps,
+                    train_nll,
+                    learning_rate,
                 )
-                metrics["time/total"] = time.time() - submitted.batch_start_time
 
-                if val_dataset and eval_every > 0 and submitted.step % eval_every == 0 and submitted.step > 0:
-                    with timed("validation", metrics):
-                        val_metrics = await self._validate(training_client, val_dataset, compute_mean_nll)
-                    metrics.update(val_metrics)
-
-                tracking_logger.log(data=metrics, step=submitted.step)
-                logger.info(f"Step {submitted.step}: train_nll={train_nll:.4f}, lr={metrics['learning_rate']:.2e}")
-
-            pending: _SubmittedBatch | None = None
-            for epoch_idx in range(start_epoch, total_epochs):
-                logger.info(f"Starting epoch {epoch_idx}")
-                train_dataset.set_epoch(seed=epoch_idx)
-                start_batch_idx = start_batch if epoch_idx == start_epoch else 0
-                for batch_idx in range(start_batch_idx, n_batches):
-                    submitted = await submit_batch(epoch_idx, batch_idx)
-                    if pending is not None:
-                        await finish_batch(pending)
-                    pending = submitted
-            if pending is not None:
-                await finish_batch(pending)
-
-            if start_epoch < total_epochs:
+            if start_step < total_steps:
+                final_epoch, final_batch = divmod(total_steps, n_batches)
                 await checkpoint_utils.save_checkpoint_async(
                     training_client=training_client,
                     name="final",
                     log_path=config.trainer.default_local_dir,
                     kind="both",
-                    loop_state={"epoch": total_epochs, "batch": n_batches},
+                    loop_state={
+                        "epoch": final_epoch,
+                        "batch": final_batch,
+                        "step": total_steps,
+                        "final": True,
+                    },
                 )
             else:
                 logger.info("Training was already complete; nothing to do")
@@ -412,24 +640,37 @@ class TinkerSFTBackend(SFTBackend):
         finally:
             try:
                 tracking_logger.finish()
-            except Exception:
-                pass
+            except Exception:  # noqa: BLE001 - preserve the training exception
+                logger.exception("Tracking backend cleanup failed")
 
     @staticmethod
     async def _validate(training_client, val_dataset, compute_mean_nll) -> dict[str, float]:
+        """Token-weighted held-out NLL over the val set.
+
+        Must stay forward-only: Tinker accumulates gradients server-side across
+        ``forward_backward`` calls until the next ``optim_step``, so a backward
+        pass here folds the val set into the following update — the model would
+        train on its own validation data.
+        """
         logger.info("Running validation...")
         total_nll = 0.0
         total_tokens = 0
         for batch_idx in range(len(val_dataset)):
             data = val_dataset.get_batch(batch_idx)
-            fwd_bwd_future = await training_client.forward_backward_async(data, loss_fn="cross_entropy")
-            fwd_bwd_result = await fwd_bwd_future.result_async()
-            logprobs = [x["logprobs"] for x in fwd_bwd_result.loss_fn_outputs]
+            forward_future = await training_client.forward_async(data, loss_fn="cross_entropy")
+            forward_result = await forward_future.result_async()
             weights = [datum.loss_fn_inputs["weights"] for datum in data]
-            batch_nll = compute_mean_nll(logprobs, weights)
-            batch_tokens = sum(sum(datum.loss_fn_inputs["weights"].data) for datum in data)
-            total_nll += batch_nll * batch_tokens
+            batch_tokens = sum(sum(w.data) for w in weights)
+            # A batch whose rows are all loss-masked (e.g. every row truncated
+            # past its trainable tail) scores nan; skip it rather than let one
+            # such batch poison the whole metric.
+            if not batch_tokens:
+                continue
+            logprobs = [x["logprobs"] for x in forward_result.loss_fn_outputs]
+            total_nll += compute_mean_nll(logprobs, weights) * batch_tokens
             total_tokens += batch_tokens
-        val_nll = total_nll / total_tokens if total_tokens > 0 else 0.0
+        if total_tokens <= 0:
+            raise SFTConfigError("The validation dataset has no trainable tokens after rendering and masking.")
+        val_nll = total_nll / total_tokens
         logger.info(f"Validation NLL: {val_nll:.4f}")
         return {"test/mean_nll": val_nll}

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -7,10 +7,12 @@ Imported lazily by :class:`rllm.trainer.sft.tinker_backend.TinkerSFTBackend`, so
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
 import random
+from collections.abc import Iterable
 from typing import Literal
 
 import datasets
@@ -312,6 +314,68 @@ class TinkerSFTDataset(SupervisedDataset):
             raise SFTConfigError("SFT batch has no trainable tokens after rendering and masking.")
         return datums
 
+    def preflight(
+        self,
+        label: str = "train",
+        planned_batches: Iterable[tuple[int, int]] | None = None,
+    ) -> None:
+        """Render planned batches without retaining rendered data."""
+        original_order = list(self._order)
+        try:
+            for batch_idx in range(len(self)):
+                try:
+                    self.get_batch(batch_idx)
+                except SFTConfigError as e:
+                    raise SFTConfigError(f"{label} preflight failed at batch {batch_idx}: {e}") from e
+            if planned_batches is None:
+                return
+
+            current_epoch = None
+            for epoch_idx, batch_idx in planned_batches:
+                if epoch_idx != current_epoch:
+                    self.set_epoch(seed=epoch_idx)
+                    current_epoch = epoch_idx
+                try:
+                    self.get_batch(batch_idx)
+                except SFTConfigError as e:
+                    raise SFTConfigError(f"{label} preflight failed at epoch {epoch_idx}, batch {batch_idx}: {e}") from e
+        finally:
+            self._order = original_order
+
+    def content_fingerprint(self) -> str:
+        """Hash the ordered training payload and batching boundary."""
+
+        def json_default(value):
+            if hasattr(value, "model_dump"):
+                return value.model_dump(mode="json", exclude_none=True)
+            if hasattr(value, "tolist"):
+                return value.tolist()
+            raise TypeError(f"Unsupported value {type(value).__name__} in SFT dataset fingerprint")
+
+        digest = hashlib.sha256()
+        header = json.dumps(
+            {"batch_size": self.batch_size, "row_count": len(self.dataset)},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        digest.update(len(header).to_bytes(8, "big"))
+        digest.update(header)
+        for index in range(len(self.dataset)):
+            row = self.dataset[index]
+            payload = json.dumps(
+                {
+                    "messages": row["messages"],
+                    "tools": row.get("tools"),
+                },
+                default=json_default,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+            digest.update(len(payload).to_bytes(8, "big"))
+            digest.update(payload)
+        return digest.hexdigest()
+
     def set_epoch(self, seed: int = 0):
         n = len(self.dataset)
         if self.group_by_length and self._lengths is not None:
@@ -340,12 +404,17 @@ class TinkerSFTDataset(SupervisedDataset):
 
     def step_for_data_cursor(self, data_consumed: int) -> int:
         """Inverse of :meth:`data_cursor_for_step` at batch boundaries."""
+        if isinstance(data_consumed, bool) or not isinstance(data_consumed, int) or data_consumed < 0:
+            raise SFTConfigError(f"Checkpoint data cursor must be a non-negative integer, got {data_consumed!r}.")
         rows_per_epoch = len(self.dataset)
         if rows_per_epoch == 0:
             return 0
         completed_epochs, rows_in_epoch = divmod(data_consumed, rows_per_epoch)
         batches_in_epoch = math.ceil(rows_in_epoch / self.batch_size)
-        return completed_epochs * len(self) + batches_in_epoch
+        step = completed_epochs * len(self) + batches_in_epoch
+        if self.data_cursor_for_step(step) != data_consumed:
+            raise SFTConfigError(f"Checkpoint data cursor {data_consumed} is not an exact SFT batch boundary; use a new trainer job or an intact rLLM checkpoint.")
+        return step
 
 
 def create_tinker_sft_datasets(

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -7,7 +7,11 @@ Imported lazily by :class:`rllm.trainer.sft.tinker_backend.TinkerSFTBackend`, so
 
 from __future__ import annotations
 
+import json
 import logging
+import math
+import random
+from typing import Literal
 
 import datasets
 import tinker
@@ -43,6 +47,46 @@ def _row_context(conversation, limit: int = 400) -> str:
     return text if len(text) <= limit else text[:limit] + "..."
 
 
+def _message_byte_length(messages) -> int:
+    """Cheap per-row length proxy: serialized byte length of the messages.
+
+    Mirrors the Fireworks training cookbook's ``group_by_length`` proxy (raw
+    JSONL byte length) — no tokenizer pass, and byte length tracks rendered
+    token count closely for text-only rows (poor for base64 image parts, which
+    this SFT path does not carry).
+    """
+    try:
+        return len(json.dumps(messages, default=str))
+    except (TypeError, ValueError):
+        return len(str(messages))
+
+
+def length_grouped_order(lengths: list[int], batch_size: int, factor: int, seed: int) -> list[int]:
+    """Row ordering that packs similarly-sized rows into the same batch.
+
+    Bucket-then-shuffle (the standard length-grouped sampler, matching the
+    Fireworks cookbook's ``group_by_length``): a fresh seeded permutation is cut
+    into windows of ``batch_size * factor`` rows, each window is sorted by length
+    descending, then flattened. Contiguous ``batch_size`` slices of the result
+    therefore hold near-equal-length rows, so a batch pads to little more than
+    its own rows' real length. The result is always a permutation of
+    ``range(len(lengths))`` — no row is dropped or duplicated — and is fully
+    determined by ``seed``.
+    """
+    n = len(lengths)
+    order = list(range(n))
+    random.Random(seed).shuffle(order)
+    if factor < 1:
+        factor = 1
+    window = max(1, batch_size) * factor
+    grouped: list[int] = []
+    for start in range(0, n, window):
+        chunk = order[start : start + window]
+        chunk.sort(key=lambda idx: lengths[idx], reverse=True)
+        grouped.extend(chunk)
+    return grouped
+
+
 # Process-wide truncation-warning counter: warn loudly on the first few
 # over-length rows, then thin out so a fully over-length dataset doesn't flood
 # the logs (one reminder every 1000 rows).
@@ -71,6 +115,10 @@ def conversation_to_datum(
     renderer: Renderer,
     max_length: int | None,
     last_only: bool = False,
+    *,
+    tools: list[dict] | None = None,
+    overlength_policy: Literal["error", "truncate"] = "error",
+    loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
 ) -> tinker.Datum:
     """Convert a conversation (list of messages) to a Tinker Datum.
 
@@ -90,10 +138,82 @@ def conversation_to_datum(
         tinker_messages = [m.to_tinker_message() for m in messages]
     except SFTSchemaError as e:
         raise SFTConfigError(f"SFT row failed schema normalization: {e}\n  row={_row_context(conversation)}") from e
-    model_input, weights = renderer.build_supervised_example(tinker_messages, train_on_what=TrainOnWhat.CUSTOMIZED)
+    if not getattr(renderer, "strip_thinking_from_history", False):
+        # Qwen-family templates keep reasoning only after the last genuine user
+        # query (tool observations do not reset the boundary). Apply the same
+        # policy as serving before the cookbook renderer sees structured parts.
+        from rllm.renderers.adapters import prepare_tinker_messages_for_history
+
+        tinker_messages = prepare_tinker_messages_for_history(
+            renderer,
+            tinker_messages,
+            lift_reasoning=False,
+        )
+    if tools and hasattr(renderer, "build_supervised_example_with_tools"):
+        model_input, weights = renderer.build_supervised_example_with_tools(
+            tinker_messages,
+            tools,
+            train_on_what=TrainOnWhat.CUSTOMIZED,
+        )
+    else:
+        if tools:
+            from rllm.renderers.adapters import prepare_tinker_messages_with_tools
+
+            try:
+                tinker_messages = prepare_tinker_messages_with_tools(
+                    renderer,
+                    tinker_messages,
+                    tools,
+                )
+            except (TypeError, ValueError) as e:
+                raise SFTConfigError(f"SFT row has invalid tool declarations: {e}") from e
+            for message in tinker_messages:
+                message.setdefault("trainable", False)
+        model_input, weights = renderer.build_supervised_example(
+            tinker_messages,
+            train_on_what=TrainOnWhat.CUSTOMIZED,
+        )
+
+    if overlength_policy not in ("error", "truncate"):
+        raise SFTConfigError(f"Unknown overlength policy {overlength_policy!r}; use 'error' or 'truncate'.")
+    if loss_reduction not in ("none", "sequence_mean", "token_mean"):
+        raise SFTConfigError(f"Unknown SFT loss reduction {loss_reduction!r}; use 'none', 'sequence_mean', or 'token_mean'.")
     if max_length is not None and model_input.length > max_length:
+        if overlength_policy == "error":
+            raise SFTConfigError(
+                f"SFT row renders to {model_input.length} tokens > data.max_length={max_length}. "
+                "The trajectory was not truncated. Drop it whole during preprocessing, raise "
+                "max_length, or explicitly select overlength_policy='truncate' for the lossy "
+                "compatibility behavior."
+            )
         _warn_truncation(model_input.length, max_length)
-    return datum_from_model_input_weights(model_input, weights, max_length)
+    datum_max_length = max_length if overlength_policy == "truncate" else None
+    reduction = "mean" if loss_reduction == "sequence_mean" else "none"
+    return datum_from_model_input_weights(
+        model_input,
+        weights,
+        datum_max_length,
+        reduction=reduction,
+    )
+
+
+def count_loss_tokens(datums: list[tinker.Datum]) -> int:
+    """Count supervised positions independently of loss-weight scaling."""
+    return sum(1 for datum in datums for weight in datum.loss_fn_inputs["weights"].data if weight > 0)
+
+
+def _normalize_token_mean(datums: list[tinker.Datum]) -> None:
+    """Make one batch loss the mean over all of its supervised tokens."""
+    total_weight = sum(float(weight) for datum in datums for weight in datum.loss_fn_inputs["weights"].data)
+    if total_weight <= 0:
+        raise SFTConfigError("SFT batch has no trainable tokens after rendering and masking.")
+    for datum in datums:
+        weights = datum.loss_fn_inputs["weights"]
+        datum.loss_fn_inputs["weights"] = tinker.TensorData(
+            data=[float(weight) / total_weight for weight in weights.data],
+            dtype=weights.dtype,
+            shape=list(weights.shape),
+        )
 
 
 class TinkerSFTDataset(SupervisedDataset):
@@ -112,11 +232,27 @@ class TinkerSFTDataset(SupervisedDataset):
         max_length: int | None = None,
         last_only: bool = False,
         max_samples: int = -1,
+        group_by_length: bool = False,
+        length_group_factor: int = 50,
+        overlength_policy: Literal["error", "truncate"] = "error",
+        loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
     ):
         self.renderer = renderer
+        if batch_size <= 0:
+            raise SFTConfigError(f"SFT batch_size must be positive, got {batch_size}.")
+        if max_length is not None and max_length <= 1:
+            raise SFTConfigError(f"SFT max_length must be greater than 1, got {max_length}.")
+        if overlength_policy not in ("error", "truncate"):
+            raise SFTConfigError(f"Unknown overlength policy {overlength_policy!r}; use 'error' or 'truncate'.")
+        if loss_reduction not in ("none", "sequence_mean", "token_mean"):
+            raise SFTConfigError(f"Unknown SFT loss reduction {loss_reduction!r}; use 'none', 'sequence_mean', or 'token_mean'.")
         self.batch_size = batch_size
         self.max_length = max_length
         self.last_only = last_only
+        self.group_by_length = group_by_length
+        self.length_group_factor = max(1, int(length_group_factor))
+        self.overlength_policy = overlength_policy
+        self.loss_reduction = loss_reduction
 
         if isinstance(dataset_or_files, str | list):
             if isinstance(dataset_or_files, str):
@@ -133,27 +269,83 @@ class TinkerSFTDataset(SupervisedDataset):
             self.dataset = self.dataset.select(range(max_samples))
             logger.info(f"Limited dataset to {max_samples} samples")
 
+        # Explicit per-epoch row ordering (identity until set_epoch); get_batch
+        # reads rows through it, so shuffling never mutates the base dataset and
+        # the length-grouping order can be recomputed each epoch. Row-length
+        # proxies are precomputed once, only when grouping is on.
+        self._order = list(range(len(self.dataset)))
+        self._lengths: list[int] | None = None
+        if self.group_by_length:
+            # Per-row indexing (not column access): the rLLM Dataset object and a
+            # parquet-backed HF dataset both index by int but only HF supports
+            # string columns.
+            self._lengths = [_message_byte_length(self.dataset[i]["messages"]) for i in range(len(self.dataset))]
+            logger.info(f"Length-grouped batching enabled (factor={self.length_group_factor})")
+
         logger.info(f"Loaded {len(self.dataset)} examples from {source}")
         logger.info(f"Masking: CUSTOMIZED (derive last_only={last_only} for flag-less rows)")
 
     def get_batch(self, index: int) -> list[tinker.Datum]:
         start_idx = index * self.batch_size
-        end_idx = min(start_idx + self.batch_size, len(self.dataset))
+        end_idx = min(start_idx + self.batch_size, len(self._order))
         datums = []
-        for i in range(start_idx, end_idx):
+        for pos in range(start_idx, end_idx):
+            i = self._order[pos]
             row = self.dataset[i]
             try:
-                datums.append(conversation_to_datum(row["messages"], self.renderer, self.max_length, self.last_only))
+                datums.append(
+                    conversation_to_datum(
+                        row["messages"],
+                        self.renderer,
+                        self.max_length,
+                        self.last_only,
+                        tools=row.get("tools"),
+                        overlength_policy=self.overlength_policy,
+                        loss_reduction=self.loss_reduction,
+                    )
+                )
             except SFTConfigError as e:
                 raise SFTConfigError(f"dataset row {i}: {e}") from e
+        if self.loss_reduction == "token_mean":
+            _normalize_token_mean(datums)
+        elif datums and count_loss_tokens(datums) == 0:
+            raise SFTConfigError("SFT batch has no trainable tokens after rendering and masking.")
         return datums
 
     def set_epoch(self, seed: int = 0):
-        self.dataset = self.dataset.shuffle(seed=seed)
-        logger.info(f"Shuffled dataset with seed {seed} ({len(self.dataset)} samples)")
+        n = len(self.dataset)
+        if self.group_by_length and self._lengths is not None:
+            self._order = length_grouped_order(self._lengths, self.batch_size, self.length_group_factor, seed)
+            logger.info(f"Length-grouped order for epoch (seed={seed}, {n} samples)")
+        else:
+            order = list(range(n))
+            random.Random(seed).shuffle(order)
+            self._order = order
+            logger.info(f"Shuffled dataset with seed {seed} ({n} samples)")
 
     def __len__(self) -> int:
-        return len(self.dataset) // self.batch_size
+        return math.ceil(len(self.dataset) / self.batch_size)
+
+    def data_cursor_for_step(self, completed_steps: int) -> int:
+        """Raw-row cursor after ``completed_steps`` optimizer batches."""
+        batches_per_epoch = len(self)
+        if batches_per_epoch == 0:
+            return 0
+        completed_epochs, batches_in_epoch = divmod(completed_steps, batches_per_epoch)
+        rows_per_epoch = len(self.dataset)
+        return completed_epochs * rows_per_epoch + min(
+            batches_in_epoch * self.batch_size,
+            rows_per_epoch,
+        )
+
+    def step_for_data_cursor(self, data_consumed: int) -> int:
+        """Inverse of :meth:`data_cursor_for_step` at batch boundaries."""
+        rows_per_epoch = len(self.dataset)
+        if rows_per_epoch == 0:
+            return 0
+        completed_epochs, rows_in_epoch = divmod(data_consumed, rows_per_epoch)
+        batches_in_epoch = math.ceil(rows_in_epoch / self.batch_size)
+        return completed_epochs * len(self) + batches_in_epoch
 
 
 def create_tinker_sft_datasets(
@@ -166,8 +358,18 @@ def create_tinker_sft_datasets(
     last_only: bool = False,
     max_train_samples: int = -1,
     max_val_samples: int = -1,
+    group_by_length: bool = False,
+    length_group_factor: int = 50,
+    overlength_policy: Literal["error", "truncate"] = "error",
+    loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
 ) -> tuple[TinkerSFTDataset, TinkerSFTDataset | None]:
-    """Create train and optional validation datasets for Tinker SFT."""
+    """Create train and optional validation datasets for Tinker SFT.
+
+    ``group_by_length`` applies only to the train dataset: validation iterates
+    every batch and reduces over all tokens, so its batch composition does not
+    affect the metric — only the (single, sequential) pass cost, which the extra
+    length-proxy computation would not repay.
+    """
     if val_batch_size is None:
         val_batch_size = batch_size
 
@@ -178,6 +380,10 @@ def create_tinker_sft_datasets(
         max_length=max_length,
         last_only=last_only,
         max_samples=max_train_samples,
+        group_by_length=group_by_length,
+        length_group_factor=length_group_factor,
+        overlength_policy=overlength_policy,
+        loss_reduction=loss_reduction,
     )
 
     val_dataset = None
@@ -189,6 +395,9 @@ def create_tinker_sft_datasets(
             max_length=max_length,
             last_only=last_only,
             max_samples=max_val_samples,
+            overlength_policy=overlength_policy,
+            # Validation is always reported as a token-weighted NLL.
+            loss_reduction="none",
         )
 
     return train_dataset, val_dataset

--- a/rllm/trainer/sft/verl_backend.py
+++ b/rllm/trainer/sft/verl_backend.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 
 from omegaconf import DictConfig, OmegaConf
 
@@ -37,6 +38,47 @@ _CUSTOM_CLS_NAME = "RLLMSFTDataset"
 # constant/cosine/wsd; "linear" has no direct analogue, so fall back to cosine.
 _LR_SCHEDULE_MAP = {"constant": "constant", "cosine": "cosine", "linear": "cosine"}
 
+_HOSTED_OVERRIDE_HINTS = {
+    "optim.grad_clip_norm": "use optim.clip_grad",
+    "optim.min_lr": "use optim.min_lr_ratio, which is a fraction of optim.lr rather than an absolute learning rate",
+    "optim.warmup_ratio": "use optim.lr_warmup_steps_ratio",
+    "optim.warmup_steps": "use optim.lr_warmup_steps",
+    "optim.warmup_steps_ratio": "use optim.lr_warmup_steps_ratio",
+    "trainer.max_steps": "use trainer.total_training_steps",
+}
+_SUPPORTED_RLLM_DATA_OVERRIDE = "data.rllm.tokenize_and_mask_method"
+
+
+def _iter_override_paths(node, prefix: tuple[str, ...] = ()):
+    if not isinstance(node, Mapping):
+        return
+    for key, value in node.items():
+        path = (*prefix, str(key))
+        if isinstance(value, Mapping):
+            yield from _iter_override_paths(value, path)
+        else:
+            yield ".".join(path)
+
+
+def _hosted_override_hint(path: str) -> str | None:
+    if path in _HOSTED_OVERRIDE_HINTS:
+        return _HOSTED_OVERRIDE_HINTS[path]
+    if path == "data.rllm":
+        return f"use a mapping; {_SUPPORTED_RLLM_DATA_OVERRIDE} is the only supported rLLM-specific verl data key"
+    if not path.startswith("data.rllm.") or path == _SUPPORTED_RLLM_DATA_OVERRIDE:
+        return None
+
+    key = path.removeprefix("data.rllm.")
+    if key in {"group_by_length", "length_group_factor", "group_by_length_factor"}:
+        return "unsupported on verl; its dynamic token batching (data.use_dynamic_bsz) is a different mechanism"
+    if key == "overlength_policy":
+        return "use data.truncation with one of 'error', 'left', or 'right'"
+    if key in {"loss_reduction", "loss_normalization"}:
+        return "unsupported because verl SFT is fixed to a global token mean"
+    if key.startswith("strip_"):
+        return "unsupported because verl has no renderer/history policy; curate the input messages or use a hosted backend"
+    return f"{_SUPPORTED_RLLM_DATA_OVERRIDE} is the only supported rLLM-specific verl data key"
+
 
 class VerlSFTBackend(SFTBackend):
     """Supervised fine-tuning on verl's FSDP trainer (multi-GPU, torchrun)."""
@@ -47,9 +89,18 @@ class VerlSFTBackend(SFTBackend):
     # -- contract -----------------------------------------------------------
 
     def validate_spec(self) -> None:
-        validate_messages_dataset(self.spec.train_dataset, "train")
+        self._reject_hosted_overrides()
+        validate_messages_dataset(
+            self.spec.train_dataset,
+            "train",
+            allow_structural_inline_thinking_text=True,
+        )
         if self.spec.val_dataset is not None:
-            validate_messages_dataset(self.spec.val_dataset, "val")
+            validate_messages_dataset(
+                self.spec.val_dataset,
+                "val",
+                allow_structural_inline_thinking_text=True,
+            )
         if self.spec.lr_schedule not in _LR_SCHEDULE_MAP:
             raise SFTConfigError(f"Unsupported lr_schedule {self.spec.lr_schedule!r} for verl. Use one of {sorted(_LR_SCHEDULE_MAP)}.")
         if self.spec.lr_schedule == "linear":
@@ -57,6 +108,19 @@ class VerlSFTBackend(SFTBackend):
         self._reject_structured_rows(self.spec.train_dataset, "train")
         if self.spec.val_dataset is not None:
             self._reject_structured_rows(self.spec.val_dataset, "val")
+
+    def _reject_hosted_overrides(self) -> None:
+        if not self.spec.overrides:
+            return
+        overrides = OmegaConf.to_container(OmegaConf.create(self.spec.overrides), resolve=False)
+        rejected = {path: hint for path in _iter_override_paths(overrides) if (hint := _hosted_override_hint(path)) is not None}
+        if not rejected:
+            return
+
+        details = "\n".join(f"- {path}: {rejected[path]}" for path in sorted(rejected))
+        raise SFTConfigError(
+            f"verl cannot use hosted-backend SFT override keys:\n{details}\nUse the listed verl-native keys in --config, or choose --backend tinker/fireworks. These spellings are not translated."
+        )
 
     @staticmethod
     def _reject_structured_rows(dataset, label: str) -> None:

--- a/tests/cli/test_dataset_commands.py
+++ b/tests/cli/test_dataset_commands.py
@@ -188,3 +188,89 @@ class TestDatasetRegister:
         result = runner.invoke(cli, ["dataset", "inspect", "rt_ds", "--split", "test", "-n", "1"])
         assert result.exit_code == 0
         assert "Best pizza?" in result.output
+
+
+class TestDatasetImport:
+    """Tests for 'rllm dataset import' — the bridge → register → reload path."""
+
+    # A reasoning-model export: CoT in ``reasoning_content``, ``tool_calls`` as a
+    # JSON string, and the boundary whitespace serving chat templates trim away.
+    SOURCE_ROW = {
+        "messages": [
+            {"role": "system", "content": "sys\n\n"},
+            {"role": "user", "content": "  fix it\n"},
+            {
+                "role": "assistant",
+                "content": "\n\nTHOUGHT: look\n",
+                "reasoning_content": "Let me explore.\n\n",
+                "tool_calls": '[{"id": "c1", "type": "function", "function": {"name": "bash", "arguments": "{\\"cmd\\": \\"ls\\"}"}}]',
+            },
+            {"role": "tool", "content": "a.py\t\n"},
+            {"role": "assistant", "content": "done\n"},
+        ],
+        "task_id": "t1",
+    }
+
+    def _write_source(self, tmp_path):
+        f = tmp_path / "traces.jsonl"
+        f.write_text(json.dumps(self.SOURCE_ROW))
+        return str(f)
+
+    def _reload_raw(self, name):
+        from rllm.data import DatasetRegistry
+
+        return DatasetRegistry.load_dataset(name, "train").get_data()
+
+    def _reload(self, name):
+        from rllm.data.sft_schema import normalize_row
+
+        return [normalize_row(r) for r in self._reload_raw(name)]
+
+    def test_import_normalizes_source_shape_through_parquet(self, runner, tmp_rllm_home, tmp_path):
+        """Reasoning, tool calls and the trim all survive register → reload:
+        the normalization is baked into the stored rows, not re-derived later."""
+        result = runner.invoke(
+            cli,
+            [
+                "dataset",
+                "import",
+                self._write_source(tmp_path),
+                "--name",
+                "imported-sft",
+                "--trim-whitespace",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        # Asserted on the STORED record first: nothing downstream re-trims, so a
+        # normalize_row-only check could not tell a trimmed dataset from an
+        # untrimmed one.
+        stored = self._reload_raw("imported-sft")[0]
+        for m in stored["messages"]:
+            for part in m["content"]:
+                payload = part.get("thinking") or part.get("text") or ""
+                assert payload == payload.strip(), f"{m['role']}: {payload!r}"
+
+        row = self._reload("imported-sft")[0]
+        asst = row.messages[2]
+        assert asst.thinking() == "Let me explore."
+        assert asst.text() == "THOUGHT: look"
+        assert asst.tool_calls[0].function.name == "bash"
+        assert asst.tool_calls[0].function.arguments == '{"cmd": "ls"}'
+        for m in row.messages:
+            for part in m.content:
+                payload = part.thinking if part.type == "thinking" else part.text
+                assert payload == payload.strip(), f"{m.role}: {payload!r}"
+        assert [m.trainable for m in row.messages] == [False, False, True, False, True]
+        assert row.to_record()["task_id"] == "t1"
+
+    def test_import_preserves_whitespace_by_default(self, runner, tmp_rllm_home, tmp_path):
+        result = runner.invoke(
+            cli,
+            ["dataset", "import", self._write_source(tmp_path), "--name", "untrimmed-sft"],
+        )
+        assert result.exit_code == 0, result.output
+
+        asst = self._reload("untrimmed-sft")[0].messages[2]
+        assert asst.thinking() == "Let me explore.\n\n"
+        assert asst.text() == "\n\nTHOUGHT: look\n"

--- a/tests/cli/test_dataset_commands.py
+++ b/tests/cli/test_dataset_commands.py
@@ -194,7 +194,7 @@ class TestDatasetImport:
     """Tests for 'rllm dataset import' — the bridge → register → reload path."""
 
     # A reasoning-model export: CoT in ``reasoning_content``, ``tool_calls`` as a
-    # JSON string, and the boundary whitespace serving chat templates trim away.
+    # JSON string, and source-significant boundary whitespace.
     SOURCE_ROW = {
         "messages": [
             {"role": "system", "content": "sys\n\n"},
@@ -227,8 +227,8 @@ class TestDatasetImport:
         return [normalize_row(r) for r in self._reload_raw(name)]
 
     def test_import_normalizes_source_shape_through_parquet(self, runner, tmp_rllm_home, tmp_path):
-        """Reasoning, tool calls and the trim all survive register → reload:
-        the normalization is baked into the stored rows, not re-derived later."""
+        """Reasoning, tool calls, masks, and whitespace survive registration,
+        parquet reload, and schema re-validation."""
         result = runner.invoke(
             cli,
             [
@@ -237,40 +237,66 @@ class TestDatasetImport:
                 self._write_source(tmp_path),
                 "--name",
                 "imported-sft",
-                "--trim-whitespace",
             ],
         )
         assert result.exit_code == 0, result.output
 
-        # Asserted on the STORED record first: nothing downstream re-trims, so a
-        # normalize_row-only check could not tell a trimmed dataset from an
-        # untrimmed one.
         stored = self._reload_raw("imported-sft")[0]
-        for m in stored["messages"]:
-            for part in m["content"]:
-                payload = part.get("thinking") or part.get("text") or ""
-                assert payload == payload.strip(), f"{m['role']}: {payload!r}"
+        assert stored["messages"][0]["content"][0]["text"] == "sys\n\n"
+        assert stored["messages"][1]["content"][0]["text"] == "  fix it\n"
+        assert stored["messages"][2]["content"][0]["thinking"] == "Let me explore.\n\n"
+        assert stored["messages"][2]["content"][1]["text"] == "\n\nTHOUGHT: look\n"
 
         row = self._reload("imported-sft")[0]
         asst = row.messages[2]
-        assert asst.thinking() == "Let me explore."
-        assert asst.text() == "THOUGHT: look"
+        assert asst.thinking() == "Let me explore.\n\n"
+        assert asst.text() == "\n\nTHOUGHT: look\n"
         assert asst.tool_calls[0].function.name == "bash"
         assert asst.tool_calls[0].function.arguments == '{"cmd": "ls"}'
-        for m in row.messages:
-            for part in m.content:
-                payload = part.thinking if part.type == "thinking" else part.text
-                assert payload == payload.strip(), f"{m.role}: {payload!r}"
         assert [m.trainable for m in row.messages] == [False, False, True, False, True]
         assert row.to_record()["task_id"] == "t1"
 
-    def test_import_preserves_whitespace_by_default(self, runner, tmp_rllm_home, tmp_path):
+    def test_import_rejects_removed_trim_whitespace_option(self, runner, tmp_rllm_home, tmp_path):
         result = runner.invoke(
             cli,
-            ["dataset", "import", self._write_source(tmp_path), "--name", "untrimmed-sft"],
+            [
+                "dataset",
+                "import",
+                self._write_source(tmp_path),
+                "--name",
+                "must-not-trim",
+                "--trim-whitespace",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "No such option" in result.output
+        assert "--trim-whitespace" in result.output
+
+    def test_think_tags_no_explode_preserves_complete_masks(self, runner, tmp_rllm_home, tmp_path):
+        source = {
+            "messages": [
+                {"role": "user", "content": "q", "trainable": False},
+                {"role": "assistant", "content": "<think>skip</think>bad", "trainable": False},
+                {"role": "user", "content": "retry", "trainable": False},
+                {"role": "assistant", "content": "<think>use</think>good", "trainable": True},
+            ]
+        }
+        path = tmp_path / "masked.jsonl"
+        path.write_text(json.dumps(source))
+
+        result = runner.invoke(
+            cli,
+            [
+                "dataset",
+                "import",
+                str(path),
+                "--name",
+                "masked-sft",
+                "--format",
+                "think-tags",
+                "--no-explode",
+            ],
         )
         assert result.exit_code == 0, result.output
-
-        asst = self._reload("untrimmed-sft")[0].messages[2]
-        assert asst.thinking() == "Let me explore.\n\n"
-        assert asst.text() == "\n\nTHOUGHT: look\n"
+        row = self._reload("masked-sft")[0]
+        assert [m.trainable for m in row.messages] == [False, False, False, True]

--- a/tests/data/test_arrow_ipc.py
+++ b/tests/data/test_arrow_ipc.py
@@ -253,3 +253,37 @@ class TestDatasetLoadDataArrow:
         ds = Dataset.load_data(path)
         assert len(ds) == 1
         assert ds[0]["img"] == b"\x89PNG_data"
+
+
+class TestDatasetLoadDataParquet:
+    def test_nested_columns_are_python_lists(self, tmp_path):
+        """Direct SFT files must not leak pandas/NumPy container types."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        rows = [
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi"},
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            }
+        ]
+        path = tmp_path / "nested.parquet"
+        pq.write_table(pa.Table.from_pylist(rows), path)
+
+        row = Dataset.load_data(str(path))[0]
+
+        assert isinstance(row["messages"], list)
+        assert isinstance(row["messages"][0], dict)
+        assert isinstance(row["tools"], list)
+        assert isinstance(row["tools"][0], dict)

--- a/tests/data/test_sft_bridges.py
+++ b/tests/data/test_sft_bridges.py
@@ -1,16 +1,17 @@
 """Contract tests for the SFT ingestion bridges (``rllm.data.sft_bridges``).
 
 Bridges turn raw dataset rows (plain OpenAI ``messages`` or ``<think>``-tagged
-assistant turns) into schema ``SFTRow`` objects. Fixtures are built inline. RED
-today: the module does not exist yet, so the import below fails at collection.
+assistant turns) into schema ``SFTRow`` objects. Fixtures are built inline.
 """
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from rllm.data.sft_bridges import BRIDGES, bridge_messages, bridge_think_tags, get_bridge
-from rllm.data.sft_schema import SFTRow, TextPart, ThinkingPart
+from rllm.data.sft_schema import SFTRow, SFTSchemaError, TextPart, ThinkingPart
 
 # Two think-tagged rows: one multi-turn think-tagged conversation, plus a row whose
 # assistant turn carries NO think tag.
@@ -37,6 +38,21 @@ ROW_NO_THINK = {
     "_group": "g2",
     "_model": "opus",
     "_reward": 0,
+}
+
+# A pre-masked conversation: every message carries an explicit bool ``trainable``
+# and the MIDDLE assistant turn is masked out (a parse-error/recovery step that
+# must not be imitated). The two other assistant turns are trainable targets.
+ROW_FLAGGED = {
+    "messages": [
+        {"role": "user", "content": "u1", "trainable": False},
+        {"role": "assistant", "content": '<think>\nplan A\n</think>\n\n{"cmd": "ls"}', "trainable": True},
+        {"role": "user", "content": "Previous response had parsing errors", "trainable": False},
+        {"role": "assistant", "content": "<think>\noops\n</think>\n\nbadjson", "trainable": False},
+        {"role": "user", "content": "out2", "trainable": False},
+        {"role": "assistant", "content": "<think>\nplan C\n</think>\n\ndone", "trainable": True},
+    ],
+    "_task": "tf",
 }
 
 
@@ -98,6 +114,30 @@ def test_explode_history_stripped_single_trainable_target():
     assert hist_asst[0].text() == '{"cmd": "ls"}'
 
 
+def test_explode_honours_preexisting_trainable_flags():
+    # A fully-flagged conversation explodes only its trainable assistant turns:
+    # the masked middle step is never a target, but survives in later history
+    # (thinking stripped, non-trainable) as a recovery example.
+    rows = bridge_think_tags([ROW_FLAGGED])
+    assert len(rows) == 2  # two trainable targets, NOT three assistant turns
+    targets = [next(m for m in r.messages if m.trainable) for r in rows]
+    assert [t.thinking() for t in targets] == ["plan A", "plan C"]
+    for r in rows:
+        assert sum(1 for m in r.messages if m.trainable) == 1
+
+    # The masked assistant turn ("badjson") appears in the final row's history:
+    # non-trainable and with its ThinkingPart removed — never emitted as a target.
+    # (All prior assistant turns are non-trainable history here; the first
+    # target's turn likewise appears CoT-stripped.)
+    last = rows[-1]
+    assert not any(m.trainable and m.text() == "badjson" for m in last.messages)
+    badjson = [m for m in last.messages if m.role == "assistant" and m.text() == "badjson"]
+    assert len(badjson) == 1
+    assert badjson[0].trainable is False
+    assert badjson[0].thinking() == ""
+    assert all(not isinstance(p, ThinkingPart) for m in last.messages[:-1] for p in m.content)
+
+
 # --- no-explode: one row per conversation ------------------------------------
 
 
@@ -157,6 +197,220 @@ def test_bridge_messages_train_on_all():
 def test_bridge_messages_train_on_last():
     row = bridge_messages(PLAIN, train_on="last")[0]
     assert [m.trainable for m in row.messages] == [False, False, False, True]
+
+
+# --- source-shape normalization ----------------------------------------------
+
+# The reasoning-model wire shape real exports produce: CoT in a sibling
+# ``reasoning_content`` field, ``tool_calls`` serialized as a JSON string, and
+# tool ``arguments`` stored already-parsed on the second call.
+REASONING_ROW = {
+    "messages": [
+        {"role": "user", "content": "fix it"},
+        {
+            "role": "assistant",
+            "content": "THOUGHT: look around",
+            "reasoning_content": "Let me explore.",
+            "tool_calls": json.dumps([{"id": "c1", "type": "function", "function": {"name": "bash", "arguments": '{"cmd": "ls"}'}}]),
+        },
+        {"role": "tool", "content": "a.py"},
+        {"role": "assistant", "content": "", "reasoning_content": "done", "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "submit", "arguments": {"ok": True}}}]},
+    ],
+    "task_id": "t1",
+}
+
+
+@pytest.mark.parametrize("key", ["reasoning_content", "reasoning"])
+def test_reasoning_sibling_field_becomes_thinking_part(key):
+    """A sibling reasoning field is lifted ahead of the visible text instead of
+    being dropped as an unknown message key."""
+    msg = {"role": "assistant", "content": "answer", key: "the chain of thought"}
+    row = bridge_messages([{"messages": [{"role": "user", "content": "q"}, msg]}])[0]
+    asst = row.messages[-1]
+    assert [type(p) for p in asst.content] == [ThinkingPart, TextPart]
+    assert asst.thinking() == "the chain of thought"
+    assert asst.text() == "answer"
+
+
+def test_reasoning_only_turn_has_no_empty_text_part():
+    """A pure tool-call turn (empty content) carrying reasoning renders as
+    thinking alone — no empty text part is invented."""
+    row = bridge_messages([REASONING_ROW])[0]
+    last = row.messages[-1]
+    assert [type(p) for p in last.content] == [ThinkingPart]
+    assert last.thinking() == "done"
+
+
+@pytest.mark.parametrize(
+    ("msg_idx", "call_id", "name", "arguments"),
+    [
+        # The stringified list a parquet/HF writer produces, and a call whose
+        # arguments were stored already-parsed.
+        (1, "c1", "bash", '{"cmd": "ls"}'),
+        (-1, "c2", "submit", '{"ok": true}'),
+    ],
+)
+def test_tool_calls_decoded_to_canonical_wire_shape(msg_idx, call_id, name, arguments):
+    calls = bridge_messages([REASONING_ROW])[0].messages[msg_idx].tool_calls
+    assert calls is not None and len(calls) == 1
+    assert (calls[0].id, calls[0].function.name) == (call_id, name)
+    assert calls[0].function.arguments == arguments
+    assert isinstance(json.loads(calls[0].function.arguments), dict)
+
+
+def test_unparseable_tool_calls_string_raises_naming_the_row():
+    with pytest.raises(SFTSchemaError) as exc:
+        bridge_messages([{"messages": [{"role": "assistant", "content": "x", "tool_calls": "not json"}]}])
+    assert "row 0" in str(exc.value)
+    assert "tool_calls is a string but not valid JSON" in str(exc.value)
+
+
+def test_reasoning_on_prompt_turn_raises_instead_of_being_dropped():
+    messages = [{"role": "user", "content": "q", "reasoning_content": "not mine"}, {"role": "assistant", "content": "a"}]
+    with pytest.raises(SFTSchemaError, match="only on assistant"):
+        bridge_messages([{"messages": messages}])
+
+
+def test_conflicting_reasoning_aliases_raise_instead_of_dropping_one():
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "a",
+            "reasoning_content": "first",
+            "reasoning": "second",
+        },
+    ]
+    with pytest.raises(SFTSchemaError, match="conflicting reasoning aliases"):
+        bridge_messages([{"messages": messages}])
+
+
+def test_non_string_reasoning_raises_rather_than_being_dropped():
+    """Reasoning the bridge cannot lift is a hard error, never a silent drop."""
+    messages = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a", "reasoning_content": [{"type": "thinking", "thinking": "cot"}]}]
+    with pytest.raises(SFTSchemaError) as exc:
+        bridge_messages([{"messages": messages}])
+    assert "reasoning_content must be a string" in str(exc.value)
+
+
+@pytest.mark.parametrize("content", [7, {"text": "visible answer"}])
+def test_reasoning_does_not_hide_unsupported_visible_content(content):
+    """Lifting reasoning must not turn an invalid visible answer into a
+    reasoning-only row by silently discarding it."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": content, "reasoning_content": "cot"},
+    ]
+    with pytest.raises(SFTSchemaError) as exc:
+        bridge_messages([{"messages": messages}])
+    assert "row 0" in str(exc.value)
+    assert "assistant content must be a string, list, or null" in str(exc.value)
+
+
+def test_inline_think_tag_survives_a_sibling_reasoning_field():
+    """Lifting a sibling reasoning field must not hide an inline ``<think>``
+    block from the think-tags extractor."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "<think>\ninline\n</think>\n\nvisible", "reasoning_content": "sibling"},
+    ]
+    asst = bridge_think_tags([{"messages": messages}], explode=False)[0].messages[-1]
+    assert [p.thinking for p in asst.content if isinstance(p, ThinkingPart)] == ["sibling", "inline"]
+    assert asst.text() == "visible"
+
+
+# --- whitespace trim ---------------------------------------------------------
+
+# Padding in exactly the places a serving chat template ``|trim``s away: a
+# thinking block ending in newlines, the visible text opening with them, and
+# observation/instruction turns padded by the harness.
+PADDED_MESSAGES = [
+    {"role": "system", "content": "sys prompt\n\n"},
+    {"role": "user", "content": "  fix the bug\n"},
+    {"role": "assistant", "content": "\n\nTHOUGHT: look around\n", "reasoning_content": "Let me explore.\n\n"},
+    {"role": "tool", "content": "a.py\tb.py\t\n"},
+    {"role": "assistant", "content": "\n\ndone\n\n", "reasoning_content": "finished\n"},
+]
+CLEAN_MESSAGES = [
+    {"role": "system", "content": "sys prompt"},
+    {"role": "user", "content": "fix the bug"},
+    {"role": "assistant", "content": "THOUGHT: look around", "reasoning_content": "Let me explore."},
+    {"role": "tool", "content": "a.py\tb.py"},
+    {"role": "assistant", "content": "done", "reasoning_content": "finished"},
+]
+
+
+def _bridge(name, messages, **kwargs):
+    return get_bridge(name)([{"messages": messages}], **kwargs)
+
+
+@pytest.mark.parametrize(("fmt", "opts"), [("messages", {}), ("think-tags", {"explode": False})])
+def test_trim_removes_template_trimmed_boundary_whitespace(fmt, opts):
+    """Every content stream loses its boundary whitespace, on every role — that
+    padding is deleted by the serving template, so training on it is a pure
+    train/serve mismatch."""
+    row = _bridge(fmt, PADDED_MESSAGES, trim_whitespace=True, **opts)[0]
+    for m in row.messages:
+        for part in m.content:
+            payload = part.thinking if isinstance(part, ThinkingPart) else part.text
+            assert payload == payload.strip(), f"{m.role}: {payload!r}"
+    assert row.messages[2].thinking() == "Let me explore."
+    assert row.messages[2].text() == "THOUGHT: look around"
+    assert row.messages[3].text() == "a.py\tb.py"
+
+
+@pytest.mark.parametrize(("fmt", "opts"), [("messages", {}), ("think-tags", {"explode": False})])
+def test_trim_is_a_noop_on_already_clean_rows(fmt, opts):
+    """Negative control: a row with no boundary whitespace survives byte-identical,
+    and padded input converges on exactly that record."""
+    clean = _bridge(fmt, CLEAN_MESSAGES, trim_whitespace=True, **opts)[0].to_record()
+    assert _bridge(fmt, PADDED_MESSAGES, trim_whitespace=True, **opts)[0].to_record() == clean
+    assert _bridge(fmt, CLEAN_MESSAGES, **opts)[0].to_record() == clean
+
+
+@pytest.mark.parametrize(("fmt", "opts"), [("messages", {}), ("think-tags", {"explode": False})])
+def test_default_keeps_padding_verbatim(fmt, opts):
+    row = _bridge(fmt, PADDED_MESSAGES, **opts)[0]
+    assert row.messages[2].thinking() == "Let me explore.\n\n"
+    assert row.messages[2].text() == "\n\nTHOUGHT: look around\n"
+
+
+def test_trim_keeps_whitespace_between_parts_of_one_stream():
+    """Trimming is per stream, not per part: the blank line separating two text
+    parts is rendered by the template and must survive."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": [{"type": "text", "text": "\n first\n\n"}, {"type": "text", "text": "second \n"}]},
+    ]
+    asst = bridge_messages([{"messages": messages}], trim_whitespace=True)[0].messages[-1]
+    assert [p.text for p in asst.content] == ["first\n\n", "second"]
+
+
+def test_trim_leaves_an_already_empty_part_alone():
+    """Only parts the trim emptied are dropped: a turn whose content was already
+    empty keeps the shape every pre-trim consumer already sees."""
+    messages = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "", "tool_calls": [{"id": "c", "type": "function", "function": {"name": "bash", "arguments": "{}"}}]}]
+    asst = bridge_messages([{"messages": messages}], trim_whitespace=True)[0].messages[-1]
+    assert [p.text for p in asst.content] == [""]
+
+
+def test_trim_drops_whitespace_only_content_leaving_an_empty_parts_list():
+    """A whitespace-only turn trims to no parts at all — the same nothing the
+    serving template renders for it."""
+    messages = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "\n\n \n", "tool_calls": [{"id": "c", "type": "function", "function": {"name": "bash", "arguments": "{}"}}]}]
+    asst = bridge_messages([{"messages": messages}], trim_whitespace=True)[0].messages[-1]
+    assert asst.content == []
+    assert asst.tool_calls[0].function.name == "bash"
+
+
+def test_explode_history_trimmed_too():
+    """The trim reaches exploded history turns, not just the target."""
+    rows = bridge_think_tags([{"messages": PADDED_MESSAGES}], trim_whitespace=True)
+    assert len(rows) == 2
+    for m in rows[-1].messages:
+        for part in m.content:
+            payload = part.thinking if isinstance(part, ThinkingPart) else part.text
+            assert payload == payload.strip()
 
 
 # --- registry / get_bridge ---------------------------------------------------

--- a/tests/data/test_sft_bridges.py
+++ b/tests/data/test_sft_bridges.py
@@ -153,6 +153,27 @@ def test_no_explode_single_row_all_assistant_trainable():
             assert m.trainable is False
 
 
+def test_no_explode_honours_preexisting_trainable_flags():
+    row = bridge_think_tags([ROW_FLAGGED], explode=False)[0]
+    assert [m.trainable for m in row.messages] == [False, True, False, False, False, True]
+
+
+def test_no_explode_partial_flags_trigger_full_mask_derivation():
+    row = bridge_think_tags(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": "<think>plan</think>answer", "trainable": False},
+                    {"role": "user", "content": "follow-up"},
+                ]
+            }
+        ],
+        explode=False,
+    )[0]
+    assert [m.trainable for m in row.messages] == [False, True, False]
+
+
 # --- row-level extras passthrough --------------------------------------------
 
 
@@ -271,6 +292,16 @@ def test_reasoning_on_prompt_turn_raises_instead_of_being_dropped():
         bridge_messages([{"messages": messages}])
 
 
+@pytest.mark.parametrize("key", ["reasoning_content", "reasoning"])
+@pytest.mark.parametrize("role", ["user", "assistant"])
+def test_empty_reasoning_field_is_absent_on_any_role(key, role):
+    row = bridge_messages([{"messages": [{"role": role, "content": "payload", key: ""}]}])[0]
+    message = row.messages[0]
+    assert message.text() == "payload"
+    assert message.thinking() == ""
+    assert key not in row.to_record()["messages"][0]
+
+
 def test_conflicting_reasoning_aliases_raise_instead_of_dropping_one():
     messages = [
         {"role": "user", "content": "q"},
@@ -307,36 +338,61 @@ def test_reasoning_does_not_hide_unsupported_visible_content(content):
     assert "assistant content must be a string, list, or null" in str(exc.value)
 
 
-def test_inline_think_tag_survives_a_sibling_reasoning_field():
-    """Lifting a sibling reasoning field must not hide an inline ``<think>``
-    block from the think-tags extractor."""
+@pytest.mark.parametrize(
+    ("bridge", "kwargs"),
+    [(bridge_messages, {}), (bridge_think_tags, {"explode": False})],
+)
+def test_sibling_reasoning_conflicts_with_structural_inline_thinking(bridge, kwargs):
     messages = [
         {"role": "user", "content": "q"},
         {"role": "assistant", "content": "<think>\ninline\n</think>\n\nvisible", "reasoning_content": "sibling"},
     ]
+    with pytest.raises(SFTSchemaError, match="sibling reasoning.*structural inline"):
+        bridge([{"messages": messages}], **kwargs)
+
+
+# --- structural inline thinking ---------------------------------------------
+
+
+def test_plain_messages_rejects_structural_inline_thinking():
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "<think>inline</think>visible"},
+    ]
+    with pytest.raises(SFTSchemaError, match="think-tags.*thinking parts"):
+        bridge_messages([{"messages": messages}])
+
+
+def test_think_tags_remains_the_inline_thinking_parser():
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "<think>inline</think>visible"},
+    ]
     asst = bridge_think_tags([{"messages": messages}], explode=False)[0].messages[-1]
-    assert [p.thinking for p in asst.content if isinstance(p, ThinkingPart)] == ["sibling", "inline"]
+    assert asst.thinking() == "inline"
     assert asst.text() == "visible"
 
 
-# --- whitespace trim ---------------------------------------------------------
+def test_literal_think_tags_outside_structural_assistant_prefix_are_text():
+    messages = [
+        {"role": "user", "content": "<think>literal prompt text</think>"},
+        {"role": "assistant", "content": "The literal is <think>not wire syntax</think>."},
+    ]
+    row = bridge_messages([{"messages": messages}])[0]
+    assert [m.text() for m in row.messages] == [
+        "<think>literal prompt text</think>",
+        "The literal is <think>not wire syntax</think>.",
+    ]
 
-# Padding in exactly the places a serving chat template ``|trim``s away: a
-# thinking block ending in newlines, the visible text opening with them, and
-# observation/instruction turns padded by the harness.
+
+# --- source whitespace preservation -----------------------------------------
+
 PADDED_MESSAGES = [
     {"role": "system", "content": "sys prompt\n\n"},
     {"role": "user", "content": "  fix the bug\n"},
     {"role": "assistant", "content": "\n\nTHOUGHT: look around\n", "reasoning_content": "Let me explore.\n\n"},
     {"role": "tool", "content": "a.py\tb.py\t\n"},
     {"role": "assistant", "content": "\n\ndone\n\n", "reasoning_content": "finished\n"},
-]
-CLEAN_MESSAGES = [
-    {"role": "system", "content": "sys prompt"},
-    {"role": "user", "content": "fix the bug"},
-    {"role": "assistant", "content": "THOUGHT: look around", "reasoning_content": "Let me explore."},
-    {"role": "tool", "content": "a.py\tb.py"},
-    {"role": "assistant", "content": "done", "reasoning_content": "finished"},
 ]
 
 
@@ -345,72 +401,15 @@ def _bridge(name, messages, **kwargs):
 
 
 @pytest.mark.parametrize(("fmt", "opts"), [("messages", {}), ("think-tags", {"explode": False})])
-def test_trim_removes_template_trimmed_boundary_whitespace(fmt, opts):
-    """Every content stream loses its boundary whitespace, on every role — that
-    padding is deleted by the serving template, so training on it is a pure
-    train/serve mismatch."""
-    row = _bridge(fmt, PADDED_MESSAGES, trim_whitespace=True, **opts)[0]
-    for m in row.messages:
-        for part in m.content:
-            payload = part.thinking if isinstance(part, ThinkingPart) else part.text
-            assert payload == payload.strip(), f"{m.role}: {payload!r}"
-    assert row.messages[2].thinking() == "Let me explore."
-    assert row.messages[2].text() == "THOUGHT: look around"
-    assert row.messages[3].text() == "a.py\tb.py"
-
-
-@pytest.mark.parametrize(("fmt", "opts"), [("messages", {}), ("think-tags", {"explode": False})])
-def test_trim_is_a_noop_on_already_clean_rows(fmt, opts):
-    """Negative control: a row with no boundary whitespace survives byte-identical,
-    and padded input converges on exactly that record."""
-    clean = _bridge(fmt, CLEAN_MESSAGES, trim_whitespace=True, **opts)[0].to_record()
-    assert _bridge(fmt, PADDED_MESSAGES, trim_whitespace=True, **opts)[0].to_record() == clean
-    assert _bridge(fmt, CLEAN_MESSAGES, **opts)[0].to_record() == clean
-
-
-@pytest.mark.parametrize(("fmt", "opts"), [("messages", {}), ("think-tags", {"explode": False})])
-def test_default_keeps_padding_verbatim(fmt, opts):
+def test_bridges_preserve_source_whitespace_verbatim(fmt, opts):
     row = _bridge(fmt, PADDED_MESSAGES, **opts)[0]
+    assert row.messages[0].text() == "sys prompt\n\n"
+    assert row.messages[1].text() == "  fix the bug\n"
     assert row.messages[2].thinking() == "Let me explore.\n\n"
     assert row.messages[2].text() == "\n\nTHOUGHT: look around\n"
-
-
-def test_trim_keeps_whitespace_between_parts_of_one_stream():
-    """Trimming is per stream, not per part: the blank line separating two text
-    parts is rendered by the template and must survive."""
-    messages = [
-        {"role": "user", "content": "q"},
-        {"role": "assistant", "content": [{"type": "text", "text": "\n first\n\n"}, {"type": "text", "text": "second \n"}]},
-    ]
-    asst = bridge_messages([{"messages": messages}], trim_whitespace=True)[0].messages[-1]
-    assert [p.text for p in asst.content] == ["first\n\n", "second"]
-
-
-def test_trim_leaves_an_already_empty_part_alone():
-    """Only parts the trim emptied are dropped: a turn whose content was already
-    empty keeps the shape every pre-trim consumer already sees."""
-    messages = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "", "tool_calls": [{"id": "c", "type": "function", "function": {"name": "bash", "arguments": "{}"}}]}]
-    asst = bridge_messages([{"messages": messages}], trim_whitespace=True)[0].messages[-1]
-    assert [p.text for p in asst.content] == [""]
-
-
-def test_trim_drops_whitespace_only_content_leaving_an_empty_parts_list():
-    """A whitespace-only turn trims to no parts at all — the same nothing the
-    serving template renders for it."""
-    messages = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "\n\n \n", "tool_calls": [{"id": "c", "type": "function", "function": {"name": "bash", "arguments": "{}"}}]}]
-    asst = bridge_messages([{"messages": messages}], trim_whitespace=True)[0].messages[-1]
-    assert asst.content == []
-    assert asst.tool_calls[0].function.name == "bash"
-
-
-def test_explode_history_trimmed_too():
-    """The trim reaches exploded history turns, not just the target."""
-    rows = bridge_think_tags([{"messages": PADDED_MESSAGES}], trim_whitespace=True)
-    assert len(rows) == 2
-    for m in rows[-1].messages:
-        for part in m.content:
-            payload = part.thinking if isinstance(part, ThinkingPart) else part.text
-            assert payload == payload.strip()
+    assert row.messages[3].text() == "a.py\tb.py\t\n"
+    assert row.messages[4].thinking() == "finished\n"
+    assert row.messages[4].text() == "\n\ndone\n\n"
 
 
 # --- registry / get_bridge ---------------------------------------------------

--- a/tests/data/test_sft_schema.py
+++ b/tests/data/test_sft_schema.py
@@ -2,8 +2,7 @@
 
 Pure-pydantic — no tinker/verl. Covers message cleanup (str/None content
 coercion, arrow-None artifact stripping), trainable-flag derivation policies,
-validation errors, and the ``SFTRow`` record round-trip. RED today: the module
-does not exist yet, so the import below fails at collection.
+validation errors, and the ``SFTRow`` record round-trip.
 """
 
 from __future__ import annotations
@@ -118,6 +117,27 @@ def test_normalize_messages_content_is_parts_list():
     assert all(isinstance(m, SFTMessage) for m in msgs)
     assert all(isinstance(p, TextPart) for p in msgs[0].content)
     assert msgs[2].text() == "a1"
+
+
+def test_normalize_messages_rejects_unbridged_reasoning_field():
+    """A direct ``--train-file`` must not silently discard provider-style CoT.
+
+    Source-format bridges lift ``reasoning_content`` into a canonical thinking
+    part. Reaching the core schema with the sibling field still present means
+    that ingestion was skipped; failing is safer than training on visible text
+    while quietly deleting every reasoning trace.
+    """
+    with pytest.raises(SFTSchemaError, match="reasoning_content.*dataset import"):
+        normalize_messages(
+            [
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "content": "a",
+                    "reasoning_content": "important hidden reasoning",
+                },
+            ]
+        )
 
 
 # --- validation errors (raised as SFTSchemaError by normalize_*) -------------

--- a/tests/data/test_sft_schema.py
+++ b/tests/data/test_sft_schema.py
@@ -140,6 +140,46 @@ def test_normalize_messages_rejects_unbridged_reasoning_field():
         )
 
 
+@pytest.mark.parametrize("key", ["reasoning_content", "reasoning"])
+@pytest.mark.parametrize("role", ["user", "assistant"])
+def test_normalize_messages_treats_empty_reasoning_as_absent(key, role):
+    message = normalize_messages([{"role": role, "content": "payload", key: ""}])[0]
+    assert message.text() == "payload"
+    assert message.thinking() == ""
+
+
+def test_normalize_row_rejects_structural_thinking_in_canonical_text_part():
+    with pytest.raises(SFTSchemaError, match="think-tags.*thinking parts"):
+        normalize_row(
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "<think>inline</think>visible"}],
+                    },
+                ]
+            }
+        )
+
+
+def test_structural_thinking_check_uses_concatenated_text_stream():
+    with pytest.raises(SFTSchemaError, match="think-tags.*thinking parts"):
+        normalize_row(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "<think>split"},
+                            {"type": "text", "text": " block</think>visible"},
+                        ],
+                    }
+                ]
+            }
+        )
+
+
 # --- validation errors (raised as SFTSchemaError by normalize_*) -------------
 
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -126,10 +126,88 @@ def test_tinker_adapter_renders(qwen_tokenizer):
     assert a.get_stop_token_ids()  # non-empty
 
 
+@pytest.mark.parametrize(
+    "reasoning_field",
+    [
+        {"reasoning_content": "PRIOR-REASONING"},
+        {"reasoning": "PRIOR-REASONING"},
+        {"provider_specific_fields": {"refusal": None, "reasoning": "PRIOR-REASONING"}},
+    ],
+    ids=["reasoning_content", "reasoning", "provider_specific_fields"],
+)
+def test_tinker_adapter_renders_harness_wire_shape(qwen_tokenizer, reasoning_field):
+    """A reasoning harness re-sends prior turns as OpenAI dicts: reasoning in a
+    sibling field, tool calls as plain dicts, content sometimes absent. Cookbook
+    renderers read none of that, so the adapter has to translate — otherwise the
+    tool call raises and every prior turn's reasoning is missing from the prompt."""
+    adapter = _tinker_qwen3(qwen_tokenizer)
+    messages = [
+        {"role": "user", "content": "Fix the bug."},
+        {
+            "role": "assistant",
+            "content": "Exploring.",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}],
+            **reasoning_field,
+        },
+        {"role": "tool", "content": "setup.py", "tool_call_id": "c1"},
+        # A content-less assistant turn is the dominant shape in real episodes.
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "bash", "arguments": '{"command": "cat a.py"}'}}],
+            "reasoning_content": "SECOND-REASONING",
+        },
+        {"role": "tool", "content": "def f(): pass", "tool_call_id": "c2"},
+    ]
+
+    text = qwen_tokenizer.decode(adapter.render_ids(messages, add_generation_prompt=True))
+    assert "PRIOR-REASONING" in text
+    assert "SECOND-REASONING" in text
+    assert '"name": "bash"' in text
+
+
+def test_tinker_adapter_strips_reasoning_before_new_user_like_hf(qwen_tokenizer):
+    """A genuine follow-up user turn starts a new Qwen reasoning boundary."""
+    messages = [
+        {"role": "user", "content": "First question."},
+        {
+            "role": "assistant",
+            "content": "First answer.",
+            "reasoning_content": "SECRET-OLD-REASONING",
+        },
+        {"role": "user", "content": "Second question."},
+        {
+            "role": "assistant",
+            "content": "Second answer.",
+            "reasoning_content": "CURRENT-REASONING",
+        },
+    ]
+    adapter_ids = _tinker_qwen3(qwen_tokenizer).render_ids(
+        messages,
+        add_generation_prompt=False,
+    )
+    hf_ids = qwen_tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=False,
+    )
+
+    text = qwen_tokenizer.decode(adapter_ids)
+    hf_text = qwen_tokenizer.decode(hf_ids)
+    assert "SECRET-OLD-REASONING" not in text
+    assert "CURRENT-REASONING" in text
+    assert ("SECRET-OLD-REASONING" in text, "CURRENT-REASONING" in text) == (
+        "SECRET-OLD-REASONING" in hf_text,
+        "CURRENT-REASONING" in hf_text,
+    )
+
+
 def test_tinker_adapter_bridge_matches_prime(qwen_tokenizer):
     """The synthesized bridge must equal prime-rl's hand-tuned qwen3 bridge."""
     adapter = _tinker_qwen3(qwen_tokenizer)
     prime = _prime_qwen3(qwen_tokenizer)
+    # Splicing prior tokens verbatim is only sound if the wrapped renderer
+    # actually extends its previous render.
+    assert adapter._inner.has_extension_property is True
 
     prompt = prime.render_ids([{"role": "user", "content": "hello there"}], add_generation_prompt=True)
     completion = [
@@ -229,7 +307,7 @@ def test_fireworks_engine_skips_chatparser_when_renderer_pinned(qwen_tokenizer):
     pinned = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler(), renderer_family="qwen3")
     assert pinned.unified_renderer is not None
     assert pinned.chat_parser is None
-    assert pinned.bypass_render_with_parser is False  # renderer owns rendering+parsing
+    assert pinned.bypass_render_with_parser is False
 
     default = FireworksEngine(tokenizer=qwen_tokenizer, sampler=_StubSampler())
     assert default.unified_renderer is None

--- a/tests/test_tinker_adapter_cumulative.py
+++ b/tests/test_tinker_adapter_cumulative.py
@@ -106,6 +106,12 @@ def test_to_openai_tool_calls_handles_all_producer_shapes():
     assert _to_openai_tool_calls([{"function": {"name": "bash", "arguments": {"command": "ls"}}}]) == [
         {"id": "call_0", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}
     ]
+    # tinker/Fireworks-cookbook ToolCall: the same nesting as a pydantic object,
+    # which TinkerRendererAdapter.parse_response hands back verbatim.
+    from tinker_cookbook.renderers.base import ToolCall as CookbookToolCall
+
+    cookbook = CookbookToolCall(id="c1", function=CookbookToolCall.FunctionBody(name="bash", arguments='{"command": "ls"}'))
+    assert _to_openai_tool_calls([cookbook]) == [{"id": "call_0", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}]
     # flat dict and ToolCall object still work.
     assert _to_openai_tool_calls([{"name": "edit", "arguments": {"p": 1}}])[0]["function"]["name"] == "edit"
     assert _to_openai_tool_calls([SimpleNamespace(name="read", arguments={"f": "x"})])[0]["function"]["name"] == "read"

--- a/tests/trainer/test_fireworks_sft_training.py
+++ b/tests/trainer/test_fireworks_sft_training.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from rllm.data import Dataset
 from rllm.trainer.sft import SFTSpec
+from rllm.trainer.sft.backend import SFTConfigError
 from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
+from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset
 
 
 class _Future:
@@ -46,16 +50,35 @@ class _Dataset:
     def __init__(self, events, n_batches):
         self.events = events
         self.n_batches = n_batches
+        self.preflighting = False
 
     def __len__(self):
         return self.n_batches
 
     def set_epoch(self, seed):
-        self.events.append(f"epoch-{seed}")
+        prefix = "preflight-" if self.preflighting else ""
+        self.events.append(f"{prefix}epoch-{seed}")
 
     def get_batch(self, index):
-        self.events.append(f"batch-{index}")
+        prefix = "preflight-batch" if self.preflighting else "batch"
+        self.events.append(f"{prefix}-{index}")
         return [index]
+
+    def preflight(self, label="train", planned_batches=None):
+        self.events.append(f"preflight-{label}")
+        self.preflighting = True
+        try:
+            for index in range(len(self)):
+                self.get_batch(index)
+            batches = planned_batches or ()
+            current_epoch = None
+            for epoch, index in batches:
+                if epoch is not None and epoch != current_epoch:
+                    self.set_epoch(epoch)
+                    current_epoch = epoch
+                self.get_batch(index)
+        finally:
+            self.preflighting = False
 
     def data_cursor_for_step(self, completed_steps):
         return completed_steps
@@ -77,9 +100,10 @@ class _Tracking:
 
 
 class _Checkpoints:
-    def __init__(self, events, resume_step):
+    def __init__(self, events, resume_step, resume_checkpoint_step):
         self.events = events
         self.resume_step = resume_step
+        self.resume_checkpoint_step = resume_checkpoint_step
         self.saves = []
 
     def resume(self):
@@ -88,7 +112,10 @@ class _Checkpoints:
             return None
         # Simulate a provider-renamed checkpoint whose name-derived step is
         # unusable; the separately persisted data cursor remains authoritative.
-        return SimpleNamespace(step=0, data_consumed=self.resume_step)
+        return SimpleNamespace(
+            step=self.resume_checkpoint_step,
+            data_consumed=self.resume_step,
+        )
 
     def save(self, name, **kwargs):
         self.saves.append((name, kwargs))
@@ -100,17 +127,26 @@ class _Checkpoints:
         return {"name": output_model_id}
 
 
-def _run_fit(monkeypatch, tmp_path, *, resume_step=None):
+def _run_fit(
+    monkeypatch,
+    tmp_path,
+    *,
+    resume_step=None,
+    save_freq=2,
+    test_freq=2,
+    events=None,
+    resume_checkpoint_step=0,
+):
     import training.utils.checkpoints as checkpoints_module
 
     import rllm.trainer.sft.fireworks_backend as module
     import rllm.utils.tracking as tracking_module
 
-    events = []
+    events = [] if events is None else events
     train_dataset = _Dataset(events, n_batches=3)
-    val_dataset = object()
+    val_dataset = _Dataset(events, n_batches=1)
     client = _Client(events)
-    checkpoints = _Checkpoints(events, resume_step)
+    checkpoints = _Checkpoints(events, resume_step, resume_checkpoint_step)
     infra = SimpleNamespace(
         policy=client,
         service=object(),
@@ -141,8 +177,8 @@ def _run_fit(monkeypatch, tmp_path, *, resume_step=None):
     )
     config = backend.build_config()
     config.trainer.max_steps = 3
-    config.trainer.save_freq = 2
-    config.trainer.test_freq = 2
+    config.trainer.save_freq = save_freq
+    config.trainer.test_freq = test_freq
 
     monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
     monkeypatch.setattr(
@@ -150,7 +186,11 @@ def _run_fit(monkeypatch, tmp_path, *, resume_step=None):
         "build_sft_data",
         lambda config, train, val: (None, train_dataset, val_dataset),
     )
-    monkeypatch.setattr(backend, "_provision", lambda config, api_key, base_url: infra)
+    monkeypatch.setattr(
+        backend,
+        "_provision",
+        lambda config, api_key, base_url: events.append("provision") or infra,
+    )
     monkeypatch.setattr(
         backend,
         "_validate",
@@ -173,6 +213,12 @@ def _run_fit(monkeypatch, tmp_path, *, resume_step=None):
 
 def test_fireworks_validation_and_checkpoint_follow_completed_update(monkeypatch, tmp_path):
     events, checkpoints = _run_fit(monkeypatch, tmp_path)
+
+    assert events.index("preflight-validation") < events.index("provision")
+
+    # Ordinary updates keep one later update submitted while the prior result
+    # is collected.
+    assert events.index("submit-fb-1") < events.index("finish-fb-0")
 
     assert events.count("validate") == 2  # initial step 0, then completed step 2
     second_validate = [i for i, event in enumerate(events) if event == "validate"][1]
@@ -207,3 +253,180 @@ def test_fireworks_resume_uses_checkpoint_as_next_batch_cursor(monkeypatch, tmp_
     assert "epoch-0" in events  # reconstruct the epoch's deterministic ordering
     assert "validate" not in events  # initial validation is fresh-run only
     assert [name for name, _ in checkpoints.saves] == ["step-3"]
+
+
+def test_fireworks_resume_rejects_missing_persisted_cursor_before_training(
+    monkeypatch,
+    tmp_path,
+):
+    events = []
+
+    with pytest.raises(SFTConfigError, match="without a positive persisted dataset cursor"):
+        _run_fit(
+            monkeypatch,
+            tmp_path,
+            resume_step=0,
+            resume_checkpoint_step=5,
+            events=events,
+        )
+
+    assert not any(event.startswith("submit-fb-") for event in events)
+
+
+@pytest.mark.parametrize("data_consumed", [-1, 4])
+def test_fireworks_resume_rejects_invalid_data_cursor(
+    monkeypatch,
+    tmp_path,
+    data_consumed,
+):
+    events = []
+
+    with pytest.raises(SFTConfigError, match="cursor|horizon"):
+        _run_fit(
+            monkeypatch,
+            tmp_path,
+            resume_step=data_consumed,
+            events=events,
+        )
+
+    assert not any(event.startswith("submit-fb-") for event in events)
+
+
+def test_fireworks_normalizes_quoted_checkpoint_cadence_before_provision(
+    monkeypatch,
+    tmp_path,
+):
+    events, checkpoints = _run_fit(
+        monkeypatch,
+        tmp_path,
+        save_freq="2",
+        test_freq="2",
+    )
+
+    assert events.index("preflight-train") < events.index("provision")
+    assert [name for name, _ in checkpoints.saves] == ["step-2", "step-3"]
+
+
+@pytest.mark.parametrize("setting", ["save_freq", "test_freq"])
+def test_fireworks_rejects_malformed_cadence_before_provision(
+    monkeypatch,
+    tmp_path,
+    setting,
+):
+    events = []
+    kwargs = {setting: "every-two-steps"}
+
+    with pytest.raises(SFTConfigError, match=rf"trainer.{setting}.*integer"):
+        _run_fit(monkeypatch, tmp_path, events=events, **kwargs)
+
+    assert "provision" not in events
+
+
+class _MaskRenderer:
+    def build_supervised_example(self, messages, train_on_what):
+        del train_on_what
+        import tinker
+        import torch
+
+        n = int(messages[-1]["content"][0]["text"])
+        return tinker.ModelInput.from_ints(list(range(n + 2))), torch.tensor(
+            [0.0, *([1.0] * n), 0.0],
+            dtype=torch.float32,
+        )
+
+
+def test_fireworks_preflights_the_shuffled_epoch_order_before_provision(
+    monkeypatch,
+    tmp_path,
+):
+    import rllm.trainer.sft.fireworks_backend as module
+
+    source = Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": str(n), "trainable": True},
+                ]
+            }
+            for n in [0, 2, 0, 2]
+        ],
+        name="shuffled-mask",
+        split="train",
+    )
+    train_dataset = TinkerSFTDataset(
+        source,
+        renderer=_MaskRenderer(),
+        batch_size=2,
+        max_length=100,
+    )
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=source,
+            output_dir=str(tmp_path),
+            batch_size=2,
+            overrides={"trainer": {"max_steps": 2}},
+        )
+    )
+    backend.build_config()
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
+    monkeypatch.setattr(
+        module,
+        "build_sft_data",
+        lambda *_: (None, train_dataset, None),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_provision",
+        lambda *_: pytest.fail("provider trainer must not be provisioned"),
+    )
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        backend.fit()
+
+
+def test_fireworks_bad_preflight_never_provisions(monkeypatch, tmp_path):
+    import rllm.trainer.sft.fireworks_backend as module
+
+    events = []
+    train_dataset = _Dataset(events, n_batches=2)
+
+    def fail_preflight(label, planned_batches=None):
+        del planned_batches
+        raise module.SFTConfigError(f"{label} row is invalid")
+
+    train_dataset.preflight = fail_preflight
+    source = Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant", "content": "a"},
+                ]
+            }
+        ],
+        name="invalid-preflight",
+        split="train",
+    )
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=source,
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 1}},
+        )
+    )
+    backend.build_config()
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
+    monkeypatch.setattr(
+        module,
+        "build_sft_data",
+        lambda *_: (None, train_dataset, None),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_provision",
+        lambda *_: pytest.fail("provider trainer must not be provisioned"),
+    )
+
+    with pytest.raises(module.SFTConfigError, match="train row is invalid"):
+        backend.fit()

--- a/tests/trainer/test_fireworks_sft_training.py
+++ b/tests/trainer/test_fireworks_sft_training.py
@@ -1,0 +1,209 @@
+"""Fireworks SFT cursor, cadence, and request-ordering contracts.
+
+The loop runs entirely against fakes: no provider resources are created and no
+API calls are made.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from rllm.data import Dataset
+from rllm.trainer.sft import SFTSpec
+from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
+
+
+class _Future:
+    def __init__(self, events, event, result):
+        self.events = events
+        self.event = event
+        self.value = result
+
+    def result(self, timeout=None):
+        del timeout
+        self.events.append(self.event)
+        return self.value
+
+
+class _Client:
+    def __init__(self, events):
+        self.events = events
+
+    def submit_forward_backward(self, data, loss_fn):
+        assert loss_fn == "cross_entropy"
+        batch = data[0]
+        self.events.append(f"submit-fb-{batch}")
+        result = SimpleNamespace(metrics={"response_tokens": 2, "loss:sum": 2.0})
+        return _Future(self.events, f"finish-fb-{batch}", result)
+
+    def submit_optim_step(self, adam):
+        del adam
+        self.events.append("submit-opt")
+        return _Future(self.events, "finish-opt", SimpleNamespace())
+
+
+class _Dataset:
+    def __init__(self, events, n_batches):
+        self.events = events
+        self.n_batches = n_batches
+
+    def __len__(self):
+        return self.n_batches
+
+    def set_epoch(self, seed):
+        self.events.append(f"epoch-{seed}")
+
+    def get_batch(self, index):
+        self.events.append(f"batch-{index}")
+        return [index]
+
+    def data_cursor_for_step(self, completed_steps):
+        return completed_steps
+
+    def step_for_data_cursor(self, data_consumed):
+        return data_consumed
+
+
+class _Tracking:
+    def __init__(self, events, **kwargs):
+        del kwargs
+        self.events = events
+
+    def log(self, data, step):
+        self.events.append(f"log-{step}-{data.get('status', 'metrics')}")
+
+    def finish(self):
+        self.events.append("tracking-finish")
+
+
+class _Checkpoints:
+    def __init__(self, events, resume_step):
+        self.events = events
+        self.resume_step = resume_step
+        self.saves = []
+
+    def resume(self):
+        self.events.append("resume")
+        if self.resume_step is None:
+            return None
+        # Simulate a provider-renamed checkpoint whose name-derived step is
+        # unusable; the separately persisted data cursor remains authoritative.
+        return SimpleNamespace(step=0, data_consumed=self.resume_step)
+
+    def save(self, name, **kwargs):
+        self.saves.append((name, kwargs))
+        self.events.append(f"save-{name}")
+
+    def promote_latest(self, output_model_id, base_model):
+        del base_model
+        self.events.append("promote")
+        return {"name": output_model_id}
+
+
+def _run_fit(monkeypatch, tmp_path, *, resume_step=None):
+    import training.utils.checkpoints as checkpoints_module
+
+    import rllm.trainer.sft.fireworks_backend as module
+    import rllm.utils.tracking as tracking_module
+
+    events = []
+    train_dataset = _Dataset(events, n_batches=3)
+    val_dataset = object()
+    client = _Client(events)
+    checkpoints = _Checkpoints(events, resume_step)
+    infra = SimpleNamespace(
+        policy=client,
+        service=object(),
+        policy_job_id="fake-job",
+        close=lambda: events.append("infra-close"),
+    )
+
+    source = Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant", "content": "a"},
+                ]
+            }
+        ],
+        name="fake",
+        split="train",
+    )
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            model="Qwen/Qwen3-0.6B",
+            train_dataset=source,
+            val_dataset=source,
+            epochs=1,
+            output_dir=str(tmp_path),
+        )
+    )
+    config = backend.build_config()
+    config.trainer.max_steps = 3
+    config.trainer.save_freq = 2
+    config.trainer.test_freq = 2
+
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
+    monkeypatch.setattr(
+        module,
+        "build_sft_data",
+        lambda config, train, val: (None, train_dataset, val_dataset),
+    )
+    monkeypatch.setattr(backend, "_provision", lambda config, api_key, base_url: infra)
+    monkeypatch.setattr(
+        backend,
+        "_validate",
+        lambda client, dataset: events.append("validate") or {"test/loss": 1.0},
+    )
+    monkeypatch.setattr(
+        tracking_module,
+        "Tracking",
+        lambda **kwargs: _Tracking(events, **kwargs),
+    )
+    monkeypatch.setattr(
+        checkpoints_module,
+        "TrainingCheckpoints",
+        lambda *args, **kwargs: checkpoints,
+    )
+
+    backend.fit()
+    return events, checkpoints
+
+
+def test_fireworks_validation_and_checkpoint_follow_completed_update(monkeypatch, tmp_path):
+    events, checkpoints = _run_fit(monkeypatch, tmp_path)
+
+    assert events.count("validate") == 2  # initial step 0, then completed step 2
+    second_validate = [i for i, event in enumerate(events) if event == "validate"][1]
+    assert events.index("finish-opt", events.index("batch-1")) < second_validate
+    assert second_validate < events.index("batch-2")
+    assert checkpoints.saves == [
+        (
+            "step-2",
+            {
+                "resumable": True,
+                "promotable": False,
+                "data_consumed": 2,
+            },
+        ),
+        (
+            "step-3",
+            {
+                "resumable": True,
+                "promotable": True,
+                "data_consumed": 3,
+            },
+        ),
+    ]
+
+
+def test_fireworks_resume_uses_checkpoint_as_next_batch_cursor(monkeypatch, tmp_path):
+    events, checkpoints = _run_fit(monkeypatch, tmp_path, resume_step=2)
+
+    assert "batch-0" not in events
+    assert "batch-1" not in events
+    assert events.count("batch-2") == 1
+    assert "epoch-0" in events  # reconstruct the epoch's deterministic ordering
+    assert "validate" not in events  # initial validation is fresh-run only
+    assert [name for name, _ in checkpoints.saves] == ["step-3"]

--- a/tests/trainer/test_sft_dispatcher.py
+++ b/tests/trainer/test_sft_dispatcher.py
@@ -432,6 +432,144 @@ def test_verl_rejects_structured_rows():
         VerlSFTBackend(spec).validate_spec()
 
 
+@pytest.mark.parametrize("think_row_index", [0, 1])
+def test_verl_keeps_legacy_inline_think_text_regardless_of_row_order(
+    think_row_index,
+):
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    plain = {
+        "messages": [
+            {"role": "user", "content": "plain"},
+            {"role": "assistant", "content": "answer"},
+        ]
+    }
+    inline = {
+        "messages": [
+            {"role": "user", "content": "reason"},
+            {
+                "role": "assistant",
+                "content": "<think>work</think>answer",
+            },
+        ]
+    }
+    rows = [plain, plain.copy()]
+    rows[think_row_index] = inline
+    dataset = Dataset(data=rows, name="legacy-think-text", split="train")
+
+    VerlSFTBackend(_spec(train_dataset=dataset)).validate_spec()
+
+
+def test_verl_rejects_hosted_override_paths_in_one_actionable_error():
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    overrides = OmegaConf.create(
+        {
+            "trainer": {"max_steps": 12},
+            "data": {
+                "rllm": {
+                    "group_by_length": True,
+                    "length_group_factor": 4,
+                    "group_by_length_factor": 4,
+                    "overlength_policy": "error",
+                    "loss_reduction": "token_mean",
+                    "loss_normalization": "token_mean",
+                    "strip_thinking_from_history": True,
+                    "strip_tool_history": True,
+                }
+            },
+            "optim": {
+                "warmup_steps": 4,
+                "warmup_steps_ratio": 0.1,
+                "warmup_ratio": 0.1,
+                "min_lr": 1e-6,
+                "grad_clip_norm": 1.0,
+            },
+        }
+    )
+
+    with pytest.raises(SFTConfigError) as exc_info:
+        VerlSFTBackend(_spec(overrides=overrides)).validate_spec()
+
+    message = str(exc_info.value)
+    rejected_paths = (
+        "trainer.max_steps",
+        "data.rllm.group_by_length",
+        "data.rllm.length_group_factor",
+        "data.rllm.group_by_length_factor",
+        "data.rllm.overlength_policy",
+        "data.rllm.loss_reduction",
+        "data.rllm.loss_normalization",
+        "data.rllm.strip_thinking_from_history",
+        "data.rllm.strip_tool_history",
+        "optim.warmup_steps",
+        "optim.warmup_steps_ratio",
+        "optim.warmup_ratio",
+        "optim.min_lr",
+        "optim.grad_clip_norm",
+    )
+    assert message.startswith("verl cannot use hosted-backend SFT override keys:")
+    for path in rejected_paths:
+        assert f"- {path}:" in message
+    for native_path in (
+        "trainer.total_training_steps",
+        "data.truncation",
+        "optim.lr_warmup_steps",
+        "optim.lr_warmup_steps_ratio",
+        "optim.min_lr_ratio",
+        "optim.clip_grad",
+    ):
+        assert native_path in message
+    assert "global token mean" in message
+    assert "dynamic token batching" in message
+    assert "renderer/history policy" in message
+
+
+def test_dispatch_verl_rejects_hosted_overrides_before_build_or_launch(monkeypatch):
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    calls = []
+    monkeypatch.setattr(VerlSFTBackend, "build_config", lambda self: calls.append("build"))
+    monkeypatch.setattr(VerlSFTBackend, "prepare_data", lambda self: calls.append("prepare_data"))
+    monkeypatch.setattr(AgentSFTTrainer, "_launch_distributed", lambda self, backend: calls.append("launch"))
+
+    with pytest.raises(SFTConfigError, match=r"trainer\.max_steps"):
+        AgentSFTTrainer(_spec(overrides={"trainer": {"max_steps": 12}}), backend="verl").train()
+    assert calls == []
+
+
+def test_verl_accepts_native_override_paths():
+    pytest.importorskip("verl")
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    backend = VerlSFTBackend(
+        _spec(
+            overrides={
+                "trainer": {"total_training_steps": 12},
+                "data": {"truncation": "error", "rllm": {"tokenize_and_mask_method": "stepwise"}},
+                "optim": {
+                    "lr_warmup_steps": 4,
+                    "lr_warmup_steps_ratio": 0.1,
+                    "min_lr_ratio": 0.2,
+                    "clip_grad": 1.0,
+                    "weight_decay": 0.1,
+                },
+            }
+        )
+    )
+
+    backend.validate_spec()
+    cfg = backend.build_config()
+    assert cfg.trainer.total_training_steps == 12
+    assert cfg.data.truncation == "error"
+    assert cfg.data.rllm.tokenize_and_mask_method == "stepwise"
+    assert cfg.optim.lr_warmup_steps == 4
+    assert cfg.optim.lr_warmup_steps_ratio == pytest.approx(0.1)
+    assert cfg.optim.min_lr_ratio == pytest.approx(0.2)
+    assert cfg.optim.clip_grad == pytest.approx(1.0)
+    assert cfg.optim.weight_decay == pytest.approx(0.1)
+
+
 # -- full-parameter (lora_rank=0) support ------------------------------------
 # (build_config shape/tokenizer resolution + the provision doc for rank 0 are
 # covered by the parametrized tests above; here: spec + validate_spec gating.)

--- a/tests/trainer/test_sft_dispatcher.py
+++ b/tests/trainer/test_sft_dispatcher.py
@@ -83,6 +83,14 @@ def test_validate_spec_accepts_messages():
     TinkerSFTBackend(_spec()).validate_spec()  # no raise
 
 
+def test_tinker_family_rejects_hf_template_without_native_serving_parity():
+    from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
+
+    for cls in (TinkerSFTBackend, FireworksSFTBackend):
+        with pytest.raises(SFTConfigError, match="train/serve mismatch"):
+            cls(_spec(tokenize_method="hf_template")).validate_spec()
+
+
 def test_validate_spec_rejects_missing_messages():
     bad = Dataset(data=[{"prompt": "x", "response": "y"}], name="bad", split="train")
     with pytest.raises(SFTConfigError):
@@ -370,6 +378,19 @@ def test_fireworks_provision_doc_parses_sft(spec_kwargs, expect):
         assert pc.lora_rank == expect["lora_rank"]
 
 
+def test_fireworks_warmup_default_off_and_overridable():
+    """Warmup defaults OFF (the fireworks yaml knob was live-but-0), and both the
+    cosine schedule and an overrides warmup ratio reach the fireworks config the
+    fit loop reads."""
+    from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
+
+    cfg = FireworksSFTBackend(_spec(lr_schedule="cosine")).build_config()
+    assert cfg.optim.lr_scheduler == "cosine"
+    assert cfg.optim.warmup_steps_ratio == 0.0
+    cfg2 = FireworksSFTBackend(_spec(lr_schedule="cosine", overrides={"optim": {"warmup_steps_ratio": 0.1}})).build_config()
+    assert cfg2.optim.warmup_steps_ratio == pytest.approx(0.1)
+
+
 def test_fireworks_inherits_validation():
     from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
 
@@ -403,11 +424,7 @@ def _structured_ds(n: int = 2):
 
 
 def test_verl_rejects_structured_rows():
-    """verl must reject structured (schema) rows and point at the tinker backend.
-
-    RED today: ``validate_spec`` only checks for role/content presence, and
-    structured rows have both (content is a parts list), so nothing is raised.
-    """
+    """verl must reject structured (schema) rows and point at the tinker backend."""
     from rllm.trainer.sft.verl_backend import VerlSFTBackend
 
     spec = _spec(train_dataset=_structured_ds())

--- a/tests/trainer/test_sft_length_grouping.py
+++ b/tests/trainer/test_sft_length_grouping.py
@@ -1,0 +1,120 @@
+"""Length-grouped SFT batching.
+
+``TinkerSFTDataset`` can bucket similarly-sized rows into a batch so a batch pads
+to little more than its own rows' real length — mirroring the Fireworks training
+cookbook's ``group_by_length``. These assert the batching invariants the lever
+must never break (full per-epoch coverage, seeded determinism, no silent drops)
+and that grouping actually cuts padding versus a plain shuffle.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+# tinker_dataset imports tinker / tinker_cookbook at module load.
+pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+import rllm.trainer.sft.tinker_dataset as td  # noqa: E402
+from rllm.data import Dataset  # noqa: E402
+from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset, length_grouped_order  # noqa: E402
+
+
+def _lengths(n=1000, seed=0):
+    r = random.Random(seed)
+    return [r.randint(100, 30000) for _ in range(n)]
+
+
+def _padding_waste(order, lengths, bs, L=32768):
+    """Fraction of processed tokens that are padding under pad-to-batch-max."""
+    caps = [min(lengths[i], L) for i in order]
+    nb = len(order) // bs
+    padded = real = 0
+    for b in range(nb):
+        chunk = caps[b * bs : (b + 1) * bs]
+        real += sum(chunk)
+        padded += bs * max(chunk)
+    return 1 - real / padded
+
+
+def _messages_ds(n=200):
+    """Rows with a unique per-row id (user content) and varied length."""
+    rows = [{"messages": [{"role": "user", "content": f"q{i}"}, {"role": "assistant", "content": "a" * (1 + (i * 7) % 60)}]} for i in range(n)]
+    return Dataset(data=rows, name="grp", split="train")
+
+
+# -- sampler invariants -------------------------------------------------------
+
+
+def test_length_grouped_order_is_full_permutation():
+    """Every row appears exactly once — no drop, no duplicate."""
+    order = length_grouped_order(_lengths(1000), batch_size=32, factor=50, seed=1)
+    assert sorted(order) == list(range(1000))
+
+
+@pytest.mark.parametrize("seed", [0, 7])
+def test_length_grouped_order_deterministic_and_seed_sensitive(seed):
+    lengths = _lengths(500)
+    a = length_grouped_order(lengths, 16, 25, seed)
+    assert a == length_grouped_order(lengths, 16, 25, seed)  # same seed -> same order
+    assert a != length_grouped_order(lengths, 16, 25, seed + 1)  # seed matters
+
+
+def test_length_grouping_cuts_padding_vs_shuffle():
+    """The point of the lever: grouped batches waste far less on padding."""
+    lengths = _lengths(2000, seed=3)
+    bs = 32
+    plain = list(range(len(lengths)))
+    random.Random(3).shuffle(plain)
+    grouped = length_grouped_order(lengths, bs, 50, seed=3)
+    assert _padding_waste(grouped, lengths, bs) < 0.5 * _padding_waste(plain, lengths, bs)
+
+
+# -- dataset integration ------------------------------------------------------
+
+
+def test_group_by_length_covers_every_row_through_get_batch(monkeypatch):
+    """set_epoch(grouped) + get_batch over all batches touches every row once,
+    including the final partial batch."""
+    ds = TinkerSFTDataset(_messages_ds(203), renderer=object(), batch_size=8, group_by_length=True, length_group_factor=5)
+    # Stub the renderer-dependent datum build; return raw messages so coverage
+    # is measured through the real get_batch index mapping (not the renderer).
+    monkeypatch.setattr(td, "conversation_to_datum", lambda messages, renderer, max_length, last_only, **kwargs: messages)
+    monkeypatch.setattr(td, "count_loss_tokens", lambda datums: 1)
+    ds.set_epoch(seed=0)
+    assert sorted(ds._order) == list(range(203))  # full permutation
+
+    seen = [m[0]["content"] for b in range(len(ds)) for m in ds.get_batch(b)]
+    assert len(seen) == 203
+    assert len(set(seen)) == len(seen)  # each trained row exactly once
+
+
+def test_group_by_length_is_deterministic_across_instances():
+    a = TinkerSFTDataset(_messages_ds(120), renderer=object(), batch_size=8, group_by_length=True, length_group_factor=4)
+    b = TinkerSFTDataset(_messages_ds(120), renderer=object(), batch_size=8, group_by_length=True, length_group_factor=4)
+    a.set_epoch(3)
+    b.set_epoch(3)
+    assert a._order == b._order
+
+
+def test_default_shuffle_path_is_full_permutation_and_deterministic():
+    """Grouping off (default): the explicit-order refactor still yields a seeded
+    full-coverage permutation each epoch."""
+    ds = TinkerSFTDataset(_messages_ds(120), renderer=object(), batch_size=8)
+    ds.set_epoch(seed=1)
+    assert sorted(ds._order) == list(range(120))
+    first = list(ds._order)
+    ds.set_epoch(seed=1)
+    assert ds._order == first
+
+
+def test_raw_row_cursor_round_trips_full_and_partial_batches():
+    ds = TinkerSFTDataset(_messages_ds(10), renderer=object(), batch_size=4)
+
+    # Three batches/epoch (4, 4, 2 rows); every checkpoint boundary maps back
+    # to the next unseen batch, including across the partial final batch.
+    assert [ds.data_cursor_for_step(step) for step in range(7)] == [0, 4, 8, 10, 14, 18, 20]
+    for step in range(7):
+        assert ds.step_for_data_cursor(ds.data_cursor_for_step(step)) == step

--- a/tests/trainer/test_sft_length_grouping.py
+++ b/tests/trainer/test_sft_length_grouping.py
@@ -54,9 +54,9 @@ def test_length_grouped_order_is_full_permutation():
     assert sorted(order) == list(range(1000))
 
 
-@pytest.mark.parametrize("seed", [0, 7])
-def test_length_grouped_order_deterministic_and_seed_sensitive(seed):
+def test_length_grouped_order_deterministic_and_seed_sensitive():
     lengths = _lengths(500)
+    seed = 7
     a = length_grouped_order(lengths, 16, 25, seed)
     assert a == length_grouped_order(lengths, 16, 25, seed)  # same seed -> same order
     assert a != length_grouped_order(lengths, 16, 25, seed + 1)  # seed matters
@@ -91,14 +91,6 @@ def test_group_by_length_covers_every_row_through_get_batch(monkeypatch):
     assert len(set(seen)) == len(seen)  # each trained row exactly once
 
 
-def test_group_by_length_is_deterministic_across_instances():
-    a = TinkerSFTDataset(_messages_ds(120), renderer=object(), batch_size=8, group_by_length=True, length_group_factor=4)
-    b = TinkerSFTDataset(_messages_ds(120), renderer=object(), batch_size=8, group_by_length=True, length_group_factor=4)
-    a.set_epoch(3)
-    b.set_epoch(3)
-    assert a._order == b._order
-
-
 def test_default_shuffle_path_is_full_permutation_and_deterministic():
     """Grouping off (default): the explicit-order refactor still yields a seeded
     full-coverage permutation each epoch."""
@@ -118,3 +110,33 @@ def test_raw_row_cursor_round_trips_full_and_partial_batches():
     assert [ds.data_cursor_for_step(step) for step in range(7)] == [0, 4, 8, 10, 14, 18, 20]
     for step in range(7):
         assert ds.step_for_data_cursor(ds.data_cursor_for_step(step)) == step
+
+
+def test_grouped_resume_reconstructs_uninterrupted_epoch_suffix(monkeypatch):
+    uninterrupted = TinkerSFTDataset(
+        _messages_ds(23),
+        renderer=object(),
+        batch_size=4,
+        group_by_length=True,
+        length_group_factor=3,
+    )
+    resumed = TinkerSFTDataset(
+        _messages_ds(23),
+        renderer=object(),
+        batch_size=4,
+        group_by_length=True,
+        length_group_factor=3,
+    )
+    monkeypatch.setattr(
+        td,
+        "conversation_to_datum",
+        lambda messages, renderer, max_length, last_only, **kwargs: messages,
+    )
+    monkeypatch.setattr(td, "count_loss_tokens", lambda datums: 1)
+
+    uninterrupted.set_epoch(seed=2)
+    resumed.set_epoch(seed=2)
+    next_batch = 3
+    expected = [uninterrupted.get_batch(index) for index in range(next_batch, len(uninterrupted))]
+    actual = [resumed.get_batch(index) for index in range(next_batch, len(resumed))]
+    assert actual == expected

--- a/tests/trainer/test_sft_lr_warmup.py
+++ b/tests/trainer/test_sft_lr_warmup.py
@@ -69,20 +69,6 @@ def test_zero_warmup_reduces_to_cookbook(schedule):
         assert sft_lr_multiplier(schedule, step, 100, warmup_steps_ratio=0.0) == pytest.approx(_cookbook(lr_schedule=schedule, step=step, total_steps=100))
 
 
-def test_cosine_and_warmup_reach_fireworks_subclass_config():
-    """cosine + warmup must land in the FIREWORKS config (the subclass path the
-    real run uses), not just tinker's."""
-    from rllm.data import Dataset
-    from rllm.trainer.sft import SFTSpec
-    from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
-
-    ds = Dataset(data=[{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}], name="t", split="train")
-    spec = SFTSpec(model="Qwen/Qwen2.5-7B-Instruct", train_dataset=ds, lr_schedule="cosine", overrides={"optim": {"warmup_steps_ratio": 0.1}})
-    cfg = FireworksSFTBackend(spec).build_config()
-    assert cfg.optim.lr_scheduler == "cosine"
-    assert cfg.optim.warmup_steps_ratio == pytest.approx(0.1)
-
-
 @pytest.mark.parametrize(
     ("overrides", "match"),
     [

--- a/tests/trainer/test_sft_lr_warmup.py
+++ b/tests/trainer/test_sft_lr_warmup.py
@@ -1,0 +1,114 @@
+"""SFT learning-rate schedule and optimizer configuration.
+
+The SFT fits multiply the base LR by ``sft_lr_multiplier`` each step. Paper-
+aligned agentic SFT uses a linear warmup (ratio 0.1) then a cosine decay; the
+tinker_cookbook multiplier the fits used before had no warmup term, so the
+``warmup_steps_ratio`` config knob was dead. These pin the warmup math and that
+``warmup_steps_ratio=0`` is an exact no-op (unchanged default behavior).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tinker_cookbook")  # sft_lr_multiplier delegates decay to it
+
+from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier as _cookbook  # noqa: E402
+
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.tinker_backend import (  # noqa: E402
+    resolve_sft_optimizer_settings,
+    sft_lr_multiplier,
+)
+
+
+def test_warmup_ramps_linearly_then_cosine_decays():
+    # 10% of 100 steps => 10 warmup steps: linear 0->1, then cosine over the rest.
+    assert sft_lr_multiplier("cosine", 0, 100, warmup_steps_ratio=0.1) == pytest.approx(0.0)
+    assert sft_lr_multiplier("cosine", 5, 100, warmup_steps_ratio=0.1) == pytest.approx(0.5)
+    assert sft_lr_multiplier("cosine", 10, 100, warmup_steps_ratio=0.1) == pytest.approx(1.0)  # cosine(0)
+    assert sft_lr_multiplier("cosine", 100, 100, warmup_steps_ratio=0.1) == pytest.approx(0.0)  # cosine(pi)
+
+
+def test_cosine_decay_respects_minimum_lr_ratio():
+    """A configured 10% floor decays to that floor, not to zero."""
+    assert sft_lr_multiplier(
+        "cosine",
+        100,
+        100,
+        min_lr_ratio=0.1,
+    ) == pytest.approx(0.1)
+    assert sft_lr_multiplier(
+        "cosine",
+        50,
+        100,
+        min_lr_ratio=0.1,
+    ) == pytest.approx(0.55)
+
+
+def test_invalid_minimum_lr_ratio_fails_during_warmup():
+    with pytest.raises(SFTConfigError, match="must be in"):
+        sft_lr_multiplier(
+            "cosine",
+            step=0,
+            total_steps=100,
+            warmup_steps=10,
+            min_lr_ratio=1.1,
+        )
+
+
+def test_absolute_warmup_steps_override_ratio():
+    # warmup_steps=4 wins over the ratio: LR is half-ramped at step 2.
+    assert sft_lr_multiplier("constant", 2, 100, warmup_steps_ratio=0.5, warmup_steps=4) == pytest.approx(0.5)
+    assert sft_lr_multiplier("constant", 4, 100, warmup_steps_ratio=0.5, warmup_steps=4) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("schedule", ["cosine", "linear", "constant"])
+def test_zero_warmup_reduces_to_cookbook(schedule):
+    for step in (0, 25, 50, 99):
+        assert sft_lr_multiplier(schedule, step, 100, warmup_steps_ratio=0.0) == pytest.approx(_cookbook(lr_schedule=schedule, step=step, total_steps=100))
+
+
+def test_cosine_and_warmup_reach_fireworks_subclass_config():
+    """cosine + warmup must land in the FIREWORKS config (the subclass path the
+    real run uses), not just tinker's."""
+    from rllm.data import Dataset
+    from rllm.trainer.sft import SFTSpec
+    from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
+
+    ds = Dataset(data=[{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}], name="t", split="train")
+    spec = SFTSpec(model="Qwen/Qwen2.5-7B-Instruct", train_dataset=ds, lr_schedule="cosine", overrides={"optim": {"warmup_steps_ratio": 0.1}})
+    cfg = FireworksSFTBackend(spec).build_config()
+    assert cfg.optim.lr_scheduler == "cosine"
+    assert cfg.optim.warmup_steps_ratio == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"lr": 0}, "optim.lr must be positive"),
+        ({"lr": 1e-4, "min_lr": 2e-4}, "optim.min_lr"),
+        ({"lr_scheduler": "polynomial"}, "optim.lr_scheduler"),
+        ({"warmup_steps_ratio": 1.5}, "warmup_steps_ratio"),
+        ({"warmup_steps": 101}, "cannot exceed"),
+        ({"betas": [0.9, 1.0]}, "optim.betas"),
+        ({"eps": 0}, "optim.eps"),
+        ({"weight_decay": -0.1}, "weight_decay"),
+        ({"grad_clip_norm": -1}, "grad_clip_norm"),
+    ],
+)
+def test_optimizer_settings_reject_invalid_runs_before_provision(overrides, match):
+    config = {
+        "lr": 1e-4,
+        "min_lr": 1e-5,
+        "lr_scheduler": "cosine",
+        "warmup_steps_ratio": 0.0,
+        "warmup_steps": 10,
+        "betas": [0.9, 0.999],
+        "eps": 1e-8,
+        "weight_decay": 1e-2,
+        "grad_clip_norm": 1.0,
+        **overrides,
+    }
+    with pytest.raises(SFTConfigError, match=match):
+        resolve_sft_optimizer_settings(config, total_steps=100)

--- a/tests/trainer/test_sft_render_path.py
+++ b/tests/trainer/test_sft_render_path.py
@@ -37,10 +37,12 @@ from tinker_cookbook.renderers import get_renderer  # noqa: E402
 
 from rllm.data import Dataset  # noqa: E402
 from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
 from rllm.trainer.sft.tinker_backend import TinkerSFTBackend, build_sft_data  # noqa: E402
 from rllm.trainer.sft.tinker_dataset import conversation_to_datum  # noqa: E402
 
 QWEN = "Qwen/Qwen3-0.6B"
+NEMOTRON = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
 
 
 @pytest.fixture(scope="module")
@@ -50,6 +52,16 @@ def qwen_tokenizer():
         return transformers.AutoTokenizer.from_pretrained(QWEN)
     except OSError as e:  # not cached / offline
         pytest.skip(f"Qwen3-0.6B tokenizer unavailable: {e}")
+
+
+@pytest.fixture(scope="module")
+def nemotron_tokenizer():
+    from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+    try:
+        return get_tokenizer(NEMOTRON)
+    except Exception as e:  # noqa: BLE001 - optional offline integration asset
+        pytest.skip(f"Nemotron-3 tokenizer unavailable: {e}")
 
 
 # -- Datum introspection helpers ---------------------------------------------
@@ -75,18 +87,57 @@ def _trained_text(datum, tokenizer) -> str:
     return tokenizer.decode(trained)
 
 
+def _full_tokens(datum) -> list[int]:
+    """Reconstruct the pre-shift token stream from a Datum.
+
+    ``datum_from_model_input_weights`` stores right-shifted inputs
+    (``tokens[:-1]``) and left-shifted targets (``tokens[1:]``); the original
+    render is ``inputs + [last target]``.
+    """
+    return _input_ids(datum) + _targets(datum)[-1:]
+
+
 # -- F1: default renderer must not crash on reasoning rows -------------------
+
+
+def test_hf_template_config_override_is_rejected_before_tokenizer_load(
+    monkeypatch,
+):
+    from tinker_cookbook import tokenizer_utils
+
+    ds = Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant", "content": "a"},
+                ]
+            }
+        ],
+        name="hf-template-rejection",
+        split="train",
+    )
+    spec = SFTSpec(
+        model=QWEN,
+        train_dataset=ds,
+        overrides={"data": {"rllm": {"tokenize_and_mask_method": "hf_template"}}},
+    )
+    cfg = TinkerSFTBackend(spec).build_config()
+    monkeypatch.setattr(
+        tokenizer_utils,
+        "get_tokenizer",
+        lambda *_: pytest.fail("tokenizer should not load for a rejected mode"),
+    )
+
+    with pytest.raises(SFTConfigError, match="train/serve mismatch"):
+        build_sft_data(cfg, ds, None)
 
 
 def test_f1_reasoning_row_renders_through_build_sft_data(qwen_tokenizer):
     """A reasoning row (assistant ``thinking`` + ``text`` parts) must survive the
     full ``build_config`` -> ``build_sft_data`` -> ``get_batch`` path.
 
-    RED today: ``build_sft_data`` resolves the ``role_colon`` default renderer
-    (tinker.yaml), and ``get_batch(0)`` raises tinker's ``RendererError``
-    ("Expected text content, got multimodal content ...").
-
-    GREEN: the model's renderer resolves to a qwen thinking renderer, which
+    The model's renderer resolves to a qwen thinking renderer, which
     preserves the reasoning as a ``<think>...</think>`` block. (Qwen3-0.6B is
     absent from ``model_info``'s recommended-renderer map, but every qwen3-family
     thinking renderer emits the ``<think>`` tag, so we assert the literals.)
@@ -109,7 +160,7 @@ def test_f1_reasoning_row_renders_through_build_sft_data(qwen_tokenizer):
     cfg = TinkerSFTBackend(spec).build_config()
     tokenizer, train_ds, val_ds = build_sft_data(cfg, spec.train_dataset, None)
 
-    datums = train_ds.get_batch(0)  # RED: RendererError here on current code
+    datums = train_ds.get_batch(0)
     assert len(datums) == 1
     datum = datums[0]
     assert sum(_weights(datum)) > 0
@@ -125,10 +176,7 @@ def test_f1_reasoning_row_renders_through_build_sft_data(qwen_tokenizer):
 def test_f2_dict_tool_calls_render(qwen_tokenizer):
     """OpenAI dict-shaped ``tool_calls`` must render.
 
-    RED today: the qwen3 renderer does ``tool_call.function`` on a plain dict ->
-    ``AttributeError: 'dict' object has no attribute 'function'``.
-
-    GREEN: the dict is normalized to a structured ``ToolCall`` and the tool name
+    The dict is normalized to a structured ``ToolCall`` and the tool name
     lands in the rendered assistant turn.
     """
     renderer = get_renderer("qwen3", qwen_tokenizer)
@@ -142,7 +190,7 @@ def test_f2_dict_tool_calls_render(qwen_tokenizer):
         },
     ]
 
-    datum = conversation_to_datum(conversation, renderer, max_length=None)  # RED: AttributeError here
+    datum = conversation_to_datum(conversation, renderer, max_length=None)
     assert sum(_weights(datum)) > 0
     assert "bash" in qwen_tokenizer.decode(_input_ids(datum))
 
@@ -155,10 +203,7 @@ def test_f3_roundtrip_stamps_tool_calls_none(qwen_tokenizer, tmp_path):
     unifies the messages struct schema, so a message WITHOUT ``tool_calls`` gets
     the key stamped to ``None`` (here the user turn).
 
-    RED today: the qwen3 renderer iterates ``message["tool_calls"]`` on the user
-    turn -> ``TypeError: 'NoneType' object is not iterable``.
-
-    GREEN: a ``None`` ``tool_calls`` is treated as absent and every row renders.
+    A ``None`` ``tool_calls`` is treated as absent and every row renders.
     """
     renderer = get_renderer("qwen3", qwen_tokenizer)
     rows = [
@@ -181,7 +226,7 @@ def test_f3_roundtrip_stamps_tool_calls_none(qwen_tokenizer, tmp_path):
     # Root cause: the flag-less user turn now carries tool_calls=None.
     assert rt[0]["messages"][0]["tool_calls"] is None
 
-    datums = [conversation_to_datum(row["messages"], renderer, max_length=None) for row in rt]  # RED: TypeError here
+    datums = [conversation_to_datum(row["messages"], renderer, max_length=None) for row in rt]
     assert all(sum(_weights(d)) > 0 for d in datums)
     # The real tool call still renders once None is handled.
     assert "bash" in qwen_tokenizer.decode(_input_ids(datums[0]))
@@ -195,10 +240,7 @@ def test_f3_roundtrip_stamps_trainable_none(qwen_tokenizer, tmp_path):
     ``None``), so ``_ensure_trainable`` treats it as self-describing and passes
     it straight to the CUSTOMIZED renderer.
 
-    RED today: ``build_supervised_example`` does ``int(None)`` for the flag-less
-    row -> ``TypeError: int() argument must be a string ... not 'NoneType'``.
-
-    GREEN: a ``None`` flag is treated as absent; the flag-less row falls back to
+    A ``None`` flag is treated as absent; the flag-less row falls back to
     the derived default (train the assistant turn only).
 
     NOTE: both rows use list-of-parts ``content`` so the parquet ``messages``
@@ -243,17 +285,15 @@ def test_f3_roundtrip_stamps_trainable_none(qwen_tokenizer, tmp_path):
     assert "hi" not in trained
 
 
-# -- max_length truncation must be loud (vetting handoff item b) --------------
+# -- max_length truncation must be explicit ----------------------------------
 
 
-def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
-    """A row that renders past ``data.max_length`` must emit a loud warning.
+def test_overlength_row_errors_unless_truncation_is_explicit(qwen_tokenizer, caplog):
+    """A row past ``data.max_length`` must be rejected by default.
 
-    ``SFTSpec.max_length`` defaults to 2048, which silently truncated every
-    long trajectory row at datum build (the tail — including the final trainable
-    turn — dropped from training with zero signal to the user).
-
-    RED today: ``datum_from_model_input_weights`` truncates silently.
+    Right-truncating an agent trajectory preferentially deletes its final patch
+    and explanation, so rLLM must never mutate one unless the caller explicitly
+    selects the compatibility policy.
     """
     import logging
 
@@ -266,8 +306,17 @@ def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
     ]
 
     td._truncation_warn_count = 0
+    with pytest.raises(SFTConfigError, match="renders to .*max_length=64"):
+        conversation_to_datum(convo, renderer, max_length=64)
+
+    # The lossy compatibility path remains available only by explicit opt-in.
     with caplog.at_level(logging.WARNING, logger="rllm.trainer.sft.tinker_dataset"):
-        datum = conversation_to_datum(convo, renderer, max_length=64)
+        datum = conversation_to_datum(
+            convo,
+            renderer,
+            max_length=64,
+            overlength_policy="truncate",
+        )
     assert datum.model_input.length <= 64
     warned = [r for r in caplog.records if "max_length" in r.getMessage()]
     assert warned, "expected a loud truncation warning"
@@ -279,3 +328,202 @@ def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
     with caplog.at_level(logging.WARNING, logger="rllm.trainer.sft.tinker_dataset"):
         conversation_to_datum(convo, renderer, max_length=100_000)
     assert not [r for r in caplog.records if "max_length" in r.getMessage()]
+
+
+def test_tools_and_reasoning_match_unified_serving_renderer(qwen_tokenizer):
+    """Training and Tinker serving must render the same complete trajectory.
+
+    This covers the actual agentic boundary: sibling reasoning, structured tool
+    calls, tool-role observations, and row-level tool declarations. The serving
+    side is rLLM's unified ``TinkerRendererAdapter``; the training side is the
+    SFT ``conversation_to_datum`` path.
+    """
+    from rllm.data.sft_bridges import bridge_messages
+    from rllm.renderers.adapters import TinkerRendererAdapter
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Run a shell command.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        }
+    ]
+    wire_messages = [
+        {"role": "system", "content": "Solve the task."},
+        {"role": "user", "content": "Inspect the repository."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "I should list the files first.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "a.py"},
+        {
+            "role": "assistant",
+            "content": "Done.",
+            "reasoning_content": "The repository has one file.",
+        },
+    ]
+    canonical = bridge_messages(
+        [{"messages": wire_messages, "tools": tools}],
+        train_on="all",
+    )[0].to_record()
+
+    ds = Dataset(data=[canonical], name="tool-parity", split="train")
+    spec = SFTSpec(
+        model=QWEN,
+        train_dataset=ds,
+        max_length=100_000,
+        overrides={"data": {"renderer_name": "qwen3"}},
+    )
+    cfg = TinkerSFTBackend(spec).build_config()
+    _, training_ds, _ = build_sft_data(cfg, ds, None)
+    datum = training_ds.get_batch(0)[0]
+    serving_renderer = TinkerRendererAdapter(get_renderer("qwen3", qwen_tokenizer))
+    serving_ids = serving_renderer.render_ids(
+        wire_messages,
+        tools=tools,
+        add_generation_prompt=False,
+    )
+
+    assert _full_tokens(datum) == serving_ids
+    trained = _trained_text(datum, qwen_tokenizer)
+    assert "list the files" in trained
+    assert "repository has one file" in trained
+    assert "Inspect the repository" not in trained
+
+
+def test_new_user_query_strips_prior_reasoning_in_training_and_serving(qwen_tokenizer):
+    """Qwen retains the active trace across tools but clears CoT before a new
+    genuine user query; SFT and serving must choose the same boundary."""
+    from tinker_cookbook.renderers import get_renderer
+
+    from rllm.data.sft_bridges import bridge_messages
+    from rllm.renderers.adapters import TinkerRendererAdapter
+
+    wire_messages = [
+        {"role": "user", "content": "First question."},
+        {
+            "role": "assistant",
+            "content": "First answer.",
+            "reasoning_content": "SECRET-OLD-REASONING",
+        },
+        {"role": "user", "content": "Second question."},
+        {
+            "role": "assistant",
+            "content": "Second answer.",
+            "reasoning_content": "CURRENT-REASONING",
+        },
+    ]
+    canonical = bridge_messages([{"messages": wire_messages}], train_on="all")[0]
+    renderer = get_renderer("qwen3", qwen_tokenizer)
+    renderer.strip_thinking_from_history = False
+    datum = conversation_to_datum(
+        canonical.to_record()["messages"],
+        renderer,
+        max_length=None,
+    )
+    serving_ids = TinkerRendererAdapter(get_renderer("qwen3", qwen_tokenizer)).render_ids(wire_messages, add_generation_prompt=False)
+
+    assert _full_tokens(datum) == serving_ids
+    rendered = qwen_tokenizer.decode(serving_ids)
+    assert "SECRET-OLD-REASONING" not in rendered
+    assert "CURRENT-REASONING" in rendered
+
+
+def test_invalid_row_tool_declaration_fails_with_dataset_error(qwen_tokenizer):
+    renderer = get_renderer("qwen3", qwen_tokenizer)
+    messages = [
+        {"role": "user", "content": "inspect", "trainable": False},
+        {"role": "assistant", "content": "done", "trainable": True},
+    ]
+
+    with pytest.raises(SFTConfigError, match="invalid tool declarations"):
+        conversation_to_datum(
+            messages,
+            renderer,
+            max_length=None,
+            tools=[{"type": "custom", "name": "not-supported"}],
+        )
+
+
+def test_nemotron_multiturn_training_matches_tinker_serving(nemotron_tokenizer):
+    """The Nemotron renderer preserves every post-user reasoning turn."""
+    from rllm.data.sft_bridges import bridge_messages
+    from rllm.renderers.adapters import TinkerRendererAdapter
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Execute a bash command",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        }
+    ]
+    wire_messages = [
+        {"role": "system", "content": "Use the shell."},
+        {"role": "user", "content": "Inspect the repository."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "First inspect the files.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "a.py"},
+        {
+            "role": "assistant",
+            "content": "Done.",
+            "reasoning_content": "The repository has one file.",
+        },
+    ]
+    canonical = bridge_messages(
+        [{"messages": wire_messages, "tools": tools}],
+        train_on="all",
+    )[0].to_record()
+    renderer = get_renderer(
+        "nemotron3",
+        nemotron_tokenizer,
+        model_name=NEMOTRON,
+    )
+    renderer.strip_thinking_from_history = False
+    datum = conversation_to_datum(
+        canonical["messages"],
+        renderer,
+        max_length=None,
+        tools=tools,
+    )
+    serving_ids = TinkerRendererAdapter(get_renderer("nemotron3", nemotron_tokenizer, model_name=NEMOTRON)).render_ids(
+        wire_messages,
+        tools=tools,
+        add_generation_prompt=False,
+    )
+
+    assert _full_tokens(datum) == serving_ids
+    trained = _trained_text(datum, nemotron_tokenizer)
+    assert "First inspect the files" in trained
+    assert "repository has one file" in trained

--- a/tests/trainer/test_sft_render_path.py
+++ b/tests/trainer/test_sft_render_path.py
@@ -444,6 +444,52 @@ def test_new_user_query_strips_prior_reasoning_in_training_and_serving(qwen_toke
     assert "CURRENT-REASONING" in rendered
 
 
+def test_wrapped_tool_response_parts_do_not_reset_qwen_reasoning(qwen_tokenizer):
+    """Canonical text parts preserve the active trace across legacy tool results."""
+    from rllm.data.sft_bridges import bridge_messages
+    from rllm.renderers.adapters import TinkerRendererAdapter
+
+    wire_messages = [
+        {"role": "user", "content": "Inspect the repository."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "ACTIVE-TOOL-REASONING",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "<tool_response>one.py</tool_response>",
+                }
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "Done.",
+            "reasoning_content": "FINAL-REASONING",
+        },
+    ]
+    canonical = bridge_messages(
+        [{"messages": wire_messages}],
+        train_on="all",
+    )[0].to_record()["messages"]
+    renderer = get_renderer("qwen3", qwen_tokenizer)
+    renderer.strip_thinking_from_history = False
+    datum = conversation_to_datum(
+        canonical,
+        renderer,
+        max_length=None,
+    )
+    serving_ids = TinkerRendererAdapter(get_renderer("qwen3", qwen_tokenizer)).render_ids(wire_messages, add_generation_prompt=False)
+
+    assert _full_tokens(datum) == serving_ids
+    rendered = qwen_tokenizer.decode(serving_ids)
+    assert "ACTIVE-TOOL-REASONING" in rendered
+    assert "FINAL-REASONING" in rendered
+
+
 def test_invalid_row_tool_declaration_fails_with_dataset_error(qwen_tokenizer):
     renderer = get_renderer("qwen3", qwen_tokenizer)
     messages = [

--- a/tests/trainer/test_sft_validation.py
+++ b/tests/trainer/test_sft_validation.py
@@ -11,10 +11,6 @@ The two backends share the assertions but not the call protocol: tinker's
 ``ReconnectableClient.forward`` (which blocks internally).
 """
 
-import ast
-import inspect
-from pathlib import Path
-
 import pytest
 
 tinker = pytest.importorskip("tinker")
@@ -178,27 +174,3 @@ def test_validate_rejects_an_entirely_masked_dataset(
     del metric_key
     with pytest.raises(SFTConfigError, match="no trainable tokens"):
         run_validate(client_cls([_MASKED_OUTPUT]), [_MASKED_BATCH])
-
-
-@pytest.mark.parametrize(
-    ("backend_cls", "module_path"),
-    [
-        pytest.param(TinkerSFTBackend, "rllm/trainer/sft/tinker_backend.py", id="tinker"),
-        pytest.param(FireworksSFTBackend, "rllm/trainer/sft/fireworks_backend.py", id="fireworks"),
-    ],
-)
-def test_fit_loop_calls_validate_with_a_bindable_signature(backend_cls, module_path):
-    """Every ``self._validate(...)`` call in a fit loop binds to that backend's
-    own ``_validate``.
-
-    The call sites run only inside a live, billed training job on a step where
-    validation is due, so an arity drift between the two would otherwise first
-    surface as a ``TypeError`` mid-run.
-    """
-    source = (Path(__file__).resolve().parents[2] / module_path).read_text()
-    signature = inspect.signature(backend_cls._validate)
-    call_sites = [node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_validate"]
-    assert call_sites, f"no self._validate(...) call site found in {module_path}"
-    for call in call_sites:
-        # bind() over placeholders: only the shape of the call is under test.
-        signature.bind(*["<arg>"] * len(call.args), **{kw.arg: "<arg>" for kw in call.keywords})

--- a/tests/trainer/test_sft_validation.py
+++ b/tests/trainer/test_sft_validation.py
@@ -1,0 +1,204 @@
+"""In-loop SFT validation on the tinker/fireworks family.
+
+Both backends accumulate gradients server-side across ``forward_backward``
+calls until the next ``optim_step``, so a validation pass that runs backward
+silently trains on the held-out set. These tests pin the val loop to the
+forward-only API, pin the metric it reports, and pin the ``fit`` call sites —
+all on fakes, so no Tinker/Fireworks spend.
+
+The two backends share the assertions but not the call protocol: tinker's
+``_validate`` is async over ``forward_async`` futures, fireworks' is sync over
+``ReconnectableClient.forward`` (which blocks internally).
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+from tinker_cookbook.supervised.common import compute_mean_nll  # noqa: E402
+
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend  # noqa: E402
+from rllm.trainer.sft.tinker_backend import TinkerSFTBackend  # noqa: E402
+
+
+def _tensor(values):
+    import torch
+
+    return tinker.TensorData.from_torch(torch.tensor(values, dtype=torch.float32))
+
+
+class _Datum:
+    """Only the fields ``_validate`` reads off a tinker Datum."""
+
+    def __init__(self, weights):
+        self.loss_fn_inputs = {"weights": _tensor(weights)}
+
+
+class _Output:
+    """A forward / forward_backward response: per-token logprobs per datum."""
+
+    def __init__(self, logprobs_per_datum):
+        self.loss_fn_outputs = [{"logprobs": _tensor(lp)} for lp in logprobs_per_datum]
+
+
+class _ValDataset:
+    def __init__(self, batches):
+        self._batches = batches
+
+    def __len__(self):
+        return len(self._batches)
+
+    def get_batch(self, idx):
+        return self._batches[idx]
+
+
+class _AsyncFuture:
+    def __init__(self, output):
+        self._output = output
+
+    async def result_async(self):
+        return self._output
+
+
+class _SyncFuture:
+    def __init__(self, output):
+        self._output = output
+
+    def result(self, timeout=None):
+        return self._output
+
+
+class _FakeTinkerClient:
+    """Tinker training client logging (pass, loss_fn) per call.
+
+    Exhausting ``outputs`` raises rather than replaying, so a val loop that
+    calls more times than there are batches fails loudly.
+    """
+
+    def __init__(self, outputs):
+        self.calls: list[tuple[str, str]] = []
+        self._outputs = iter(outputs)
+
+    async def forward_async(self, data, loss_fn):
+        self.calls.append(("forward", loss_fn))
+        return _AsyncFuture(next(self._outputs))
+
+    async def forward_backward_async(self, data, loss_fn):
+        self.calls.append(("forward_backward", loss_fn))
+        return _AsyncFuture(next(self._outputs))
+
+
+class _FakeFireworksClient:
+    """``ReconnectableClient`` surface, logging (pass, loss_fn) per call."""
+
+    def __init__(self, outputs):
+        self.calls: list[tuple[str, str]] = []
+        self._outputs = iter(outputs)
+
+    def forward(self, data, loss_fn):
+        self.calls.append(("forward", loss_fn))
+        return next(self._outputs)
+
+    def submit_forward_backward(self, data, loss_fn="cross_entropy", loss_fn_config=None):
+        self.calls.append(("forward_backward", loss_fn))
+        return _SyncFuture(next(self._outputs))
+
+
+# Two batches with different loss-token counts, so a token-weighted mean
+# (2*1.5 + 3*6.0) / 5 = 4.2 is distinguishable from a plain batch mean of 3.75.
+_BATCHES = [[_Datum([1.0, 1.0, 0.0])], [_Datum([1.0, 1.0, 1.0])]]
+_OUTPUTS = [_Output([[-1.0, -2.0, -3.0]]), _Output([[-4.0, -6.0, -8.0]])]
+_EXPECTED_NLL = 4.2
+
+# A fully loss-masked batch: every token weight 0, so it carries no signal.
+_MASKED_BATCH = [_Datum([0.0, 0.0])]
+_MASKED_OUTPUT = _Output([[-9.0, -9.0]])
+
+
+def _run_tinker(client, batches):
+    import asyncio
+
+    return asyncio.run(TinkerSFTBackend._validate(client, _ValDataset(batches), compute_mean_nll))
+
+
+def _run_fireworks(client, batches):
+    return FireworksSFTBackend._validate(client, _ValDataset(batches))
+
+
+_BACKENDS = [
+    pytest.param(_FakeTinkerClient, _run_tinker, "test/mean_nll", id="tinker"),
+    pytest.param(_FakeFireworksClient, _run_fireworks, "test/loss", id="fireworks"),
+]
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_never_runs_backward(client_cls, run_validate, metric_key):
+    """Validation scores every batch through the forward-only API.
+
+    A ``forward_backward`` here would land in the server's gradient accumulator
+    and be applied by the next ``optim_step`` — the val set would be trained on.
+    """
+    client = client_cls(_OUTPUTS)
+    metrics = run_validate(client, _BATCHES)
+    assert client.calls == [("forward", "cross_entropy")] * len(_BATCHES)
+    assert list(metrics) == [metric_key]
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_returns_token_weighted_nll(client_cls, run_validate, metric_key):
+    """The reported metric is the token-weighted mean NLL over the whole val set,
+    reduced client-side from per-token logprobs on both backends."""
+    metrics = run_validate(client_cls(_OUTPUTS), _BATCHES)
+    assert metrics[metric_key] == pytest.approx(_EXPECTED_NLL)
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_skips_fully_masked_batch(client_cls, run_validate, metric_key):
+    """A batch with no loss tokens scores nan and must not poison the run's metric.
+
+    Reachable whenever ``data.max_length`` truncates rows past their trainable
+    tail — the dataset warns about it but still yields the datum.
+    """
+    batches = [_BATCHES[0], _MASKED_BATCH, _BATCHES[1]]
+    outputs = [_OUTPUTS[0], _MASKED_OUTPUT, _OUTPUTS[1]]
+    metrics = run_validate(client_cls(outputs), batches)
+    assert metrics[metric_key] == pytest.approx(_EXPECTED_NLL)
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_rejects_an_entirely_masked_dataset(
+    client_cls,
+    run_validate,
+    metric_key,
+):
+    del metric_key
+    with pytest.raises(SFTConfigError, match="no trainable tokens"):
+        run_validate(client_cls([_MASKED_OUTPUT]), [_MASKED_BATCH])
+
+
+@pytest.mark.parametrize(
+    ("backend_cls", "module_path"),
+    [
+        pytest.param(TinkerSFTBackend, "rllm/trainer/sft/tinker_backend.py", id="tinker"),
+        pytest.param(FireworksSFTBackend, "rllm/trainer/sft/fireworks_backend.py", id="fireworks"),
+    ],
+)
+def test_fit_loop_calls_validate_with_a_bindable_signature(backend_cls, module_path):
+    """Every ``self._validate(...)`` call in a fit loop binds to that backend's
+    own ``_validate``.
+
+    The call sites run only inside a live, billed training job on a step where
+    validation is due, so an arity drift between the two would otherwise first
+    surface as a ``TypeError`` mid-run.
+    """
+    source = (Path(__file__).resolve().parents[2] / module_path).read_text()
+    signature = inspect.signature(backend_cls._validate)
+    call_sites = [node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_validate"]
+    assert call_sites, f"no self._validate(...) call site found in {module_path}"
+    for call in call_sites:
+        # bind() over placeholders: only the shape of the call is under test.
+        signature.bind(*["<arg>"] * len(call.args), **{kw.arg: "<arg>" for kw in call.keywords})

--- a/tests/trainer/test_tinker_sft_training.py
+++ b/tests/trainer/test_tinker_sft_training.py
@@ -1,0 +1,325 @@
+"""Tinker SFT dataset, optimizer, scheduling, and fit-loop contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+from rllm.data import Dataset  # noqa: E402
+from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.tinker_backend import (  # noqa: E402
+    TinkerSFTBackend,
+    build_adam_params,
+    iter_training_batches,
+)
+from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset  # noqa: E402
+
+
+class _TokenRenderer:
+    """Small real Renderer boundary without a tokenizer dependency."""
+
+    def build_supervised_example(self, messages, train_on_what):
+        import torch
+
+        n = int(messages[-1]["content"][0]["text"])
+        return tinker.ModelInput.from_ints(list(range(n + 2))), torch.tensor(
+            [0.0, *([1.0] * n), 0.0],
+            dtype=torch.float32,
+        )
+
+
+def _length_dataset(lengths):
+    return Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": str(n), "trainable": True},
+                ]
+            }
+            for n in lengths
+        ],
+        name="lengths",
+        split="train",
+    )
+
+
+def test_token_mean_reduction_weights_every_assistant_token_equally():
+    ds = TinkerSFTDataset(
+        _length_dataset([2, 6]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        max_length=100,
+        loss_reduction="token_mean",
+    )
+    batch = ds.get_batch(0)
+    weights = [d.loss_fn_inputs["weights"].data for d in batch]
+
+    assert sum(sum(w) for w in weights) == pytest.approx(1.0)
+    positive = [x for w in weights for x in w if x > 0]
+    assert len(positive) == 8
+    assert positive == pytest.approx([1 / 8] * 8)
+
+
+def test_sequence_mean_reduction_gives_each_trajectory_equal_weight():
+    ds = TinkerSFTDataset(
+        _length_dataset([2, 6]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        max_length=100,
+        loss_reduction="sequence_mean",
+    )
+    weights = [d.loss_fn_inputs["weights"].data for d in ds.get_batch(0)]
+    assert [sum(w) for w in weights] == pytest.approx([1.0, 1.0])
+
+
+def test_dataset_rejects_nonpositive_batch_size():
+    with pytest.raises(SFTConfigError, match="batch_size must be positive"):
+        TinkerSFTDataset(
+            _length_dataset([2]),
+            renderer=_TokenRenderer(),
+            batch_size=0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"max_length": 1}, "max_length"),
+        ({"overlength_policy": "drop"}, "overlength policy"),
+        ({"loss_reduction": "batch_mean"}, "loss reduction"),
+    ],
+)
+def test_dataset_rejects_invalid_render_settings_before_iteration(kwargs, match):
+    with pytest.raises(SFTConfigError, match=match):
+        TinkerSFTDataset(
+            _length_dataset([2]),
+            renderer=_TokenRenderer(),
+            batch_size=1,
+            **kwargs,
+        )
+
+
+def test_training_batch_iterator_caps_mid_epoch_at_exact_max_steps():
+    batches = list(
+        iter_training_batches(
+            n_batches=3262,
+            total_epochs=1,
+            start_epoch=0,
+            start_batch=0,
+            max_steps=1000,
+        )
+    )
+    assert len(batches) == 1000
+    assert batches[0] == (0, 0, 0)
+    assert batches[-1] == (999, 0, 999)
+
+
+def test_training_batch_iterator_resumes_at_next_unseen_batch():
+    batches = list(
+        iter_training_batches(
+            n_batches=20,
+            total_epochs=2,
+            start_epoch=1,
+            start_batch=3,
+            max_steps=30,
+        )
+    )
+    assert batches[0] == (23, 1, 3)
+    assert batches[-1] == (29, 1, 9)
+
+
+def test_adamw_options_reach_tinker_sdk():
+    adam = build_adam_params(
+        learning_rate=1e-4,
+        betas=[0.9, 0.999],
+        eps=1e-8,
+        weight_decay=1e-2,
+        grad_clip_norm=1.0,
+    )
+    assert adam.learning_rate == pytest.approx(1e-4)
+    assert adam.beta1 == pytest.approx(0.9)
+    assert adam.beta2 == pytest.approx(0.999)
+    assert adam.weight_decay == pytest.approx(1e-2)
+    assert adam.grad_clip_norm == pytest.approx(1.0)
+
+
+class _FakeDataset:
+    def __init__(self, datums, batches):
+        self.datums = datums
+        self.batches = batches
+        self.batch_calls = []
+        self.epoch_seeds = []
+
+    def __len__(self):
+        return self.batches
+
+    def get_batch(self, index):
+        self.batch_calls.append(index)
+        return self.datums
+
+    def set_epoch(self, seed):
+        self.epoch_seeds.append(seed)
+
+
+class _FakeFuture:
+    def __init__(self, value):
+        self.value = value
+
+    async def result_async(self):
+        return self.value
+
+
+class _FakeTrainingClient:
+    def __init__(self, datums):
+        self.datums = datums
+        self.adam = []
+        self.forward_calls = 0
+        self.forward_backward_calls = 0
+
+    def _forward_output(self):
+        outputs = []
+        for datum in self.datums:
+            weights = datum.loss_fn_inputs["weights"]
+            outputs.append(
+                {
+                    "logprobs": tinker.TensorData(
+                        data=[-1.0] * len(weights.data),
+                        dtype=weights.dtype,
+                        shape=list(weights.shape),
+                    )
+                }
+            )
+        return SimpleNamespace(loss_fn_outputs=outputs)
+
+    async def forward_async(self, data, loss_fn):
+        assert data == self.datums
+        assert loss_fn == "cross_entropy"
+        self.forward_calls += 1
+        return _FakeFuture(self._forward_output())
+
+    async def forward_backward_async(self, data, loss_fn):
+        assert data == self.datums
+        assert loss_fn == "cross_entropy"
+        self.forward_backward_calls += 1
+        return _FakeFuture(self._forward_output())
+
+    async def optim_step_async(self, adam):
+        self.adam.append(adam)
+        return _FakeFuture(SimpleNamespace(metrics={"optim/grad_norm": 0.5}))
+
+
+class _FakeTracking:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.logs = []
+        self.finished = False
+        self.instances.append(self)
+
+    def log(self, data, step):
+        self.logs.append((step, dict(data)))
+
+    def finish(self):
+        self.finished = True
+
+
+def _one_datum():
+    import torch
+    from tinker_cookbook.supervised.common import datum_from_model_input_weights
+
+    return datum_from_model_input_weights(
+        tinker.ModelInput.from_ints([1, 2, 3, 4]),
+        torch.tensor([0.0, 1.0, 1.0, 0.0]),
+        max_length=None,
+        reduction="none",
+    )
+
+
+def test_fit_loop_uses_completed_step_cadence_and_saves_resume_cursor(
+    monkeypatch,
+    tmp_path,
+):
+    """Exercise the real async loop boundary without opening a provider job."""
+    from tinker_cookbook import checkpoint_utils, display
+
+    import rllm.trainer.sft.tinker_backend as backend_module
+    import rllm.utils.tracking as tracking_module
+
+    datum = _one_datum()
+    train = _FakeDataset([datum], batches=3)
+    val = _FakeDataset([datum], batches=1)
+    client = _FakeTrainingClient([datum])
+    saves = []
+
+    class _ServiceClient:
+        def __init__(self, base_url=None):
+            self.base_url = base_url
+
+        async def create_lora_training_client_async(self, **kwargs):
+            return client
+
+    async def _save(**kwargs):
+        saves.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(backend_module, "build_sft_data", lambda *_: (object(), train, val))
+    monkeypatch.setattr(tinker, "ServiceClient", _ServiceClient)
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: None)
+    monkeypatch.setattr(checkpoint_utils, "save_checkpoint_async", _save)
+    monkeypatch.setattr(display, "colorize_example", lambda *_: "example")
+    monkeypatch.setattr(tracking_module, "Tracking", _FakeTracking)
+    _FakeTracking.instances.clear()
+
+    spec = SFTSpec(
+        train_dataset=_length_dataset([2]),
+        val_dataset=_length_dataset([2]),
+        output_dir=str(tmp_path),
+        overrides={
+            "trainer": {
+                "total_epochs": 2,
+                "max_steps": 3,
+                "save_freq": 2,
+                "test_freq": 2,
+            },
+            "optim": {
+                "lr": 1e-4,
+                "min_lr": 1e-5,
+                "lr_scheduler": "cosine",
+                "warmup_steps": 1,
+                "betas": [0.9, 0.999],
+                "eps": 1e-8,
+                "weight_decay": 1e-2,
+                "grad_clip_norm": 1.0,
+            },
+        },
+    )
+    backend = TinkerSFTBackend(spec)
+    backend.build_config()
+    asyncio.run(backend._fit_async())
+
+    assert train.batch_calls == [0, 1, 2]
+    assert train.epoch_seeds == [0]
+    assert client.forward_backward_calls == 3
+    assert client.forward_calls == 2  # validation at step 0 and completed step 2
+    assert [save["name"] for save in saves] == ["000002", "final"]
+    assert saves[0]["loop_state"] == {"epoch": 0, "batch": 2, "step": 2}
+    assert saves[1]["loop_state"] == {
+        "epoch": 1,
+        "batch": 0,
+        "step": 3,
+        "final": True,
+    }
+    assert len(client.adam) == 3
+    assert all(adam.weight_decay == pytest.approx(1e-2) for adam in client.adam)
+    tracking = _FakeTracking.instances[-1]
+    assert [step for step, _ in tracking.logs] == [0, 1, 2, 3, 3]
+    assert tracking.logs[-1][1] == {"status": "completed"}
+    assert tracking.finished is True

--- a/tests/trainer/test_tinker_sft_training.py
+++ b/tests/trainer/test_tinker_sft_training.py
@@ -14,9 +14,15 @@ from rllm.data import Dataset  # noqa: E402
 from rllm.trainer.sft import SFTSpec  # noqa: E402
 from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
 from rllm.trainer.sft.tinker_backend import (  # noqa: E402
+    SFTResumeContract,
     TinkerSFTBackend,
-    build_adam_params,
+    build_tinker_resume_contract,
     iter_training_batches,
+    iter_training_batches_from_step,
+    prepare_tinker_resume_contract,
+    resolve_sft_optimizer_settings,
+    validate_tinker_checkpoint_identity,
+    validate_tinker_resume_cursor,
 )
 from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset  # noqa: E402
 
@@ -79,6 +85,17 @@ def test_sequence_mean_reduction_gives_each_trajectory_equal_weight():
     assert [sum(w) for w in weights] == pytest.approx([1.0, 1.0])
 
 
+def test_default_loss_reduction_preserves_raw_per_token_weights():
+    ds = TinkerSFTDataset(
+        _length_dataset([2, 6]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        max_length=100,
+    )
+    weights = [d.loss_fn_inputs["weights"].data for d in ds.get_batch(0)]
+    assert [sum(w) for w in weights] == pytest.approx([2.0, 6.0])
+
+
 def test_dataset_rejects_nonpositive_batch_size():
     with pytest.raises(SFTConfigError, match="batch_size must be positive"):
         TinkerSFTDataset(
@@ -104,6 +121,85 @@ def test_dataset_rejects_invalid_render_settings_before_iteration(kwargs, match)
             batch_size=1,
             **kwargs,
         )
+
+
+def test_dataset_preflight_renders_every_batch_before_training():
+    ds = TinkerSFTDataset(
+        _length_dataset([2, 20]),
+        renderer=_TokenRenderer(),
+        batch_size=1,
+        max_length=10,
+    )
+
+    with pytest.raises(SFTConfigError, match="train preflight.*dataset row 1.*max_length=10"):
+        ds.preflight()
+
+
+def test_fit_preflights_the_shuffled_epoch_order_before_tinker_client(
+    monkeypatch,
+    tmp_path,
+):
+    from tinker_cookbook import checkpoint_utils
+
+    import rllm.trainer.sft.tinker_backend as backend_module
+
+    # Identity batches [0, 2] / [0, 2] each have loss tokens. Epoch seed 0
+    # produces [0, 0] / [2, 2], so the first submitted batch would be invalid.
+    train = TinkerSFTDataset(
+        _length_dataset([0, 2, 0, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        max_length=100,
+    )
+    monkeypatch.setattr(
+        backend_module,
+        "build_sft_data",
+        lambda *_: (object(), train, None),
+    )
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: None)
+    monkeypatch.setattr(
+        tinker,
+        "ServiceClient",
+        lambda **_: pytest.fail("provider client must not be created"),
+    )
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_length_dataset([2]),
+            output_dir=str(tmp_path),
+            batch_size=2,
+            overrides={"trainer": {"max_steps": 2}},
+        )
+    )
+    backend.build_config()
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        asyncio.run(backend._fit_async())
+
+
+def test_dataset_fingerprint_covers_messages_tools_rows_and_batch_size():
+    first = _length_dataset([2, 6])
+    second = _length_dataset([2, 7])
+    a = TinkerSFTDataset(first, renderer=_TokenRenderer(), batch_size=2)
+    a_again = TinkerSFTDataset(first, renderer=_TokenRenderer(), batch_size=2)
+    changed_row = TinkerSFTDataset(second, renderer=_TokenRenderer(), batch_size=2)
+    changed_batch = TinkerSFTDataset(first, renderer=_TokenRenderer(), batch_size=1)
+
+    assert a.content_fingerprint() == a_again.content_fingerprint()
+    assert a.content_fingerprint() != changed_row.content_fingerprint()
+    assert a.content_fingerprint() != changed_batch.content_fingerprint()
+
+
+@pytest.mark.parametrize("data_consumed", [-1, 3])
+def test_dataset_resume_cursor_requires_an_exact_batch_boundary(data_consumed):
+    dataset = TinkerSFTDataset(
+        _length_dataset([2, 2, 2, 2, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+    )
+
+    with pytest.raises(SFTConfigError, match="cursor.*non-negative|cursor.*exact"):
+        dataset.step_for_data_cursor(data_consumed)
 
 
 def test_training_batch_iterator_caps_mid_epoch_at_exact_max_steps():
@@ -135,25 +231,382 @@ def test_training_batch_iterator_resumes_at_next_unseen_batch():
     assert batches[-1] == (29, 1, 9)
 
 
-def test_adamw_options_reach_tinker_sdk():
-    adam = build_adam_params(
-        learning_rate=1e-4,
-        betas=[0.9, 0.999],
-        eps=1e-8,
-        weight_decay=1e-2,
-        grad_clip_norm=1.0,
+def test_training_batch_iterator_resumes_from_absolute_step_past_epoch_one():
+    batches = list(
+        iter_training_batches_from_step(
+            n_batches=3,
+            total_epochs=3,
+            start_step=7,
+            max_steps=9,
+        )
     )
-    assert adam.learning_rate == pytest.approx(1e-4)
-    assert adam.beta1 == pytest.approx(0.9)
-    assert adam.beta2 == pytest.approx(0.999)
-    assert adam.weight_decay == pytest.approx(1e-2)
-    assert adam.grad_clip_norm == pytest.approx(1.0)
+    assert batches == [(7, 2, 1), (8, 2, 2)]
+
+
+def test_default_checkpoint_directories_are_isolated_but_explicit_is_exact(tmp_path):
+    source = _length_dataset([2])
+    first = TinkerSFTBackend(SFTSpec(train_dataset=source, experiment="same"))
+    second = TinkerSFTBackend(SFTSpec(train_dataset=source, experiment="same"))
+
+    first_path = first.checkpoint_dir
+    assert first.checkpoint_dir == first_path
+    assert second.checkpoint_dir != first_path
+    assert first_path.startswith("/tmp/rllm-tinker-sft-checkpoints/same/")
+
+    explicit = TinkerSFTBackend(SFTSpec(train_dataset=source, output_dir=str(tmp_path / "resume")))
+    assert explicit.checkpoint_dir == str(tmp_path / "resume")
+
+
+def test_resume_contract_rejects_legacy_and_changed_identity(tmp_path):
+    contract = SFTResumeContract(
+        payload={"contract_version": 1, "dataset": {"fingerprint": "first"}},
+        digest="contract-one",
+    )
+    prepare_tinker_resume_contract(str(tmp_path), contract, None)
+    matching = SimpleNamespace(
+        get=lambda key, default=None: {
+            "contract_version": 1,
+            "contract_hash": "contract-one",
+        }.get(key, default)
+    )
+    prepare_tinker_resume_contract(str(tmp_path), contract, matching)
+
+    changed = SFTResumeContract(
+        payload={"contract_version": 1, "dataset": {"fingerprint": "second"}},
+        digest="contract-two",
+    )
+    with pytest.raises(SFTConfigError, match="dataset.fingerprint.*new output"):
+        prepare_tinker_resume_contract(str(tmp_path), changed, matching)
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    legacy = SimpleNamespace(get=lambda *_: None)
+    with pytest.raises(SFTConfigError, match="legacy checkpoint.*sft-run.json.*missing"):
+        prepare_tinker_resume_contract(str(legacy_dir), contract, legacy)
+
+
+@pytest.mark.parametrize(
+    ("cursor", "match"),
+    [
+        ({"epoch": 0, "batch": 2, "step": 1}, "inconsistent"),
+        ({"epoch": 0, "batch": 3, "step": 3}, "inconsistent"),
+        ({"epoch": 0, "batch": 1}, "loop_state.step.*integer"),
+    ],
+)
+def test_tinker_resume_cursor_fails_closed(cursor, match):
+    resume = SimpleNamespace(get=lambda key, default=None: cursor.get(key, default))
+
+    with pytest.raises(SFTConfigError, match=match):
+        validate_tinker_resume_cursor(resume, n_batches=3, total_steps=3)
+
+
+@pytest.mark.parametrize(
+    ("override", "difference"),
+    [
+        ({"model": {"tokenizer_model": "different/tokenizer"}}, "rendering.tokenizer_model"),
+        ({"data": {"rllm": {"strip_thinking_from_history": True}}}, "rendering.strip_thinking_from_history"),
+    ],
+)
+def test_resume_contract_rejects_tokenization_changes_before_tinker_client(
+    monkeypatch,
+    tmp_path,
+    override,
+    difference,
+):
+    from tinker_cookbook import checkpoint_utils
+
+    import rllm.trainer.sft.tinker_backend as backend_module
+
+    train = _FakeDataset([_one_datum()], batches=1)
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_length_dataset([2]),
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 1}},
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=1)
+    original = build_tinker_resume_contract(
+        config,
+        train,
+        optimizer,
+        n_batches=1,
+        total_epochs=1,
+        total_steps=1,
+    )
+    prepare_tinker_resume_contract(str(tmp_path), original, None)
+
+    config = backend_module.OmegaConf.merge(config, backend_module.OmegaConf.create(override))
+    backend._config = config
+    changed = build_tinker_resume_contract(
+        config,
+        train,
+        optimizer,
+        n_batches=1,
+        total_epochs=1,
+        total_steps=1,
+    )
+    assert changed.digest != original.digest
+
+    checkpoint = SimpleNamespace(
+        state_path="tinker://run/weights/step",
+        get=lambda key, default=None: {
+            "contract_version": 1,
+            "contract_hash": original.digest,
+            "epoch": 0,
+            "batch": 1,
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        backend_module,
+        "build_sft_data",
+        lambda *_: (object(), train, None),
+    )
+    monkeypatch.setattr(
+        checkpoint_utils,
+        "get_last_checkpoint",
+        lambda *_: checkpoint,
+    )
+    monkeypatch.setattr(
+        tinker,
+        "ServiceClient",
+        lambda **_: pytest.fail("provider client must not be created"),
+    )
+
+    with pytest.raises(SFTConfigError, match=rf"{difference}.*new output"):
+        asyncio.run(backend._fit_async())
+
+
+def test_provider_checkpoint_identity_is_a_hard_error_before_resume_client():
+    source = _length_dataset([2])
+    backend = TinkerSFTBackend(SFTSpec(train_dataset=source))
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+
+    class _RestClient:
+        async def get_weights_info_by_tinker_path(self, path):
+            assert path == "tinker://run/weights/step"
+            return SimpleNamespace(
+                base_model="different/model",
+                lora_rank=8,
+                train_unembed=True,
+                train_attn=True,
+                train_mlp=True,
+            )
+
+        async def get_training_run_by_tinker_path_async(self, path):
+            assert path == "tinker://run/weights/step"
+            return SimpleNamespace(user_metadata={})
+
+    service = SimpleNamespace(create_rest_client=lambda: _RestClient())
+    with pytest.raises(
+        SFTConfigError,
+        match="base_model=.*lora_rank=.*renderer=.*new output directory",
+    ):
+        asyncio.run(
+            validate_tinker_checkpoint_identity(
+                service,
+                "tinker://run/weights/step",
+                config,
+            )
+        )
+
+
+def test_fit_rejects_provider_identity_before_resumed_training_client(
+    monkeypatch,
+    tmp_path,
+):
+    from tinker_cookbook import checkpoint_utils
+
+    import rllm.trainer.sft.tinker_backend as backend_module
+    import rllm.utils.tracking as tracking_module
+
+    contract = SFTResumeContract(
+        payload={"contract_version": 1, "dataset": {"fingerprint": "same"}},
+        digest="same-contract",
+    )
+    prepare_tinker_resume_contract(str(tmp_path), contract, None)
+
+    class _Checkpoint:
+        state_path = "tinker://run/weights/step"
+
+        def get(self, key, default=None):
+            return {
+                "contract_version": 1,
+                "contract_hash": "same-contract",
+                "epoch": 0,
+                "batch": 1,
+                "step": 1,
+            }.get(key, default)
+
+    class _RestClient:
+        async def get_weights_info_by_tinker_path(self, path):
+            return SimpleNamespace(
+                base_model="wrong/model",
+                lora_rank=32,
+                train_unembed=True,
+                train_attn=True,
+                train_mlp=True,
+            )
+
+        async def get_training_run_by_tinker_path_async(self, path):
+            return SimpleNamespace(user_metadata={checkpoint_utils.RENDERER_NAME_METADATA_KEY: "qwen3_5"})
+
+    class _ServiceClient:
+        def __init__(self, base_url=None):
+            del base_url
+
+        def create_rest_client(self):
+            return _RestClient()
+
+        async def create_training_client_from_state_with_optimizer_async(
+            self,
+            *args,
+            **kwargs,
+        ):
+            pytest.fail("resumed training client must not be created")
+
+    datum = _one_datum()
+    train = _FakeDataset([datum], batches=2)
+    monkeypatch.setattr(
+        backend_module,
+        "build_sft_data",
+        lambda *_: (object(), train, None),
+    )
+    monkeypatch.setattr(
+        backend_module,
+        "build_tinker_resume_contract",
+        lambda *_args, **_kwargs: contract,
+    )
+    monkeypatch.setattr(
+        checkpoint_utils,
+        "get_last_checkpoint",
+        lambda *_: _Checkpoint(),
+    )
+    monkeypatch.setattr(tinker, "ServiceClient", _ServiceClient)
+    monkeypatch.setattr(tracking_module, "Tracking", _FakeTracking)
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_length_dataset([2]),
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 2}},
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+
+    with pytest.raises(SFTConfigError, match="base_model=.*wrong/model"):
+        asyncio.run(backend._fit_async())
+
+
+def test_fit_matching_resume_starts_at_next_unseen_batch(monkeypatch, tmp_path):
+    from tinker_cookbook import checkpoint_utils, display
+
+    import rllm.trainer.sft.tinker_backend as backend_module
+    import rllm.utils.tracking as tracking_module
+
+    contract = SFTResumeContract(
+        payload={"contract_version": 1, "dataset": {"fingerprint": "same"}},
+        digest="same-contract",
+    )
+    prepare_tinker_resume_contract(str(tmp_path), contract, None)
+
+    class _Checkpoint:
+        state_path = "tinker://run/weights/step"
+
+        def get(self, key, default=None):
+            return {
+                "contract_version": 1,
+                "contract_hash": "same-contract",
+                "epoch": 0,
+                "batch": 2,
+                "step": 2,
+            }.get(key, default)
+
+    datum = _one_datum()
+    train = _FakeDataset([datum], batches=3)
+    client = _FakeTrainingClient([datum])
+    saves = []
+
+    class _RestClient:
+        async def get_weights_info_by_tinker_path(self, path):
+            return SimpleNamespace(
+                base_model="Qwen/Qwen3.5-4B",
+                lora_rank=32,
+                train_unembed=True,
+                train_attn=True,
+                train_mlp=True,
+            )
+
+        async def get_training_run_by_tinker_path_async(self, path):
+            return SimpleNamespace(user_metadata={checkpoint_utils.RENDERER_NAME_METADATA_KEY: "qwen3_5"})
+
+    class _ServiceClient:
+        def __init__(self, base_url=None):
+            del base_url
+
+        def create_rest_client(self):
+            return _RestClient()
+
+        async def create_training_client_from_state_with_optimizer_async(
+            self,
+            path,
+            **kwargs,
+        ):
+            assert path == "tinker://run/weights/step"
+            return client
+
+    async def save(**kwargs):
+        saves.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(
+        backend_module,
+        "build_sft_data",
+        lambda *_: (object(), train, None),
+    )
+    monkeypatch.setattr(
+        backend_module,
+        "build_tinker_resume_contract",
+        lambda *_args, **_kwargs: contract,
+    )
+    monkeypatch.setattr(
+        checkpoint_utils,
+        "get_last_checkpoint",
+        lambda *_: _Checkpoint(),
+    )
+    monkeypatch.setattr(checkpoint_utils, "save_checkpoint_async", save)
+    monkeypatch.setattr(display, "colorize_example", lambda *_: "example")
+    monkeypatch.setattr(tinker, "ServiceClient", _ServiceClient)
+    monkeypatch.setattr(tracking_module, "Tracking", _FakeTracking)
+    _FakeTracking.instances.clear()
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_length_dataset([2]),
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 3}},
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    asyncio.run(backend._fit_async())
+
+    assert train.batch_calls == [0, 1, 2, 0, 1, 2, 2]
+    assert train.epoch_seeds == [0]
+    assert client.forward_backward_calls == 1
+    assert [save["name"] for save in saves] == ["final"]
 
 
 class _FakeDataset:
     def __init__(self, datums, batches):
         self.datums = datums
         self.batches = batches
+        self.batch_size = 1
+        self.dataset = [object()] * batches
         self.batch_calls = []
         self.epoch_seeds = []
 
@@ -167,12 +620,27 @@ class _FakeDataset:
     def set_epoch(self, seed):
         self.epoch_seeds.append(seed)
 
+    def preflight(self, label="train", planned_batches=None):
+        del label
+        for index in range(len(self)):
+            self.get_batch(index)
+        if planned_batches is not None:
+            for _epoch, index in planned_batches:
+                self.get_batch(index)
+
+    def content_fingerprint(self):
+        return "fake-dataset"
+
 
 class _FakeFuture:
-    def __init__(self, value):
+    def __init__(self, value, events=None, finish_event=None):
         self.value = value
+        self.events = events
+        self.finish_event = finish_event
 
     async def result_async(self):
+        if self.events is not None and self.finish_event is not None:
+            self.events.append(self.finish_event)
         return self.value
 
 
@@ -182,6 +650,7 @@ class _FakeTrainingClient:
         self.adam = []
         self.forward_calls = 0
         self.forward_backward_calls = 0
+        self.events = []
 
     def _forward_output(self):
         outputs = []
@@ -207,8 +676,14 @@ class _FakeTrainingClient:
     async def forward_backward_async(self, data, loss_fn):
         assert data == self.datums
         assert loss_fn == "cross_entropy"
+        batch = self.forward_backward_calls
         self.forward_backward_calls += 1
-        return _FakeFuture(self._forward_output())
+        self.events.append(f"submit-{batch}")
+        return _FakeFuture(
+            self._forward_output(),
+            self.events,
+            f"finish-{batch}",
+        )
 
     async def optim_step_async(self, adam):
         self.adam.append(adam)
@@ -241,6 +716,47 @@ def _one_datum():
         max_length=None,
         reduction="none",
     )
+
+
+@pytest.mark.parametrize("bad_split", ["train", "validation"])
+def test_fit_preflight_fails_before_tinker_service_client(
+    monkeypatch,
+    tmp_path,
+    bad_split,
+):
+    import rllm.trainer.sft.tinker_backend as backend_module
+
+    datum = _one_datum()
+    train = _FakeDataset([datum], batches=2)
+    val = _FakeDataset([datum], batches=1)
+
+    def fail_preflight(label, planned_batches=None):
+        del planned_batches
+        raise SFTConfigError(f"{label} row is invalid")
+
+    (train if bad_split == "train" else val).preflight = fail_preflight
+    monkeypatch.setattr(
+        backend_module,
+        "build_sft_data",
+        lambda *_: (object(), train, val),
+    )
+    monkeypatch.setattr(
+        tinker,
+        "ServiceClient",
+        lambda **_: pytest.fail("provider client must not be created"),
+    )
+    source = _length_dataset([2])
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=source,
+            val_dataset=source,
+            output_dir=str(tmp_path),
+        )
+    )
+    backend.build_config()
+
+    with pytest.raises(SFTConfigError, match=f"{bad_split} row is invalid"):
+        asyncio.run(backend._fit_async())
 
 
 def test_fit_loop_uses_completed_step_cadence_and_saves_resume_cursor(
@@ -305,20 +821,33 @@ def test_fit_loop_uses_completed_step_cadence_and_saves_resume_cursor(
     backend.build_config()
     asyncio.run(backend._fit_async())
 
-    assert train.batch_calls == [0, 1, 2]
+    assert train.batch_calls == [0, 1, 2, 0, 1, 2, 0, 1, 2]
     assert train.epoch_seeds == [0]
     assert client.forward_backward_calls == 3
+    assert client.events.index("submit-1") < client.events.index("finish-0")
+    assert client.events.index("finish-1") < client.events.index("submit-2")
     assert client.forward_calls == 2  # validation at step 0 and completed step 2
     assert [save["name"] for save in saves] == ["000002", "final"]
-    assert saves[0]["loop_state"] == {"epoch": 0, "batch": 2, "step": 2}
+    assert saves[0]["loop_state"] == {
+        "epoch": 0,
+        "batch": 2,
+        "step": 2,
+        "contract_version": 1,
+        "contract_hash": saves[0]["loop_state"]["contract_hash"],
+    }
     assert saves[1]["loop_state"] == {
         "epoch": 1,
         "batch": 0,
         "step": 3,
         "final": True,
+        "contract_version": 1,
+        "contract_hash": saves[0]["loop_state"]["contract_hash"],
     }
     assert len(client.adam) == 3
     assert all(adam.weight_decay == pytest.approx(1e-2) for adam in client.adam)
+    assert all(adam.beta1 == pytest.approx(0.9) for adam in client.adam)
+    assert all(adam.beta2 == pytest.approx(0.999) for adam in client.adam)
+    assert all(adam.grad_clip_norm == pytest.approx(1.0) for adam in client.adam)
     tracking = _FakeTracking.instances[-1]
     assert [step for step, _ in tracking.logs] == [0, 1, 2, 3, 3]
     assert tracking.logs[-1][1] == {"status": "completed"}


### PR DESCRIPTION
## Summary

This makes structured, multi-turn SFT a lossless and fail-closed path across rLLM's data boundary and hosted trainers. It normalizes reasoning/tool trajectories, aligns Qwen training and serving renders, preflights the exact hosted batch plan before spend, and hardens checkpoint, resume, optimizer, validation, and request-order semantics. Unsupported or ambiguous combinations fail locally with actionable errors.

## Type of change

- [x] Feature
- [x] Fix
- [x] Docs
- [x] Refactor
- [ ] Example / Project
- [x] Infra / CI

## What changed

- Canonicalize reasoning and tool calls without mutating source whitespace; preserve explicit masks under both think-tag import modes and reject ambiguous duplicate/inline thinking representations.
- Match Qwen's last-real-user reasoning boundary for string and canonical wrapped-tool-response content.
- Render every identity-order and planned shuffled/grouped train batch plus validation data before creating a hosted client.
- Isolate default Tinker output paths; require a versioned local/provider resume identity covering model, renderer/tokenizer, dataset, optimizer, and horizon; validate cursors before resumed-client creation.
- Restore one-step hosted submission overlap while draining before validation/checkpoint boundaries.
- Reject hosted-only override keys on verl with native alternatives; retain the documented structured-row capability edge.
- Pin a reproducible Fireworks SDK/cookbook pair and fail closed when a Fireworks checkpoint lacks its persisted raw-row cursor.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- Integrated the current `terminal-rl` tip (`e4c28795`) without conflicts.
- 245 focused trainer, schema, bridge, and dataset CLI tests passed on the pinned provider stack; the full trainer suite passed (162 tests).
- Changed-file pre-commit hooks, `uv lock --check`, `git diff --check`, and Mintlify validation passed.
- Independent data/verl and hosted-backend reviews approved the final schema, preflight, resume, cursor, pipelining, and provider API boundaries.
- Tinker E2E: Qwen3.5-4B LoRA completed 3 updates, validation at steps 0/2, a step-2 periodic checkpoint, final step-3 checkpoint, same-directory no-op resume, and local mismatch rejection.
- Fireworks E2E: Qwen3.5-9B LoRA completed 3 updates, validation at steps 0/2, resumable/final checkpoints, a READY promoted model, and provider-confirmed trainer deletion.
- One-step overlap was behaviorally tested and provider-compatible, but no throughput improvement is claimed because throughput was not measured.

## Breaking changes / migration notes

- `rllm dataset import --trim-whitespace` is removed. Core import now preserves source whitespace; model-aware cleanup belongs at the renderer/dataset-recipe boundary.
- Assistant text beginning with a structural `<think>...</think>` block is rejected by the plain `messages` bridge; use `--format think-tags` or canonical thinking parts.
- Over-length hosted trajectories error by default. Set `data.rllm.overlength_policy=truncate` only when lossy compatibility is intentional.
- Final partial batches are trained, so epoch-derived step counts can increase by one.
- Reusing a Tinker `--output` path is explicit resume intent; legacy or identity-mismatched checkpoints require a new output directory.
- Fireworks auto-resume requires a positive persisted `dataloader.json` cursor; legacy/missing cursor state is rejected rather than replayed.
- `hf_template` remains unsupported on Tinker/Fireworks until native sampler-render parity exists; use `cumulative`/`stepwise`, or verl.

## Docs / examples

- [ ] Not needed
- [x] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

Updated `docs/guides/sft-distillation.mdx` with a concise import → inspect → short hosted run → scale workflow, backend support, preflight/resume behavior, config examples, and troubleshooting.

## Related issues / PRs

- Round 1 audit follow-up for this PR.

## Screenshots / logs

- Not applicable.
