### PR TITLE
[Fireworks Trainer] Use Serverless in cookbooks (port of #806 onto terminal-rl)

### DIFF
--- a/cookbooks/deepcoder/train_fireworks_serverless.sh
+++ b/cookbooks/deepcoder/train_fireworks_serverless.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Train the DeepCoder agent with pooled Fireworks serverless training.
+
+set -euo pipefail
+
+python -u train.py \
+    rllm/backend=fireworks_serverless \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    training.max_length=32768 \
+    training.group_size=4 \
+    data.train_batch_size=16 \
+    data.val_batch_size=50 \
+    data.max_prompt_length=8192 \
+    data.max_response_length=16384 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.test_freq=20 \
+    rllm.trainer.project_name=deepcoder \
+    rllm.trainer.experiment_name=qwen3p5-9b-fireworks-serverless \
+    rllm.trainer.logger=[console,ui] \
+    "$@"

--- a/cookbooks/math/README.md
+++ b/cookbooks/math/README.md
@@ -86,6 +86,21 @@ For LoRA-only training (the legacy `examples/gsm8k_lora/` use case), set `--lora
 bash cookbooks/math/train_tinker.sh
 ```
 
+### Fireworks (serverless)
+
+```bash
+uv pip install -e ".[fireworks]"
+export FIREWORKS_API_KEY=...
+bash cookbooks/math/train_fireworks_serverless.sh
+```
+
+This uses a shared pooled trainer and rollout host. It does not provision a
+trainer job or inference deployment. `training.max_length` and a positive
+`model.lora_rank` are required.
+
+For dedicated managed infrastructure instead, use
+`cookbooks/math/train_fireworks.sh`.
+
 ### Verl (distributed GPU)
 
 ```bash
@@ -108,6 +123,8 @@ pytest cookbooks/math/test.py -v
 | `evaluator.py` | `math_evaluator` — wraps `rllm.eval.reward_fns.math` |
 | `train.py` | Python API training script (Hydra config) |
 | `train_tinker.sh` | Tinker backend — single-machine training |
+| `train_fireworks_serverless.sh` | Fireworks backend — pooled serverless training |
+| `train_fireworks.sh` | Fireworks backend — dedicated managed infrastructure |
 | `train_verl.sh` | Verl backend — distributed multi-GPU training |
 | `pyproject.toml` | Plugin metadata and entry points |
 | `test.py` | Unit tests for evaluator scoring |

--- a/cookbooks/math/train_fireworks_serverless.sh
+++ b/cookbooks/math/train_fireworks_serverless.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 
 python -u train.py \
     rllm/backend=fireworks_serverless \
-    model.name=accounts/fireworks/models/qwen3-4b-instruct-2507 \
-    model.tokenizer_model=Qwen/Qwen3-4B-Instruct-2507 \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
     model.lora_rank=32 \
     training.max_length=16384 \
     training.group_size=8 \
@@ -26,6 +26,6 @@ python -u train.py \
     rllm.trainer.total_epochs=1 \
     rllm.trainer.test_freq=10 \
     rllm.trainer.project_name=math \
-    rllm.trainer.experiment_name=qwen3-4b-instruct-fireworks-serverless \
+    rllm.trainer.experiment_name=qwen3p5-9b-fireworks-serverless \
     rllm.trainer.logger=[console,ui] \
     "$@"

--- a/cookbooks/math/train_fireworks_serverless.sh
+++ b/cookbooks/math/train_fireworks_serverless.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Train the math agent with pooled Fireworks serverless training.
+#
+# Prerequisites:
+#   1. Install rllm with fireworks extras:  uv pip install -e ".[fireworks]"
+#   2. Install this cookbook:                uv pip install --no-deps -e cookbooks/math
+#   3. Pull the datasets:                    rllm dataset pull hendrycks_math && rllm dataset pull math500
+#   4. Set your API key:                     export FIREWORKS_API_KEY=...
+#
+# No trainer job or inference deployment is provisioned. The shared serverless
+# session supplies both the LoRA training client and snapshot sampling clients.
+
+set -euo pipefail
+
+python -u train.py \
+    rllm/backend=fireworks_serverless \
+    model.name=accounts/fireworks/models/qwen3-4b-instruct-2507 \
+    model.tokenizer_model=Qwen/Qwen3-4B-Instruct-2507 \
+    model.lora_rank=32 \
+    training.max_length=16384 \
+    training.group_size=8 \
+    data.train_batch_size=32 \
+    data.val_batch_size=500 \
+    data.max_prompt_length=4096 \
+    data.max_response_length=4096 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.project_name=math \
+    rllm.trainer.experiment_name=qwen3-4b-instruct-fireworks-serverless \
+    rllm.trainer.logger=[console,ui] \
+    "$@"

--- a/examples/countdown/unified_trainer/train_countdown_unified_fireworks.py
+++ b/examples/countdown/unified_trainer/train_countdown_unified_fireworks.py
@@ -19,7 +19,7 @@ def main(config):
         config=config,
         train_dataset=train_dataset,
         val_dataset=test_dataset,
-        backend="fireworks",
+        backend=config.rllm.get("backend", "fireworks"),
     )
     trainer.train()
 

--- a/examples/countdown/unified_trainer/train_countdown_unified_fireworks_serverless.sh
+++ b/examples/countdown/unified_trainer/train_countdown_unified_fireworks_serverless.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# One-step Countdown smoke run on Fireworks serverless training.
+
+set -euo pipefail
+
+python -m examples.countdown.unified_trainer.train_countdown_unified_fireworks \
+    rllm/backend=fireworks_serverless \
+    model.name=accounts/fireworks/models/qwen3p5-9b \
+    model.tokenizer_model=Qwen/Qwen3.5-9B \
+    model.lora_rank=32 \
+    rollout_engine.renderer_name=qwen3_5 \
+    rollout_engine.reasoning_effort=none \
+    training.group_size=4 \
+    training.learning_rate=2e-5 \
+    training.max_length=4096 \
+    validation.group_size=1 \
+    rllm.workflow.n_parallel_tasks=8 \
+    rllm.workflow.retry_limit=1 \
+    rllm.workflow.raise_on_error=false \
+    data.max_prompt_length=2048 \
+    data.max_response_length=1024 \
+    data.train_batch_size=4 \
+    data.val_batch_size=16 \
+    rllm.data.max_prompt_length=2048 \
+    rllm.data.max_response_length=1024 \
+    rllm.data.train_batch_size=4 \
+    rllm.data.val_batch_size=16 \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.algorithm.norm_adv_by_std_in_grpo=true \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.total_batches=1 \
+    rllm.trainer.logger='[console]' \
+    rllm.trainer.project_name='rllm-countdown' \
+    rllm.trainer.experiment_name='countdown-qwen3p5-9b-fireworks-serverless' \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=0 \
+    rllm.trainer.save_freq=1 \
+    "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ tinker = [
 ]
 
 fireworks = [
-    "fireworks-ai[training]==1.2.1 ; python_version >= '3.11'",
-    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
+    "fireworks-ai[training]>=1.2.4 ; python_version >= '3.11'",
+    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@bba676c6d00bd595f9453e0b2165b7457a01e0d5#subdirectory=training ; python_version >= '3.11'",
 ]
 
 opentelemetry = [

--- a/rllm/trainer/config/rllm/backend/fireworks_serverless.yaml
+++ b/rllm/trainer/config/rllm/backend/fireworks_serverless.yaml
@@ -3,12 +3,12 @@
 # Fireworks pooled serverless training. Unlike the managed Fireworks backend,
 # this provisions neither a trainer job nor an inference deployment.
 fireworks_base_url: "https://api.fireworks.ai"
-tinker_base_url: ${fireworks_base_url}
+tinker_base_url: "${fireworks_base_url}/training/v1/serverless"
 fuse_forward_backward_and_optim_step: false
 
 model:
-  name: accounts/fireworks/models/qwen3-4b-instruct-2507
-  tokenizer_model: Qwen/Qwen3-4B-Instruct-2507
+  name: accounts/fireworks/models/qwen3p5-9b
+  tokenizer_model: Qwen/Qwen3.5-9B
   lora_rank: 32
   train_unembed: false
   train_attn: true

--- a/rllm/trainer/config/rllm/backend/fireworks_serverless.yaml
+++ b/rllm/trainer/config/rllm/backend/fireworks_serverless.yaml
@@ -1,0 +1,69 @@
+# @package _global_
+
+# Fireworks pooled serverless training. Unlike the managed Fireworks backend,
+# this provisions neither a trainer job nor an inference deployment.
+fireworks_base_url: "https://api.fireworks.ai"
+tinker_base_url: ${fireworks_base_url}
+fuse_forward_backward_and_optim_step: false
+
+model:
+  name: accounts/fireworks/models/qwen3-4b-instruct-2507
+  tokenizer_model: Qwen/Qwen3-4B-Instruct-2507
+  lora_rank: 32
+  train_unembed: false
+  train_attn: true
+  train_mlp: true
+
+training:
+  group_size: ???
+  learning_rate: 2e-5
+  lr_schedule: "constant"
+  warmup_steps_ratio: 0.0
+  beta1: 0.9
+  beta2: 0.95
+  eps: 1e-8
+  max_length: 16384
+  num_minibatches: 1
+  default_local_dir: 'checkpoints/${rllm.trainer.project_name}/${rllm.trainer.experiment_name}'
+  resume_mode: auto
+  resume_from_path: null
+
+validation:
+  group_size: ???
+
+workflow:
+  n_parallel_tasks: 256
+  retry_limit: 3
+
+agent:
+  max_steps: 1
+  agent_args: {}
+
+rollout_engine:
+  reasoning_effort: "medium"
+  accumulate_reasoning: false
+  disable_thinking: false
+  bypass_render_with_parser: false
+  renderer_name: null
+
+data:
+  train_files: null
+  val_files: null
+  max_prompt_length: 8192
+  max_response_length: 4096
+  train_batch_size: 32
+  val_batch_size: 32
+
+rllm:
+  backend: fireworks_serverless
+  rollout:
+    n: ${oc.select:training.group_size, 8}
+    n_val: ${oc.select:validation.group_size, 1}
+    train:
+      top_k: 0
+    val:
+      top_k: 0
+  algorithm:
+    loss_fn: importance_sampling
+    rollout_correction:
+      bypass_mode: true

--- a/rllm/trainer/config/rllm/backend/fireworks_serverless.yaml
+++ b/rllm/trainer/config/rllm/backend/fireworks_serverless.yaml
@@ -44,7 +44,7 @@ rollout_engine:
   accumulate_reasoning: false
   disable_thinking: false
   bypass_render_with_parser: false
-  renderer_name: null
+  renderer_name: qwen3_5
 
 data:
   train_files: null

--- a/rllm/trainer/fireworks/__init__.py
+++ b/rllm/trainer/fireworks/__init__.py
@@ -1,9 +1,21 @@
 from rllm.trainer.fireworks.fireworks_backend import FireworksBackend
 from rllm.trainer.fireworks.fireworks_launcher import FireworksTrainerLauncher
 from rllm.trainer.fireworks.fireworks_policy_trainer import FireworksPolicyTrainer
+from rllm.trainer.fireworks.fireworks_serverless_backend import (
+    FireworksServerlessBackend,
+)
+from rllm.trainer.fireworks.fireworks_serverless_launcher import (
+    FireworksServerlessTrainerLauncher,
+)
+from rllm.trainer.fireworks.fireworks_serverless_policy_trainer import (
+    FireworksServerlessPolicyTrainer,
+)
 
 __all__ = [
     "FireworksBackend",
     "FireworksTrainerLauncher",
     "FireworksPolicyTrainer",
+    "FireworksServerlessBackend",
+    "FireworksServerlessPolicyTrainer",
+    "FireworksServerlessTrainerLauncher",
 ]

--- a/rllm/trainer/fireworks/fireworks_serverless_backend.py
+++ b/rllm/trainer/fireworks/fireworks_serverless_backend.py
@@ -1,0 +1,90 @@
+"""Fireworks serverless backend using the Tinker-compatible rLLM pipeline."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fireworks.training.sdk import FiretitanServiceClient
+from omegaconf import DictConfig
+
+from rllm.trainer.backend_protocol import BackendProtocol
+from rllm.trainer.fireworks.fireworks_serverless_policy_trainer import (
+    FireworksServerlessPolicyTrainer,
+)
+from rllm.trainer.tinker.tinker_backend import TinkerBackend
+
+
+def serverless_base_url(base_url: str) -> str:
+    """Normalize a Fireworks API URL to its serverless training endpoint."""
+    root = base_url.rstrip("/")
+    if root.endswith("/training/v1/serverless"):
+        return root
+    if root.endswith("/training/v1"):
+        return f"{root}/serverless"
+    return f"{root}/training/v1/serverless"
+
+
+class FireworksServerlessBackend(TinkerBackend):
+    """Train and sample from one pooled Fireworks serverless session."""
+
+    name = "fireworks_serverless"
+
+    def __init__(self, config: DictConfig, **kwargs: Any) -> None:
+        # Deliberately skip TinkerBackend.__init__: it creates a Tinker
+        # ServiceClient, while this backend needs Fireworks' pooled session.
+        BackendProtocol.__init__(self, config, **kwargs)
+        self.full_config = config
+        self.service_client = FiretitanServiceClient(
+            api_key=os.environ.get("FIREWORKS_API_KEY"),
+            base_url=serverless_base_url(config.fireworks_base_url),
+        )
+        self.policy_trainer = None
+        self.tokenizer = None
+        self.rollout_engine = None
+        self.sampling_client = None
+        self._algorithm_config = None
+        self._policy_updated_this_step = False
+        self.learning_rate = config.training.get("learning_rate", 1e-6)
+        self.beta1 = config.training.get("beta1", 0.9)
+        self.beta2 = config.training.get("beta2", 0.95)
+        self.eps = config.training.get("eps", 1e-8)
+
+    def init_rollout_engine(self, **kwargs: Any):
+        rollout_engine = super().init_rollout_engine(**kwargs)
+        self.policy_trainer = FireworksServerlessPolicyTrainer(
+            config=self.full_config,
+            service_client=self.service_client,
+            tokenizer=self.tokenizer,
+            cf_config=kwargs.get("cf_config"),
+            transform_config=kwargs.get("transform_config"),
+            algorithm_config=kwargs.get("algorithm_config"),
+        )
+        return rollout_engine
+
+    def validate_config(self) -> None:
+        super().validate_config()
+        if not os.environ.get("FIREWORKS_API_KEY"):
+            raise ValueError("FIREWORKS_API_KEY is required for Fireworks serverless training")
+        if self.full_config.model.lora_rank <= 0:
+            raise ValueError("Fireworks serverless training requires model.lora_rank > 0")
+        if not self.full_config.training.max_length:
+            raise ValueError(
+                "Fireworks serverless training requires training.max_length "
+                "(there is no training shape to infer it from)"
+            )
+
+    async def on_policy_updated(self, trainer_state) -> None:
+        previous_client = self.sampling_client
+        await super().on_policy_updated(trainer_state)
+        if previous_client is not None and previous_client is not self.sampling_client:
+            previous_client.close()
+
+    def shutdown(self) -> None:
+        try:
+            if self.sampling_client is not None:
+                self.sampling_client.close()
+                self.sampling_client = None
+        finally:
+            self.service_client.close()
+            super().shutdown()

--- a/rllm/trainer/fireworks/fireworks_serverless_backend.py
+++ b/rllm/trainer/fireworks/fireworks_serverless_backend.py
@@ -15,16 +15,6 @@ from rllm.trainer.fireworks.fireworks_serverless_policy_trainer import (
 from rllm.trainer.tinker.tinker_backend import TinkerBackend
 
 
-def serverless_base_url(base_url: str) -> str:
-    """Normalize a Fireworks API URL to its serverless training endpoint."""
-    root = base_url.rstrip("/")
-    if root.endswith("/training/v1/serverless"):
-        return root
-    if root.endswith("/training/v1"):
-        return f"{root}/serverless"
-    return f"{root}/training/v1/serverless"
-
-
 class FireworksServerlessBackend(TinkerBackend):
     """Train and sample from one pooled Fireworks serverless session."""
 
@@ -37,7 +27,7 @@ class FireworksServerlessBackend(TinkerBackend):
         self.full_config = config
         self.service_client = FiretitanServiceClient(
             api_key=os.environ.get("FIREWORKS_API_KEY"),
-            base_url=serverless_base_url(config.fireworks_base_url),
+            base_url=config.tinker_base_url,
         )
         self.policy_trainer = None
         self.tokenizer = None

--- a/rllm/trainer/fireworks/fireworks_serverless_backend.py
+++ b/rllm/trainer/fireworks/fireworks_serverless_backend.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fireworks.training.sdk import FiretitanServiceClient
 from omegaconf import DictConfig
+from transformers import AutoTokenizer
 
 from rllm.trainer.backend_protocol import BackendProtocol
 from rllm.trainer.fireworks.fireworks_serverless_policy_trainer import (
@@ -25,12 +26,13 @@ class FireworksServerlessBackend(TinkerBackend):
         # ServiceClient, while this backend needs Fireworks' pooled session.
         BackendProtocol.__init__(self, config, **kwargs)
         self.full_config = config
+        tokenizer_name = config.model.get("tokenizer_model") or config.model.name
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
         self.service_client = FiretitanServiceClient(
             api_key=os.environ.get("FIREWORKS_API_KEY"),
             base_url=config.tinker_base_url,
         )
         self.policy_trainer = None
-        self.tokenizer = None
         self.rollout_engine = None
         self.sampling_client = None
         self._algorithm_config = None

--- a/rllm/trainer/fireworks/fireworks_serverless_launcher.py
+++ b/rllm/trainer/fireworks/fireworks_serverless_launcher.py
@@ -1,0 +1,29 @@
+"""Launcher for pooled Fireworks serverless training."""
+
+from rllm.trainer.fireworks.fireworks_serverless_backend import (
+    FireworksServerlessBackend,
+)
+from rllm.trainer.unified_trainer import TrainerLauncher, UnifiedTrainer
+
+
+class FireworksServerlessTrainerLauncher(TrainerLauncher):
+    def train(self):
+        trainer = None
+        try:
+            trainer = UnifiedTrainer(
+                backend_cls=FireworksServerlessBackend,
+                config=self.config,
+                workflow_class=self.workflow_class,
+                train_dataset=self.train_dataset,
+                val_dataset=self.val_dataset,
+                workflow_args=self.workflow_args,
+                store=self.store,
+                **self.kwargs,
+            )
+            trainer.fit()
+        except Exception as e:
+            print(f"Error training with Fireworks serverless: {e}")
+            raise
+        finally:
+            if trainer is not None:
+                trainer.shutdown()

--- a/rllm/trainer/fireworks/fireworks_serverless_policy_trainer.py
+++ b/rllm/trainer/fireworks/fireworks_serverless_policy_trainer.py
@@ -1,0 +1,76 @@
+"""Tinker-compatible policy trainer for Fireworks serverless training."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import tinker
+
+from rllm.trainer.tinker.tinker_policy_trainer import (
+    TinkerPolicyTrainer,
+    require_training_client,
+)
+
+
+class FireworksServerlessPolicyTrainer(TinkerPolicyTrainer):
+    """Use Fireworks' service-owned sampler for each saved LoRA snapshot."""
+
+    def __init__(self, *args: Any, tokenizer: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.tokenizer = tokenizer
+
+    @require_training_client
+    def create_sampling_client(self, sampler_path: str) -> tinker.SamplingClient:
+        return self.service_client.create_sampling_client(
+            model_path=sampler_path,
+            tokenizer=self.tokenizer,
+        )
+
+    @require_training_client
+    async def save_checkpoint_and_get_sampling_client(
+        self,
+        batch_idx: int,
+        do_save: bool = False,
+        dataloader_state: dict | None = None,
+    ) -> tinker.SamplingClient:
+        # Fireworks serverless does not implement Tinker's
+        # save_weights_and_get_sampling_client shortcut. A sampler must be
+        # opened through the service against an explicit snapshot.
+        name = f"{batch_idx:06d}"
+        sampler_future = await self.training_client.save_weights_for_sampler_async(name)
+
+        state_future = None
+        if do_save:
+            state_future = await self.training_client.save_state_async(name)
+
+        sampler_path = (await sampler_future.result_async()).path
+        if do_save:
+            assert state_future is not None
+            state_path = (await state_future.result_async()).path
+            step_dir = os.path.join(
+                self.config.training.default_local_dir,
+                f"global_step_{batch_idx}",
+            )
+            os.makedirs(step_dir, exist_ok=True)
+            with open(os.path.join(step_dir, "checkpoint.json"), "w") as f:
+                json.dump(
+                    {
+                        "name": name,
+                        "state_path": state_path,
+                        "sampler_path": sampler_path,
+                        "dataloader_state": dataloader_state,
+                    },
+                    f,
+                )
+            with open(
+                os.path.join(
+                    self.config.training.default_local_dir,
+                    "latest_checkpointed_iteration.txt",
+                ),
+                "w",
+            ) as f:
+                f.write(str(batch_idx))
+
+        return self.create_sampling_client(sampler_path)

--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -112,9 +112,10 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
             transform_config=kwargs.get("transform_config"),
             algorithm_config=kwargs.get("algorithm_config"),
         )
-        # model.name may be a Tinker model id (e.g. "nvidia/...:peft:262144") that
-        # isn't a valid HF repo id; render/tokenize from the HF tokenizer_model when
-        # set, falling back to model.name. (Mirrors the fireworks + SFT tinker backends.)
+        # model.name may be a Tinker model id (e.g. "nvidia/...:peft:262144") or a
+        # Fireworks model resource name — neither is a valid HF repo id; render/
+        # tokenize from the HF tokenizer_model when set, falling back to model.name.
+        # (Mirrors the fireworks + SFT tinker backends.)
         tokenizer_name = self.full_config.model.get("tokenizer_model") or self.full_config.model.name
         # we need to get it from `AutoTokenizer` since the `policy_trainer` has not been initialized yet
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
@@ -156,7 +157,7 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
         rollout_extra.setdefault("renderer_family", gateway_family)
         self.rollout_engine = TinkerEngine(
             base_url=self.full_config.tinker_base_url,
-            model_name=self.full_config.model.name,
+            model_name=tokenizer_name,
             service_client=self.service_client,
             tokenizer=self.tokenizer,
             max_prompt_length=self.full_config.data.max_prompt_length,

--- a/rllm/trainer/tinker/tinker_backend.py
+++ b/rllm/trainer/tinker/tinker_backend.py
@@ -117,8 +117,11 @@ class TinkerBackend(BackendProtocol[Iterable, list[tinker.Datum]]):
         # tokenize from the HF tokenizer_model when set, falling back to model.name.
         # (Mirrors the fireworks + SFT tinker backends.)
         tokenizer_name = self.full_config.model.get("tokenizer_model") or self.full_config.model.name
-        # we need to get it from `AutoTokenizer` since the `policy_trainer` has not been initialized yet
-        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+        # we need to get it from `AutoTokenizer` since the `policy_trainer` has not been
+        # initialized yet — unless a subclass (e.g. the Fireworks serverless backend)
+        # already built one in its own __init__.
+        if self.tokenizer is None:
+            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
 
         # Load image processor for vision-language models.
         # For VLM models, the tinker renderer requires an image_processor to

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 def _detached_warm_queue(hooks):
     """Temporarily detach a training warm queue so the enclosed work (validation,
     whose tasks aren't in the train schedule) falls back to direct sandbox creation."""
-    if hooks is None:
+    if hooks is None or not hasattr(hooks, "warm_queue"):
         yield
         return
     saved = hooks.warm_queue

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -1079,7 +1079,7 @@ class AgentTrainer:
         train_dataset: Dataset | None = None,
         val_dataset: Dataset | None = None,
         workflow_args: dict | None = None,
-        backend: Literal["verl", "tinker", "fireworks"] = "verl",
+        backend: Literal["verl", "tinker", "fireworks", "fireworks_serverless"] = "verl",
         agent_flow: Any = None,
         evaluator: Any = None,
         hooks: Any = None,
@@ -1169,6 +1169,20 @@ class AgentTrainer:
             from rllm.trainer.fireworks.fireworks_launcher import FireworksTrainerLauncher
 
             self.launcher = FireworksTrainerLauncher(
+                config=config,
+                workflow_class=workflow_class,
+                train_dataset=train_dataset,
+                val_dataset=val_dataset,
+                workflow_args=workflow_args,
+                store=store,
+                **kwargs,
+            )
+        elif backend == "fireworks_serverless":
+            from rllm.trainer.fireworks.fireworks_serverless_launcher import (
+                FireworksServerlessTrainerLauncher,
+            )
+
+            self.launcher = FireworksServerlessTrainerLauncher(
                 config=config,
                 workflow_class=workflow_class,
                 train_dataset=train_dataset,

--- a/tests/unified_trainer/test_warm_queue_wiring.py
+++ b/tests/unified_trainer/test_warm_queue_wiring.py
@@ -29,6 +29,11 @@ def test_detached_warm_queue_detaches_and_restores():
     with _detached_warm_queue(None):
         pass
 
+    # Hooks without sandbox warm-queue support are also a no-op.
+    hooks_without_queue = SimpleNamespace()
+    with _detached_warm_queue(hooks_without_queue):
+        assert not hasattr(hooks_without_queue, "warm_queue")
+
 
 def _fake_trainer(warm_queue_size, sandbox_backend, hooks_present=True):
     rllm_config = OmegaConf.create(


### PR DESCRIPTION
Ports [#806](https://github.com/rllm-org/rllm/pull/806) (`fw-ai-external:fireworks_sampling_client` → `main`) onto `terminal-rl`, so the serverless path is available on the branch we're actually training from.

## What's here

A pooled **Fireworks serverless** backend, reusing the Tinker-compatible pipeline:

- `rllm/trainer/fireworks/fireworks_serverless_{backend,launcher,policy_trainer}.py` — `FireworksServerlessBackend` extends `TinkerBackend` but skips its `__init__` (Tinker `ServiceClient` → Fireworks `FiretitanServiceClient`), and trains/samples from one pooled session.
- `rllm/trainer/config/rllm/backend/fireworks_serverless.yaml` — backend config.
- `unified_trainer.py` — `backend="fireworks_serverless"` wired into `AgentTrainer`; `_detached_warm_queue` now tolerates hooks without a `warm_queue` attribute.
- `tinker_backend.py` — don't clobber a tokenizer a subclass already built (`if self.tokenizer is None`). The `tokenizer_model` fallback and `model_name=tokenizer_name` that #806 also added are already on `terminal-rl`.
- Cookbook/example launch scripts for math, deepcoder, and countdown; `pyproject.toml` bumps `fireworks-ai` to `>=1.2.4` and pins the training-cookbook rev.

## What's intentionally *not* here

#806's first commit (`a17c02e1 FiretitanSamplingClient`) rewrites `rllm/engine/rollout/fireworks_engine.py`, dropping the `DeploymentSampler` token-in/token-out path in favour of inheriting it from `TinkerEngine`. That commit is **omitted**:

- It's orthogonal to this feature — `FireworksServerlessBackend` gets a `TinkerEngine` from `super().init_rollout_engine()` and never constructs a `FireworksEngine`.
- `terminal-rl` has since built substantially on that file: session-affinity headers, the orjson httpx/SDK-parse patches, unified-renderer resolution, `handler_factory_spec`, and the bounded retry budget. Applying it would delete all of that and break `rllm/gateway/worker_handlers.py`, `gateway/tinker_adapter.py` (`supports_session_affinity`), and `tests/test_renderers.py` (which constructs `FireworksEngine(sampler=...)`).

If the dedicated-deployment engine should move to `FiretitanSamplingClient`, that's a separate change that has to preserve the gateway wiring above.

## Conflict resolution

Two conflicts, both trivial:

- `pyproject.toml` — took #806's `fireworks-ai>=1.2.4` + pinned cookbook rev over `terminal-rl`'s `==1.2.1`.
- `tinker_backend.py` — kept `terminal-rl`'s comment for the `tokenizer_model` fallback (both branches added the same code) and layered #806's `if self.tokenizer is None:` guard on top.

## Testing

`ruff check` and `py_compile` pass on the touched files. `fireworks-ai` and `pytest` aren't installed in this environment, so `tests/unified_trainer/test_warm_queue_wiring.py` was not run locally — leaving that to CI.
