### PR TITLE
feat(eval): honour harbor's separate verifier environment (opt-in)

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -841,7 +841,13 @@ class AgentFlowEngine:
         for signal in eval_output.signals:
             enriched.metrics[signal.name] = signal.value
 
-        if _no_usable_model_output(enriched) and not enriched.is_correct and enriched.termination_reason not in INFRA_ERROR_REASONS:
+        # Harnesses that drive no model at all (oracle: runs the task's reference
+        # solution) trip the canary below by construction — every rollout has zero
+        # completions because none were ever requested. Left unguarded it reports
+        # the one thing the oracle exists to detect, a task whose *reference
+        # solution* fails its own verifier, as "upstream/proxy/gateway failure".
+        _llm_driven = getattr(self.agent_flow, "makes_llm_calls", True)
+        if _llm_driven and _no_usable_model_output(enriched) and not enriched.is_correct and enriched.termination_reason not in INFRA_ERROR_REASONS:
             # The agent produced nothing usable — no LLM calls at all, or every
             # call came back empty: a downed/erroring upstream (proxy died, auth or
             # tunnel failure), NOT a clean rollout. The reward (0) is meaningless;

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -841,11 +841,9 @@ class AgentFlowEngine:
         for signal in eval_output.signals:
             enriched.metrics[signal.name] = signal.value
 
-        # Harnesses that drive no model at all (oracle: runs the task's reference
-        # solution) trip the canary below by construction — every rollout has zero
-        # completions because none were ever requested. Left unguarded it reports
-        # the one thing the oracle exists to detect, a task whose *reference
-        # solution* fails its own verifier, as "upstream/proxy/gateway failure".
+        # A harness that drives no model (oracle) has zero completions by
+        # construction, so the canary below would report its every failure — i.e.
+        # a task whose reference solution fails its own verifier — as an outage.
         _llm_driven = getattr(self.agent_flow, "makes_llm_calls", True)
         if _llm_driven and _no_usable_model_output(enriched) and not enriched.is_correct and enriched.termination_reason not in INFRA_ERROR_REASONS:
             # The agent produced nothing usable — no LLM calls at all, or every

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -20,6 +20,7 @@ import base64
 import importlib
 import inspect
 import logging
+import os
 import re
 import shlex
 import uuid
@@ -121,13 +122,27 @@ def _capture_git_heads(task: Task, sandbox: Sandbox) -> dict[str, str]:
     Scans the declared ``workdir`` plus the top-level directories, so it covers
     ``/app``, ``/testbed``, ``/workspace`` and friends without knowing which task
     family it's looking at. Best-effort: a git-less environment yields an empty
-    map and the restore is a no-op. Set ``RLLM_VERIFIER_RESTORE_GIT_HEAD=0`` to
-    disable for a verifier that genuinely wants to grade the agent's commits.
+    map and the restore is a no-op.
+
+    Only for tasks that declared ``[verifier].environment_mode = "separate"``
+    and are being graded in the agent's container anyway — i.e. exactly where
+    rLLM knowingly deviates from the contract, which is what makes the verifier's
+    pristine-HEAD assumption false. Moving HEAD is wrong for a task whose agent is
+    *supposed* to move it (a shared-mode task that builds commits: terminal-bench's
+    git-object-builder asserts on ``refs/heads/main`` and ``git ls-tree HEAD``), so
+    shared-mode tasks are left alone. ``RLLM_VERIFIER_RESTORE_GIT_HEAD`` forces it
+    on (``1``) for a shared task whose verifier does assume a pristine HEAD, or off
+    (``0``) entirely.
     """
     from rllm.env import env_int
     from rllm.eval.script_evaluator import _GIT
+    from rllm.tasks.loader import VERIFIER_MODE_SEPARATE
 
-    if not env_int("RLLM_VERIFIER_RESTORE_GIT_HEAD", 1):
+    override = os.environ.get("RLLM_VERIFIER_RESTORE_GIT_HEAD")
+    if override is not None:
+        if not env_int("RLLM_VERIFIER_RESTORE_GIT_HEAD", 1):
+            return {}
+    elif task.metadata.get("verifier_mode") != VERIFIER_MODE_SEPARATE:
         return {}
     roots = "/*"
     workdir = task.metadata.get("workdir")
@@ -159,6 +174,9 @@ def _resolve_evaluator(
     if kind == "sandbox-shell":
         if sandbox is None:
             raise RuntimeError("sandbox-shell verifier requires an active sandbox")
+        from rllm.tasks.loader import VERIFIER_MODE_SEPARATE
+
+        separate = task.metadata.get("verifier_mode") == VERIFIER_MODE_SEPARATE and _separate_verifier_enabled()
         return ShellScriptEvaluator(
             sandbox=sandbox,
             script_path=verifier_config.get("script", "tests/test.sh"),
@@ -166,6 +184,9 @@ def _resolve_evaluator(
             verifier_timeout=(_effective_verifier_timeout(task) or 600.0),
             reward_file_override=verifier_config.get("reward_file"),
             git_heads=_capture_git_heads(task, sandbox),
+            verifier_sandbox_factory=(lambda: _create_verifier_sandbox(task, task.metadata.get("sandbox_backend"))) if separate else None,
+            collect_commands=task.metadata.get("verifier_collect") if separate else None,
+            artifacts=task.metadata.get("artifacts") if separate else None,
         )
 
     if kind in ("python-host", "python-hybrid"):
@@ -237,12 +258,22 @@ def _resolve_backend(task: Task, sandbox_backend: str | None) -> str:
     return sandbox_backend or task.metadata.get("sandbox_backend") or "docker"
 
 
-def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, name: str | None = None, **backend_kwargs) -> Sandbox:
+def _create_base_sandbox(
+    task: Task,
+    backend: str,
+    *,
+    image: str | None = None,
+    name: str | None = None,
+    env_override: dict | None = None,
+    **backend_kwargs,
+) -> Sandbox:
     """Create a sandbox from a base ``image`` — no Dockerfile RUN replay.
 
     ``image`` defaults to the task's resolved base image; pass a snapshot
-    ref to boot from a pre-warmed environment instead. ``backend_kwargs``
-    pass through to the backend constructor (e.g. Modal's ``timeout``).
+    ref to boot from a pre-warmed environment instead. ``env_override``
+    replaces the ``[environment]`` section resources are read from (used for a
+    separate verifier container). ``backend_kwargs`` pass through to the backend
+    constructor (e.g. Modal's ``timeout``).
     """
     from rllm.sandbox.sandboxed_flow import create_sandbox
 
@@ -252,7 +283,7 @@ def _create_base_sandbox(task: Task, backend: str, *, image: str | None = None, 
         name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
     # Explicit caller kwargs override the per-task resource defaults — both may
     # carry Modal's ``timeout`` (e.g. the snapshot builder's build_timeout).
-    kwargs = {**_sandbox_resource_kwargs(task, backend), **backend_kwargs}
+    kwargs = {**_sandbox_resource_kwargs(task, backend, env_override), **backend_kwargs}
     return create_sandbox(backend, name=name, image=image, **kwargs)
 
 
@@ -374,7 +405,52 @@ def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox
     return sandbox
 
 
-def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
+def _separate_verifier_enabled() -> bool:
+    """Whether to honour ``environment_mode = "separate"`` by grading in a fresh box.
+
+    Off by default while the in-place path is the one with a measured track
+    record: it is *more* permissive (it grades the working tree, where the
+    contract grades ``git diff <base> HEAD`` — committed work only), so turning
+    this on can lower a benchmark's score for agents that don't commit. Set
+    ``RLLM_SEPARATE_VERIFIER_ENV=1`` to grade the way the tasks declare.
+    """
+    from rllm.env import env_int
+
+    return bool(env_int("RLLM_SEPARATE_VERIFIER_ENV", 0))
+
+
+def _verifier_env_section(task: Task) -> dict:
+    """The ``[environment]`` a separate-mode verifier container runs under.
+
+    Harbor's ``resolve_effective_verifier_env_config`` prefers the task's
+    ``[verifier.environment]`` and otherwise copies ``[environment]``. Tasks
+    routinely declare only resources there (deepswe sets cpus/memory/storage and
+    no image), so layer it *over* the task's section rather than replacing it —
+    replacing would drop the image and leave nothing to boot.
+    """
+    return {**(task.metadata.get("environment") or {}), **(task.metadata.get("verifier_environment") or {})}
+
+
+def _create_verifier_sandbox(task: Task, sandbox_backend: str | None) -> Sandbox:
+    """A fresh container to grade a separate-mode task in.
+
+    Harbor builds this image from ``tests/`` as the build context — deepswe's
+    ``tests/Dockerfile`` is "the pinned task image with the hidden tests baked
+    in". Creating from the task's own image reproduces it, because
+    :class:`~rllm.eval.script_evaluator.ShellScriptEvaluator` uploads ``tests/``
+    to ``/tests`` regardless. Resources come from the verifier's own section.
+    """
+    backend = _resolve_backend(task, sandbox_backend)
+    safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
+    return _create_base_sandbox(
+        task,
+        backend,
+        name=f"rllm-verify-{safe_id}-{uuid.uuid4().hex[:6]}",
+        env_override=_verifier_env_section(task),
+    )
+
+
+def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None = None) -> dict:
     """Map a harbor task's declared ``[environment]`` resources to backend kwargs.
 
     Harbor task.toml declares ``cpus`` / ``memory_mb`` / ``storage_mb``; without
@@ -411,7 +487,7 @@ def _sandbox_resource_kwargs(task: Task, backend: str) -> dict:
     """
     from rllm.env import env_float, env_int, sandbox_timeout_override_s
 
-    env = task.metadata.get("environment", {}) or {}
+    env = env_override if env_override is not None else (task.metadata.get("environment", {}) or {})
     cpus, mem_mb, disk_mb = env.get("cpus"), env.get("memory_mb"), env.get("storage_mb")
 
     # Operator caps clamp the baked-in task.toml values down (see docstring):

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -386,7 +386,13 @@ def _dockerfile_context_fingerprint(dockerfile: Path) -> str:
     return h.hexdigest()[:16]
 
 
-def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox:
+def _create_sandbox_for_task(
+    task: Task,
+    sandbox_backend: str | None,
+    *,
+    name: str | None = None,
+    env_override: dict | None = None,
+) -> Sandbox:
     """Cold-path sandbox creation.
 
     When a Dockerfile-based task runs on a remote backend that builds images itself
@@ -399,8 +405,8 @@ def _create_sandbox_for_task(task: Task, sandbox_backend: str | None) -> Sandbox
     backend = _resolve_backend(task, sandbox_backend)
     dockerfile = _builds_from_dockerfile(task, backend)
     if dockerfile is not None:
-        return _create_base_sandbox(task, backend, image=_dockerfile_image(backend, dockerfile))
-    sandbox = _create_base_sandbox(task, backend)
+        return _create_base_sandbox(task, backend, image=_dockerfile_image(backend, dockerfile), name=name, env_override=env_override)
+    sandbox = _create_base_sandbox(task, backend, name=name, env_override=env_override)
     _replay_dockerfile(task, sandbox, backend)
     return sandbox
 
@@ -440,11 +446,10 @@ def _create_verifier_sandbox(task: Task, sandbox_backend: str | None) -> Sandbox
     :class:`~rllm.eval.script_evaluator.ShellScriptEvaluator` uploads ``tests/``
     to ``/tests`` regardless. Resources come from the verifier's own section.
     """
-    backend = _resolve_backend(task, sandbox_backend)
     safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
-    return _create_base_sandbox(
+    return _create_sandbox_for_task(
         task,
-        backend,
+        sandbox_backend,
         name=f"rllm-verify-{safe_id}-{uuid.uuid4().hex[:6]}",
         env_override=_verifier_env_section(task),
     )

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -21,6 +21,7 @@ import importlib
 import inspect
 import logging
 import re
+import shlex
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -108,6 +109,46 @@ def _effective_verifier_timeout(task: Task) -> float | None:
     return float(declared)
 
 
+def _capture_git_heads(task: Task, sandbox: Sandbox) -> dict[str, str]:
+    """Map ``repo root -> HEAD sha`` for the sandbox's git repos, before the agent runs.
+
+    Handed to :class:`ShellScriptEvaluator`, which puts HEAD back (soft) right
+    before grading — see :meth:`ShellScriptEvaluator._restore_git_heads` for why
+    an agent's commits break in-sandbox verifiers. Called at evaluator-resolution
+    time, which the hook does after environment setup and before the agent, so
+    what's recorded is the image's own commit.
+
+    Scans the declared ``workdir`` plus the top-level directories, so it covers
+    ``/app``, ``/testbed``, ``/workspace`` and friends without knowing which task
+    family it's looking at. Best-effort: a git-less environment yields an empty
+    map and the restore is a no-op. Set ``RLLM_VERIFIER_RESTORE_GIT_HEAD=0`` to
+    disable for a verifier that genuinely wants to grade the agent's commits.
+    """
+    from rllm.env import env_int
+    from rllm.eval.script_evaluator import _GIT
+
+    if not env_int("RLLM_VERIFIER_RESTORE_GIT_HEAD", 1):
+        return {}
+    roots = "/*"
+    workdir = task.metadata.get("workdir")
+    if workdir:
+        roots = f"{shlex.quote(str(workdir))} /*"
+    script = (
+        f'for d in {roots}; do [ -d "$d" ] || continue; '
+        f't=$({_GIT} -C "$d" rev-parse --show-toplevel 2>/dev/null) || continue; '
+        f'h=$({_GIT} -C "$t" rev-parse HEAD 2>/dev/null) || continue; '
+        f'printf "%s %s\\n" "$t" "$h"; done | sort -u'
+    )
+    heads: dict[str, str] = {}
+    for line in _safe_exec(sandbox, script, timeout=60).splitlines():
+        parts = line.split()
+        if len(parts) == 2 and len(parts[1]) == 40:
+            heads.setdefault(parts[0], parts[1])
+    if heads:
+        logger.debug("Captured pre-agent git HEADs for %s: %s", task.id, heads)
+    return heads
+
+
 def _resolve_evaluator(
     task: Task,
     sandbox: Sandbox | None,
@@ -124,6 +165,7 @@ def _resolve_evaluator(
             verifier_user=task.metadata.get("verifier_user"),
             verifier_timeout=(_effective_verifier_timeout(task) or 600.0),
             reward_file_override=verifier_config.get("reward_file"),
+            git_heads=_capture_git_heads(task, sandbox),
         )
 
     if kind in ("python-host", "python-hybrid"):

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -11,9 +11,12 @@ Reward contract (Harbor-compatible): the script writes to one of
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
-from pathlib import Path
+import shlex
+from collections.abc import Callable
+from pathlib import Path, PurePosixPath
 
 from rllm.eval.types import EvalOutput, Signal
 from rllm.sandbox.protocol import Sandbox, SandboxCommandTimeout
@@ -57,6 +60,9 @@ class ShellScriptEvaluator:
         verifier_timeout: float = 600.0,
         reward_file_override: str | None = None,
         git_heads: dict[str, str] | None = None,
+        verifier_sandbox_factory: Callable[[], Sandbox] | None = None,
+        collect_commands: list[dict] | None = None,
+        artifacts: list[str] | None = None,
     ):
         self.sandbox = sandbox
         self.script_path = script_path  # relative to the task's directory
@@ -65,6 +71,17 @@ class ShellScriptEvaluator:
         self.reward_file_override = reward_file_override
         # repo root -> HEAD sha as of before the agent ran (see _restore_git_heads).
         self.git_heads = git_heads or {}
+        # Set only for a task declaring [verifier].environment_mode = "separate":
+        # grading then runs in a container this builds, not the agent's. See
+        # :meth:`_grading_sandbox`.
+        self.verifier_sandbox_factory = verifier_sandbox_factory
+        self.collect_commands = collect_commands or []
+        self.artifacts = artifacts or []
+
+    @property
+    def separate_env(self) -> bool:
+        """Whether grading runs in its own container rather than the agent's."""
+        return self.verifier_sandbox_factory is not None
 
     def evaluate(self, task: Task, episode: Episode) -> EvalOutput:
         tests_dir = task.task_dir / Path(self.script_path).parent
@@ -79,9 +96,53 @@ class ShellScriptEvaluator:
 
         v_user = self.verifier_user
 
+        if not (tests_dir / script_name).exists():
+            return EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                error="AddTestsDirError",
+                metadata={"error": f"verifier script {script_name} not found in {tests_dir}"},
+            )
+
+        # A separate-mode task grades in a fresh container; everything the agent
+        # produced reaches it as collected artifacts. Own it for the duration so
+        # the box can't outlive the grade.
+        grading_sandbox = self.sandbox
+        collected: dict[str, bytes] = {}
+        if self.separate_env:
+            collected = self._run_collect(task, v_user)
+            try:
+                grading_sandbox = self.verifier_sandbox_factory()  # type: ignore[misc]
+            except Exception as e:
+                logger.warning("Could not create verifier sandbox for %s: %s", task.id, e)
+                return EvalOutput(
+                    reward=0.0,
+                    is_correct=False,
+                    error="VerifierEnvironmentError",
+                    metadata={"error": f"failed to create separate verifier environment: {e}"},
+                )
+        try:
+            return self._grade_in(grading_sandbox, task, tests_dir, script_name, v_user, collected)
+        finally:
+            if grading_sandbox is not self.sandbox:
+                try:
+                    grading_sandbox.close()
+                except Exception:
+                    logger.debug("Verifier sandbox teardown failed for %s", task.id, exc_info=True)
+
+    def _grade_in(
+        self,
+        sandbox: Sandbox,
+        task: Task,
+        tests_dir: Path,
+        script_name: str,
+        v_user: str | None,
+        collected: dict[str, bytes],
+    ) -> EvalOutput:
+        """Upload the tests (and any collected artifacts), run the verifier, read the reward."""
         # Prepare reward directories
         try:
-            self.sandbox.exec("mkdir -p /tmp/rllm /logs/verifier", timeout=10, user=v_user)
+            sandbox.exec("mkdir -p /tmp/rllm /logs/verifier", timeout=10, user=v_user)
         except Exception:
             pass
 
@@ -89,7 +150,7 @@ class ShellScriptEvaluator:
         # A failed upload means the verifier can't run — a grading-infra failure,
         # not a task score; tag it so the engine doesn't read it as reward 0.
         try:
-            self.sandbox.upload_dir(str(tests_dir), "/tests")
+            sandbox.upload_dir(str(tests_dir), "/tests")
         except Exception as e:
             logger.warning("Failed to upload tests dir for %s: %s", task.id, e)
             return EvalOutput(
@@ -99,13 +160,13 @@ class ShellScriptEvaluator:
                 metadata={"error": f"failed to upload tests dir: {e}"},
             )
 
-        if not (tests_dir / script_name).exists():
-            return EvalOutput(
-                reward=0.0,
-                is_correct=False,
-                error="AddTestsDirError",
-                metadata={"error": f"verifier script {script_name} not found in {tests_dir}"},
-            )
+        # Re-materialise what the collect step snapshotted, at the same paths it
+        # wrote them to — the verifier image doesn't pre-create those dirs.
+        for path, blob in collected.items():
+            try:
+                _write_remote_file(sandbox, path, blob, user=v_user)
+            except Exception as e:
+                logger.warning("Could not upload artifact %s for %s: %s", path, task.id, e)
 
         # Only ``cd`` when the task explicitly declared a workdir.
         # Otherwise the Dockerfile's WORKDIR wins — required for swesmith
@@ -115,11 +176,14 @@ class ShellScriptEvaluator:
         workdir = task.metadata.get("workdir")
         cd_prefix = f"cd {workdir} && " if workdir else ""
 
-        self._restore_git_heads(v_user)
+        # Only meaningful in the agent's own container; a fresh verifier box is
+        # already at the image's commit.
+        if sandbox is self.sandbox:
+            self._restore_git_heads(v_user)
 
         verifier_stdout = ""
         try:
-            verifier_stdout = self.sandbox.exec(
+            verifier_stdout = sandbox.exec(
                 f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
                 timeout=self.verifier_timeout,
                 user=v_user,
@@ -150,7 +214,7 @@ class ShellScriptEvaluator:
         reward_paths = list(_REWARD_PATHS)
         if self.reward_file_override:
             reward_paths.insert(0, self.reward_file_override)
-        out = _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+        out = _read_reward_from_sandbox(sandbox, reward_paths, user=v_user)
         # Harbor verifiers cat every suite's raw log to stdout so "the reason a
         # test failed is never lost", and the sandbox dies at teardown — without
         # this a failed task records only a bare count (f2p 42/43) with no way to
@@ -158,6 +222,36 @@ class ShellScriptEvaluator:
         if verifier_stdout:
             out.metadata["verifier_stdout_tail"] = verifier_stdout[-_VERIFIER_STDOUT_TAIL_CHARS:]
         return out
+
+    def _run_collect(self, task: Task, user: str | None) -> dict[str, bytes]:
+        """Run ``[[verifier.collect]]`` in the agent's box and pull the artifacts out.
+
+        Harbor's separate-mode contract: the agent's container is the only place
+        the work exists, so it snapshots state into files (deepswe writes
+        ``git diff --binary <base_commit> HEAD`` to ``model.patch``) which are then
+        re-materialised in the verifier container. Best-effort per command — a
+        collect step that fails leaves that artifact missing, which the verifier
+        reports as an unsubmitted patch rather than a grading crash.
+        """
+        for entry in self.collect_commands:
+            command = entry.get("command") if isinstance(entry, dict) else str(entry)
+            if not command:
+                continue
+            try:
+                self.sandbox.exec(command, timeout=float((entry or {}).get("timeout_sec", 300.0)), user=user)
+            except Exception as e:
+                logger.warning("collect step failed for %s (%s): %s", task.id, command[:80], e)
+
+        collected: dict[str, bytes] = {}
+        for path in self.artifacts:
+            try:
+                blob = _read_remote_file(self.sandbox, str(path), user=user)
+            except Exception as e:
+                logger.warning("Could not collect artifact %s for %s: %s", path, task.id, e)
+                continue
+            if blob is not None:
+                collected[str(path)] = blob
+        return collected
 
     def _restore_git_heads(self, user: str | None) -> None:
         """Move each repo's HEAD back to the commit it had before the agent ran.
@@ -182,6 +276,49 @@ class ShellScriptEvaluator:
                     logger.info("Restored %s HEAD to pre-agent commit %s before grading", root, sha[:12])
             except Exception as e:
                 logger.warning("Could not restore %s HEAD to %s: %s", root, sha[:12], e)
+
+
+# ---------------------------------------------------------------------------
+# Artifact transfer between the agent's box and a separate verifier box
+# ---------------------------------------------------------------------------
+
+# Cap on a single collected artifact. The transfer rides on ``exec`` stdout
+# (base64), so an unbounded blob would be an unbounded string in memory; a SWE
+# patch is orders of magnitude under this.
+_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
+
+
+def _read_remote_file(sandbox: Sandbox, path: str, user: str | None = None) -> bytes | None:
+    """Read a file out of a sandbox, or ``None`` when it isn't there.
+
+    Base64 because the payload is binary: ``git diff --binary`` output is not
+    text-safe, and the ``Sandbox`` protocol has upload primitives but no
+    download, so ``exec`` stdout is the only channel out.
+    """
+    quoted = shlex.quote(path)
+    size = sandbox.exec(f"test -f {quoted} && wc -c < {quoted} || echo -1", timeout=30, user=user).strip()
+    try:
+        n = int(size.split()[-1])
+    except (ValueError, IndexError):
+        return None
+    if n < 0:
+        return None
+    if n > _MAX_ARTIFACT_BYTES:
+        raise ValueError(f"artifact {path} is {n} bytes, over the {_MAX_ARTIFACT_BYTES} transfer cap")
+    encoded = sandbox.exec(f"base64 {quoted} | tr -d '\\n'", timeout=300, user=user)
+    return base64.b64decode(encoded.strip())
+
+
+def _write_remote_file(sandbox: Sandbox, path: str, blob: bytes, user: str | None = None) -> None:
+    """Write bytes into a sandbox at *path*, creating parent directories."""
+    quoted = shlex.quote(path)
+    parent = shlex.quote(str(PurePosixPath(path).parent))
+    encoded = base64.b64encode(blob).decode("ascii")
+    sandbox.exec(
+        f"mkdir -p {parent} && printf '%s' {shlex.quote(encoded)} | base64 -d > {quoted}",
+        timeout=300,
+        user=user,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -11,10 +11,10 @@ Reward contract (Harbor-compatible): the script writes to one of
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 import shlex
+import tempfile
 from collections.abc import Callable
 from pathlib import Path, PurePosixPath
 
@@ -245,7 +245,7 @@ class ShellScriptEvaluator:
         collected: dict[str, bytes] = {}
         for path in self.artifacts:
             try:
-                blob = _read_remote_file(self.sandbox, str(path), user=user)
+                blob = _read_remote_file(self.sandbox, str(path))
             except Exception as e:
                 logger.warning("Could not collect artifact %s for %s: %s", path, task.id, e)
                 continue
@@ -282,43 +282,35 @@ class ShellScriptEvaluator:
 # Artifact transfer between the agent's box and a separate verifier box
 # ---------------------------------------------------------------------------
 
-# Cap on a single collected artifact. The transfer rides on ``exec`` stdout
-# (base64), so an unbounded blob would be an unbounded string in memory; a SWE
-# patch is orders of magnitude under this.
-_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
-
-
-def _read_remote_file(sandbox: Sandbox, path: str, user: str | None = None) -> bytes | None:
+def _read_remote_file(sandbox: Sandbox, path: str) -> bytes | None:
     """Read a file out of a sandbox, or ``None`` when it isn't there.
 
-    Base64 because the payload is binary: ``git diff --binary`` output is not
-    text-safe, and the ``Sandbox`` protocol has upload primitives but no
-    download, so ``exec`` stdout is the only channel out.
+    Uses the backend's native transfer (:meth:`Sandbox.download_file`) rather
+    than shelling out: ``git diff --binary`` output is not text-safe, and routing
+    binary through ``exec`` stdout costs a base64 round-trip and holds the whole
+    payload as a string on both ends.
     """
-    quoted = shlex.quote(path)
-    size = sandbox.exec(f"test -f {quoted} && wc -c < {quoted} || echo -1", timeout=30, user=user).strip()
     try:
-        n = int(size.split()[-1])
-    except (ValueError, IndexError):
+        return sandbox.download_file(path)
+    except FileNotFoundError:
         return None
-    if n < 0:
-        return None
-    if n > _MAX_ARTIFACT_BYTES:
-        raise ValueError(f"artifact {path} is {n} bytes, over the {_MAX_ARTIFACT_BYTES} transfer cap")
-    encoded = sandbox.exec(f"base64 {quoted} | tr -d '\\n'", timeout=300, user=user)
-    return base64.b64decode(encoded.strip())
 
 
 def _write_remote_file(sandbox: Sandbox, path: str, blob: bytes, user: str | None = None) -> None:
-    """Write bytes into a sandbox at *path*, creating parent directories."""
-    quoted = shlex.quote(path)
+    """Write bytes into a sandbox at *path*, creating parent directories.
+
+    Staged through a temp file so the backend's native ``upload_file`` carries
+    the bytes; the protocol has no "write these bytes" primitive.
+    """
     parent = shlex.quote(str(PurePosixPath(path).parent))
-    encoded = base64.b64encode(blob).decode("ascii")
-    sandbox.exec(
-        f"mkdir -p {parent} && printf '%s' {shlex.quote(encoded)} | base64 -d > {quoted}",
-        timeout=300,
-        user=user,
-    )
+    try:
+        sandbox.exec(f"mkdir -p {parent}", timeout=30, user=user)
+    except Exception:
+        pass
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(blob)
+        tmp.flush()
+        sandbox.upload_file(tmp.name, path)
 
 
 # ---------------------------------------------------------------------------

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -37,6 +37,9 @@ _REWARD_PATHS = [
 # grader detail lifted to signals (see _parse_reward_json).
 _RESERVED_REWARD_KEYS = frozenset({"reward", "rewards", "is_correct", "signals", "metadata"})
 
+# Enough for a suite's failure summary without bloating results.json.
+_VERIFIER_STDOUT_TAIL_CHARS = 8000
+
 
 class ShellScriptEvaluator:
     """Run a verifier script inside the sandbox, parse the reward file.
@@ -114,8 +117,9 @@ class ShellScriptEvaluator:
 
         self._restore_git_heads(v_user)
 
+        verifier_stdout = ""
         try:
-            self.sandbox.exec(
+            verifier_stdout = self.sandbox.exec(
                 f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
                 timeout=self.verifier_timeout,
                 user=v_user,
@@ -138,12 +142,22 @@ class ShellScriptEvaluator:
             # below) carries the signal. Log at debug so a benchmark of
             # 100 unsolved tasks doesn't spam 100 multi-KB stack traces.
             logger.debug("Verifier exited non-zero for %s: %s", task.id, e)
+            # The backend raises with the output attached — the only copy we get
+            # on the failure path, which is the one worth debugging.
+            verifier_stdout = str(e)
 
         # Read reward (as verifier — agent may not have read access)
         reward_paths = list(_REWARD_PATHS)
         if self.reward_file_override:
             reward_paths.insert(0, self.reward_file_override)
-        return _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+        out = _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+        # Harbor verifiers cat every suite's raw log to stdout so "the reason a
+        # test failed is never lost", and the sandbox dies at teardown — without
+        # this a failed task records only a bare count (f2p 42/43) with no way to
+        # tell which test failed. Tail, not head: the verdict is at the end.
+        if verifier_stdout:
+            out.metadata["verifier_stdout_tail"] = verifier_stdout[-_VERIFIER_STDOUT_TAIL_CHARS:]
+        return out
 
     def _restore_git_heads(self, user: str | None) -> None:
         """Move each repo's HEAD back to the commit it had before the agent ran.

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -22,12 +22,20 @@ from rllm.types import Episode, Task
 logger = logging.getLogger(__name__)
 
 
+# Sandbox repos are root-owned but may be inspected as another user, which trips
+# git's dubious-ownership guard; every git call rLLM makes opts out of it.
+_GIT = "git -c safe.directory='*'"
+
 # Reward file search order (first existing file wins)
 _REWARD_PATHS = [
     "/tmp/rllm/reward.json",
     "/logs/verifier/reward.json",
     "/logs/verifier/reward.txt",
 ]
+
+# Keys of a reward file that carry the verdict itself; everything else in it is
+# grader detail lifted to signals (see _parse_reward_json).
+_RESERVED_REWARD_KEYS = frozenset({"reward", "rewards", "is_correct", "signals", "metadata"})
 
 
 class ShellScriptEvaluator:
@@ -45,12 +53,15 @@ class ShellScriptEvaluator:
         verifier_user: str | None = None,
         verifier_timeout: float = 600.0,
         reward_file_override: str | None = None,
+        git_heads: dict[str, str] | None = None,
     ):
         self.sandbox = sandbox
         self.script_path = script_path  # relative to the task's directory
         self.verifier_user = verifier_user
         self.verifier_timeout = verifier_timeout
         self.reward_file_override = reward_file_override
+        # repo root -> HEAD sha as of before the agent ran (see _restore_git_heads).
+        self.git_heads = git_heads or {}
 
     def evaluate(self, task: Task, episode: Episode) -> EvalOutput:
         tests_dir = task.task_dir / Path(self.script_path).parent
@@ -100,6 +111,9 @@ class ShellScriptEvaluator:
         # and silently collect zero tests when forced into ``/workspace``.
         workdir = task.metadata.get("workdir")
         cd_prefix = f"cd {workdir} && " if workdir else ""
+
+        self._restore_git_heads(v_user)
+
         try:
             self.sandbox.exec(
                 f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
@@ -130,6 +144,30 @@ class ShellScriptEvaluator:
         if self.reward_file_override:
             reward_paths.insert(0, self.reward_file_override)
         return _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+
+    def _restore_git_heads(self, user: str | None) -> None:
+        """Move each repo's HEAD back to the commit it had before the agent ran.
+
+        In-sandbox verifiers restore the task's official test files with
+        ``git checkout HEAD -- <path>`` before applying their test patch, which
+        assumes HEAD is still the *image's* commit. rLLM runs the verifier in the
+        agent's own sandbox, so an agent that commits its work (mini-swe-agent
+        and other git-oriented agents do) moves HEAD — and that "restore" then
+        resurrects the agent's own edited/added test files, making the official
+        test patch unappliable ("already exists in working directory" / "patch
+        does not apply") and crashing the verifier before it grades anything.
+
+        ``reset --soft`` moves the branch ref only: the working tree and index
+        keep the agent's edits, which is exactly what the verifier grades. No-op
+        when nothing was captured (``_capture_git_heads``) or HEAD never moved.
+        """
+        for root, sha in self.git_heads.items():
+            cmd = f'cur=$({_GIT} -C {root} rev-parse HEAD 2>/dev/null); [ "$cur" = {sha} ] || {{ {_GIT} -C {root} reset --soft {sha} && echo moved; }}'
+            try:
+                if "moved" in self.sandbox.exec(cmd, timeout=60, user=user):
+                    logger.info("Restored %s HEAD to pre-agent commit %s before grading", root, sha[:12])
+            except Exception as e:
+                logger.warning("Could not restore %s HEAD to %s: %s", root, sha[:12], e)
 
 
 # ---------------------------------------------------------------------------
@@ -162,8 +200,9 @@ def _read_reward_from_sandbox(sandbox: Sandbox, paths: list[str], user: str | No
         try:
             if path.endswith(".txt"):
                 reward = float(raw)
-                return EvalOutput(reward=reward, is_correct=reward >= 1.0)
-            return _parse_reward_json(raw)
+                out = EvalOutput(reward=reward, is_correct=reward >= 1.0)
+            else:
+                out = _parse_reward_json(raw)
         except Exception as e:
             logger.warning("Could not parse reward file %s: %s", path, e)
             return EvalOutput(
@@ -172,6 +211,22 @@ def _read_reward_from_sandbox(sandbox: Sandbox, paths: list[str], user: str | No
                 error="VerifierOutputParseError",
                 metadata={"error": f"could not parse reward file {path}: {e}"},
             )
+        # A negative reward is the harness's "no verdict" sentinel, not a score:
+        # harbor-style test.sh wrappers trap a crashed grader and write -1 so the
+        # failure stays visible instead of masquerading as a legitimate 0. Tag it
+        # as a grading error (and zero the reward, which is not on the task's
+        # scale and would otherwise skew mean reward); the raw sentinel is kept in
+        # metadata and a ``verifier_crash`` signal for triage.
+        if out.reward < 0:
+            logger.warning("Verifier wrote crash sentinel %s to %s", out.reward, path)
+            return EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                error="VerifierCrashError",
+                signals=[*out.signals, Signal(name="verifier_crash", value=1.0)],
+                metadata={**out.metadata, "error": f"verifier wrote crash sentinel {out.reward} to {path}", "reward_sentinel": out.reward},
+            )
+        return out
 
     # A missing reward file means the verifier produced no verdict — a verifier/
     # infra failure, NOT a legitimate score of 0 (a correctly-failing verifier
@@ -189,6 +244,13 @@ def _parse_reward_json(raw: str) -> EvalOutput:
     """Parse a JSON reward file into an EvalOutput.
 
     Supports both ``{"reward": 0.5}`` and Harbor-style ``{"rewards": {...}}``.
+
+    Every other top-level scalar becomes a :class:`Signal`, so whatever
+    fine-grained state the grader reported alongside its verdict — SWE-bench
+    style ``f2p_passed``/``p2p_failed``/``apply_failed`` counts, a partial
+    score, per-suite tallies — lands on the episode (and in the eval report's
+    signal averages) instead of being collapsed into one number. Graders differ
+    per benchmark, so nothing here is keyed to a specific field name.
     """
     data = json.loads(raw)
 
@@ -206,6 +268,9 @@ def _parse_reward_json(raw: str) -> EvalOutput:
         signals.append(Signal(name=key, value=float(val)))
     for key, val in data.get("rewards", {}).items():
         if key != "reward":
+            signals.append(Signal(name=key, value=float(val)))
+    for key, val in data.items():
+        if key not in _RESERVED_REWARD_KEYS and isinstance(val, bool | int | float):
             signals.append(Signal(name=key, value=float(val)))
 
     return EvalOutput(

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -40,10 +40,8 @@ class OracleHarness(SandboxedAgentFlow):
     name = "oracle"
     sandbox_backend = "docker"
 
-    # No LLM is involved, so every episode has zero completions. Tells the engine
-    # not to read that as a downed upstream — for this harness a reward of 0 means
-    # the task's own reference solution failed its verifier, which is the signal
-    # the harness exists to produce.
+    # No LLM, so every episode has zero completions: tells the engine not to read
+    # that as a downed upstream (see AgentFlowEngine._finish_episode).
     makes_llm_calls = False
 
     # Mirror Harbor's ``env_paths.solution_dir`` convention so anyone

--- a/rllm/harnesses/oracle.py
+++ b/rllm/harnesses/oracle.py
@@ -40,6 +40,12 @@ class OracleHarness(SandboxedAgentFlow):
     name = "oracle"
     sandbox_backend = "docker"
 
+    # No LLM is involved, so every episode has zero completions. Tells the engine
+    # not to read that as a downed upstream — for this harness a reward of 0 means
+    # the task's own reference solution failed its verifier, which is the signal
+    # the harness exists to produce.
+    makes_llm_calls = False
+
     # Mirror Harbor's ``env_paths.solution_dir`` convention so anyone
     # comparing the two implementations doesn't trip on path drift.
     _SOLUTION_DIR = "/solution"

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -258,6 +258,11 @@ class SandboxTaskHooks:
                 install = install_script_for(agent_flow)
                 sandbox = self.warm_queue.pop(task) if self.warm_queue is not None else get_sandbox(task, self.sandbox_backend, self._registry, install)
                 env_backend = _resolve_backend(task, self.sandbox_backend)
+                # Record the backend this task actually got, so anything resolved
+                # later can provision against the same one. Without it a separate
+                # verifier container re-resolves from an empty override and falls
+                # back to docker while the agent ran on Modal.
+                task.metadata["sandbox_backend"] = env_backend
                 _setup_task_environment(task, sandbox)
                 # CLI install, unless the image already contains exactly this
                 # script (baked_install, recorded at snapshot boot).

--- a/rllm/sandbox/backends/daytona.py
+++ b/rllm/sandbox/backends/daytona.py
@@ -550,6 +550,13 @@ class DaytonaSandbox:
         self._sandbox.fs.upload_file(local_path, remote_path)
         logger.debug("Uploaded %s -> %s in sandbox %s", local_path, remote_path, self.name)
 
+    def download_file(self, remote_path: str) -> bytes:
+        """Read a file out via Daytona's native ``fs.download_file``."""
+        try:
+            return self._sandbox.fs.download_file(remote_path)
+        except Exception as e:
+            raise FileNotFoundError(f"download_file: {remote_path} not readable in sandbox {self.name}: {e}") from e
+
     def upload_dir(self, local_path: str, remote_path: str) -> None:
         """Upload a directory tree.
 

--- a/rllm/sandbox/backends/docker.py
+++ b/rllm/sandbox/backends/docker.py
@@ -87,6 +87,21 @@ class DockerSandbox:
         tar_stream.seek(0)
         self._container.put_archive(remote_dir, tar_stream)
 
+    def download_file(self, remote_path: str) -> bytes:
+        """Read a file out of the container via tar archive (``docker cp``)."""
+        try:
+            stream, _ = self._container.get_archive(remote_path)
+        except Exception as e:
+            raise FileNotFoundError(f"download_file: {remote_path} not readable in container {self.name}: {e}") from e
+        buf = io.BytesIO(b"".join(stream))
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            member = next((m for m in tar.getmembers() if m.isfile()), None)
+            if member is None:
+                raise FileNotFoundError(f"download_file: {remote_path} is not a regular file")
+            extracted = tar.extractfile(member)
+            return extracted.read() if extracted else b""
+
     def upload_dir(self, local_path: str, remote_path: str) -> None:
         """Upload a directory tree into the container via tar archive."""
         remote_parent = os.path.dirname(remote_path.rstrip("/"))

--- a/rllm/sandbox/backends/local.py
+++ b/rllm/sandbox/backends/local.py
@@ -52,6 +52,14 @@ class LocalSandbox:
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         shutil.copy2(local_path, dest)
 
+    def download_file(self, remote_path: str) -> bytes:
+        """Read a file out of the sandbox working directory."""
+        src = self._translate_path(remote_path)
+        if not os.path.isfile(src):
+            raise FileNotFoundError(f"download_file: {remote_path} not found in sandbox")
+        with open(src, "rb") as f:
+            return f.read()
+
     def upload_dir(self, local_path: str, remote_path: str) -> None:
         """Copy a directory tree into the sandbox working directory."""
         dest = self._translate_path(remote_path)

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -379,6 +379,31 @@ class ModalSandbox:
         self._push_b64(b64, f"base64 -d > {remote_path}")
         logger.debug("Uploaded %s -> %s in sandbox %s", local_path, remote_path, self.name)
 
+    def download_file(self, remote_path: str) -> bytes:
+        """Read a file out of the Modal sandbox.
+
+        Prefers the SDK's filesystem API (a real binary read) and falls back to
+        base64 over exec, which is how ``upload_file`` goes the other way. Not
+        ``Sandbox.open()``: deprecated as of 2026-03-09 in favour of
+        ``Sandbox.filesystem``.
+        """
+        try:
+            return self._sandbox.filesystem.read_bytes(remote_path)
+        except FileNotFoundError:
+            raise
+        except Exception as e:
+            logger.debug("Modal filesystem read failed for %s (%s); falling back to base64", remote_path, e)
+
+        import base64
+        import shlex as _shlex
+
+        quoted = _shlex.quote(remote_path)
+        probe = self._exec_unchecked(f"test -f {quoted} && echo yes || echo no").strip()
+        if not probe.endswith("yes"):
+            raise FileNotFoundError(f"download_file: {remote_path} not found in sandbox {self.name}")
+        encoded = self._exec_unchecked(f"base64 {quoted} | tr -d '\\n'")
+        return base64.b64decode(encoded.strip())
+
     def upload_dir(self, local_path: str, remote_path: str) -> None:
         """Upload a directory tree into the Modal sandbox.
 

--- a/rllm/sandbox/protocol.py
+++ b/rllm/sandbox/protocol.py
@@ -45,6 +45,17 @@ class Sandbox(Protocol):
         """Upload a directory tree into the sandbox."""
         ...
 
+    def download_file(self, remote_path: str) -> bytes:
+        """Read a file out of the sandbox.
+
+        The counterpart to :meth:`upload_file`, needed whenever something has to
+        leave a sandbox — collecting a separate-mode verifier's artifacts, for
+        one. Backends use their native transfer (Modal's filesystem API, Daytona's
+        ``fs``, ``docker cp``) rather than shelling out, so binary payloads survive
+        intact. Raises ``FileNotFoundError`` when the path isn't there.
+        """
+        ...
+
     def close(self) -> None:
         """Destroy the sandbox and release resources."""
         ...

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -244,6 +244,41 @@ def _normalize_env_section(env_section: dict, explicit_docker_image: bool) -> No
             env_section["storage_mb"] = mb
 
 
+# Harbor's ``[verifier]`` environment contract (schema >= 1.3). A task declares
+# whether its verifier runs in the agent's container or a dedicated one; a task
+# that declares nothing keeps the legacy shared behaviour, so reading this can
+# never change an existing benchmark's outcome.
+VERIFIER_MODE_SHARED = "shared"
+VERIFIER_MODE_SEPARATE = "separate"
+
+
+def _resolve_verifier_mode(verifier_section: dict) -> str:
+    """The verifier's environment mode, resolved the way harbor resolves it.
+
+    Explicit ``environment_mode`` wins; declaring a ``[verifier.environment]``
+    implies ``separate`` (that is how harbor infers it); everything else is
+    ``shared``. Mirrors ``harbor.models.task.verifier_mode._resolve_mode``.
+    """
+    declared = verifier_section.get("environment_mode")
+    if declared:
+        return str(declared)
+    if verifier_section.get("environment"):
+        return VERIFIER_MODE_SEPARATE
+    return VERIFIER_MODE_SHARED
+
+
+def _lift_verifier_contract(raw: dict, into: dict) -> None:
+    """Copy the task's declared verifier contract onto a metadata dict."""
+    verifier_section = raw.get("verifier", {}) or {}
+    into["verifier_mode"] = _resolve_verifier_mode(verifier_section)
+    into["verifier_environment"] = verifier_section.get("environment")
+    into["verifier_collect"] = verifier_section.get("collect", []) or []
+    into["verifier_network_mode"] = verifier_section.get("network_mode")
+    # Top-level ``artifacts``: paths the collect step produces, which a separate
+    # verifier container needs re-materialised at their original locations.
+    into["artifacts"] = raw.get("artifacts", []) or []
+
+
 def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     """Merge per-task ``task.toml`` metadata into *base*.
 
@@ -289,6 +324,7 @@ def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     _agent_timeout = raw.get("agent", {}).get("timeout_sec")
     if _agent_timeout is not None:
         merged["agent_timeout"] = _agent_timeout
+    _lift_verifier_contract(raw, merged)
     rllm_section = raw.get("rllm", {}) or {}
     merged["setup_commands"] = rllm_section.get("setup_commands", merged.get("setup_commands", [])) or []
     return merged
@@ -618,6 +654,7 @@ def _load_task_from_dir(
     _agent_timeout = raw.get("agent", {}).get("timeout_sec")
     if _agent_timeout is not None:
         metadata["agent_timeout"] = _agent_timeout
+    _lift_verifier_contract(raw, metadata)
     rllm_section = raw.get("rllm", {}) or {}
     metadata["setup_commands"] = rllm_section.get("setup_commands", []) or []
 

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -93,6 +93,7 @@ _ERROR_TYPE_TO_REASON: dict[str, TerminationReason] = {
     "RewardFileNotFoundError": TerminationReason.GRADING_ERROR,
     "RewardFileEmptyError": TerminationReason.GRADING_ERROR,
     "VerifierOutputParseError": TerminationReason.GRADING_ERROR,
+    "VerifierCrashError": TerminationReason.GRADING_ERROR,  # grader died before a verdict (negative-reward sentinel)
     # Environment/sandbox (harbor.environments.base + rllm.sandbox.protocol + backends)
     "HealthcheckError": TerminationReason.SANDBOX_ERROR,
     "SandboxBuildFailedError": TerminationReason.SANDBOX_ERROR,

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -269,6 +269,21 @@ def test_no_usable_model_output_detects_dead_upstream():
     assert _no_usable_model_output(NS(trajectories=[NS(steps=[step(""), step("echo hi")])])) is False  # partial — real work
 
 
+def test_llm_free_harness_opts_out_of_the_empty_completion_canary():
+    """A harness that drives no model (oracle) has zero completions by
+    construction, so the canary would report every one of its failures as an
+    upstream outage — burying the one thing it exists to detect: a task whose
+    reference solution fails its own verifier."""
+    from rllm.harnesses.oracle import OracleHarness
+
+    assert OracleHarness.makes_llm_calls is False
+    # Anything that does drive a model keeps the canary (the engine reads the
+    # attribute with a True default, so harnesses need not declare it).
+    from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
+
+    assert getattr(MiniSweAgentHarness, "makes_llm_calls", True) is True
+
+
 def test_infra_taxonomy_membership_and_mapping():
     from rllm.types import INFRA_ERROR_REASONS, TerminationReason, termination_reason_from_error
 

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -270,17 +270,14 @@ def test_no_usable_model_output_detects_dead_upstream():
 
 
 def test_llm_free_harness_opts_out_of_the_empty_completion_canary():
-    """A harness that drives no model (oracle) has zero completions by
-    construction, so the canary would report every one of its failures as an
-    upstream outage — burying the one thing it exists to detect: a task whose
-    reference solution fails its own verifier."""
+    """The oracle has zero completions by construction, so the canary would
+    report its every failure — a task whose reference solution fails its own
+    verifier — as an upstream outage."""
+    from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
     from rllm.harnesses.oracle import OracleHarness
 
     assert OracleHarness.makes_llm_calls is False
-    # Anything that does drive a model keeps the canary (the engine reads the
-    # attribute with a True default, so harnesses need not declare it).
-    from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
-
+    # True default: model-driven harnesses keep the canary without declaring it.
     assert getattr(MiniSweAgentHarness, "makes_llm_calls", True) is True
 
 

--- a/tests/eval/test_harbor_parity.py
+++ b/tests/eval/test_harbor_parity.py
@@ -196,3 +196,64 @@ def test_create_base_sandbox_explicit_timeout_overrides_resource_default(monkeyp
     task = _budget_task()
     _create_base_sandbox(task, "modal", image="img", name="n", timeout=12345)
     assert captured["timeout"] == 12345
+# ---------------------------------------------------------------------------
+# [verifier] environment contract (harbor schema >= 1.3)
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_mode_defaults_to_shared(tmp_path):
+    """A task declaring nothing keeps the legacy in-place behaviour, so reading
+    the contract can never change an existing benchmark's outcome."""
+    task = _write_task(tmp_path, "[environment]\n", "FROM org/img:t\n")
+    assert task.metadata["verifier_mode"] == "shared"
+    assert task.metadata["verifier_collect"] == []
+    assert task.metadata["artifacts"] == []
+
+
+def test_declaring_a_verifier_environment_implies_separate(tmp_path):
+    """Harbor infers separate from the presence of [verifier.environment]."""
+    task = _write_task(tmp_path, "[environment]\n[verifier.environment]\ncpus = 2\n", "FROM org/img:t\n")
+    assert task.metadata["verifier_mode"] == "separate"
+
+
+def test_explicit_mode_wins_over_inference(tmp_path):
+    task = _write_task(
+        tmp_path,
+        '[environment]\n[verifier]\nenvironment_mode = "shared"\n',
+        "FROM org/img:t\n",
+    )
+    assert task.metadata["verifier_mode"] == "shared"
+
+
+def test_collect_and_artifacts_are_lifted(tmp_path):
+    """The collect commands and the artifact paths they produce — what a separate
+    verifier container needs to see the agent's work at all."""
+    task = _write_task(
+        tmp_path,
+        # ``artifacts`` is top-level, ahead of any table header (as real
+        # harbor task.toml files write it).
+        'artifacts = ["/logs/artifacts/model.patch"]\n'
+        '[environment]\n'
+        '[verifier]\nenvironment_mode = "separate"\n'
+        '[[verifier.collect]]\ncommand = "git diff --binary base HEAD > /logs/artifacts/model.patch"\n',
+        "FROM org/img:t\n",
+    )
+    assert task.metadata["verifier_mode"] == "separate"
+    assert task.metadata["artifacts"] == ["/logs/artifacts/model.patch"]
+    assert task.metadata["verifier_collect"][0]["command"].startswith("git diff --binary")
+
+
+def test_verifier_resources_layer_over_the_task_environment(tmp_path):
+    """deepswe declares cpus/memory under [verifier.environment] and no image, so
+    the verifier box must inherit the task's image rather than boot nothing."""
+    from rllm.eval._resolution import _verifier_env_section
+
+    task = _write_task(
+        tmp_path,
+        '[environment]\ndocker_image = "org/img:t"\ncpus = 8\nmemory_mb = 32768\n[verifier.environment]\ncpus = 2\n',
+        "FROM org/img:t\n",
+    )
+    env = _verifier_env_section(task)
+    assert env["docker_image"] == "org/img:t"  # inherited
+    assert env["cpus"] == 2  # verifier's own value wins
+    assert env["memory_mb"] == 32768

--- a/tests/eval/test_harbor_parity.py
+++ b/tests/eval/test_harbor_parity.py
@@ -257,3 +257,19 @@ def test_verifier_resources_layer_over_the_task_environment(tmp_path):
     assert env["docker_image"] == "org/img:t"  # inherited
     assert env["cpus"] == 2  # verifier's own value wins
     assert env["memory_mb"] == 32768
+
+
+def test_hook_records_the_backend_the_task_actually_got(tmp_path):
+    """A separate verifier container re-resolves the backend when it provisions.
+    Without the effective one recorded on the task it falls back to docker and
+    tries a local build while the agent ran on Modal — which is exactly how the
+    first end-to-end run of separate mode failed.
+    """
+    from rllm.eval._resolution import _resolve_backend
+
+    task = _write_task(tmp_path, '[environment]\ndocker_image = "org/img:t"\n', "FROM org/img:t\n")
+    assert _resolve_backend(task, None) == "docker"  # no override, no record
+
+    # What SandboxTaskHooks.setup writes once it has provisioned.
+    task.metadata["sandbox_backend"] = "modal"
+    assert _resolve_backend(task, None) == "modal"

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -31,8 +31,10 @@ class _FakeSandbox:
     ``test -f``/``cat`` shell commands the evaluator runs.
     """
 
-    def __init__(self, files: dict[str, str] | None = None):
+    def __init__(self, files: dict[str, str] | None = None, blobs: dict[str, bytes] | None = None):
         self.files: dict[str, str] = dict(files or {})
+        # Binary payloads reachable via upload_file/download_file (artifacts).
+        self.blobs: dict[str, bytes] = dict(blobs or {})
         self.execs: list[tuple[str, str | None]] = []
         self.uploads: list[tuple[str, str]] = []
 
@@ -50,6 +52,15 @@ class _FakeSandbox:
 
     def upload_dir(self, src: str, dst: str) -> None:
         self.uploads.append((src, dst))
+
+    def upload_file(self, local_path: str, remote_path: str) -> None:
+        with open(local_path, "rb") as f:
+            self.blobs[remote_path] = f.read()
+
+    def download_file(self, remote_path: str) -> bytes:
+        if remote_path not in self.blobs:
+            raise FileNotFoundError(remote_path)
+        return self.blobs[remote_path]
 
 
 def _episode() -> Episode:
@@ -552,3 +563,92 @@ class TestCoerceEvalResult:
         assert "Cannot coerce" in out.metadata["error"]
 
 
+class TestSeparateVerifierEnvironment:
+    """Harbor's `[verifier].environment_mode = "separate"`: the agent's work
+    reaches a fresh container as collected artifacts, so the verifier never sees
+    the box the agent mutated."""
+
+    @staticmethod
+    def _task(tmp_path: Path) -> Task:
+        return Task(
+            id="0",
+            instruction="",
+            metadata={"verifier_mode": "separate"},
+            dataset_dir=_bench(tmp_path),
+        )
+
+    def test_grades_in_the_fresh_box_and_tears_it_down(self, tmp_path):
+        agent = _FakeSandbox(files={"/logs/verifier/reward.txt": "0.0"})  # stale: agent's box
+        verifier = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        verifier.closed = False
+        verifier.close = lambda: setattr(verifier, "closed", True)
+
+        ev = ShellScriptEvaluator(sandbox=agent, verifier_sandbox_factory=lambda: verifier)
+        out = ev.evaluate(self._task(tmp_path), _episode())
+
+        assert out.reward == 1.0  # read from the verifier box, not the agent's
+        assert any(dst == "/tests" for _, dst in verifier.uploads)
+        assert verifier.closed, "the verifier box must not outlive the grade"
+
+    def test_collect_runs_in_the_agent_box_and_artifact_lands_in_the_verifier(self, tmp_path):
+        # Binary, and not valid UTF-8: `git diff --binary` output is why the
+        # transfer uses the backend's native primitive rather than exec stdout.
+        patch = b"diff --git a/x b/x\n\x00\xff\x01binary"
+        agent = _FakeSandbox(files={}, blobs={"/logs/artifacts/model.patch": patch})
+        verifier = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        verifier.close = lambda: None
+
+        ev = ShellScriptEvaluator(
+            sandbox=agent,
+            verifier_sandbox_factory=lambda: verifier,
+            collect_commands=[{"command": "git diff --binary base HEAD > /logs/artifacts/model.patch"}],
+            artifacts=["/logs/artifacts/model.patch"],
+        )
+        ev.evaluate(self._task(tmp_path), _episode())
+
+        assert any("git diff --binary" in c for c, _ in agent.execs), "collect must run in the agent's box"
+        assert verifier.blobs.get("/logs/artifacts/model.patch") == patch, "artifact must arrive byte-identical"
+
+    def test_a_missing_artifact_is_not_fatal(self, tmp_path):
+        """A collect step that produced nothing leaves the artifact absent; the
+        verifier reports that as an unsubmitted patch, not a grading crash."""
+        agent = _FakeSandbox(files={})  # no blobs -> download_file raises FileNotFoundError
+        verifier = _FakeSandbox(files={"/logs/verifier/reward.txt": "0.0"})
+        verifier.close = lambda: None
+
+        ev = ShellScriptEvaluator(
+            sandbox=agent,
+            verifier_sandbox_factory=lambda: verifier,
+            collect_commands=[{"command": "true"}],
+            artifacts=["/logs/artifacts/model.patch"],
+        )
+        out = ev.evaluate(self._task(tmp_path), _episode())
+        assert out.reward == 0.0
+        assert out.error is None  # a real 0, not an infra failure
+        assert "/logs/artifacts/model.patch" not in verifier.blobs
+
+    def test_head_is_not_touched_when_grading_elsewhere(self, tmp_path):
+        """A fresh box is already at the image's commit; the reset exists only to
+        undo an agent's commits in its own container."""
+        agent = _FakeSandbox(files={})
+        verifier = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        verifier.close = lambda: None
+
+        ev = ShellScriptEvaluator(
+            sandbox=agent,
+            verifier_sandbox_factory=lambda: verifier,
+            git_heads={"/app": "a" * 40},
+        )
+        ev.evaluate(self._task(tmp_path), _episode())
+
+        assert not any("reset --soft" in c for c, _ in agent.execs + verifier.execs)
+
+    def test_unbuildable_verifier_env_is_an_infra_error_not_a_zero(self, tmp_path):
+        def boom():
+            raise RuntimeError("no capacity")
+
+        ev = ShellScriptEvaluator(sandbox=_FakeSandbox(files={}), verifier_sandbox_factory=boom)
+        out = ev.evaluate(self._task(tmp_path), _episode())
+
+        assert out.error == "VerifierEnvironmentError"
+        assert out.reward == 0.0

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -247,6 +247,62 @@ class TestShellScriptEvaluatorErrorTagging:
         assert termination_reason_from_error("VerifierCrashError") is TerminationReason.GRADING_ERROR
 
 
+class TestVerifierStdoutCapture:
+    """The verifier's output is the only record of *why* a suite failed, and the
+    sandbox is torn down right after grading — what isn't lifted here is gone."""
+
+    def test_stdout_kept_on_pass(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        real_exec = sb.exec
+
+        def exec_(cmd: str, timeout: float | None = None, user: str | None = None) -> str:
+            if "/tests/test.sh" in cmd:
+                return "===== raw suite output =====\n7 passed"
+            return real_exec(cmd, timeout, user)
+
+        sb.exec = exec_  # type: ignore[method-assign]
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert "7 passed" in out.metadata["verifier_stdout_tail"]
+
+    def test_stdout_kept_when_verifier_exits_nonzero(self, tmp_path):
+        """The failure path is the one worth debugging, and there the backend
+        hands the output back on the exception rather than as a return value."""
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "0.0"})
+        real_exec = sb.exec
+
+        def exec_(cmd: str, timeout: float | None = None, user: str | None = None) -> str:
+            if "/tests/test.sh" in cmd:
+                raise RuntimeError("exit 1: FAILED tests/test_sort.py::test_natural_order")
+            return real_exec(cmd, timeout, user)
+
+        sb.exec = exec_  # type: ignore[method-assign]
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.reward == 0.0
+        assert out.error is None  # a real 0, not a grading failure
+        assert "test_natural_order" in out.metadata["verifier_stdout_tail"]
+
+    def test_stdout_tail_is_bounded(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "0.0"})
+        real_exec = sb.exec
+
+        def exec_(cmd: str, timeout: float | None = None, user: str | None = None) -> str:
+            if "/tests/test.sh" in cmd:
+                return "x" * 50_000 + "TAIL_MARKER"
+            return real_exec(cmd, timeout, user)
+
+        sb.exec = exec_  # type: ignore[method-assign]
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        tail = out.metadata["verifier_stdout_tail"]
+        assert len(tail) == 8000
+        assert tail.endswith("TAIL_MARKER")  # tail, not head
+
+
 class TestGraderStateCapture:
     """Whatever a grader reports beside its verdict becomes a signal, so the
     fine-grained state survives on the episode instead of being collapsed into

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -379,14 +379,44 @@ class TestPreAgentGitHeadRestore:
         assert _capture_git_heads(task, sb) == {}
         assert sb.execs == []
 
+    @staticmethod
+    def _sandbox_reporting(sha_a: str, sha_b: str) -> "_FakeSandbox":
+        sb = _FakeSandbox()
+        sb.exec = lambda cmd, timeout=None, user=None: f"/app {sha_a}\n/testbed {sha_b}\nnot-a-repo\n"
+        return sb
+
     def test_capture_parses_repo_roots(self, tmp_path):
         from rllm.eval._resolution import _capture_git_heads
 
         sha_a, sha_b = "a" * 40, "b" * 40
-        sb = _FakeSandbox()
-        sb.exec = lambda cmd, timeout=None, user=None: f"/app {sha_a}\n/testbed {sha_b}\nnot-a-repo\n"
-        task = Task(id="0", instruction="", metadata={"workdir": "/testbed"}, dataset_dir=tmp_path)
+        sb = self._sandbox_reporting(sha_a, sha_b)
+        task = Task(id="0", instruction="", metadata={"workdir": "/testbed", "verifier_mode": "separate"}, dataset_dir=tmp_path)
 
+        assert _capture_git_heads(task, sb) == {"/app": sha_a, "/testbed": sha_b}
+
+    def test_shared_mode_tasks_are_left_alone(self, tmp_path):
+        """Moving HEAD is only right where we grade a separate-mode task in the
+        agent's box anyway. A shared-mode task's agent may be *supposed* to move
+        HEAD — terminal-bench's git-object-builder is scored on refs/heads/main
+        and `git ls-tree HEAD` — so resetting it would destroy the deliverable."""
+        from rllm.eval._resolution import _capture_git_heads
+
+        sb = self._sandbox_reporting("a" * 40, "b" * 40)
+        task = Task(id="0", instruction="", metadata={"verifier_mode": "shared"}, dataset_dir=tmp_path)
+        assert _capture_git_heads(task, sb) == {}
+        assert sb.execs == []  # not even probed
+
+        # A task that declares nothing at all is shared by default.
+        assert _capture_git_heads(Task(id="0", instruction="", metadata={}, dataset_dir=tmp_path), sb) == {}
+
+    def test_env_var_forces_it_on_for_a_shared_task(self, tmp_path, monkeypatch):
+        """Escape hatch for a shared-mode verifier that does assume pristine HEAD."""
+        from rllm.eval._resolution import _capture_git_heads
+
+        monkeypatch.setenv("RLLM_VERIFIER_RESTORE_GIT_HEAD", "1")
+        sha_a, sha_b = "a" * 40, "b" * 40
+        sb = self._sandbox_reporting(sha_a, sha_b)
+        task = Task(id="0", instruction="", metadata={"verifier_mode": "shared"}, dataset_dir=tmp_path)
         assert _capture_git_heads(task, sb) == {"/app": sha_a, "/testbed": sha_b}
 
 
@@ -520,3 +550,5 @@ class TestCoerceEvalResult:
         out = _coerce_eval_result(object())
         assert out.reward == 0.0
         assert "Cannot coerce" in out.metadata["error"]
+
+

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -223,6 +223,116 @@ class TestShellScriptEvaluatorErrorTagging:
         assert out.reward == 0.0
         assert out.error is None
 
+    def test_crash_sentinel_tagged(self, tmp_path):
+        """A negative reward is a harness "no verdict" sentinel, not a score.
+
+        Harbor-style ``test.sh`` wrappers trap a crashed grader and write -1. Read
+        as a reward it would count as a task failure *and* drag mean reward below
+        the task's scale, so it is tagged and zeroed instead — with the raw value
+        kept for triage.
+        """
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "-1"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert out.error == "VerifierCrashError"
+        assert out.reward == 0.0
+        assert out.is_correct is False
+        assert out.metadata["reward_sentinel"] == -1.0
+        assert any(s.name == "verifier_crash" and s.value == 1.0 for s in out.signals)
+
+    def test_crash_sentinel_maps_to_grading_error(self):
+        from rllm.types import TerminationReason, termination_reason_from_error
+
+        assert termination_reason_from_error("VerifierCrashError") is TerminationReason.GRADING_ERROR
+
+
+class TestGraderStateCapture:
+    """Whatever a grader reports beside its verdict becomes a signal, so the
+    fine-grained state survives on the episode instead of being collapsed into
+    one number. Field names are grader-specific, so nothing is keyed to them."""
+
+    def test_extra_scalars_become_signals(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.json": ('{"reward": 0, "f2p_total": 3, "f2p_passed": 1, "p2p_failed": 0, "partial": 0.33, "apply_failed": true, "runner": "mocha"}')})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+
+        signals = {s.name: s.value for s in out.signals}
+        assert signals["f2p_total"] == 3.0
+        assert signals["f2p_passed"] == 1.0
+        assert signals["p2p_failed"] == 0.0
+        assert signals["partial"] == pytest.approx(0.33)
+        assert signals["apply_failed"] == 1.0  # bools count
+        assert "runner" not in signals  # non-numeric detail is not a signal
+        assert "reward" not in signals  # the verdict itself is not duplicated
+
+
+class TestPreAgentGitHeadRestore:
+    """In-sandbox graders restore the task's official tests from ``HEAD``, so the
+    verifier has to see the image's commit — not the agent's. See
+    ShellScriptEvaluator._restore_git_heads."""
+
+    def test_soft_resets_each_repo_before_grading(self, tmp_path):
+        bench = _bench(tmp_path)
+        sha = "a" * 40
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+
+        ShellScriptEvaluator(sandbox=sb, git_heads={"/app": sha}).evaluate(task, _episode())
+
+        resets = [cmd for cmd, _ in sb.execs if "reset --soft" in cmd]
+        assert len(resets) == 1
+        assert f"-C /app reset --soft {sha}" in resets[0]
+        # Soft only: the agent's working tree is what gets graded.
+        assert "--hard" not in resets[0]
+        # And it happens before the verifier script runs.
+        order = [i for i, (cmd, _) in enumerate(sb.execs) if "reset --soft" in cmd or "/tests/test.sh" in cmd]
+        assert "reset --soft" in sb.execs[order[0]][0]
+
+    def test_no_repos_captured_is_a_noop(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+
+        ShellScriptEvaluator(sandbox=sb).evaluate(task, _episode())
+        assert not [cmd for cmd, _ in sb.execs if "reset" in cmd]
+
+    def test_restore_failure_does_not_break_grading(self, tmp_path):
+        bench = _bench(tmp_path)
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        base_exec = sb.exec
+
+        def exec_git_broken(cmd, timeout=None, user=None):
+            if "reset --soft" in cmd:
+                raise RuntimeError("no git in this image")
+            return base_exec(cmd, timeout=timeout, user=user)
+
+        sb.exec = exec_git_broken
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=bench)
+        out = ShellScriptEvaluator(sandbox=sb, git_heads={"/app": "b" * 40}).evaluate(task, _episode())
+        assert out.reward == 1.0
+        assert out.error is None
+
+    def test_capture_skips_when_disabled(self, monkeypatch, tmp_path):
+        from rllm.eval._resolution import _capture_git_heads
+
+        sb = _FakeSandbox()
+        task = Task(id="0", instruction="", metadata={}, dataset_dir=tmp_path)
+        monkeypatch.setenv("RLLM_VERIFIER_RESTORE_GIT_HEAD", "0")
+        assert _capture_git_heads(task, sb) == {}
+        assert sb.execs == []
+
+    def test_capture_parses_repo_roots(self, tmp_path):
+        from rllm.eval._resolution import _capture_git_heads
+
+        sha_a, sha_b = "a" * 40, "b" * 40
+        sb = _FakeSandbox()
+        sb.exec = lambda cmd, timeout=None, user=None: f"/app {sha_a}\n/testbed {sha_b}\nnot-a-repo\n"
+        task = Task(id="0", instruction="", metadata={"workdir": "/testbed"}, dataset_dir=tmp_path)
+
+        assert _capture_git_heads(task, sb) == {"/app": sha_a, "/testbed": sha_b}
+
 
 # ---------------------------------------------------------------------------
 # PythonModuleEvaluator


### PR DESCRIPTION
**New feature**, off by default behind `RLLM_SEPARATE_VERIFIER_ENV=1`.

⚠️ **Contains #811** (grading correctness) as its first 4 commits — it builds on the `[verifier]` contract parsing added there. Review #811 first; this diff is only the last 3 commits (+341/−20). Happy to rebase once #811 lands.

Implements harbor's separate-verifier contract, which rLLM tasks already declare but nothing acted on: `[verifier].environment_mode`, `[verifier.environment]`, `[[verifier.collect]]`, and top-level `artifacts` appear in every DeepSWE `task.toml` and in no code path.

## What it does

Sequence mirrors harbor's `trial/single_step.py`: run `[[verifier.collect]]` in the agent's box → pull the artifacts it snapshotted → create a fresh container → re-materialise them at their original paths → grade there → tear it down.

The verifier box is created from the task's image and `tests/` is uploaded to `/tests` as the evaluator already did, which reproduces what harbor builds from `tests/` as a build context (DeepSWE's `tests/Dockerfile` is "the pinned task image with the hidden tests baked in"). Resources come from `[verifier.environment]`.

The HEAD workaround from #811 goes **inert** here — a fresh box is already at the image's commit, which is the assumption that reset existed to fake.

## `download_file` on the Sandbox protocol

`Sandbox` had `upload_file`/`upload_dir` and no counterpart, so nothing could leave a sandbox. Harbor treats this as a first-class environment primitive (`download_file`/`download_dir` abstract on `BaseEnvironment`), and its `tar_transfer` module spells out why shelling out is wrong: per-file writes "drop executable bits, symlinks, and empty directories", and a partial transfer "can drop files silently".

| backend | mechanism |
|---|---|
| local | direct read |
| daytona | `fs.download_file` |
| docker | `container.get_archive` (tar) |
| modal | `filesystem.read_bytes`, base64-over-exec fallback |

Not `Sandbox.open()` on Modal — deprecated 2026-03-09 in favour of `Sandbox.filesystem`.

## Verified on Modal

| | result |
|---|---|
| separate mode (DeepSWE oracle, 4 tasks) | **4/4 = 1.0**, f2p 1.0, p2p 1.0, no deprecation warnings |
| shared mode (default, same 4 tasks) | **4/4** — unchanged |

Two bugs only end-to-end runs caught, both now covered by regression tests: the verifier container re-resolving its backend to `docker` while the agent ran on Modal, and the Modal `Sandbox.open()` deprecation.

## Why it's off by default

This is a behaviour change, not a bug fix. Honouring the contract is **stricter** than today's path: it grades `git diff <base> HEAD` (committed work only) where in-place grading sees the whole working tree, so it scores 0 for an agent that never commits. The oracle sweep in #811 shows in-place grading is not currently producing wrong verdicts (112/113), so this buys contract fidelity, tamper resistance and immunity to environment pollution — not a score correction. Enabling it by default should be a deliberate, separate decision.

## Two judgment calls worth a second opinion

1. **`[verifier.environment]` layers *over* `[environment]`** rather than replacing it — a deliberate deviation from harbor, which returns the verifier section wholesale. DeepSWE declares only cpus/memory/storage there and no image, so replacing would leave nothing to boot.
2. **Artifacts stage through a temp file** on the way in, since the protocol has no "write these bytes" primitive.

707 pass. One pre-existing failure, unrelated and untouched (`test_harbor_parity` lifetime, drift from #736).

🤖 Generated with [Claude Code](https://claude.com/claude-code)