### PR TITLE
eval: grade the agent's tree, keep the verifier's output, stop misreading dead graders

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -841,7 +841,13 @@ class AgentFlowEngine:
         for signal in eval_output.signals:
             enriched.metrics[signal.name] = signal.value
 
-        if _no_usable_model_output(enriched) and not enriched.is_correct and enriched.termination_reason not in INFRA_ERROR_REASONS:
+        # Harnesses that drive no model at all (oracle: runs the task's reference
+        # solution) trip the canary below by construction — every rollout has zero
+        # completions because none were ever requested. Left unguarded it reports
+        # the one thing the oracle exists to detect, a task whose *reference
+        # solution* fails its own verifier, as "upstream/proxy/gateway failure".
+        _llm_driven = getattr(self.agent_flow, "makes_llm_calls", True)
+        if _llm_driven and _no_usable_model_output(enriched) and not enriched.is_correct and enriched.termination_reason not in INFRA_ERROR_REASONS:
             # The agent produced nothing usable — no LLM calls at all, or every
             # call came back empty: a downed/erroring upstream (proxy died, auth or
             # tunnel failure), NOT a clean rollout. The reward (0) is meaningless;

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -841,11 +841,9 @@ class AgentFlowEngine:
         for signal in eval_output.signals:
             enriched.metrics[signal.name] = signal.value
 
-        # Harnesses that drive no model at all (oracle: runs the task's reference
-        # solution) trip the canary below by construction — every rollout has zero
-        # completions because none were ever requested. Left unguarded it reports
-        # the one thing the oracle exists to detect, a task whose *reference
-        # solution* fails its own verifier, as "upstream/proxy/gateway failure".
+        # A harness that drives no model (oracle) has zero completions by
+        # construction, so the canary below would report its every failure — i.e.
+        # a task whose reference solution fails its own verifier — as an outage.
         _llm_driven = getattr(self.agent_flow, "makes_llm_calls", True)
         if _llm_driven and _no_usable_model_output(enriched) and not enriched.is_correct and enriched.termination_reason not in INFRA_ERROR_REASONS:
             # The agent produced nothing usable — no LLM calls at all, or every

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -20,6 +20,7 @@ import base64
 import importlib
 import inspect
 import logging
+import os
 import re
 import shlex
 import uuid
@@ -121,13 +122,27 @@ def _capture_git_heads(task: Task, sandbox: Sandbox) -> dict[str, str]:
     Scans the declared ``workdir`` plus the top-level directories, so it covers
     ``/app``, ``/testbed``, ``/workspace`` and friends without knowing which task
     family it's looking at. Best-effort: a git-less environment yields an empty
-    map and the restore is a no-op. Set ``RLLM_VERIFIER_RESTORE_GIT_HEAD=0`` to
-    disable for a verifier that genuinely wants to grade the agent's commits.
+    map and the restore is a no-op.
+
+    Only for tasks that declared ``[verifier].environment_mode = "separate"``
+    and are being graded in the agent's container anyway — i.e. exactly where
+    rLLM knowingly deviates from the contract, which is what makes the verifier's
+    pristine-HEAD assumption false. Moving HEAD is wrong for a task whose agent is
+    *supposed* to move it (a shared-mode task that builds commits: terminal-bench's
+    git-object-builder asserts on ``refs/heads/main`` and ``git ls-tree HEAD``), so
+    shared-mode tasks are left alone. ``RLLM_VERIFIER_RESTORE_GIT_HEAD`` forces it
+    on (``1``) for a shared task whose verifier does assume a pristine HEAD, or off
+    (``0``) entirely.
     """
     from rllm.env import env_int
     from rllm.eval.script_evaluator import _GIT
+    from rllm.tasks.loader import VERIFIER_MODE_SEPARATE
 
-    if not env_int("RLLM_VERIFIER_RESTORE_GIT_HEAD", 1):
+    override = os.environ.get("RLLM_VERIFIER_RESTORE_GIT_HEAD")
+    if override is not None:
+        if not env_int("RLLM_VERIFIER_RESTORE_GIT_HEAD", 1):
+            return {}
+    elif task.metadata.get("verifier_mode") != VERIFIER_MODE_SEPARATE:
         return {}
     roots = "/*"
     workdir = task.metadata.get("workdir")
@@ -159,6 +174,9 @@ def _resolve_evaluator(
     if kind == "sandbox-shell":
         if sandbox is None:
             raise RuntimeError("sandbox-shell verifier requires an active sandbox")
+        from rllm.tasks.loader import VERIFIER_MODE_SEPARATE
+
+        separate = task.metadata.get("verifier_mode") == VERIFIER_MODE_SEPARATE and _separate_verifier_enabled()
         return ShellScriptEvaluator(
             sandbox=sandbox,
             script_path=verifier_config.get("script", "tests/test.sh"),
@@ -166,6 +184,9 @@ def _resolve_evaluator(
             verifier_timeout=(_effective_verifier_timeout(task) or 600.0),
             reward_file_override=verifier_config.get("reward_file"),
             git_heads=_capture_git_heads(task, sandbox),
+            verifier_sandbox_factory=(lambda: _create_verifier_sandbox(task, task.metadata.get("sandbox_backend"))) if separate else None,
+            collect_commands=task.metadata.get("verifier_collect") if separate else None,
+            artifacts=task.metadata.get("artifacts") if separate else None,
         )
 
     if kind in ("python-host", "python-hybrid"):
@@ -237,12 +258,22 @@ def _resolve_backend(task: Task, sandbox_backend: str | None) -> str:
     return sandbox_backend or task.metadata.get("sandbox_backend") or "docker"
 
 
-def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, name: str | None = None, **backend_kwargs) -> Sandbox:
+def _create_base_sandbox(
+    task: Task,
+    backend: str,
+    *,
+    image: str | None = None,
+    name: str | None = None,
+    env_override: dict | None = None,
+    **backend_kwargs,
+) -> Sandbox:
     """Create a sandbox from a base ``image`` — no Dockerfile RUN replay.
 
     ``image`` defaults to the task's resolved base image; pass a snapshot
-    ref to boot from a pre-warmed environment instead. ``backend_kwargs``
-    pass through to the backend constructor (e.g. Modal's ``timeout``).
+    ref to boot from a pre-warmed environment instead. ``env_override``
+    replaces the ``[environment]`` section resources are read from (used for a
+    separate verifier container). ``backend_kwargs`` pass through to the backend
+    constructor (e.g. Modal's ``timeout``).
     """
     from rllm.sandbox.sandboxed_flow import create_sandbox
 
@@ -252,7 +283,7 @@ def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, 
         name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
     # Explicit caller kwargs override the per-task resource defaults — both may
     # carry Modal's ``timeout`` (e.g. the snapshot builder's build_timeout).
-    kwargs = {**_sandbox_resource_kwargs(task, backend), **backend_kwargs}
+    kwargs = {**_sandbox_resource_kwargs(task, backend, env_override), **backend_kwargs}
     return create_sandbox(backend, name=name, image=image, **kwargs)
 
 
@@ -374,7 +405,52 @@ def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox
     return sandbox
 
 
-def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
+def _separate_verifier_enabled() -> bool:
+    """Whether to honour ``environment_mode = "separate"`` by grading in a fresh box.
+
+    Off by default while the in-place path is the one with a measured track
+    record: it is *more* permissive (it grades the working tree, where the
+    contract grades ``git diff <base> HEAD`` — committed work only), so turning
+    this on can lower a benchmark's score for agents that don't commit. Set
+    ``RLLM_SEPARATE_VERIFIER_ENV=1`` to grade the way the tasks declare.
+    """
+    from rllm.env import env_int
+
+    return bool(env_int("RLLM_SEPARATE_VERIFIER_ENV", 0))
+
+
+def _verifier_env_section(task: Task) -> dict:
+    """The ``[environment]`` a separate-mode verifier container runs under.
+
+    Harbor's ``resolve_effective_verifier_env_config`` prefers the task's
+    ``[verifier.environment]`` and otherwise copies ``[environment]``. Tasks
+    routinely declare only resources there (deepswe sets cpus/memory/storage and
+    no image), so layer it *over* the task's section rather than replacing it —
+    replacing would drop the image and leave nothing to boot.
+    """
+    return {**(task.metadata.get("environment") or {}), **(task.metadata.get("verifier_environment") or {})}
+
+
+def _create_verifier_sandbox(task: Task, sandbox_backend: str | None) -> Sandbox:
+    """A fresh container to grade a separate-mode task in.
+
+    Harbor builds this image from ``tests/`` as the build context — deepswe's
+    ``tests/Dockerfile`` is "the pinned task image with the hidden tests baked
+    in". Creating from the task's own image reproduces it, because
+    :class:`~rllm.eval.script_evaluator.ShellScriptEvaluator` uploads ``tests/``
+    to ``/tests`` regardless. Resources come from the verifier's own section.
+    """
+    backend = _resolve_backend(task, sandbox_backend)
+    safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
+    return _create_base_sandbox(
+        task,
+        backend,
+        name=f"rllm-verify-{safe_id}-{uuid.uuid4().hex[:6]}",
+        env_override=_verifier_env_section(task),
+    )
+
+
+def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None = None) -> dict:
     """Map a harbor task's declared ``[environment]`` resources to backend kwargs.
 
     Harbor task.toml declares ``cpus`` / ``memory_mb`` / ``storage_mb``; without
@@ -411,7 +487,7 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
     """
     from rllm.env import env_float, env_int, sandbox_timeout_override_s
 
-    env = task.metadata.get("environment", {}) or {}
+    env = env_override if env_override is not None else (task.metadata.get("environment", {}) or {})
     cpus, mem_mb, disk_mb = env.get("cpus"), env.get("memory_mb"), env.get("storage_mb")
 
     # Operator caps clamp the baked-in task.toml values down (see docstring):

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -21,6 +21,7 @@ import importlib
 import inspect
 import logging
 import re
+import shlex
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -108,6 +109,46 @@ def _effective_verifier_timeout(task: Task) -> float | None:
     return float(declared)
 
 
+def _capture_git_heads(task: Task, sandbox: Sandbox) -> dict[str, str]:
+    """Map ``repo root -> HEAD sha`` for the sandbox's git repos, before the agent runs.
+
+    Handed to :class:`ShellScriptEvaluator`, which puts HEAD back (soft) right
+    before grading — see :meth:`ShellScriptEvaluator._restore_git_heads` for why
+    an agent's commits break in-sandbox verifiers. Called at evaluator-resolution
+    time, which the hook does after environment setup and before the agent, so
+    what's recorded is the image's own commit.
+
+    Scans the declared ``workdir`` plus the top-level directories, so it covers
+    ``/app``, ``/testbed``, ``/workspace`` and friends without knowing which task
+    family it's looking at. Best-effort: a git-less environment yields an empty
+    map and the restore is a no-op. Set ``RLLM_VERIFIER_RESTORE_GIT_HEAD=0`` to
+    disable for a verifier that genuinely wants to grade the agent's commits.
+    """
+    from rllm.env import env_int
+    from rllm.eval.script_evaluator import _GIT
+
+    if not env_int("RLLM_VERIFIER_RESTORE_GIT_HEAD", 1):
+        return {}
+    roots = "/*"
+    workdir = task.metadata.get("workdir")
+    if workdir:
+        roots = f"{shlex.quote(str(workdir))} /*"
+    script = (
+        f'for d in {roots}; do [ -d "$d" ] || continue; '
+        f't=$({_GIT} -C "$d" rev-parse --show-toplevel 2>/dev/null) || continue; '
+        f'h=$({_GIT} -C "$t" rev-parse HEAD 2>/dev/null) || continue; '
+        f'printf "%s %s\\n" "$t" "$h"; done | sort -u'
+    )
+    heads: dict[str, str] = {}
+    for line in _safe_exec(sandbox, script, timeout=60).splitlines():
+        parts = line.split()
+        if len(parts) == 2 and len(parts[1]) == 40:
+            heads.setdefault(parts[0], parts[1])
+    if heads:
+        logger.debug("Captured pre-agent git HEADs for %s: %s", task.id, heads)
+    return heads
+
+
 def _resolve_evaluator(
     task: Task,
     sandbox: Sandbox | None,
@@ -124,6 +165,7 @@ def _resolve_evaluator(
             verifier_user=task.metadata.get("verifier_user"),
             verifier_timeout=(_effective_verifier_timeout(task) or 600.0),
             reward_file_override=verifier_config.get("reward_file"),
+            git_heads=_capture_git_heads(task, sandbox),
         )
 
     if kind in ("python-host", "python-hybrid"):

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -37,6 +37,9 @@ _REWARD_PATHS = [
 # grader detail lifted to signals (see _parse_reward_json).
 _RESERVED_REWARD_KEYS = frozenset({"reward", "rewards", "is_correct", "signals", "metadata"})
 
+# Enough for a suite's failure summary without bloating results.json.
+_VERIFIER_STDOUT_TAIL_CHARS = 8000
+
 
 class ShellScriptEvaluator:
     """Run a verifier script inside the sandbox, parse the reward file.
@@ -114,8 +117,9 @@ class ShellScriptEvaluator:
 
         self._restore_git_heads(v_user)
 
+        verifier_stdout = ""
         try:
-            self.sandbox.exec(
+            verifier_stdout = self.sandbox.exec(
                 f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
                 timeout=self.verifier_timeout,
                 user=v_user,
@@ -138,12 +142,22 @@ class ShellScriptEvaluator:
             # below) carries the signal. Log at debug so a benchmark of
             # 100 unsolved tasks doesn't spam 100 multi-KB stack traces.
             logger.debug("Verifier exited non-zero for %s: %s", task.id, e)
+            # The backend raises with the output attached — the only copy we get
+            # on the failure path, which is the one worth debugging.
+            verifier_stdout = str(e)
 
         # Read reward (as verifier — agent may not have read access)
         reward_paths = list(_REWARD_PATHS)
         if self.reward_file_override:
             reward_paths.insert(0, self.reward_file_override)
-        return _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+        out = _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+        # Harbor verifiers cat every suite's raw log to stdout so "the reason a
+        # test failed is never lost", and the sandbox dies at teardown — without
+        # this a failed task records only a bare count (f2p 42/43) with no way to
+        # tell which test failed. Tail, not head: the verdict is at the end.
+        if verifier_stdout:
+            out.metadata["verifier_stdout_tail"] = verifier_stdout[-_VERIFIER_STDOUT_TAIL_CHARS:]
+        return out
 
     def _restore_git_heads(self, user: str | None) -> None:
         """Move each repo's HEAD back to the commit it had before the agent ran.

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -22,12 +22,20 @@ from rllm.types import Episode, Task
 logger = logging.getLogger(__name__)
 
 
+# Sandbox repos are root-owned but may be inspected as another user, which trips
+# git's dubious-ownership guard; every git call rLLM makes opts out of it.
+_GIT = "git -c safe.directory='*'"
+
 # Reward file search order (first existing file wins)
 _REWARD_PATHS = [
     "/tmp/rllm/reward.json",
     "/logs/verifier/reward.json",
     "/logs/verifier/reward.txt",
 ]
+
+# Keys of a reward file that carry the verdict itself; everything else in it is
+# grader detail lifted to signals (see _parse_reward_json).
+_RESERVED_REWARD_KEYS = frozenset({"reward", "rewards", "is_correct", "signals", "metadata"})
 
 
 class ShellScriptEvaluator:
@@ -45,12 +53,15 @@ class ShellScriptEvaluator:
         verifier_user: str | None = None,
         verifier_timeout: float = 600.0,
         reward_file_override: str | None = None,
+        git_heads: dict[str, str] | None = None,
     ):
         self.sandbox = sandbox
         self.script_path = script_path  # relative to the task's directory
         self.verifier_user = verifier_user
         self.verifier_timeout = verifier_timeout
         self.reward_file_override = reward_file_override
+        # repo root -> HEAD sha as of before the agent ran (see _restore_git_heads).
+        self.git_heads = git_heads or {}
 
     def evaluate(self, task: Task, episode: Episode) -> EvalOutput:
         tests_dir = task.task_dir / Path(self.script_path).parent
@@ -100,6 +111,9 @@ class ShellScriptEvaluator:
         # and silently collect zero tests when forced into ``/workspace``.
         workdir = task.metadata.get("workdir")
         cd_prefix = f"cd {workdir} && " if workdir else ""
+
+        self._restore_git_heads(v_user)
+
         try:
             self.sandbox.exec(
                 f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
@@ -130,6 +144,30 @@ class ShellScriptEvaluator:
         if self.reward_file_override:
             reward_paths.insert(0, self.reward_file_override)
         return _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+
+    def _restore_git_heads(self, user: str | None) -> None:
+        """Move each repo's HEAD back to the commit it had before the agent ran.
+
+        In-sandbox verifiers restore the task's official test files with
+        ``git checkout HEAD -- <path>`` before applying their test patch, which
+        assumes HEAD is still the *image's* commit. rLLM runs the verifier in the
+        agent's own sandbox, so an agent that commits its work (mini-swe-agent
+        and other git-oriented agents do) moves HEAD — and that "restore" then
+        resurrects the agent's own edited/added test files, making the official
+        test patch unappliable ("already exists in working directory" / "patch
+        does not apply") and crashing the verifier before it grades anything.
+
+        ``reset --soft`` moves the branch ref only: the working tree and index
+        keep the agent's edits, which is exactly what the verifier grades. No-op
+        when nothing was captured (``_capture_git_heads``) or HEAD never moved.
+        """
+        for root, sha in self.git_heads.items():
+            cmd = f'cur=$({_GIT} -C {root} rev-parse HEAD 2>/dev/null); [ "$cur" = {sha} ] || {{ {_GIT} -C {root} reset --soft {sha} && echo moved; }}'
+            try:
+                if "moved" in self.sandbox.exec(cmd, timeout=60, user=user):
+                    logger.info("Restored %s HEAD to pre-agent commit %s before grading", root, sha[:12])
+            except Exception as e:
+                logger.warning("Could not restore %s HEAD to %s: %s", root, sha[:12], e)
 
 
 # ---------------------------------------------------------------------------
@@ -162,8 +200,9 @@ def _read_reward_from_sandbox(sandbox: Sandbox, paths: list[str], user: str | No
         try:
             if path.endswith(".txt"):
                 reward = float(raw)
-                return EvalOutput(reward=reward, is_correct=reward >= 1.0)
-            return _parse_reward_json(raw)
+                out = EvalOutput(reward=reward, is_correct=reward >= 1.0)
+            else:
+                out = _parse_reward_json(raw)
         except Exception as e:
             logger.warning("Could not parse reward file %s: %s", path, e)
             return EvalOutput(
@@ -172,6 +211,22 @@ def _read_reward_from_sandbox(sandbox: Sandbox, paths: list[str], user: str | No
                 error="VerifierOutputParseError",
                 metadata={"error": f"could not parse reward file {path}: {e}"},
             )
+        # A negative reward is the harness's "no verdict" sentinel, not a score:
+        # harbor-style test.sh wrappers trap a crashed grader and write -1 so the
+        # failure stays visible instead of masquerading as a legitimate 0. Tag it
+        # as a grading error (and zero the reward, which is not on the task's
+        # scale and would otherwise skew mean reward); the raw sentinel is kept in
+        # metadata and a ``verifier_crash`` signal for triage.
+        if out.reward < 0:
+            logger.warning("Verifier wrote crash sentinel %s to %s", out.reward, path)
+            return EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                error="VerifierCrashError",
+                signals=[*out.signals, Signal(name="verifier_crash", value=1.0)],
+                metadata={**out.metadata, "error": f"verifier wrote crash sentinel {out.reward} to {path}", "reward_sentinel": out.reward},
+            )
+        return out
 
     # A missing reward file means the verifier produced no verdict — a verifier/
     # infra failure, NOT a legitimate score of 0 (a correctly-failing verifier
@@ -189,6 +244,13 @@ def _parse_reward_json(raw: str) -> EvalOutput:
     """Parse a JSON reward file into an EvalOutput.
 
     Supports both ``{"reward": 0.5}`` and Harbor-style ``{"rewards": {...}}``.
+
+    Every other top-level scalar becomes a :class:`Signal`, so whatever
+    fine-grained state the grader reported alongside its verdict — SWE-bench
+    style ``f2p_passed``/``p2p_failed``/``apply_failed`` counts, a partial
+    score, per-suite tallies — lands on the episode (and in the eval report's
+    signal averages) instead of being collapsed into one number. Graders differ
+    per benchmark, so nothing here is keyed to a specific field name.
     """
     data = json.loads(raw)
 
@@ -206,6 +268,9 @@ def _parse_reward_json(raw: str) -> EvalOutput:
         signals.append(Signal(name=key, value=float(val)))
     for key, val in data.get("rewards", {}).items():
         if key != "reward":
+            signals.append(Signal(name=key, value=float(val)))
+    for key, val in data.items():
+        if key not in _RESERVED_REWARD_KEYS and isinstance(val, bool | int | float):
             signals.append(Signal(name=key, value=float(val)))
 
     return EvalOutput(

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -40,10 +40,8 @@ class OracleHarness(SandboxedAgentFlow):
     name = "oracle"
     sandbox_backend = "docker"
 
-    # No LLM is involved, so every episode has zero completions. Tells the engine
-    # not to read that as a downed upstream — for this harness a reward of 0 means
-    # the task's own reference solution failed its verifier, which is the signal
-    # the harness exists to produce.
+    # No LLM, so every episode has zero completions: tells the engine not to read
+    # that as a downed upstream (see AgentFlowEngine._finish_episode).
     makes_llm_calls = False
 
     # Mirror Harbor's ``env_paths.solution_dir`` convention so anyone

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -40,6 +40,12 @@ class OracleHarness(SandboxedAgentFlow):
     name = "oracle"
     sandbox_backend = "docker"
 
+    # No LLM is involved, so every episode has zero completions. Tells the engine
+    # not to read that as a downed upstream — for this harness a reward of 0 means
+    # the task's own reference solution failed its verifier, which is the signal
+    # the harness exists to produce.
+    makes_llm_calls = False
+
     # Mirror Harbor's ``env_paths.solution_dir`` convention so anyone
     # comparing the two implementations doesn't trip on path drift.
     _SOLUTION_DIR = "/solution"

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -244,6 +244,41 @@ def _normalize_env_section(env_section: dict, explicit_docker_image: bool) -> No
             env_section["storage_mb"] = mb
 
 
+# Harbor's ``[verifier]`` environment contract (schema >= 1.3). A task declares
+# whether its verifier runs in the agent's container or a dedicated one; a task
+# that declares nothing keeps the legacy shared behaviour, so reading this can
+# never change an existing benchmark's outcome.
+VERIFIER_MODE_SHARED = "shared"
+VERIFIER_MODE_SEPARATE = "separate"
+
+
+def _resolve_verifier_mode(verifier_section: dict) -> str:
+    """The verifier's environment mode, resolved the way harbor resolves it.
+
+    Explicit ``environment_mode`` wins; declaring a ``[verifier.environment]``
+    implies ``separate`` (that is how harbor infers it); everything else is
+    ``shared``. Mirrors ``harbor.models.task.verifier_mode._resolve_mode``.
+    """
+    declared = verifier_section.get("environment_mode")
+    if declared:
+        return str(declared)
+    if verifier_section.get("environment"):
+        return VERIFIER_MODE_SEPARATE
+    return VERIFIER_MODE_SHARED
+
+
+def _lift_verifier_contract(raw: dict, into: dict) -> None:
+    """Copy the task's declared verifier contract onto a metadata dict."""
+    verifier_section = raw.get("verifier", {}) or {}
+    into["verifier_mode"] = _resolve_verifier_mode(verifier_section)
+    into["verifier_environment"] = verifier_section.get("environment")
+    into["verifier_collect"] = verifier_section.get("collect", []) or []
+    into["verifier_network_mode"] = verifier_section.get("network_mode")
+    # Top-level ``artifacts``: paths the collect step produces, which a separate
+    # verifier container needs re-materialised at their original locations.
+    into["artifacts"] = raw.get("artifacts", []) or []
+
+
 def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     """Merge per-task ``task.toml`` metadata into *base*.
 
@@ -289,6 +324,7 @@ def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     _agent_timeout = raw.get("agent", {}).get("timeout_sec")
     if _agent_timeout is not None:
         merged["agent_timeout"] = _agent_timeout
+    _lift_verifier_contract(raw, merged)
     rllm_section = raw.get("rllm", {}) or {}
     merged["setup_commands"] = rllm_section.get("setup_commands", merged.get("setup_commands", [])) or []
     return merged
@@ -618,6 +654,7 @@ def _load_task_from_dir(
     _agent_timeout = raw.get("agent", {}).get("timeout_sec")
     if _agent_timeout is not None:
         metadata["agent_timeout"] = _agent_timeout
+    _lift_verifier_contract(raw, metadata)
     rllm_section = raw.get("rllm", {}) or {}
     metadata["setup_commands"] = rllm_section.get("setup_commands", []) or []
 

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -93,6 +93,7 @@ _ERROR_TYPE_TO_REASON: dict[str, TerminationReason] = {
     "RewardFileNotFoundError": TerminationReason.GRADING_ERROR,
     "RewardFileEmptyError": TerminationReason.GRADING_ERROR,
     "VerifierOutputParseError": TerminationReason.GRADING_ERROR,
+    "VerifierCrashError": TerminationReason.GRADING_ERROR,  # grader died before a verdict (negative-reward sentinel)
     # Environment/sandbox (harbor.environments.base + rllm.sandbox.protocol + backends)
     "HealthcheckError": TerminationReason.SANDBOX_ERROR,
     "SandboxBuildFailedError": TerminationReason.SANDBOX_ERROR,

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -269,6 +269,21 @@ def test_no_usable_model_output_detects_dead_upstream():
     assert _no_usable_model_output(NS(trajectories=[NS(steps=[step(""), step("echo hi")])])) is False  # partial — real work
 
 
+def test_llm_free_harness_opts_out_of_the_empty_completion_canary():
+    """A harness that drives no model (oracle) has zero completions by
+    construction, so the canary would report every one of its failures as an
+    upstream outage — burying the one thing it exists to detect: a task whose
+    reference solution fails its own verifier."""
+    from rllm.harnesses.oracle import OracleHarness
+
+    assert OracleHarness.makes_llm_calls is False
+    # Anything that does drive a model keeps the canary (the engine reads the
+    # attribute with a True default, so harnesses need not declare it).
+    from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
+
+    assert getattr(MiniSweAgentHarness, "makes_llm_calls", True) is True
+
+
 def test_infra_taxonomy_membership_and_mapping():
     from rllm.types import INFRA_ERROR_REASONS, TerminationReason, termination_reason_from_error
 

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -270,17 +270,14 @@ def test_no_usable_model_output_detects_dead_upstream():
 
 
 def test_llm_free_harness_opts_out_of_the_empty_completion_canary():
-    """A harness that drives no model (oracle) has zero completions by
-    construction, so the canary would report every one of its failures as an
-    upstream outage — burying the one thing it exists to detect: a task whose
-    reference solution fails its own verifier."""
+    """The oracle has zero completions by construction, so the canary would
+    report its every failure — a task whose reference solution fails its own
+    verifier — as an upstream outage."""
+    from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
     from rllm.harnesses.oracle import OracleHarness
 
     assert OracleHarness.makes_llm_calls is False
-    # Anything that does drive a model keeps the canary (the engine reads the
-    # attribute with a True default, so harnesses need not declare it).
-    from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
-
+    # True default: model-driven harnesses keep the canary without declaring it.
     assert getattr(MiniSweAgentHarness, "makes_llm_calls", True) is True
 
 

--- a/tests/eval/test_harbor_parity.py
+++ b/tests/eval/test_harbor_parity.py
@@ -196,3 +196,64 @@ def test_create_base_sandbox_explicit_timeout_overrides_resource_default(monkeyp
     task = _budget_task()
     _create_base_sandbox(task, "modal", image="img", name="n", timeout=12345)
     assert captured["timeout"] == 12345
+# ---------------------------------------------------------------------------
+# [verifier] environment contract (harbor schema >= 1.3)
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_mode_defaults_to_shared(tmp_path):
+    """A task declaring nothing keeps the legacy in-place behaviour, so reading
+    the contract can never change an existing benchmark's outcome."""
+    task = _write_task(tmp_path, "[environment]\n", "FROM org/img:t\n")
+    assert task.metadata["verifier_mode"] == "shared"
+    assert task.metadata["verifier_collect"] == []
+    assert task.metadata["artifacts"] == []
+
+
+def test_declaring_a_verifier_environment_implies_separate(tmp_path):
+    """Harbor infers separate from the presence of [verifier.environment]."""
+    task = _write_task(tmp_path, "[environment]\n[verifier.environment]\ncpus = 2\n", "FROM org/img:t\n")
+    assert task.metadata["verifier_mode"] == "separate"
+
+
+def test_explicit_mode_wins_over_inference(tmp_path):
+    task = _write_task(
+        tmp_path,
+        '[environment]\n[verifier]\nenvironment_mode = "shared"\n',
+        "FROM org/img:t\n",
+    )
+    assert task.metadata["verifier_mode"] == "shared"
+
+
+def test_collect_and_artifacts_are_lifted(tmp_path):
+    """The collect commands and the artifact paths they produce — what a separate
+    verifier container needs to see the agent's work at all."""
+    task = _write_task(
+        tmp_path,
+        # ``artifacts`` is top-level, ahead of any table header (as real
+        # harbor task.toml files write it).
+        'artifacts = ["/logs/artifacts/model.patch"]\n'
+        '[environment]\n'
+        '[verifier]\nenvironment_mode = "separate"\n'
+        '[[verifier.collect]]\ncommand = "git diff --binary base HEAD > /logs/artifacts/model.patch"\n',
+        "FROM org/img:t\n",
+    )
+    assert task.metadata["verifier_mode"] == "separate"
+    assert task.metadata["artifacts"] == ["/logs/artifacts/model.patch"]
+    assert task.metadata["verifier_collect"][0]["command"].startswith("git diff --binary")
+
+
+def test_verifier_resources_layer_over_the_task_environment(tmp_path):
+    """deepswe declares cpus/memory under [verifier.environment] and no image, so
+    the verifier box must inherit the task's image rather than boot nothing."""
+    from rllm.eval._resolution import _verifier_env_section
+
+    task = _write_task(
+        tmp_path,
+        '[environment]\ndocker_image = "org/img:t"\ncpus = 8\nmemory_mb = 32768\n[verifier.environment]\ncpus = 2\n',
+        "FROM org/img:t\n",
+    )
+    env = _verifier_env_section(task)
+    assert env["docker_image"] == "org/img:t"  # inherited
+    assert env["cpus"] == 2  # verifier's own value wins
+    assert env["memory_mb"] == 32768

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -247,6 +247,62 @@ class TestShellScriptEvaluatorErrorTagging:
         assert termination_reason_from_error("VerifierCrashError") is TerminationReason.GRADING_ERROR
 
 
+class TestVerifierStdoutCapture:
+    """The verifier's output is the only record of *why* a suite failed, and the
+    sandbox is torn down right after grading — what isn't lifted here is gone."""
+
+    def test_stdout_kept_on_pass(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        real_exec = sb.exec
+
+        def exec_(cmd: str, timeout: float | None = None, user: str | None = None) -> str:
+            if "/tests/test.sh" in cmd:
+                return "===== raw suite output =====\n7 passed"
+            return real_exec(cmd, timeout, user)
+
+        sb.exec = exec_  # type: ignore[method-assign]
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert "7 passed" in out.metadata["verifier_stdout_tail"]
+
+    def test_stdout_kept_when_verifier_exits_nonzero(self, tmp_path):
+        """The failure path is the one worth debugging, and there the backend
+        hands the output back on the exception rather than as a return value."""
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "0.0"})
+        real_exec = sb.exec
+
+        def exec_(cmd: str, timeout: float | None = None, user: str | None = None) -> str:
+            if "/tests/test.sh" in cmd:
+                raise RuntimeError("exit 1: FAILED tests/test_sort.py::test_natural_order")
+            return real_exec(cmd, timeout, user)
+
+        sb.exec = exec_  # type: ignore[method-assign]
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.reward == 0.0
+        assert out.error is None  # a real 0, not a grading failure
+        assert "test_natural_order" in out.metadata["verifier_stdout_tail"]
+
+    def test_stdout_tail_is_bounded(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "0.0"})
+        real_exec = sb.exec
+
+        def exec_(cmd: str, timeout: float | None = None, user: str | None = None) -> str:
+            if "/tests/test.sh" in cmd:
+                return "x" * 50_000 + "TAIL_MARKER"
+            return real_exec(cmd, timeout, user)
+
+        sb.exec = exec_  # type: ignore[method-assign]
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        tail = out.metadata["verifier_stdout_tail"]
+        assert len(tail) == 8000
+        assert tail.endswith("TAIL_MARKER")  # tail, not head
+
+
 class TestGraderStateCapture:
     """Whatever a grader reports beside its verdict becomes a signal, so the
     fine-grained state survives on the episode instead of being collapsed into

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -379,14 +379,44 @@ class TestPreAgentGitHeadRestore:
         assert _capture_git_heads(task, sb) == {}
         assert sb.execs == []
 
+    @staticmethod
+    def _sandbox_reporting(sha_a: str, sha_b: str) -> "_FakeSandbox":
+        sb = _FakeSandbox()
+        sb.exec = lambda cmd, timeout=None, user=None: f"/app {sha_a}\n/testbed {sha_b}\nnot-a-repo\n"
+        return sb
+
     def test_capture_parses_repo_roots(self, tmp_path):
         from rllm.eval._resolution import _capture_git_heads
 
         sha_a, sha_b = "a" * 40, "b" * 40
-        sb = _FakeSandbox()
-        sb.exec = lambda cmd, timeout=None, user=None: f"/app {sha_a}\n/testbed {sha_b}\nnot-a-repo\n"
-        task = Task(id="0", instruction="", metadata={"workdir": "/testbed"}, dataset_dir=tmp_path)
+        sb = self._sandbox_reporting(sha_a, sha_b)
+        task = Task(id="0", instruction="", metadata={"workdir": "/testbed", "verifier_mode": "separate"}, dataset_dir=tmp_path)
 
+        assert _capture_git_heads(task, sb) == {"/app": sha_a, "/testbed": sha_b}
+
+    def test_shared_mode_tasks_are_left_alone(self, tmp_path):
+        """Moving HEAD is only right where we grade a separate-mode task in the
+        agent's box anyway. A shared-mode task's agent may be *supposed* to move
+        HEAD — terminal-bench's git-object-builder is scored on refs/heads/main
+        and `git ls-tree HEAD` — so resetting it would destroy the deliverable."""
+        from rllm.eval._resolution import _capture_git_heads
+
+        sb = self._sandbox_reporting("a" * 40, "b" * 40)
+        task = Task(id="0", instruction="", metadata={"verifier_mode": "shared"}, dataset_dir=tmp_path)
+        assert _capture_git_heads(task, sb) == {}
+        assert sb.execs == []  # not even probed
+
+        # A task that declares nothing at all is shared by default.
+        assert _capture_git_heads(Task(id="0", instruction="", metadata={}, dataset_dir=tmp_path), sb) == {}
+
+    def test_env_var_forces_it_on_for_a_shared_task(self, tmp_path, monkeypatch):
+        """Escape hatch for a shared-mode verifier that does assume pristine HEAD."""
+        from rllm.eval._resolution import _capture_git_heads
+
+        monkeypatch.setenv("RLLM_VERIFIER_RESTORE_GIT_HEAD", "1")
+        sha_a, sha_b = "a" * 40, "b" * 40
+        sb = self._sandbox_reporting(sha_a, sha_b)
+        task = Task(id="0", instruction="", metadata={"verifier_mode": "shared"}, dataset_dir=tmp_path)
         assert _capture_git_heads(task, sb) == {"/app": sha_a, "/testbed": sha_b}
 
 
@@ -520,3 +550,5 @@ class TestCoerceEvalResult:
         out = _coerce_eval_result(object())
         assert out.reward == 0.0
         assert "Cannot coerce" in out.metadata["error"]
+
+

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -223,6 +223,116 @@ class TestShellScriptEvaluatorErrorTagging:
         assert out.reward == 0.0
         assert out.error is None
 
+    def test_crash_sentinel_tagged(self, tmp_path):
+        """A negative reward is a harness "no verdict" sentinel, not a score.
+
+        Harbor-style ``test.sh`` wrappers trap a crashed grader and write -1. Read
+        as a reward it would count as a task failure *and* drag mean reward below
+        the task's scale, so it is tagged and zeroed instead — with the raw value
+        kept for triage.
+        """
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "-1"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.error == "VerifierCrashError"
+        assert out.reward == 0.0
+        assert out.is_correct is False
+        assert out.metadata["reward_sentinel"] == -1.0
+        assert any(s.name == "verifier_crash" and s.value == 1.0 for s in out.signals)
+
+    def test_crash_sentinel_maps_to_grading_error(self):
+        from rllm.types import TerminationReason, termination_reason_from_error
+
+        assert termination_reason_from_error("VerifierCrashError") is TerminationReason.GRADING_ERROR
+
+
+class TestGraderStateCapture:
+    """Whatever a grader reports beside its verdict becomes a signal, so the
+    fine-grained state survives on the episode instead of being collapsed into
+    one number. Field names are grader-specific, so nothing is keyed to them."""
+
+    def test_extra_scalars_become_signals(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.json": ('{"reward": 0, "f2p_total": 3, "f2p_passed": 1, "p2p_failed": 0, "partial": 0.33, "apply_failed": true, "runner": "mocha"}')})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+
+        signals = {s.name: s.value for s in out.signals}
+        assert signals["f2p_total"] == 3.0
+        assert signals["f2p_passed"] == 1.0
+        assert signals["p2p_failed"] == 0.0
+        assert signals["partial"] == pytest.approx(0.33)
+        assert signals["apply_failed"] == 1.0  # bools count
+        assert "runner" not in signals  # non-numeric detail is not a signal
+        assert "reward" not in signals  # the verdict itself is not duplicated
+
+
+class TestPreAgentGitHeadRestore:
+    """In-sandbox graders restore the task's official tests from ``HEAD``, so the
+    verifier has to see the image's commit — not the agent's. See
+    ShellScriptEvaluator._restore_git_heads."""
+
+    def test_soft_resets_each_repo_before_grading(self, tmp_path):
+        bench = _bench(tmp_path)
+        sha = "a" * 40
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+
+        ShellScriptEvaluator(sandbox=sb, git_heads={"/app": sha}).evaluate(task, _episode())
+
+        resets = [cmd for cmd, _ in sb.execs if "reset --soft" in cmd]
+        assert len(resets) == 1
+        assert f"-C /app reset --soft {sha}" in resets[0]
+        # Soft only: the agent's working tree is what gets graded.
+        assert "--hard" not in resets[0]
+        # And it happens before the verifier script runs.
+        order = [i for i, (cmd, _) in enumerate(sb.execs) if "reset --soft" in cmd or "/tests/test.sh" in cmd]
+        assert "reset --soft" in sb.execs[order[0]][0]
+
+    def test_no_repos_captured_is_a_noop(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+
+        ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert not [cmd for cmd, _ in sb.execs if "reset" in cmd]
+
+    def test_restore_failure_does_not_break_grading(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        base_exec = sb.exec
+
+        def exec_git_broken(cmd, timeout=None, user=None):
+            if "reset --soft" in cmd:
+                raise RuntimeError("no git in this image")
+            return base_exec(cmd, timeout=timeout, user=user)
+
+        sb.exec = exec_git_broken
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb, git_heads={"/app": "b" * 40}).evaluate(task, _episode())
+        assert out.reward == 1.0
+        assert out.error is None
+
+    def test_capture_skips_when_disabled(self, monkeypatch, tmp_path):
+        from rllm.eval._resolution import _capture_git_heads
+
+        sb = _FakeSandbox()
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=tmp_path)
+        monkeypatch.setenv("RLLM_VERIFIER_RESTORE_GIT_HEAD", "0")
+        assert _capture_git_heads(task, sb) == {}
+        assert sb.execs == []
+
+    def test_capture_parses_repo_roots(self, tmp_path):
+        from rllm.eval._resolution import _capture_git_heads
+
+        sha_a, sha_b = "a" * 40, "b" * 40
+        sb = _FakeSandbox()
+        sb.exec = lambda cmd, timeout=None, user=None: f"/app {sha_a}\n/testbed {sha_b}\nnot-a-repo\n"
+        task = Task(id="0", instruction="", metadata={"workdir": "/testbed"}, dataset_dir=tmp_path)
+
+        assert _capture_git_heads(task, sb) == {"/app": sha_a, "/testbed": sha_b}
+
 
 # ---------------------------------------------------------------------------
 # PythonModuleEvaluator


### PR DESCRIPTION
Grading correctness — changes what a reward *means*. Independent of #810 (different files); either can merge first.

**This is what actually moved the DeepSWE number: paired on 18 identical tasks, 22.2% → 44.4% (~+22pp).**

## The bug

In-sandbox verifiers restore a task's official test files with `git checkout HEAD -- <path>` before applying their test patch — a tamper guard that assumes HEAD is still the image's commit. rLLM runs the verifier in the agent's own sandbox, and all 113 DeepSWE `instruction.md` files end with:

> IMPORTANT: Please work on this in a new branch from main and commit everything when you are done.

So HEAD moves → that restore resurrects **the agent's own** test files → the official test patch no longer applies → the grader dies before scoring → `test.sh`'s trap writes `-1`, which was being read as a legitimate reward (dragging mean reward below the task's scale, not just costing accuracy).

`reset --soft` puts the ref back and leaves the working tree the agent produced, which is what gets graded.

## Scoped to where it's correct, not global

Moving HEAD is right only where a **separate-mode** task is graded in the agent's container anyway. Applied everywhere it corrupts any task whose agent is *supposed* to move HEAD — terminal-bench's `git-object-builder` ships a deliberately corrupted repo to repair and is scored on `refs/heads/main`, `git rev-list --count HEAD`, and `git ls-tree -r HEAD`.

So this reads the `[verifier]` contract the way harbor resolves it (`harbor.models.task.verifier_mode._resolve_mode`): explicit `environment_mode` wins → a declared `[verifier.environment]` implies `separate` → everything else is `shared`. **A task that declares nothing keeps today's behaviour**, so reading the contract cannot change an existing benchmark's outcome.

Verified across every materialized task locally:

```
terminal-bench (_hf_tasks)   shared    17792
deepswe                      separate    113
```

Zero of the 17,792 shared tasks depend on the pristine-HEAD restore, and `git-object-builder` is no longer probed at all. `RLLM_VERIFIER_RESTORE_GIT_HEAD` forces it on for a shared task whose verifier does assume a pristine HEAD, or off entirely.

## Also here

- **Crash sentinel tagged.** A negative reward is a "grader died before a verdict" sentinel, not a score → `VerifierCrashError` → `GRADING_ERROR`, so training filters it instead of learning from a spurious zero. Grader scalars beside the verdict become signals.
- **Verifier stdout kept on the episode.** Harbor verifiers deliberately cat every suite's raw log to stdout so "the reason a test failed is never lost", and the sandbox dies at teardown — so a failed task recorded only a bare count (`f2p 42/43`) with no way to see *which* test failed, or whether the suite failed at all versus erroring out. Adds a metadata key; reward/`is_correct`/`error`/signals are computed identically. It identified an unwinnable task's cause on the first try (10 pass-to-pass tests binding IPv6 loopback, unavailable on Modal).
- **Empty-completion canary gated on `makes_llm_calls`.** The oracle harness drives no model, so every episode tripped it — reporting the one thing the oracle exists to find (a task whose *reference solution* fails its own verifier) as "upstream/proxy/gateway failure". Read with a `True` default, so no other harness declares anything.

## Evidence

An oracle sweep — every task's reference `solution/solve.sh` through the same grader, no LLM — scores **112/113 = 99.1%** with this in place. Cheap (~15 min, zero LLM tokens) and the fastest way to separate "harness broken" from "model missed"; recommend it whenever a benchmark's numbers look off.

The one failure is unwinnable on Modal rather than an rLLM defect: 10 pre-existing `TestQueryLog/*` subtests bind IPv6 loopback (`[::1]:30013`–`30023`), the reference patch fails it too, and the dataset declares `default_sandbox = "docker"` (Docker supplies `::1`).

584 pass. One pre-existing failure, unrelated and untouched: `test_harbor_parity.py::test_lifetime_floor_sized_from_task_budget_when_no_override` (test expects 3000, implementation computes 2100 — drift from #736).

🤖 Generated with [Claude Code](https://claude.com/claude-code)