### PR TITLE
feat(tunnel): support Cloudflare named (production) tunnels

### DIFF
--- a/rllm/cli/tunnel.py
+++ b/rllm/cli/tunnel.py
@@ -29,14 +29,17 @@ def tunnel():
 
 @tunnel.command("setup")
 def tunnel_setup():
-    """Configure a stable tunnel backend (ngrok or cloudflared) for this machine."""
+    """Configure a stable tunnel backend (ngrok, cloudflare, or cloudflared) for this machine."""
+    import os
+
     from rllm.cli._ui import _select_from_menu, abort, console, fail
     from rllm.eval.config import load_tunnel_config, save_tunnel_config
-    from rllm.gateway.tunnel import CloudflaredTunnel, NgrokTunnel
+    from rllm.gateway.tunnel import ENV_CF_TUNNEL_TOKEN, CloudflaredTunnel, CloudflareNamedTunnel, NgrokTunnel
 
     existing = load_tunnel_config()
     backends = [
         ("ngrok", "ngrok — stable reserved domain, needs a (free) account  [recommended]"),
+        ("cloudflare", "cloudflare — named (production) tunnel on your own domain, needs a Cloudflare account"),
         ("cloudflared", "cloudflared — free quick tunnel, zero setup, shared & rate-limited"),
     ]
     cursor = next((i for i, (b, _) in enumerate(backends) if b == existing.get("backend")), 0)
@@ -46,6 +49,7 @@ def tunnel_setup():
     backend = backends[idx][0]
 
     domain: str | None = None
+    name: str | None = None
     if backend == "ngrok":
         if not NgrokTunnel.is_available():
             fail(f"ngrok not found on PATH. {NgrokTunnel.install_hint}")
@@ -69,6 +73,31 @@ def tunnel_setup():
             ).strip()
             or None
         )
+    elif backend == "cloudflare":
+        if not CloudflareNamedTunnel.is_available():
+            fail(f"cloudflared not found on PATH. {CloudflareNamedTunnel.install_hint}")
+        domain = click.prompt(
+            "  Public hostname routed to the tunnel (e.g. rllm.example.com)",
+            default=existing.get("domain", ""),
+            show_default=bool(existing.get("domain")),
+        ).strip()
+        if not domain:
+            fail("A public hostname is required for a Cloudflare named tunnel.")
+        name = (
+            click.prompt(
+                "  Locally-managed tunnel name from `cloudflared tunnel create` (blank if dashboard-managed via a token)",
+                default=existing.get("name", ""),
+                show_default=bool(existing.get("name")),
+            ).strip()
+            or None
+        )
+        if name:
+            console.print(f"  [muted]Requires `cloudflared tunnel login`, `cloudflared tunnel create {name}` and `cloudflared tunnel route dns {name} {domain}` once.[/]")
+        else:
+            console.print(f"  [muted]Dashboard-managed: export the connector token as TUNNEL_TOKEN (or {ENV_CF_TUNNEL_TOKEN}) before `rllm tunnel up`,[/]")
+            console.print("  [muted]and point the tunnel's public hostname at http://localhost:<gateway port> in Zero Trust → Networks → Tunnels.[/]")
+            if not (os.getenv("TUNNEL_TOKEN") or os.getenv(ENV_CF_TUNNEL_TOKEN)):
+                console.print("  [yellow]![/] [muted]No TUNNEL_TOKEN in this shell yet.[/]")
     else:
         if not CloudflaredTunnel.is_available():
             fail(f"cloudflared not found on PATH. {CloudflaredTunnel.install_hint}")
@@ -80,8 +109,8 @@ def tunnel_setup():
         type=int,
     )
 
-    save_tunnel_config(backend, domain=domain, port=int(port))
-    summary = backend + (f":{domain}" if domain else "")
+    save_tunnel_config(backend, domain=domain, name=name, port=int(port))
+    summary = backend + (f":{domain}" if domain else "") + (f"@{name}" if name else "")
     console.print(f"\n  [success]✓ Tunnel configured:[/] [val]{summary}[/] [muted](gateway port {port})[/]")
     console.print("  Start it with [key]rllm tunnel up[/]; training picks up the URL automatically.")
 
@@ -112,9 +141,11 @@ def tunnel_up(backend, port):
 
     cfg = load_tunnel_config()
     resolved_backend = backend or cfg.get("backend") or "cloudflared"
-    # Fold a configured reserved domain into a bare "ngrok" spec.
+    # Fold configured details into a bare backend spec.
     if resolved_backend == "ngrok" and cfg.get("domain"):
         resolved_backend = f"ngrok:{cfg['domain']}"
+    elif resolved_backend == "cloudflare" and cfg.get("domain"):
+        resolved_backend = f"cloudflare:{cfg['domain']}" + (f"@{cfg['name']}" if cfg.get("name") else "")
     resolved_port = port or cfg.get("port") or DEFAULT_PORT
     upstream = f"http://127.0.0.1:{resolved_port}"
 

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -518,7 +518,7 @@ def save_ui_config(ui_api_key: str | None) -> None:
 
 
 def load_tunnel_config() -> dict:
-    """Return the gateway-tunnel config (``backend``/``domain``/``port``) from ``~/.rllm/config.json``.
+    """Return the gateway-tunnel config (``backend``/``domain``/``name``/``port``) from ``~/.rllm/config.json``.
 
     Written by ``rllm tunnel setup``; consumed by ``rllm tunnel up`` and the
     quick-tunnel fallback warning. Empty dict if unset or unreadable.
@@ -535,11 +535,13 @@ def load_tunnel_config() -> dict:
         return {}
 
 
-def save_tunnel_config(backend: str | None, *, domain: str | None = None, port: int | None = None) -> None:
+def save_tunnel_config(backend: str | None, *, domain: str | None = None, name: str | None = None, port: int | None = None) -> None:
     """Merge or remove the ``tunnel`` block in ``~/.rllm/config.json``.
 
     ``backend=None`` removes the block. Merges into the existing file so the
-    provider/model and ``ui_api_key`` entries survive.
+    provider/model and ``ui_api_key`` entries survive. ``domain`` is the ngrok
+    reserved domain or Cloudflare public hostname; ``name`` is the
+    locally-managed Cloudflare tunnel name (blank = dashboard-managed token).
     """
     path = _config_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -556,6 +558,8 @@ def save_tunnel_config(backend: str | None, *, domain: str | None = None, port: 
         entry: dict = {"backend": backend}
         if domain:
             entry["domain"] = domain
+        if name:
+            entry["name"] = name
         if port:
             entry["port"] = port
         data["tunnel"] = entry

--- a/rllm/gateway/tunnel.py
+++ b/rllm/gateway/tunnel.py
@@ -1,12 +1,15 @@
 """Public-URL tunneling for the rLLM gateway.
 
 Tunnels expose the local gateway at a public URL so agents in *remote*
-sandboxes (Daytona, Modal, Fireworks-driven runtimes) can reach it. Two
+sandboxes (Daytona, Modal, Fireworks-driven runtimes) can reach it. Three
 backends ship:
 
 * :class:`CloudflaredTunnel` — ``cloudflared tunnel --url`` →
   ``*.trycloudflare.com``. Zero-setup, but a shared, rate-limited (HTTP 429)
   quick tunnel; fine for smoke tests, not for high-concurrency training.
+* :class:`CloudflareNamedTunnel` — ``cloudflared tunnel run`` against a
+  *named* (production) tunnel tied to a Cloudflare account, serving a stable
+  hostname on your own domain with none of the quick-tunnel limits.
 * :class:`NgrokTunnel` — ``ngrok http`` → ``*.ngrok-free.app`` or your own
   reserved domain. Needs a one-time ``rllm tunnel setup`` (authtoken) but is
   stable across restarts.
@@ -48,8 +51,14 @@ LOCAL_SANDBOX_BACKENDS: frozenset[str] = frozenset({"docker", "local", "apple-co
 
 # Environment override consulted before the daemon state file (see
 # :func:`resolve_auto_tunnel`). Either a backend name ("cloudflared",
-# "ngrok", "ngrok:<domain>") or an explicit http(s):// URL.
+# "ngrok", "ngrok:<domain>", "cloudflare:<hostname>[@<tunnel-name>]") or an
+# explicit http(s):// URL.
 ENV_TUNNEL = "RLLM_GATEWAY_TUNNEL"
+
+# Connector token for a dashboard-managed Cloudflare named tunnel.
+# ``TUNNEL_TOKEN`` is cloudflared's own env var; the rLLM-prefixed alias
+# exists so the token can live next to other RLLM_* settings.
+ENV_CF_TUNNEL_TOKEN = "CLOUDFLARE_TUNNEL_TOKEN"
 
 
 def is_local_sandbox_backend(name: str | None) -> bool:
@@ -64,13 +73,16 @@ def parse_tunnel(value: str | None) -> tuple[str | None, str | None]:
 
     URLs (``http(s)://...``) pass through as ``public_url``; anything else is
     treated as a backend spec to spawn (e.g. ``"cloudflared"``, ``"ngrok"``,
-    ``"ngrok:rllm.ngrok.dev"``) — see :func:`create_tunnel`.
+    ``"ngrok:rllm.ngrok.dev"``, ``"cloudflare:rllm.example.com@my-tunnel"``) —
+    see :func:`create_tunnel`. The spec is passed through verbatim (Cloudflare
+    tunnel names are case-sensitive); :func:`create_tunnel` normalizes the
+    backend-name part itself.
     """
     if not value:
         return None, None
     if value.startswith(("http://", "https://")):
         return value, None
-    return None, value.lower()
+    return None, value
 
 
 _TRYCF_URL_RE = re.compile(r"https?://[a-zA-Z0-9.-]+\.trycloudflare\.com")
@@ -141,6 +153,10 @@ class _Tunnel:
 
     def _command(self) -> list[str]:
         raise NotImplementedError
+
+    def _popen_env(self) -> dict[str, str] | None:
+        """Environment for the tunnel subprocess (``None`` = inherit the caller's)."""
+        return None
 
     def _extract_url(self, line: str) -> str | None:
         """Return the public URL if this log line announces it, else ``None``."""
@@ -243,7 +259,7 @@ class _Tunnel:
         else:
             stdout, stderr = subprocess.PIPE, subprocess.STDOUT
 
-        self._proc = subprocess.Popen(cmd, stdout=stdout, stderr=stderr, text=True, bufsize=1)
+        self._proc = subprocess.Popen(cmd, stdout=stdout, stderr=stderr, text=True, bufsize=1, env=self._popen_env())
         self._reader = threading.Thread(target=self._scan_stream, daemon=True)
         self._reader.start()
 
@@ -366,17 +382,103 @@ class NgrokTunnel(_Tunnel):
         return None
 
 
+class CloudflareNamedTunnel(_Tunnel):
+    """Run a *named* (production) Cloudflare tunnel serving a stable hostname.
+
+    Unlike :class:`CloudflaredTunnel` quick tunnels, named tunnels are tied to
+    a Cloudflare account and serve a hostname on your own domain, with no
+    shared-infra rate limits or 120s origin read timeout. Two modes:
+
+    * **Dashboard-managed (token)** — create the tunnel in Zero Trust
+      (Networks → Tunnels), point its public hostname at
+      ``http://localhost:<gateway port>``, and export the connector token as
+      ``TUNNEL_TOKEN`` (or ``CLOUDFLARE_TUNNEL_TOKEN``). Spec:
+      ``cloudflare:<hostname>``. Ingress lives in the dashboard, so the
+      hostname → port mapping there must match the gateway port.
+    * **Locally-managed (name)** — after ``cloudflared tunnel login``,
+      ``cloudflared tunnel create <name>`` and
+      ``cloudflared tunnel route dns <name> <hostname>``, we run
+      ``cloudflared tunnel run --url <upstream> <name>`` so ingress follows the
+      gateway port automatically. Spec: ``cloudflare:<hostname>@<name>``.
+
+    Named tunnels never log their public URL (the hostname is DNS-routed), so
+    the URL is derived from ``hostname`` once cloudflared registers its first
+    connection to the Cloudflare edge.
+    """
+
+    name = "cloudflare"
+    binary = "cloudflared"
+    install_hint = "Install: brew install cloudflared"
+    log_stream = "stderr"
+
+    _REGISTERED_RE = re.compile(r"Registered tunnel connection")
+
+    def __init__(self, upstream_url: str, *, hostname: str, tunnel_ref: str | None = None, **kwargs) -> None:
+        super().__init__(upstream_url, **kwargs)
+        self.hostname = hostname.strip().split("://", 1)[-1].rstrip("/")
+        self.tunnel_ref = tunnel_ref.strip() if tunnel_ref else None
+
+    @staticmethod
+    def _token() -> str | None:
+        return os.getenv("TUNNEL_TOKEN") or os.getenv(ENV_CF_TUNNEL_TOKEN)
+
+    def _command(self) -> list[str]:
+        if self.tunnel_ref:
+            return ["cloudflared", "tunnel", "run", "--url", self.upstream_url, self.tunnel_ref]
+        if not self._token():
+            raise TunnelStartError(
+                f"Cloudflare named tunnel for {self.hostname!r} needs credentials: export the connector "
+                f"token as TUNNEL_TOKEN or {ENV_CF_TUNNEL_TOKEN} (Zero Trust → Networks → Tunnels), or use a "
+                "locally-managed tunnel via 'cloudflare:<hostname>@<tunnel-name>'.",
+            )
+        # Dashboard-managed: ingress (hostname → local port) lives in Zero
+        # Trust, so no --url here; the token travels via the TUNNEL_TOKEN env
+        # var (see _popen_env) to keep it out of `ps` output.
+        return ["cloudflared", "tunnel", "run"]
+
+    def _popen_env(self) -> dict[str, str] | None:
+        if self.tunnel_ref:
+            return None
+        return {**os.environ, "TUNNEL_TOKEN": self._token() or ""}
+
+    def _extract_url(self, line: str) -> str | None:
+        # Named tunnels never announce a public URL; the first edge
+        # registration means "serving", and the hostname is known up front.
+        if self._REGISTERED_RE.search(line):
+            return f"https://{self.hostname}"
+        return None
+
+    def _is_transient(self, log_tail: str) -> bool:
+        return any(p.search(log_tail) for p in _CF_TRANSIENT_PATTERNS)
+
+    def _classify_fatal(self, log_tail: str) -> str | None:
+        low = log_tail.lower()
+        if "token is not valid" in low or "invalid tunnel token" in low:
+            return "Cloudflare rejected the tunnel token. Re-copy it from Zero Trust → Networks → Tunnels → your tunnel, then re-export TUNNEL_TOKEN."
+        if "cert.pem" in low or "origincert" in low:
+            return f"cloudflared has no origin certificate for locally-managed tunnels. Run `cloudflared tunnel login`, then `cloudflared tunnel create {self.tunnel_ref or '<name>'}`."
+        if "credentials file" in low or ("tunnel" in low and "not found" in low):
+            return f"cloudflared could not load tunnel {self.tunnel_ref!r}. Check `cloudflared tunnel list` and the credentials JSON in ~/.cloudflared/."
+        return None
+
+
 # Registry of spawnable backends keyed by the name in ``rllm.gateway.tunnel``.
 _BACKENDS: dict[str, type[_Tunnel]] = {
     "cloudflared": CloudflaredTunnel,
+    "cloudflare": CloudflareNamedTunnel,
     "ngrok": NgrokTunnel,
 }
 
 
 def create_tunnel(spec: str, upstream_url: str) -> _Tunnel:
-    """Build a tunnel from a backend spec (``"cloudflared"``, ``"ngrok"``, ``"ngrok:<domain>"``).
+    """Build a tunnel from a backend spec.
 
-    Raises :class:`ValueError` for an unknown backend.
+    Accepted specs: ``"cloudflared"`` (quick tunnel), ``"ngrok"``,
+    ``"ngrok:<domain>"``, ``"cloudflare:<hostname>"`` (dashboard-managed named
+    tunnel, token from ``$TUNNEL_TOKEN``), or
+    ``"cloudflare:<hostname>@<tunnel-name>"`` (locally-managed named tunnel).
+
+    Raises :class:`ValueError` for an unknown backend or a malformed spec.
     """
     name, _, opt = spec.partition(":")
     name = name.strip().lower()
@@ -384,10 +486,17 @@ def create_tunnel(spec: str, upstream_url: str) -> _Tunnel:
     if cls is None:
         supported = "', '".join(sorted(_BACKENDS))
         raise ValueError(
-            f"Unsupported gateway tunnel backend: {spec!r}. Supported: '{supported}', 'ngrok:<domain>', or an http(s):// URL.",
+            f"Unsupported gateway tunnel backend: {spec!r}. Supported: '{supported}', 'ngrok:<domain>', 'cloudflare:<hostname>[@<tunnel-name>]', or an http(s):// URL.",
         )
     if cls is NgrokTunnel:
         return NgrokTunnel(upstream_url, domain=opt or None)
+    if cls is CloudflareNamedTunnel:
+        hostname, _, tunnel_ref = opt.partition("@")
+        if not hostname.strip():
+            raise ValueError(
+                f"Cloudflare named tunnels need a public hostname: use 'cloudflare:<hostname>' or 'cloudflare:<hostname>@<tunnel-name>' (got {spec!r}).",
+            )
+        return CloudflareNamedTunnel(upstream_url, hostname=hostname, tunnel_ref=tunnel_ref or None)
     return cls(upstream_url)
 
 
@@ -423,6 +532,7 @@ def spawn_detached(tunnel: _Tunnel, *, ready_timeout: float = _DEFAULT_READY_TIM
             stderr=subprocess.STDOUT,
             text=True,
             start_new_session=True,
+            env=tunnel._popen_env(),
         )
     finally:
         log.close()

--- a/rllm/gateway/tunnel.py
+++ b/rllm/gateway/tunnel.py
@@ -227,9 +227,13 @@ class _Tunnel:
         import urllib.request
 
         deadline = time.monotonic() + timeout
+        # Identify as a real client: Cloudflare bot protection 403s urllib's
+        # default "Python-urllib/x.y" UA at the edge, which would make this
+        # probe "pass" without ever traversing the tunnel.
+        headers = {"User-Agent": "rllm-tunnel-healthcheck"}
         while True:
             try:
-                with urllib.request.urlopen(urllib.request.Request(url, method="GET"), timeout=5) as resp:
+                with urllib.request.urlopen(urllib.request.Request(url, method="GET", headers=headers), timeout=5) as resp:
                     if resp.status < 500:
                         return
             except urllib.error.HTTPError as e:

--- a/tests/engine/test_tunnel.py
+++ b/tests/engine/test_tunnel.py
@@ -1,0 +1,119 @@
+"""Tests for gateway tunnel backends and spec parsing (rllm/gateway/tunnel.py)."""
+
+import pytest
+
+from rllm.gateway.tunnel import (
+    ENV_CF_TUNNEL_TOKEN,
+    CloudflaredTunnel,
+    CloudflareNamedTunnel,
+    NgrokTunnel,
+    TunnelStartError,
+    create_tunnel,
+    parse_tunnel,
+)
+
+UPSTREAM = "http://127.0.0.1:9090"
+
+
+class TestParseTunnel:
+    def test_url_passes_through(self):
+        assert parse_tunnel("https://gw.example.com") == ("https://gw.example.com", None)
+
+    def test_backend_spec_preserves_case(self):
+        # Cloudflare tunnel names are case-sensitive; the spec must survive verbatim.
+        assert parse_tunnel("cloudflare:rllm.example.com@MyTunnel") == (None, "cloudflare:rllm.example.com@MyTunnel")
+
+    def test_empty(self):
+        assert parse_tunnel(None) == (None, None)
+        assert parse_tunnel("") == (None, None)
+
+
+class TestCreateTunnel:
+    def test_quick_tunnel(self):
+        assert isinstance(create_tunnel("cloudflared", UPSTREAM), CloudflaredTunnel)
+
+    def test_ngrok_domain(self):
+        tnl = create_tunnel("ngrok:rllm.ngrok.dev", UPSTREAM)
+        assert isinstance(tnl, NgrokTunnel)
+        assert tnl.domain == "rllm.ngrok.dev"
+
+    def test_cloudflare_token_mode(self):
+        tnl = create_tunnel("cloudflare:rllm.example.com", UPSTREAM)
+        assert isinstance(tnl, CloudflareNamedTunnel)
+        assert tnl.hostname == "rllm.example.com"
+        assert tnl.tunnel_ref is None
+
+    def test_cloudflare_named_mode(self):
+        tnl = create_tunnel("cloudflare:rllm.example.com@my-tunnel", UPSTREAM)
+        assert isinstance(tnl, CloudflareNamedTunnel)
+        assert tnl.hostname == "rllm.example.com"
+        assert tnl.tunnel_ref == "my-tunnel"
+
+    def test_cloudflare_backend_name_case_insensitive(self):
+        tnl = create_tunnel("CLOUDFLARE:rllm.example.com@MyTunnel", UPSTREAM)
+        assert isinstance(tnl, CloudflareNamedTunnel)
+        assert tnl.tunnel_ref == "MyTunnel"
+
+    def test_cloudflare_hostname_scheme_stripped(self):
+        tnl = create_tunnel("cloudflare:https://rllm.example.com/", UPSTREAM)
+        assert tnl.hostname == "rllm.example.com"
+
+    def test_cloudflare_requires_hostname(self):
+        with pytest.raises(ValueError, match="hostname"):
+            create_tunnel("cloudflare", UPSTREAM)
+        with pytest.raises(ValueError, match="hostname"):
+            create_tunnel("cloudflare:", UPSTREAM)
+
+    def test_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unsupported gateway tunnel backend"):
+            create_tunnel("wireguard", UPSTREAM)
+
+
+class TestCloudflareNamedTunnel:
+    def test_named_command_pins_upstream(self):
+        tnl = CloudflareNamedTunnel(UPSTREAM, hostname="rllm.example.com", tunnel_ref="my-tunnel")
+        assert tnl._command() == ["cloudflared", "tunnel", "run", "--url", UPSTREAM, "my-tunnel"]
+        assert tnl._popen_env() is None
+
+    def test_token_command_uses_env_not_argv(self, monkeypatch):
+        monkeypatch.setenv("TUNNEL_TOKEN", "tok-123")
+        monkeypatch.delenv(ENV_CF_TUNNEL_TOKEN, raising=False)
+        tnl = CloudflareNamedTunnel(UPSTREAM, hostname="rllm.example.com")
+        # Ingress is dashboard-managed, so no --url; token stays out of argv.
+        assert tnl._command() == ["cloudflared", "tunnel", "run"]
+        assert tnl._popen_env()["TUNNEL_TOKEN"] == "tok-123"
+
+    def test_rllm_token_alias_is_forwarded(self, monkeypatch):
+        monkeypatch.delenv("TUNNEL_TOKEN", raising=False)
+        monkeypatch.setenv(ENV_CF_TUNNEL_TOKEN, "tok-456")
+        tnl = CloudflareNamedTunnel(UPSTREAM, hostname="rllm.example.com")
+        assert tnl._command() == ["cloudflared", "tunnel", "run"]
+        assert tnl._popen_env()["TUNNEL_TOKEN"] == "tok-456"
+
+    def test_token_mode_without_token_fails(self, monkeypatch):
+        monkeypatch.delenv("TUNNEL_TOKEN", raising=False)
+        monkeypatch.delenv(ENV_CF_TUNNEL_TOKEN, raising=False)
+        tnl = CloudflareNamedTunnel(UPSTREAM, hostname="rllm.example.com")
+        with pytest.raises(TunnelStartError, match="TUNNEL_TOKEN"):
+            tnl._command()
+
+    def test_url_derived_from_hostname_on_edge_registration(self):
+        tnl = CloudflareNamedTunnel(UPSTREAM, hostname="rllm.example.com", tunnel_ref="my-tunnel")
+        assert tnl._extract_url("2026-01-01T00:00:00Z INF Registered tunnel connection connIndex=0 location=icn") == "https://rllm.example.com"
+        assert tnl._extract_url("2026-01-01T00:00:00Z INF Starting tunnel tunnelID=abc") is None
+
+    def test_fatal_hints(self):
+        tnl = CloudflareNamedTunnel(UPSTREAM, hostname="rllm.example.com", tunnel_ref="my-tunnel")
+        assert "token" in tnl._classify_fatal("Provided Tunnel token is not valid")
+        assert "cloudflared tunnel login" in tnl._classify_fatal("Cannot determine default origin certificate path. No file cert.pem in [~/.cloudflared]")
+        assert "cloudflared tunnel list" in tnl._classify_fatal("Tunnel credentials file '/x/y.json' doesn't exist")
+        assert tnl._classify_fatal("some unrelated line") is None
+
+
+class TestTunnelConfig:
+    def test_save_and_load_cloudflare_tunnel_name(self, tmp_path, monkeypatch):
+        import rllm.eval.config as cfg_mod
+
+        monkeypatch.setattr(cfg_mod, "_config_path", lambda: str(tmp_path / "config.json"))
+        cfg_mod.save_tunnel_config("cloudflare", domain="rllm.example.com", name="my-tunnel", port=9090)
+        assert cfg_mod.load_tunnel_config() == {"backend": "cloudflare", "domain": "rllm.example.com", "name": "my-tunnel", "port": 9090}


### PR DESCRIPTION
## Summary

The gateway tunnel previously offered two managed backends: Cloudflare **quick** tunnels (temporary `*.trycloudflare.com` — shared infra, HTTP 429 rate limits, 120s origin read timeout that 524s slow non-streaming LLM calls) and **ngrok**. A stable Cloudflare hostname was only possible by running `cloudflared` manually and passing the URL via `RLLM_GATEWAY_TUNNEL=https://...`, with no lifecycle management, no port coordination, and no startup verification.

This adds a `cloudflare` backend that makes **named (production) tunnels** — tied to a Cloudflare account, serving a stable hostname on your own domain — a first-class managed backend like ngrok:

- **`cloudflare:<hostname>`** — dashboard-managed: ingress lives in Zero Trust; the connector token comes from `$TUNNEL_TOKEN` (or `$CLOUDFLARE_TUNNEL_TOKEN`) and is passed to the subprocess via env, never argv (keeps it out of `ps`).
- **`cloudflare:<hostname>@<tunnel-name>`** — locally-managed: runs `cloudflared tunnel run --url <upstream> <name>` so ingress follows the gateway port automatically.

Named tunnels never log their public URL, so readiness is detected from the `Registered tunnel connection` edge-registration line and the URL is derived from the configured hostname. Known failures map to actionable hints (bad token → re-copy from dashboard; missing `cert.pem` → `cloudflared tunnel login`; missing credentials → `cloudflared tunnel list`).

Also included:
- `rllm tunnel setup` offers the new backend with per-mode guidance and persists an optional tunnel `name`; `rllm tunnel up` folds hostname/name into the spec.
- `parse_tunnel` no longer lowercases the spec (Cloudflare tunnel names are case-sensitive; backend names are still normalized).
- The reachability probe now sends a real User-Agent: Cloudflare bot protection 403s urllib's default `Python-urllib/x.y` UA at the edge, which previously let the probe "pass" (403 < 500) without ever traversing the tunnel — observed live on a zone with bot protection enabled.

Backward compatible: `cloudflared` still means quick tunnel (and remains the unconfigured fallback), ngrok and static-URL passthrough are untouched.

## Test plan

- 18 new unit tests in `tests/engine/test_tunnel.py` (spec parsing, both command modes, token-from-env, error paths, fatal hints, config round-trip); related suites (`tests/engine`, `tests/cli`, `tests/eval`) pass.
- Verified `cloudflared` 2026.1.1 emits the `Registered tunnel connection` readiness line.
- Live end-to-end test against a real Cloudflare account: backend-spawned tunnel registered 4 edge connections and a marker file served from a local origin came back through the public hostname; OpenAI SDK and httpx user agents pass the edge (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)