### PR TITLE
infra: retry provider throttles in the gateway, cache Modal's App.lookup

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -50,6 +50,25 @@ _HOP_BY_HOP = frozenset(
     }
 )
 
+# Upstream statuses the proxy retries itself: provider throttling (429) and
+# transient faults (timeout / gateway / unavailable). See _send_with_retry.
+_RETRY_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """The response's ``Retry-After`` delay in seconds, when it sends a usable one.
+
+    Only the delta-seconds form is honored (what LLM providers send); an HTTP-date
+    or a garbage value returns ``None`` so the caller falls back to its own backoff.
+    """
+    raw = response.headers.get("retry-after")
+    if not raw:
+        return None
+    try:
+        return max(0.0, min(float(raw.strip()), 60.0))
+    except ValueError:
+        return None
+
 
 def _strip_logprobs(response: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of *response* with ``logprobs`` removed from each choice.
@@ -1424,7 +1443,6 @@ class ReverseProxy:
         for attempt in range(1 + self.max_retries):
             try:
                 resp = await self._http.request(method, url, content=content, headers=headers)
-                return resp
             except httpx.ConnectError as exc:
                 last_exc = exc
                 if attempt < self.max_retries:
@@ -1434,7 +1452,28 @@ class ReverseProxy:
                         self.max_retries + 1,
                         exc,
                     )
-        raise last_exc  # type: ignore[misc]
+                continue
+            if resp.status_code not in _RETRY_STATUSES or attempt >= self.max_retries:
+                return resp
+            # Provider throttles and transient upstream faults have to be retried
+            # *here*: once the request is past `heartbeat_initial_delay_s` the
+            # response status is already committed to 200, so the error body would
+            # be forwarded under a 200 and the client's own retry logic — which
+            # keys on the status — never fires. The rollout then dies on an
+            # unparseable completion. Heartbeats keep the client's connection warm
+            # while we back off, so the retry is invisible to it.
+            delay = _retry_after_seconds(resp) or min(2.0**attempt, 30.0)
+            logger.warning(
+                "Upstream returned %d (attempt %d/%d); retrying in %.1fs",
+                resp.status_code,
+                attempt + 1,
+                self.max_retries + 1,
+                delay,
+            )
+            await asyncio.sleep(delay)
+        if last_exc is not None:
+            raise last_exc
+        return resp
 
     async def _persist(self, trace: TraceRecord) -> None:
         try:

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -135,6 +135,24 @@ _CREATE_RATE_RPS = env_float("RLLM_MODAL_SANDBOX_CREATE_RPS", 4.0)
 _CREATE_BURST = env_float("RLLM_MODAL_SANDBOX_CREATE_BURST", 150.0)
 _CREATE_LIMITER = _CreateRateLimiter(_CREATE_RATE_RPS, _CREATE_BURST)
 
+# One App.lookup per app name per process. Modal rate-limits AppGetOrCreate
+# account-wide, and a run boots one sandbox per task (dozens concurrently), so
+# looking the app up in every constructor spends that quota re-fetching a value
+# that never changes — and the server-side throttle it triggers is retried with
+# an unbounded wait, which reads as a hung run during sandbox setup. The lock is
+# held across the RPC so a burst of constructors makes exactly one call.
+_APP_CACHE: dict[str, object] = {}
+_APP_CACHE_LOCK = threading.Lock()
+
+
+def _lookup_app(app_name: str):
+    import modal
+
+    with _APP_CACHE_LOCK:
+        if app_name not in _APP_CACHE:
+            _APP_CACHE[app_name] = modal.App.lookup(app_name, create_if_missing=True)
+        return _APP_CACHE[app_name]
+
 
 def _terminate_all_live() -> None:
     """atexit hook: terminate every still-alive ModalSandbox."""
@@ -217,7 +235,7 @@ class ModalSandbox:
         # A stored snapshot ref is a bare Modal image id ("im-…", no registry/tag);
         # the ":" / "/" guard keeps real docker images off the from_id path.
         from_snapshot = isinstance(image, str) and image.startswith("im-") and ":" not in image and "/" not in image
-        self._app = modal.App.lookup(self._app_name, create_if_missing=True)
+        self._app = _lookup_app(self._app_name)
 
         # A missing snapshot surfaces as NotFoundError either at from_id (if it
         # ever resolves eagerly) or at create; translate both so get_sandbox can


### PR DESCRIPTION
Two provider-throttling failures that cost rollouts. No grading logic — transport/provider reliability only.

## Gateway retries 429/5xx itself

Long agentic calls need heartbeats to survive intermediaries (a cloudflared quick tunnel enforces a 120s origin read timeout). Once the first heartbeat byte goes out **the HTTP status is already committed as 200**, so a later upstream 429 can only be forwarded as an error body *under* a 200 — the proxy already logs exactly this:

```
"Upstream returned %d after heartbeat commit; forwarding error body under 200"
```

litellm keys its retry logic on the status code, so it never fires, and the rollout dies on an unparseable completion. Retrying **here**, before the status is committed, is the only place it can work; heartbeats keep the client's connection warm through the backoff, so the retry is invisible to it.

Honours `Retry-After` (delta-seconds form, capped at 60s), otherwise exponential backoff capped at 30s.

Measured on a 113-task deepswe run (glm-5p2, Modal sandboxes, Fireworks upstream):

| concurrency | throttles absorbed | leaked under a committed 200 |
|---|---|---|
| 64 | **1129** | 1 |
| 24 | 5 | 0 |

## One `App.lookup` per app name per process

Modal rate-limits `AppGetOrCreate` and retries it with an unbounded wait, so looking it up once per sandbox stalls startup under concurrency.

## Testing

565 pass. One pre-existing failure on `terminal-rl`, unrelated and untouched here: `test_harbor_parity.py::test_lifetime_floor_sized_from_task_budget_when_no_override` expects `agent+verifier+install+slack` (3000) while `_sandbox_resource_kwargs` computes `agent+verifier+300` (2100) — a test/implementation drift from #736 worth a separate look, since the test's intent (counting install time toward the sandbox lifetime) is arguably right and would be a latent reap risk for slow-install benchmarks.

## Related

Two follow-ups from the same investigation, independent of this one:
- grading correctness (in-sandbox verifiers vs agents that commit) — worth ~+22pp on DeepSWE
- honouring `[verifier].environment_mode = "separate"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)