### PR TITLE
Add GDPval evaluation support with Stirrup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "openai",
     "tqdm",
     "requests",
+    # Required by the first-party ``--sandbox-backend docker`` implementation.
+    "docker>=7.1",
     # Data
     "datasets>=2.20.0",
     "pillow",
@@ -114,7 +116,6 @@ langgraph = [
 ]
 
 swe = [
-    "docker",
     "kubernetes",
     "swebench",
 ]

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -1,0 +1,622 @@
+"""Materialize OpenAI GDPval as rLLM sandbox tasks.
+
+The source dataset stores prompts plus Hugging Face paths for task inputs and
+expert deliverables.  This builder stages the inputs in the task environment,
+keeps expert files under ``tests/reference`` (uploaded only after the agent
+finishes), writes the GDPval solver image, and emits an LLM-judge verifier.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import posixpath
+import re
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree
+
+logger = logging.getLogger(__name__)
+
+REPO_ID = "openai/gdpval"
+OFFICE_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
+_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+_EXTERNAL_OPEN_REL = re.compile(
+    rb"<Relationship\b(?P<attrs>[^<>]*\bTargetMode=(?:\"External\"|'External')[^<>]*?)(?<!/)>",
+    re.IGNORECASE,
+)
+_SUSPICIOUS_SETTINGS = re.compile(rb"(?:xmlns:ns\d+\s*=|</?ns\d+:)")
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relationship_source(name: str) -> str | None:
+    if name == "_rels/.rels":
+        return ""
+    marker = "/_rels/"
+    if marker not in name or not name.endswith(".rels"):
+        return None
+    parent, leaf = name.split(marker, 1)
+    return posixpath.join(parent, leaf[: -len(".rels")])
+
+
+def _validate_office_package(path: Path) -> dict:
+    report: dict = {
+        "zip_ok": False,
+        "required_parts_missing": [],
+        "xml_errors": [],
+        "missing_relationship_targets": [],
+        "valid": False,
+    }
+    try:
+        with zipfile.ZipFile(path) as package:
+            names = set(package.namelist())
+            bad_member = package.testzip()
+            if bad_member:
+                report["xml_errors"].append(f"CRC failure: {bad_member}")
+                return report
+            report["zip_ok"] = True
+            report["required_parts_missing"] = sorted({"[Content_Types].xml", "_rels/.rels"} - names)
+            for name in sorted(names):
+                if not (name.endswith(".xml") or name.endswith(".rels")):
+                    continue
+                try:
+                    root = ElementTree.fromstring(package.read(name))
+                except (ElementTree.ParseError, UnicodeError) as exc:
+                    report["xml_errors"].append(f"{name}: {exc}")
+                    continue
+                if not name.endswith(".rels"):
+                    continue
+                source = _relationship_source(name)
+                if source is None:
+                    continue
+                source_dir = posixpath.dirname(source)
+                for relationship in root.findall(f"{{{_REL_NS}}}Relationship"):
+                    if relationship.get("TargetMode", "").lower() == "external":
+                        continue
+                    target = relationship.get("Target")
+                    if not target or target.startswith("/"):
+                        continue
+                    resolved = posixpath.normpath(posixpath.join(source_dir, target))
+                    if resolved not in names:
+                        report["missing_relationship_targets"].append(f"{name} -> {resolved}")
+    except (OSError, zipfile.BadZipFile) as exc:
+        report["xml_errors"].append(str(exc))
+        return report
+
+    report["valid"] = not (report["required_parts_missing"] or report["xml_errors"] or report["missing_relationship_targets"])
+    return report
+
+
+def _repair_docx_members(package: zipfile.ZipFile) -> tuple[list[tuple[zipfile.ZipInfo, bytes]], list[str]]:
+    members = [(info, package.read(info.filename)) for info in package.infolist()]
+    by_name = {info.filename: data for info, data in members}
+    changes: list[str] = []
+    remove_settings = bool(_SUSPICIOUS_SETTINGS.search(by_name.get("word/settings.xml", b"")))
+    if remove_settings:
+        changes.append("removed suspicious word/settings.xml")
+
+    repaired: list[tuple[zipfile.ZipInfo, bytes]] = []
+    for info, data in members:
+        if remove_settings and info.filename == "word/settings.xml":
+            continue
+        if info.filename.endswith(".rels"):
+            data, count = _EXTERNAL_OPEN_REL.subn(rb"<Relationship\g<attrs>/>", data)
+            if count:
+                changes.append(f"closed {count} malformed external relationship(s) in {info.filename}")
+            if remove_settings and info.filename == "word/_rels/document.xml.rels":
+                try:
+                    root = ElementTree.fromstring(data)
+                    removed = 0
+                    for relationship in list(root):
+                        if relationship.get("Type", "").endswith("/settings") or relationship.get("Target") == "settings.xml":
+                            root.remove(relationship)
+                            removed += 1
+                    if removed:
+                        ElementTree.register_namespace("", _REL_NS)
+                        data = ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+                        changes.append(f"removed {removed} settings relationship(s) from {info.filename}")
+                except ElementTree.ParseError:
+                    pass
+        repaired.append((info, data))
+    return repaired, changes
+
+
+def _repair_office_file(path: Path, backup_path: Path) -> dict:
+    original_hash = _sha256(path)
+    before = _validate_office_package(path) if path.suffix.lower() in OFFICE_EXTENSIONS else None
+    result = {
+        "file": path.name,
+        "status": "skipped",
+        "original_sha256": original_hash,
+        "repaired_sha256": original_hash,
+        "backup": None,
+        "changes": [],
+        "validation_before": before,
+        "validation_after": before,
+    }
+    if path.suffix.lower() not in OFFICE_EXTENSIONS:
+        return result
+    if path.suffix.lower() != ".docx":
+        result["status"] = "valid" if before and before["valid"] else "unresolved"
+        return result
+    try:
+        with zipfile.ZipFile(path) as package:
+            members, changes = _repair_docx_members(package)
+    except (OSError, zipfile.BadZipFile):
+        result["status"] = "unresolved"
+        return result
+    if not changes:
+        result["status"] = "valid" if before and before["valid"] else "unresolved"
+        return result
+
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(path, backup_path)
+    with tempfile.NamedTemporaryFile(dir=path.parent, suffix=path.suffix, delete=False) as handle:
+        temporary = Path(handle.name)
+    try:
+        with zipfile.ZipFile(temporary, "w") as target:
+            for info, data in members:
+                target.writestr(info, data)
+        after = _validate_office_package(temporary)
+        if not after["valid"]:
+            result.update(status="unresolved", changes=changes, backup=str(backup_path), validation_after=after)
+            return result
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    result.update(
+        status="repaired",
+        repaired_sha256=_sha256(path),
+        backup=str(backup_path),
+        changes=changes,
+        validation_after=after,
+    )
+    return result
+
+
+def _basenames(row: dict, key: str) -> list[str]:
+    return [Path(str(value)).name for value in row.get(key) or []]
+
+
+def _download_files(paths: list[str], destination: Path) -> list[str]:
+    from huggingface_hub import hf_hub_download
+
+    destination.mkdir(parents=True, exist_ok=True)
+    names: list[str] = []
+    for repo_path in paths:
+        cached = Path(hf_hub_download(REPO_ID, str(repo_path), repo_type="dataset"))
+        target = destination / Path(str(repo_path)).name
+        shutil.copy2(cached, target)
+        names.append(target.name)
+    return names
+
+
+def _repair_staged_files(paths: list[Path], *, task_id: str, role: str, backup_root: Path) -> list[dict]:
+    records: list[dict] = []
+    for path in paths:
+        if path.suffix.lower() not in OFFICE_EXTENSIONS:
+            continue
+        record = _repair_office_file(path, backup_root / task_id / role / path.name)
+        record.update(task_id=task_id, role=role, staged_path=str(path))
+        records.append(record)
+    return records
+
+
+def _write_instruction(task_dir: Path, row: dict, input_names: list[str]) -> None:
+    lines = [str(row.get("prompt") or "").strip(), ""]
+    if input_names:
+        lines.extend(["## Input files", *[f"- /home/user/{name}" for name in input_names], ""])
+    expected = _basenames(row, "deliverable_files")
+    if expected:
+        lines.extend(["## Expected deliverable filename(s)", *[f"- {name}" for name in expected], ""])
+    lines.extend(
+        [
+            "## Submission",
+            "Save final deliverables in /home/user/deliverables and submit those files with the finish tool.",
+            "",
+        ]
+    )
+    (task_dir / "instruction.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_task_toml(task_dir: Path, row: dict, input_names: list[str], gold_names: list[str]) -> None:
+    lines = [
+        'schema_version = "1.1"',
+        f'task_id = "{row["task_id"]}"',
+        f'sector = """{_toml_escape(str(row.get("sector") or ""))}"""',
+        f'occupation = """{_toml_escape(str(row.get("occupation") or ""))}"""',
+        f"reference_files = {json.dumps(input_names)}",
+        f"reference_deliverables = {json.dumps(gold_names)}",
+        "",
+        "[task]",
+        f'name = "{row["task_id"]}"',
+        "",
+        "[environment]",
+        'workdir = "/home/user"',
+        "cpus = 4",
+        "memory_mb = 16384",
+        "storage_mb = 32768",
+        "",
+        "[agent]",
+        'user = "root"',
+        "timeout_sec = 14400",
+        "",
+        "[verifier]",
+        'script = "tests/test.sh"',
+        'user = "root"',
+        "timeout_sec = 1800",
+        "",
+        "[verifier.env]",
+        'GDPVAL_JUDGE_API_KEY = "${GDPVAL_JUDGE_API_KEY}"',
+        'GDPVAL_JUDGE_MODEL = "${GDPVAL_JUDGE_MODEL}"',
+        "",
+    ]
+    (task_dir / "task.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_tests(task_dir: Path, row: dict) -> None:
+    tests_dir = task_dir / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "task_id": row["task_id"],
+        "prompt": row.get("prompt") or "",
+        "rubric": row.get("rubric_pretty") or row.get("rubric_json") or "",
+    }
+    (tests_dir / "metadata.json").write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+    (tests_dir / "evaluate.py").write_text(_VERIFIER_SOURCE, encoding="utf-8")
+    test_sh = tests_dir / "test.sh"
+    test_sh.write_text("#!/bin/bash\nset -euo pipefail\npython /tests/evaluate.py\n", encoding="utf-8")
+    test_sh.chmod(0o755)
+
+
+def _write_dataset_toml(out: Path, *, name: str, split: str, description: str, default_agent: str) -> None:
+    (out / "dataset.toml").write_text(
+        "\n".join(
+            [
+                "[dataset]",
+                f'name = "{name}"',
+                'type = "sandbox"',
+                f'description = "{_toml_escape(description)}"',
+                'default_sandbox = "docker"',
+                f'default_agent = "{default_agent}"',
+                f'split = "{split}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def build_benchmark(
+    *,
+    name: str = "gdpval",
+    split: str = "train",
+    out_dir: str | Path,
+    catalog_entry: dict | None = None,
+    limit: int | None = None,
+    occupations: list[str] | None = None,
+    default_agent: str = "stirrup",
+    repair_office_files: bool = True,
+    clean: bool = False,
+    register: bool = True,
+) -> Path:
+    """Download and materialize the official GDPval split."""
+    from datasets import load_dataset
+
+    if catalog_entry:
+        split = catalog_entry.get("eval_split") or split
+        default_agent = catalog_entry.get("default_agent") or default_agent
+
+    out = Path(out_dir).expanduser()
+    if clean and out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = [dict(row) for row in load_dataset(REPO_ID, split=split)]
+    if occupations:
+        allowed = {value.casefold().strip() for value in occupations}
+        rows = [row for row in rows if str(row.get("occupation", "")).casefold().strip() in allowed]
+    if limit is not None:
+        rows = rows[:limit]
+
+    repair_records: list[dict] = []
+    registry_rows: list[dict] = []
+    backup_root = out / ".office-repair-originals"
+    for row in rows:
+        task_id = str(row.get("task_id") or "")
+        if not task_id:
+            continue
+        task_dir = out / task_id
+        if task_dir.exists():
+            shutil.rmtree(task_dir)
+        inputs_dir = task_dir / "environment" / "files"
+        gold_dir = task_dir / "tests" / "reference"
+        input_names = _download_files(list(row.get("reference_files") or []), inputs_dir)
+        gold_names = _download_files(list(row.get("deliverable_files") or []), gold_dir)
+        if repair_office_files:
+            repair_records.extend(
+                _repair_staged_files([inputs_dir / name for name in input_names], task_id=task_id, role="input", backup_root=backup_root)
+            )
+            repair_records.extend(
+                _repair_staged_files([gold_dir / name for name in gold_names], task_id=task_id, role="expert", backup_root=backup_root)
+            )
+
+        (task_dir / "environment" / "Dockerfile").write_text(_DOCKERFILE, encoding="utf-8")
+        _write_instruction(task_dir, row, input_names)
+        _write_task_toml(task_dir, row, input_names, gold_names)
+        _write_tests(task_dir, row)
+        registry_rows.append(
+            {
+                "task_id": task_id,
+                "id": task_id,
+                "instruction": str(row.get("prompt") or ""),
+                "task_path": str(task_dir),
+                "occupation": row.get("occupation", ""),
+                "sector": row.get("sector", ""),
+            }
+        )
+
+    if not registry_rows:
+        raise RuntimeError(f"no GDPval tasks materialized from {REPO_ID} split={split}")
+
+    description = (catalog_entry or {}).get("description") or "GDPval: 220 economically valuable knowledge-work tasks with expert deliverables."
+    _write_dataset_toml(out, name=name, split=split, description=description, default_agent=default_agent)
+    if repair_office_files:
+        statuses: dict[str, int] = {}
+        for record in repair_records:
+            statuses[record["status"]] = statuses.get(record["status"], 0) + 1
+        manifest = {
+            "schema_version": 1,
+            "policy": "Known GDPval DOCX repairs only; unknown defects are reported as unresolved.",
+            "summary": {"files": len(repair_records), "statuses": statuses},
+            "files": repair_records,
+        }
+        (out / "office_repair_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    if register:
+        try:
+            from rllm.data import DatasetRegistry
+
+            DatasetRegistry.register_dataset(
+                name=name,
+                data=registry_rows,
+                split=split,
+                source=REPO_ID,
+                description=description,
+                category=(catalog_entry or {}).get("category", "agentic"),
+            )
+        except Exception:
+            logger.warning("[gdpval] could not register rows in DatasetRegistry", exc_info=True)
+    return out
+
+
+_DOCKERFILE = r'''FROM python:3.10-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libreoffice libreoffice-writer fonts-dejavu-core tesseract-ocr tesseract-ocr-eng \
+    pandoc poppler-utils ghostscript ffmpeg graphviz libgraphviz-dev openjdk-17-jre-headless \
+    gdal-bin libgdal-dev libgeos-dev libproj-dev gcc g++ cmake pkg-config make gfortran \
+    libsndfile1 libzbar0 libgl1-mesa-glx libglib2.0-0 libcairo2-dev libpango1.0-dev \
+    libgdk-pixbuf2.0-dev libffi-dev libxml2-dev libxslt1-dev wkhtmltopdf unrar-free \
+    espeak-ng texlive-latex-base texlive-latex-recommended texlive-latex-extra latexmk \
+    && rm -rf /var/lib/apt/lists/*
+RUN fc-cache -f
+RUN pip install --no-cache-dir --upgrade 'pip>=25.0' 'setuptools<81'
+ARG PIP_FLAGS="--no-cache-dir --prefer-binary --retries 10 --timeout 60"
+RUN pip install $PIP_FLAGS \
+    numpy 'pandas<2' scipy matplotlib 'Pillow<10' seaborn plotly bokeh numpy-financial \
+    sympy h5py tables statsmodels scikit-learn scikit-image xgboost lightgbm shap \
+    nltk gensim 'spacy<3.8' textblob opencv-python pytesseract qrcode pyzbar imgkit
+RUN pip install $PIP_FLAGS \
+    ffmpeg-python pydub 'moviepy<2' soundfile 'librosa>=0.10' mutagen \
+    'python-docx<1' 'python-pptx<1' openpyxl xlrd PyMuPDF pdf2image pdfplumber \
+    pypandoc docx2txt odfpy pyxlsb 'camelot-py[base]' fpdf2 'reportlab<4' weasyprint \
+    graphviz 'pydot<2' networkx svglib svgwrite cairosvg wordcloud \
+    shapely fiona geopandas geopy rasterio rdkit biopython
+RUN pip install $PIP_FLAGS \
+    markdownify anytree rarfile chardet tqdm tabulate faker loguru rapidfuzz \
+    pycountry cryptography pyopenssl requests pytest
+RUN pip install --no-cache-dir 'setuptools<81'
+RUN mkdir -p /home/user/deliverables
+WORKDIR /home/user
+CMD ["tail", "-f", "/dev/null"]
+'''
+
+
+_VERIFIER_SOURCE = r'''from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import os
+import random
+import re
+import subprocess
+import tempfile
+import urllib.request
+from pathlib import Path
+
+import fitz
+
+CANDIDATE_DIR = Path("/home/user/deliverables")
+REFERENCE_DIR = Path("/tests/reference")
+REWARD_PATH = Path("/logs/verifier/reward.json")
+MEDIA_EXTENSIONS = {".mp3", ".wav", ".m4a", ".mp4", ".mov", ".avi", ".webm"}
+
+
+def extract_text(path: Path) -> str:
+    suffix = path.suffix.lower()
+    try:
+        if suffix in {".txt", ".md", ".csv", ".json", ".py", ".html", ".xml"}:
+            return path.read_text(encoding="utf-8", errors="replace")
+        if suffix == ".pdf":
+            with fitz.open(path) as document:
+                return "\n".join(page.get_text() for page in document)
+        if suffix in {".docx", ".doc"}:
+            from docx import Document
+
+            document = Document(path)
+            return "\n".join([*(p.text for p in document.paragraphs), *(" | ".join(c.text for c in row.cells) for table in document.tables for row in table.rows)])
+        if suffix in {".xlsx", ".xlsm"}:
+            import openpyxl
+
+            workbook = openpyxl.load_workbook(path, data_only=False, read_only=True)
+            parts = []
+            for sheet in workbook.worksheets:
+                parts.append(f"## Sheet: {sheet.title}")
+                parts.extend(" | ".join("" if value is None else str(value) for value in row) for row in sheet.iter_rows(values_only=True))
+            return "\n".join(parts)
+        if suffix == ".pptx":
+            from pptx import Presentation
+
+            deck = Presentation(path)
+            return "\n".join(shape.text for slide in deck.slides for shape in slide.shapes if hasattr(shape, "text"))
+        return f"[{path.name}: binary file, {path.stat().st_size} bytes]"
+    except Exception as exc:
+        return f"[{path.name}: extraction failed: {exc}]"
+
+
+def render_images(path: Path, max_pages: int = 8) -> list[str]:
+    suffix = path.suffix.lower()
+    if suffix in {".png", ".jpg", ".jpeg", ".webp"}:
+        mime = mimetypes.guess_type(path.name)[0] or "image/png"
+        return [f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode()}"]
+    pdf_path = path
+    temporary = None
+    if suffix in {".docx", ".xlsx", ".xlsm", ".pptx"}:
+        temporary = tempfile.TemporaryDirectory()
+        subprocess.run(
+            ["libreoffice", "--headless", "--convert-to", "pdf", "--outdir", temporary.name, str(path)],
+            check=False,
+            capture_output=True,
+            timeout=180,
+        )
+        pdf_path = Path(temporary.name) / f"{path.stem}.pdf"
+    if pdf_path.suffix.lower() != ".pdf" or not pdf_path.exists():
+        if temporary:
+            temporary.cleanup()
+        return []
+    images = []
+    try:
+        with fitz.open(pdf_path) as document:
+            for page in list(document)[:max_pages]:
+                data = page.get_pixmap(matrix=fitz.Matrix(1.5, 1.5), alpha=False).tobytes("png")
+                images.append(f"data:image/png;base64,{base64.b64encode(data).decode()}")
+    finally:
+        if temporary:
+            temporary.cleanup()
+    return images
+
+
+def describe(label: str, paths: list[Path]) -> tuple[str, list[str]]:
+    text = [f"## {label}"]
+    images = []
+    for path in paths:
+        text.extend([f"\n### File: {path.name}", extract_text(path)[:120000]])
+        images.extend(render_images(path))
+    return "\n".join(text), images[:16]
+
+
+def judge(metadata: dict, candidate: list[Path], reference: list[Path]) -> tuple[float, dict]:
+    candidate_text, candidate_images = describe("Submission A", candidate)
+    reference_text, reference_images = describe("Submission B", reference)
+    seed = int.from_bytes(metadata["task_id"].encode(), "little")
+    swapped = bool(random.Random(seed).getrandbits(1))
+    if swapped:
+        candidate_text, reference_text = reference_text, candidate_text
+        candidate_images, reference_images = reference_images, candidate_images
+
+    content = [
+        {
+            "type": "text",
+            "text": (
+                "You are an impartial evaluator. Compare two submissions for the task and rubric below. "
+                "Judge correctness, completeness, usability, and visual quality. Return only JSON: "
+                '{"winner":"A"}, {"winner":"B"}, or {"winner":"tie"}.\n\n'
+                f"TASK:\n{metadata['prompt']}\n\nRUBRIC:\n{metadata['rubric']}\n\n{candidate_text}"
+            ),
+        }
+    ]
+    content.extend({"type": "image_url", "image_url": {"url": image}} for image in candidate_images)
+    content.append({"type": "text", "text": reference_text})
+    content.extend({"type": "image_url", "image_url": {"url": image}} for image in reference_images)
+    payload = {
+        "model": os.environ["GDPVAL_JUDGE_MODEL"],
+        "messages": [{"role": "user", "content": content}],
+        "temperature": 0,
+        "max_tokens": 2048,
+    }
+    request = urllib.request.Request(
+        os.environ.get("GDPVAL_JUDGE_BASE_URL", "https://openrouter.ai/api/v1").rstrip("/") + "/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Authorization": f"Bearer {os.environ['GDPVAL_JUDGE_API_KEY']}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=600) as response:
+        body = json.loads(response.read())
+    answer = body["choices"][0]["message"]["content"]
+    match = re.search(r'"winner"\s*:\s*"(A|B|tie)"', answer, re.IGNORECASE)
+    if not match:
+        raise ValueError(f"judge returned no winner: {answer[:500]}")
+    winner = match.group(1).lower()
+    if swapped:
+        score = {"a": 0.0, "b": 1.0, "tie": 0.5}[winner]
+    else:
+        score = {"a": 1.0, "b": 0.0, "tie": 0.5}[winner]
+    return score, {"winner": winner, "positions_swapped": swapped, "judge_model": payload["model"]}
+
+
+def write_reward(reward: float, *, ungraded: bool = False, metadata: dict | None = None) -> None:
+    REWARD_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REWARD_PATH.write_text(
+        json.dumps(
+            {
+                "reward": reward,
+                "is_correct": reward > 0.5,
+                "signals": {"pairwise_win": reward, "ungraded": 1.0 if ungraded else 0.0},
+                "metadata": metadata or {},
+            }
+        )
+    )
+
+
+def main() -> None:
+    metadata = json.loads(Path("/tests/metadata.json").read_text())
+    candidate = sorted(path for path in CANDIDATE_DIR.rglob("*") if path.is_file()) if CANDIDATE_DIR.exists() else []
+    reference = sorted(path for path in REFERENCE_DIR.rglob("*") if path.is_file()) if REFERENCE_DIR.exists() else []
+    if not candidate:
+        write_reward(0.0, metadata={"reason": "no_deliverable"})
+        return
+    if not reference:
+        write_reward(0.0, ungraded=True, metadata={"reason": "no_expert_reference"})
+        return
+    if all(path.suffix.lower() in MEDIA_EXTENSIONS for path in [*candidate, *reference]):
+        write_reward(0.0, ungraded=True, metadata={"reason": "media_requires_files_api"})
+        return
+    try:
+        score, decision = judge(metadata, candidate, reference)
+    except Exception as exc:
+        write_reward(0.0, ungraded=True, metadata={"reason": "judge_failed", "error": str(exc)})
+        return
+    write_reward(score, metadata=decision)
+
+
+if __name__ == "__main__":
+    main()
+'''

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -582,14 +582,16 @@ def judge(metadata: dict, candidate: list[Path], reference: list[Path]) -> tuple
     return score, {"winner": winner, "positions_swapped": swapped, "judge_model": payload["model"]}
 
 
-def write_reward(reward: float, *, ungraded: bool = False, metadata: dict | None = None) -> None:
+def write_reward(reward: float, *, ungraded: bool = False, metadata: dict | None = None, signals: dict | None = None) -> None:
+    all_signals = {"pairwise_win": reward, "ungraded": 1.0 if ungraded else 0.0}
+    all_signals.update(signals or {})
     REWARD_PATH.parent.mkdir(parents=True, exist_ok=True)
     REWARD_PATH.write_text(
         json.dumps(
             {
                 "reward": reward,
                 "is_correct": reward > 0.5,
-                "signals": {"pairwise_win": reward, "ungraded": 1.0 if ungraded else 0.0},
+                "signals": all_signals,
                 "metadata": metadata or {},
             }
         )
@@ -601,20 +603,20 @@ def main() -> None:
     candidate = sorted(path for path in CANDIDATE_DIR.rglob("*") if path.is_file()) if CANDIDATE_DIR.exists() else []
     reference = sorted(path for path in REFERENCE_DIR.rglob("*") if path.is_file()) if REFERENCE_DIR.exists() else []
     if not candidate:
-        write_reward(0.0, metadata={"reason": "no_deliverable"})
+        write_reward(0.0, metadata={"reason": "no_deliverable"}, signals={"deliverable_present": 0.0})
         return
     if not reference:
-        write_reward(0.0, ungraded=True, metadata={"reason": "no_expert_reference"})
+        write_reward(0.0, ungraded=True, metadata={"reason": "no_expert_reference"}, signals={"deliverable_present": 1.0, "expert_reference_present": 0.0})
         return
     if all(path.suffix.lower() in MEDIA_EXTENSIONS for path in [*candidate, *reference]):
-        write_reward(0.0, ungraded=True, metadata={"reason": "media_requires_files_api"})
+        write_reward(0.0, ungraded=True, metadata={"reason": "media_requires_files_api"}, signals={"deliverable_present": 1.0, "expert_reference_present": 1.0})
         return
     try:
         score, decision = judge(metadata, candidate, reference)
     except Exception as exc:
-        write_reward(0.0, ungraded=True, metadata={"reason": "judge_failed", "error": str(exc)})
+        write_reward(0.0, ungraded=True, metadata={"reason": "judge_failed", "error": str(exc)}, signals={"deliverable_present": 1.0, "expert_reference_present": 1.0})
         return
-    write_reward(score, metadata=decision)
+    write_reward(score, metadata=decision, signals={"deliverable_present": 1.0, "expert_reference_present": 1.0})
 
 
 if __name__ == "__main__":

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -220,14 +220,14 @@ def _repair_staged_files(paths: list[Path], *, task_id: str, role: str, backup_r
 def _write_instruction(task_dir: Path, row: dict, input_names: list[str]) -> None:
     lines = [str(row.get("prompt") or "").strip(), ""]
     if input_names:
-        lines.extend(["## Input files", *[f"- /home/user/{name}" for name in input_names], ""])
+        lines.extend(["## Input files", "These files are available in the code-execution working directory:", *[f"- {name}" for name in input_names], ""])
     expected = _basenames(row, "deliverable_files")
     if expected:
         lines.extend(["## Expected deliverable filename(s)", *[f"- {name}" for name in expected], ""])
     lines.extend(
         [
             "## Submission",
-            "Save final deliverables in /home/user/deliverables and submit those files with the finish tool.",
+            "Create final deliverables in the code-execution working directory, then submit their relative paths with the finish tool.",
             "",
         ]
     )

--- a/rllm/data/gdpval_builder.py
+++ b/rllm/data/gdpval_builder.py
@@ -556,14 +556,18 @@ def judge(metadata: dict, candidate: list[Path], reference: list[Path]) -> tuple
     content.extend({"type": "image_url", "image_url": {"url": image}} for image in candidate_images)
     content.append({"type": "text", "text": reference_text})
     content.extend({"type": "image_url", "image_url": {"url": image}} for image in reference_images)
+    base_url = os.environ.get("GDPVAL_JUDGE_BASE_URL", "https://openrouter.ai/api/v1").rstrip("/")
+    judge_model = os.environ["GDPVAL_JUDGE_MODEL"]
+    if "openrouter.ai" in base_url and judge_model.startswith("openrouter/"):
+        judge_model = judge_model.removeprefix("openrouter/")
     payload = {
-        "model": os.environ["GDPVAL_JUDGE_MODEL"],
+        "model": judge_model,
         "messages": [{"role": "user", "content": content}],
         "temperature": 0,
         "max_tokens": 2048,
     }
     request = urllib.request.Request(
-        os.environ.get("GDPVAL_JUDGE_BASE_URL", "https://openrouter.ai/api/v1").rstrip("/") + "/chat/completions",
+        base_url + "/chat/completions",
         data=json.dumps(payload).encode(),
         headers={"Authorization": f"Bearer {os.environ['GDPVAL_JUDGE_API_KEY']}", "Content-Type": "application/json"},
         method="POST",

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -109,6 +109,7 @@ def _resolve_evaluator(
             verifier_user=task.metadata.get("verifier_user"),
             verifier_timeout=float(task.metadata.get("verifier_timeout", 600.0)),
             reward_file_override=verifier_config.get("reward_file"),
+            verifier_env=task.metadata.get("verifier_env", {}),
         )
 
     if kind in ("python-host", "python-hybrid"):

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import re
+import shlex
+import tempfile
 from pathlib import Path
 
 from rllm.eval.types import EvalOutput, Signal
@@ -28,6 +32,10 @@ _REWARD_PATHS = [
     "/logs/verifier/reward.json",
     "/logs/verifier/reward.txt",
 ]
+
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ENV_REFERENCE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_REMOTE_ENV_PATH = "/tmp/rllm/verifier.env"
 
 
 class ShellScriptEvaluator:
@@ -45,12 +53,14 @@ class ShellScriptEvaluator:
         verifier_user: str | None = None,
         verifier_timeout: float = 600.0,
         reward_file_override: str | None = None,
+        verifier_env: dict[str, str] | None = None,
     ):
         self.sandbox = sandbox
         self.script_path = script_path  # relative to the task's directory
         self.verifier_user = verifier_user
         self.verifier_timeout = verifier_timeout
         self.reward_file_override = reward_file_override
+        self.verifier_env = dict(verifier_env or {})
 
     def evaluate(self, task: Task, episode: Episode) -> EvalOutput:
         tests_dir = task.task_dir / Path(self.script_path).parent
@@ -88,8 +98,21 @@ class ShellScriptEvaluator:
         workdir = task.metadata.get("workdir")
         cd_prefix = f"cd {workdir} && " if workdir else ""
         try:
+            resolved_env = _resolve_verifier_env(self.verifier_env)
+        except ValueError as e:
+            return EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                metadata={"error": str(e), "ungraded": True},
+            )
+
+        env_prefix = ""
+        try:
+            if resolved_env:
+                self._upload_verifier_env(resolved_env, v_user)
+                env_prefix = f"set -a && . {_REMOTE_ENV_PATH} && set +a && "
             self.sandbox.exec(
-                f"chmod +x /tests/{script_name} && {cd_prefix}/tests/{script_name}",
+                f"chmod +x /tests/{script_name} && {env_prefix}{cd_prefix}/tests/{script_name}",
                 timeout=self.verifier_timeout,
                 user=v_user,
             )
@@ -99,12 +122,55 @@ class ShellScriptEvaluator:
             # below) carries the signal. Log at debug so a benchmark of
             # 100 unsolved tasks doesn't spam 100 multi-KB stack traces.
             logger.debug("Verifier exited non-zero for %s: %s", task.id, e)
+        finally:
+            if resolved_env:
+                try:
+                    self.sandbox.exec(f"rm -f {_REMOTE_ENV_PATH}", timeout=10, user=v_user)
+                except Exception:
+                    logger.debug("Could not remove verifier environment file for %s", task.id)
 
         # Read reward (as verifier — agent may not have read access)
         reward_paths = list(_REWARD_PATHS)
         if self.reward_file_override:
             reward_paths.insert(0, self.reward_file_override)
         return _read_reward_from_sandbox(self.sandbox, reward_paths, user=v_user)
+
+    def _upload_verifier_env(self, env: dict[str, str], verifier_user: str | None) -> None:
+        body = "\n".join(f"export {key}={shlex.quote(value)}" for key, value in env.items()) + "\n"
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", prefix="rllm-verifier-", suffix=".env") as handle:
+            handle.write(body)
+            handle.flush()
+            self.sandbox.upload_file(handle.name, _REMOTE_ENV_PATH)
+
+        owner = shlex.quote(verifier_user) if verifier_user else None
+        ownership = f"chown {owner} {_REMOTE_ENV_PATH} && " if owner else ""
+        self.sandbox.exec(f"{ownership}chmod 600 {_REMOTE_ENV_PATH}", timeout=10)
+
+
+def _resolve_verifier_env(config: dict[str, str]) -> dict[str, str]:
+    """Resolve ``${HOST_VAR}`` references without exposing values to the agent."""
+    resolved: dict[str, str] = {}
+    missing: set[str] = set()
+    for key, raw_value in config.items():
+        if not _ENV_NAME.fullmatch(key):
+            raise ValueError(f"invalid verifier environment variable name: {key!r}")
+        if not isinstance(raw_value, str):
+            raise ValueError(f"verifier environment value for {key} must be a string")
+
+        def replace(match: re.Match[str]) -> str:
+            name = match.group(1)
+            value = os.environ.get(name)
+            if value is None:
+                missing.add(name)
+                return ""
+            return value
+
+        resolved[key] = _ENV_REFERENCE.sub(replace, raw_value)
+
+    if missing:
+        names = ", ".join(sorted(missing))
+        raise ValueError(f"missing required verifier environment variable(s): {names}")
+    return resolved
 
 
 # ---------------------------------------------------------------------------

--- a/rllm/harnesses/stirrup.py
+++ b/rllm/harnesses/stirrup.py
@@ -1,0 +1,169 @@
+"""Run Stirrup inside an rLLM-managed sandbox.
+
+Stirrup normally provisions its own Docker or E2B environment.  This harness
+instead starts Stirrup inside the task sandbox and gives it Stirrup's local
+code-execution backend.  "Local" is therefore local to the isolated task
+container: the agent and the verifier share one filesystem, while rLLM keeps
+ownership of sandbox creation, teardown, tracing, and artifact collection.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+
+from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
+from rllm.types import AgentConfig, Task
+
+_VENV_DIR = "/opt/stirrup-venv"
+_DRIVER_PATH = "/opt/stirrup/driver.py"
+_INSTRUCTION_PATH = "/tmp/stirrup/instruction.txt"
+
+_INSTALL_SCRIPT = rf"""
+set -e
+export DEBIAN_FRONTEND=noninteractive
+if [ -f {_VENV_DIR}/.stirrup-ready ]; then
+    exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl ca-certificates bash
+    fi
+fi
+if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+uv venv --python 3.12 {_VENV_DIR}
+uv pip install --python {_VENV_DIR}/bin/python stirrup==0.1.12
+touch {_VENV_DIR}/.stirrup-ready
+"""
+
+
+class StirrupHarness(BaseCliHarness):
+    """Run the stock Stirrup agent in the task's existing sandbox."""
+
+    name = "stirrup"
+    sandbox_backend = "docker"
+    stdout_log_path = "/tmp/stirrup.log"
+    run_timeout = 14_400
+
+    max_turns: int = 250
+    max_output_tokens: int = 16_384
+    max_context_tokens: int = 200_000
+    enable_web: bool = True
+    enable_vision: bool = True
+
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        workdir = str(task.metadata.get("workdir") or "/workspace")
+        reference_files = [str(name) for name in task.metadata.get("reference_files", [])]
+        reasoning_effort = config.sampling_params.get("reasoning_effort")
+
+        env = {
+            "OPENAI_BASE_URL": config.base_url,
+            "OPENAI_API_KEY": self.gateway_api_key(config, "OPENAI_API_KEY"),
+            "RLLM_STIRRUP_MODEL": config.model,
+            "RLLM_STIRRUP_WORKDIR": workdir,
+            "RLLM_STIRRUP_REFERENCE_FILES": json.dumps(reference_files),
+            "RLLM_STIRRUP_MAX_TURNS": str(self.max_turns),
+            "RLLM_STIRRUP_MAX_OUTPUT_TOKENS": str(self.max_output_tokens),
+            "RLLM_STIRRUP_MAX_CONTEXT_TOKENS": str(self.max_context_tokens),
+            "RLLM_STIRRUP_ENABLE_WEB": "1" if self.enable_web else "0",
+            "RLLM_STIRRUP_ENABLE_VISION": "1" if self.enable_vision else "0",
+        }
+        if reasoning_effort is not None:
+            if not isinstance(reasoning_effort, str):
+                raise ValueError("reasoning_effort sampling parameter must be a string")
+            env["RLLM_STIRRUP_REASONING_EFFORT"] = reasoning_effort
+
+        # Stirrup consumes this key itself. Agent shell commands do not inherit
+        # the parent environment because Agent.share_parent_exec_env defaults
+        # to False.
+        brave_key = os.environ.get("BRAVE_API_KEY")
+        if brave_key:
+            env["BRAVE_API_KEY"] = brave_key
+        return env
+
+    def write_configs(
+        self,
+        sandbox: Sandbox,
+        task: Task,
+        config: AgentConfig,
+        env: dict[str, str],
+    ) -> None:
+        self._exec_agent(sandbox, self._heredoc_write(_DRIVER_PATH, _DRIVER_SCRIPT), env=env)
+        self._exec_agent(sandbox, self._heredoc_write(_INSTRUCTION_PATH, str(task.instruction).strip()), env=env)
+
+    def build_invocation(self, instruction: str, task: Task, config: AgentConfig) -> str:
+        del instruction, task, config
+        return f"{_VENV_DIR}/bin/python {_DRIVER_PATH} 2>&1 | tee {shlex.quote(self.stdout_log_path)}"
+
+
+_DRIVER_SCRIPT = r'''
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from stirrup import Agent
+from stirrup.clients.chat_completions_client import ChatCompletionsClient
+from stirrup.tools.code_backends.local import LocalCodeExecToolProvider
+from stirrup.tools.view_image import ViewImageToolProvider
+from stirrup.tools.web import WebToolProvider
+
+
+def _input_files(workdir: Path) -> list[str]:
+    configured = json.loads(os.environ.get("RLLM_STIRRUP_REFERENCE_FILES", "[]"))
+    if configured:
+        candidates = [workdir / name for name in configured]
+    else:
+        candidates = [path for path in workdir.iterdir() if path.is_file()]
+    return [str(path) for path in candidates if path.is_file()]
+
+
+async def main() -> None:
+    workdir = Path(os.environ.get("RLLM_STIRRUP_WORKDIR", "/workspace"))
+    output_dir = workdir / "deliverables"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    client = ChatCompletionsClient(
+        model=os.environ["RLLM_STIRRUP_MODEL"],
+        base_url=os.environ["OPENAI_BASE_URL"],
+        api_key=os.environ.get("OPENAI_API_KEY", "sk-rllm-gateway"),
+        max_tokens=int(os.environ.get("RLLM_STIRRUP_MAX_CONTEXT_TOKENS", "200000")),
+        reasoning_effort=os.environ.get("RLLM_STIRRUP_REASONING_EFFORT"),
+        kwargs={"max_tokens": int(os.environ.get("RLLM_STIRRUP_MAX_OUTPUT_TOKENS", "16384"))},
+    )
+    tools = [LocalCodeExecToolProvider(temp_base_dir="/tmp/stirrup-exec")]
+    if os.environ.get("RLLM_STIRRUP_ENABLE_WEB", "1") == "1":
+        tools.append(WebToolProvider())
+    if os.environ.get("RLLM_STIRRUP_ENABLE_VISION", "1") == "1":
+        tools.append(ViewImageToolProvider())
+
+    agent = Agent(
+        client=client,
+        name="rllm-stirrup",
+        max_turns=int(os.environ.get("RLLM_STIRRUP_MAX_TURNS", "250")),
+        tools=tools,
+    )
+    instruction = Path("/tmp/stirrup/instruction.txt").read_text(encoding="utf-8")
+    prompt = (
+        instruction
+        + "\n\nWhen finished, call the finish tool with a short summary and the relative paths "
+          "of every deliverable that should be graded."
+    )
+    inputs = _input_files(workdir)
+    async with agent.session(output_dir=output_dir, input_files=inputs or None) as session:
+        await session.run(prompt)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+'''

--- a/rllm/harnesses/stirrup.py
+++ b/rllm/harnesses/stirrup.py
@@ -11,15 +11,20 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
+from pathlib import Path
+from typing import Any
 
+from rllm import paths
 from rllm.harnesses.cli_harness import BaseCliHarness
 from rllm.sandbox.protocol import Sandbox
-from rllm.types import AgentConfig, Task
+from rllm.types import AgentConfig, Episode, Task, Trajectory
 
 _VENV_DIR = "/opt/stirrup-venv"
 _DRIVER_PATH = "/opt/stirrup/driver.py"
 _INSTRUCTION_PATH = "/tmp/stirrup/instruction.txt"
+_RUN_METADATA_PATH = "/tmp/stirrup/run.json"
 
 _INSTALL_SCRIPT = rf"""
 set -e
@@ -105,6 +110,85 @@ class StirrupHarness(BaseCliHarness):
         del instruction, task, config
         return f"{_VENV_DIR}/bin/python {_DRIVER_PATH} 2>&1 | tee {shlex.quote(self.stdout_log_path)}"
 
+    def run(self, task: Task, config: AgentConfig, *, env: Sandbox) -> Episode:
+        """Run Stirrup, preserve deliverables, and expose its usage metadata."""
+        super().run(task, config, env=env)
+        run_data = self._read_run_data(env)
+        metrics = _usage_metrics(run_data, config.model)
+        artifacts = self._collect_deliverables(env, task, config, run_data)
+        return Episode(task=task.metadata, trajectories=[Trajectory(name=self.name, steps=[])], metrics=metrics, artifacts=artifacts)
+
+    @staticmethod
+    def _read_run_data(sandbox: Sandbox) -> dict[str, Any]:
+        try:
+            raw = sandbox.exec(f"cat {shlex.quote(_RUN_METADATA_PATH)}", user="root")
+            data = json.loads(raw)
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _collect_deliverables(
+        sandbox: Sandbox,
+        task: Task,
+        config: AgentConfig,
+        run_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        workdir = str(task.metadata.get("workdir") or "/workspace")
+        remote_dir = f"{workdir.rstrip('/')}/deliverables"
+        safe_uid = re.sub(r"[^A-Za-z0-9_.-]+", "_", config.session_uid).strip("._") or "run"
+        local_dir = Path(paths.rllm_path("agent_outputs", safe_uid))
+        download = getattr(sandbox, "download_dir", None)
+        downloaded: list[str] = []
+        if callable(download):
+            try:
+                downloaded = [str(path) for path in download(remote_dir, str(local_dir))]
+            except Exception:
+                downloaded = []
+
+        finish = run_data.get("finish") if isinstance(run_data.get("finish"), dict) else {}
+        submitted = [str(path) for path in finish.get("paths") or []]
+        return {
+            "deliverable_dir": str(local_dir) if downloaded else None,
+            "deliverables": downloaded,
+            "submitted_paths": submitted,
+            "remote_deliverable_dir": remote_dir,
+        }
+
+
+def _usage_metrics(run_data: dict[str, Any], model: str) -> dict[str, Any]:
+    metadata = run_data.get("metadata") if isinstance(run_data.get("metadata"), dict) else {}
+    raw_usage = metadata.get("token_usage")
+    usage_entries = raw_usage if isinstance(raw_usage, list) else [raw_usage]
+    usage = [entry for entry in usage_entries if isinstance(entry, dict)]
+    input_tokens = sum(int(entry.get("input") or 0) for entry in usage)
+    answer_tokens = sum(int(entry.get("answer") or 0) for entry in usage)
+    reasoning_tokens = sum(int(entry.get("reasoning") or 0) for entry in usage)
+    output_tokens = answer_tokens + reasoning_tokens
+    metrics: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "answer_tokens": answer_tokens,
+        "reasoning_tokens": reasoning_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+
+    pricing_path = os.environ.get("RLLM_PRICING_FILE") or os.environ.get("GDPVAL_PRICING_FILE")
+    if pricing_path:
+        try:
+            pricing = json.loads(Path(pricing_path).expanduser().read_text(encoding="utf-8"))
+            models = pricing.get("models") if isinstance(pricing, dict) else {}
+            rates = models.get(model) or models.get(model.removeprefix("openrouter/"))
+            if isinstance(rates, dict):
+                metrics["cost_usd"] = (
+                    input_tokens * float(rates.get("input") or 0)
+                    + answer_tokens * float(rates.get("answer") or rates.get("output") or 0)
+                    + reasoning_tokens * float(rates.get("reasoning") or rates.get("answer") or rates.get("output") or 0)
+                ) / 1_000_000
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            pass
+    return metrics
+
 
 _DRIVER_SCRIPT = r'''
 import asyncio
@@ -112,7 +196,7 @@ import json
 import os
 from pathlib import Path
 
-from stirrup import Agent
+from stirrup import Agent, aggregate_metadata
 from stirrup.clients.chat_completions_client import ChatCompletionsClient
 from stirrup.tools.code_backends.local import LocalCodeExecToolProvider
 from stirrup.tools.view_image import ViewImageToolProvider
@@ -161,7 +245,14 @@ async def main() -> None:
     )
     inputs = _input_files(workdir)
     async with agent.session(output_dir=output_dir, input_files=inputs or None) as session:
-        await session.run(prompt)
+        finish_params, _history, metadata = await session.run(prompt)
+    run_data = {
+        "finish": finish_params.model_dump(mode="json") if finish_params is not None else None,
+        "metadata": aggregate_metadata(metadata, return_json_serializable=True),
+    }
+    metadata_path = Path("/tmp/stirrup/run.json")
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps(run_data), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -31,6 +31,11 @@
       "function": "Terminus2Harness",
       "description": "Run Harbor's Terminus-2 terminal agent inside the sandbox (harbor used only for the agent code)."
     },
+    "stirrup": {
+      "module": "rllm.harnesses.stirrup",
+      "function": "StirrupHarness",
+      "description": "Run Stirrup inside an rLLM-managed sandbox."
+    },
     "codex": {
       "module": "rllm.harnesses.codex",
       "function": "CodexHarness",

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -1,6 +1,17 @@
 {
   "version": 1,
   "datasets": {
+    "gdpval": {
+      "description": "GDPval: 220 economically valuable knowledge-work tasks with expert deliverables (sandbox; pairwise LLM-judge graded)",
+      "source": "openai/gdpval",
+      "builder": "rllm.data.gdpval_builder:build_benchmark",
+      "category": "agentic",
+      "splits": [
+        "train"
+      ],
+      "eval_split": "train",
+      "default_agent": "stirrup"
+    },
     "claw_eval": {
       "description": "Claw-Eval general split: 161 personal-assistant agent tasks (sandbox; LLM-judge graded)",
       "source": "claw-eval/Claw-Eval",

--- a/rllm/sandbox/artifacts.py
+++ b/rllm/sandbox/artifacts.py
@@ -1,0 +1,43 @@
+"""Helpers for copying generated artifacts out of sandboxes."""
+
+from __future__ import annotations
+
+import shutil
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO
+
+
+def extract_regular_files(archive: BinaryIO, local_path: str, *, root_name: str) -> list[str]:
+    """Safely extract regular files from a sandbox-created tar archive.
+
+    Sandbox backends archive the requested directory itself, so ``root_name``
+    is stripped before files are written under ``local_path``. Links, special
+    files, empty paths, and paths that could escape the destination are ignored.
+    """
+    destination = Path(local_path)
+    destination.mkdir(parents=True, exist_ok=True)
+    destination_resolved = destination.resolve()
+    downloaded: list[str] = []
+
+    with tarfile.open(fileobj=archive, mode="r:*") as bundle:
+        for member in bundle.getmembers():
+            if not member.isfile():
+                continue
+            parts = PurePosixPath(member.name).parts
+            if parts and parts[0] == root_name:
+                parts = parts[1:]
+            if not parts or any(part in {"", ".", ".."} for part in parts):
+                continue
+            target = destination.joinpath(*parts)
+            if destination_resolved not in target.resolve().parents:
+                continue
+            source = bundle.extractfile(member)
+            if source is None:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            downloaded.append(str(target))
+
+    return downloaded

--- a/rllm/sandbox/backends/docker.py
+++ b/rllm/sandbox/backends/docker.py
@@ -7,6 +7,8 @@ import logging
 import os
 import tarfile
 
+from rllm.sandbox.artifacts import extract_regular_files
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,8 +18,7 @@ class DockerSandbox:
     Creates a container with ``sleep infinity``, uploads files via tar archives,
     executes commands via ``exec_run()``, and runs agent processes with ``nohup``.
 
-    Requires the ``docker`` Python package (not in ``[sdk]`` extra — install
-    separately when using ``backend=docker``).
+    Requires the ``docker`` Python package, installed with rLLM.
     """
 
     def __init__(self, name: str, image: str = "python:3.11-slim", **kwargs):
@@ -98,6 +99,18 @@ class DockerSandbox:
             tar.add(local_path, arcname=remote_name)
         tar_stream.seek(0)
         self._container.put_archive(remote_parent, tar_stream)
+
+    def download_dir(self, remote_path: str, local_path: str) -> list[str]:
+        """Download regular files from a container directory.
+
+        Docker returns a tar stream rooted at the requested directory name.
+        Extract files manually so path traversal entries and links are never
+        written to the host.
+        """
+        chunks, _ = self._container.get_archive(remote_path)
+        archive = io.BytesIO(b"".join(chunks))
+        root_name = os.path.basename(remote_path.rstrip("/"))
+        return extract_regular_files(archive, local_path, root_name=root_name)
 
     def is_alive(self) -> bool:
         """Refresh container state from the Docker daemon and check it is running."""

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -22,6 +22,7 @@ import threading
 import weakref
 
 from rllm.env import env_int
+from rllm.sandbox.artifacts import extract_regular_files
 from rllm.sandbox.protocol import SnapshotNotFound
 
 logger = logging.getLogger(__name__)
@@ -224,6 +225,31 @@ class ModalSandbox:
         # ids and error); permissions are kept so executables stay +x.
         self._push_b64(b64, f"base64 -d | tar xzf - --no-same-owner -C {remote_parent}")
         logger.debug("Uploaded dir %s -> %s in sandbox %s", local_path, remote_path, self.name)
+
+    def download_dir(self, remote_path: str, local_path: str) -> list[str]:
+        """Download regular files from a Modal sandbox directory.
+
+        Modal's binary exec mode keeps the tar stream byte-for-byte intact.
+        Files are extracted through the shared sandbox artifact helper, which
+        rejects links and paths that could escape ``local_path``.
+        """
+        normalized = remote_path.rstrip("/")
+        remote_parent = os.path.dirname(normalized) or "/"
+        remote_name = os.path.basename(normalized)
+        if not remote_name:
+            raise ValueError("download_dir requires a directory other than the filesystem root")
+
+        process = self._sandbox.exec("tar", "czf", "-", "-C", remote_parent, remote_name, text=False)
+        archive_bytes = process.stdout.read()
+        stderr = process.stderr.read()
+        process.wait()
+        if process.returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"Failed to download {remote_path} from Modal sandbox {self.name}: {detail}")
+
+        downloaded = extract_regular_files(io.BytesIO(archive_bytes), local_path, root_name=remote_name)
+        logger.debug("Downloaded %d file(s) from %s in sandbox %s", len(downloaded), remote_path, self.name)
+        return downloaded
 
     def is_alive(self) -> bool:
         """One API call: ``poll()`` returns ``None`` while the sandbox is still running.

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -230,6 +230,7 @@ def _merge_task_toml_metadata(task_dir: Path, base: dict) -> dict:
     merged["agent_user"] = raw.get("agent", {}).get("user", merged.get("agent_user"))
     merged["verifier_user"] = raw.get("verifier", {}).get("user", merged.get("verifier_user"))
     merged["verifier_timeout"] = raw.get("verifier", {}).get("timeout_sec", merged.get("verifier_timeout", 600.0))
+    merged["verifier_env"] = raw.get("verifier", {}).get("env", merged.get("verifier_env", {})) or {}
     merged["agent_timeout"] = raw.get("agent", {}).get("timeout_sec", merged.get("agent_timeout", 600.0))
     rllm_section = raw.get("rllm", {}) or {}
     merged["setup_commands"] = rllm_section.get("setup_commands", merged.get("setup_commands", [])) or []
@@ -554,6 +555,7 @@ def _load_task_from_dir(
     metadata["agent_user"] = raw.get("agent", {}).get("user")
     metadata["verifier_user"] = raw.get("verifier", {}).get("user")
     metadata["verifier_timeout"] = raw.get("verifier", {}).get("timeout_sec", 600.0)
+    metadata["verifier_env"] = raw.get("verifier", {}).get("env", {}) or {}
     metadata["agent_timeout"] = raw.get("agent", {}).get("timeout_sec", 600.0)
     rllm_section = raw.get("rllm", {}) or {}
     metadata["setup_commands"] = rllm_section.get("setup_commands", []) or []

--- a/tests/data/test_gdpval_builder.py
+++ b/tests/data/test_gdpval_builder.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import os
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from rllm.data import gdpval_builder as gb
+from rllm.tasks.loader import BenchmarkLoader
+
+
+def _rows() -> list[dict]:
+    return [
+        {
+            "task_id": "task-one",
+            "sector": "Finance",
+            "occupation": "Analyst",
+            "prompt": "Review the workbook and produce a report.",
+            "reference_files": ["reference_files/source.xlsx"],
+            "deliverable_files": ["deliverable_files/expert.docx"],
+            "rubric_pretty": "Prefer a correct and polished report.",
+            "rubric_json": "[]",
+        },
+        {
+            "task_id": "task-without-gold",
+            "sector": "Technology",
+            "occupation": "Engineer",
+            "prompt": "Create a design.",
+            "reference_files": [],
+            "deliverable_files": [],
+            "rubric_pretty": "",
+            "rubric_json": "[]",
+        },
+    ]
+
+
+def _build(tmp_path: Path, *, limit: int | None = None) -> Path:
+    source = tmp_path / "source.xlsx"
+    source.write_bytes(b"source workbook")
+    expert = tmp_path / "expert.docx"
+    expert.write_bytes(b"expert report")
+    files = {
+        "reference_files/source.xlsx": str(source),
+        "deliverable_files/expert.docx": str(expert),
+    }
+
+    with (
+        patch("datasets.load_dataset", return_value=_rows()),
+        patch("huggingface_hub.hf_hub_download", side_effect=lambda _repo, path, **_kwargs: files[path]),
+    ):
+        out = tmp_path / "gdpval"
+        gb.build_benchmark(out_dir=out, limit=limit, repair_office_files=False, register=False)
+    return out
+
+
+def test_builder_writes_rllm_harbor_layout(tmp_path):
+    out = _build(tmp_path)
+    task = out / "task-one"
+
+    assert (out / "dataset.toml").exists()
+    assert (task / "task.toml").exists()
+    assert (task / "instruction.md").exists()
+    assert (task / "environment" / "Dockerfile").exists()
+    assert (task / "tests" / "test.sh").exists()
+    assert (task / "tests" / "evaluate.py").exists()
+    assert os.access(task / "tests" / "test.sh", os.X_OK)
+
+    # Inputs enter the solver environment; expert outputs remain hidden in
+    # tests/ until the verifier is uploaded after the agent finishes.
+    assert (task / "environment" / "files" / "source.xlsx").read_bytes() == b"source workbook"
+    assert (task / "tests" / "reference" / "expert.docx").read_bytes() == b"expert report"
+    assert not (task / "environment" / "files" / "expert.docx").exists()
+
+
+def test_task_config_uses_stirrup_and_verifier_only_judge_credentials(tmp_path):
+    out = _build(tmp_path, limit=1)
+    task_toml = (out / "task-one" / "task.toml").read_text()
+    dataset_toml = (out / "dataset.toml").read_text()
+
+    assert 'default_agent = "stirrup"' in dataset_toml
+    assert 'script = "tests/test.sh"' in task_toml
+    assert "[verifier.env]" in task_toml
+    assert 'GDPVAL_JUDGE_API_KEY = "${GDPVAL_JUDGE_API_KEY}"' in task_toml
+    assert 'GDPVAL_JUDGE_MODEL = "${GDPVAL_JUDGE_MODEL}"' in task_toml
+    assert "[environment.env]" not in task_toml
+
+
+def test_builder_output_round_trips_through_benchmark_loader(tmp_path):
+    out = _build(tmp_path)
+
+    result = BenchmarkLoader.load(str(out))
+
+    assert result.name == "gdpval"
+    assert result.harness_name == "stirrup"
+    assert sorted(task.id for task in result.tasks) == ["task-one", "task-without-gold"]
+    by_id = {task.id: task for task in result.tasks}
+    assert by_id["task-one"].metadata["reference_files"] == ["source.xlsx"]
+
+
+def test_builder_respects_limit(tmp_path):
+    out = _build(tmp_path, limit=1)
+
+    task_dirs = sorted(path.name for path in out.iterdir() if path.is_dir() and not path.name.startswith("."))
+    assert task_dirs == ["task-one"]
+
+
+def _write_repairable_docx(path: Path) -> None:
+    relationships = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="officeDocument" Target="word/document.xml"/>
+</Relationships>"""
+    document_relationships = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/>
+</Relationships>"""
+    with zipfile.ZipFile(path, "w") as package:
+        package.writestr("[Content_Types].xml", "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"/>")
+        package.writestr("_rels/.rels", relationships)
+        package.writestr("word/document.xml", "<document/>")
+        package.writestr("word/settings.xml", '<w:settings xmlns:w="w" xmlns:ns1="broken"><ns1:item/></w:settings>')
+        package.writestr("word/_rels/document.xml.rels", document_relationships)
+
+
+def test_office_repair_is_auditable_and_preserves_original(tmp_path):
+    source = tmp_path / "broken.docx"
+    backup = tmp_path / "backups" / "broken.docx"
+    _write_repairable_docx(source)
+    original = source.read_bytes()
+
+    record = gb._repair_office_file(source, backup)
+
+    assert record["status"] == "repaired"
+    assert backup.read_bytes() == original
+    assert record["original_sha256"] != record["repaired_sha256"]
+    with zipfile.ZipFile(source) as package:
+        assert "word/settings.xml" not in package.namelist()
+
+
+def test_dataset_catalog_entry_points_to_builder():
+    catalog_path = Path(gb.__file__).parents[1] / "registry" / "datasets.json"
+    catalog = json.loads(catalog_path.read_text())
+
+    entry = catalog["datasets"]["gdpval"]
+    assert entry["builder"] == "rllm.data.gdpval_builder:build_benchmark"
+    assert entry["default_agent"] == "stirrup"

--- a/tests/data/test_gdpval_builder.py
+++ b/tests/data/test_gdpval_builder.py
@@ -85,6 +85,11 @@ def test_task_config_uses_stirrup_and_verifier_only_judge_credentials(tmp_path):
     assert 'GDPVAL_JUDGE_MODEL = "${GDPVAL_JUDGE_MODEL}"' in task_toml
     assert "[environment.env]" not in task_toml
 
+    instruction = (out / "task-one" / "instruction.md").read_text()
+    assert "- source.xlsx" in instruction
+    assert "/home/user/source.xlsx" not in instruction
+    assert "relative paths" in instruction
+
 
 def test_builder_output_round_trips_through_benchmark_loader(tmp_path):
     out = _build(tmp_path)

--- a/tests/data/test_gdpval_builder.py
+++ b/tests/data/test_gdpval_builder.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+import types
 import zipfile
 from pathlib import Path
 from unittest.mock import patch
@@ -149,3 +151,45 @@ def test_dataset_catalog_entry_points_to_builder():
     entry = catalog["datasets"]["gdpval"]
     assert entry["builder"] == "rllm.data.gdpval_builder:build_benchmark"
     assert entry["default_agent"] == "stirrup"
+
+
+def test_generated_judge_normalizes_rllm_openrouter_model_prefix():
+    assert 'judge_model.startswith("openrouter/")' in gb._VERIFIER_SOURCE
+    assert 'judge_model = judge_model.removeprefix("openrouter/")' in gb._VERIFIER_SOURCE
+
+
+def test_generated_judge_sends_normalized_model_to_openrouter(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "fitz", types.SimpleNamespace())
+    namespace = {"__name__": "gdpval_verifier_test"}
+    exec(gb._VERIFIER_SOURCE, namespace)
+    candidate = tmp_path / "candidate.txt"
+    reference = tmp_path / "reference.txt"
+    candidate.write_text("candidate")
+    reference.write_text("reference")
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"choices":[{"message":{"content":"{\\"winner\\":\\"tie\\"}"}}]}'
+
+    def urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["payload"] = json.loads(request.data)
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setenv("GDPVAL_JUDGE_API_KEY", "secret")
+    monkeypatch.setenv("GDPVAL_JUDGE_MODEL", "openrouter/google/gemini-3.1-pro-preview")
+    monkeypatch.setattr(namespace["urllib"].request, "urlopen", urlopen)
+
+    namespace["judge"]({"task_id": "task", "prompt": "prompt", "rubric": "rubric"}, [candidate], [reference])
+
+    assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert captured["payload"]["model"] == "google/gemini-3.1-pro-preview"
+    assert captured["timeout"] == 600

--- a/tests/eval/test_script_module_evaluators.py
+++ b/tests/eval/test_script_module_evaluators.py
@@ -51,6 +51,10 @@ class _FakeSandbox:
     def upload_dir(self, src: str, dst: str) -> None:
         self.uploads.append((src, dst))
 
+    def upload_file(self, src: str, dst: str) -> None:
+        self.uploads.append((src, dst))
+        self.files[dst] = Path(src).read_text()
+
 
 def _episode() -> Episode:
     """A minimal episode that the script evaluator can score."""
@@ -154,6 +158,35 @@ class TestShellScriptEvaluator:
         out = ev.evaluate(task, _episode())
         assert out.reward == 0.0
         assert "no" in out.metadata.get("error", "")
+
+    def test_verifier_env_is_resolved_uploaded_and_removed(self, tmp_path, monkeypatch):
+        bench = _bench(tmp_path)
+        monkeypatch.setenv("JUDGE_SECRET", "secret with spaces")
+        sb = _FakeSandbox(files={"/logs/verifier/reward.txt": "1.0"})
+        ev = ShellScriptEvaluator(
+            sandbox=sb,
+            verifier_env={"OPENAI_API_KEY": "${JUDGE_SECRET}", "JUDGE_MODEL": "openai/example"},
+        )
+
+        out = ev.evaluate(Task(id="0", instruction="", metadata={}, dataset_dir=bench), _episode())
+
+        assert out.reward == 1.0
+        assert any(dst == "/tmp/rllm/verifier.env" for _, dst in sb.uploads)
+        invocation = next(cmd for cmd, _ in sb.execs if ". /tmp/rllm/verifier.env" in cmd)
+        assert "secret with spaces" not in invocation
+        assert any(cmd == "rm -f /tmp/rllm/verifier.env" for cmd, _ in sb.execs)
+
+    def test_missing_verifier_env_marks_task_ungraded(self, tmp_path, monkeypatch):
+        bench = _bench(tmp_path)
+        monkeypatch.delenv("MISSING_JUDGE_SECRET", raising=False)
+        sb = _FakeSandbox()
+        ev = ShellScriptEvaluator(sandbox=sb, verifier_env={"OPENAI_API_KEY": "${MISSING_JUDGE_SECRET}"})
+
+        out = ev.evaluate(Task(id="0", instruction="", metadata={}, dataset_dir=bench), _episode())
+
+        assert out.reward == 0.0
+        assert out.metadata["ungraded"] is True
+        assert "MISSING_JUDGE_SECRET" in out.metadata["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/harnesses/test_stirrup.py
+++ b/tests/harnesses/test_stirrup.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from rllm.eval.agent_loader import load_agent
-from rllm.harnesses.stirrup import _DRIVER_SCRIPT, StirrupHarness
+from rllm.harnesses.stirrup import _DRIVER_SCRIPT, StirrupHarness, _usage_metrics
 from rllm.types import AgentConfig, Task
 
 
@@ -38,6 +38,8 @@ def test_stirrup_uses_an_isolated_python_and_local_code_backend():
     assert "stirrup==0.1.12" in harness.install_script()
     assert "LocalCodeExecToolProvider" in _DRIVER_SCRIPT
     assert "DockerCodeExecToolProvider" not in _DRIVER_SCRIPT
+    assert "aggregate_metadata" in _DRIVER_SCRIPT
+    assert 'Path("/tmp/stirrup/run.json")' in _DRIVER_SCRIPT
 
 
 def test_stirrup_env_routes_model_through_gateway(monkeypatch):
@@ -62,3 +64,66 @@ def test_invocation_runs_stirrup_in_the_existing_sandbox():
 
     assert command.startswith("/opt/stirrup-venv/bin/python /opt/stirrup/driver.py")
     assert "docker" not in command.lower()
+
+
+def test_usage_metrics_include_tokens_and_priced_cost(tmp_path, monkeypatch):
+    pricing = tmp_path / "pricing.json"
+    pricing.write_text(
+        json.dumps(
+            {
+                "models": {
+                    "z-ai/glm-5.2": {
+                        "input": 1.4,
+                        "answer": 4.4,
+                        "reasoning": 4.4,
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("RLLM_PRICING_FILE", str(pricing))
+
+    metrics = _usage_metrics(
+        {"metadata": {"token_usage": [{"input": 1_000_000, "answer": 100_000, "reasoning": 50_000}]}},
+        "z-ai/glm-5.2",
+    )
+
+    assert metrics == {
+        "input_tokens": 1_000_000,
+        "answer_tokens": 100_000,
+        "reasoning_tokens": 50_000,
+        "output_tokens": 150_000,
+        "total_tokens": 1_150_000,
+        "cost_usd": pytest.approx(2.06),
+    }
+
+
+def test_stirrup_run_persists_deliverables_and_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path / "rllm-home"))
+
+    class FakeSandbox:
+        def exec(self, command, timeout=None, user=None):
+            del timeout, user
+            if command == "cat /tmp/stirrup/run.json":
+                return json.dumps(
+                    {
+                        "finish": {"paths": ["Sample.xlsx"]},
+                        "metadata": {"token_usage": [{"input": 10, "answer": 3, "reasoning": 2}]},
+                    }
+                )
+            return ""
+
+        def download_dir(self, remote_path, local_path):
+            assert remote_path == "/workspace/deliverables"
+            output = tmp_path / "rllm-home" / "agent_outputs" / "test" / "Sample.xlsx"
+            assert str(output.parent) == local_path
+            output.parent.mkdir(parents=True)
+            output.write_bytes(b"xlsx")
+            return [str(output)]
+
+    episode = StirrupHarness().run(_task(), _config(), env=FakeSandbox())
+
+    assert episode.trajectories[0].name == "stirrup"
+    assert episode.metrics["total_tokens"] == 15
+    assert episode.artifacts["submitted_paths"] == ["Sample.xlsx"]
+    assert episode.artifacts["deliverables"] == [str(tmp_path / "rllm-home" / "agent_outputs" / "test" / "Sample.xlsx")]

--- a/tests/harnesses/test_stirrup.py
+++ b/tests/harnesses/test_stirrup.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rllm.eval.agent_loader import load_agent
+from rllm.harnesses.stirrup import _DRIVER_SCRIPT, StirrupHarness
+from rllm.types import AgentConfig, Task
+
+
+def _task() -> Task:
+    return Task(
+        id="gdpval-1",
+        instruction="Read source.xlsx and create report.docx.",
+        metadata={"workdir": "/workspace", "reference_files": ["source.xlsx"]},
+    )
+
+
+def _config(**sampling_params) -> AgentConfig:
+    return AgentConfig(
+        base_url="http://gateway/sessions/test/v1",
+        model="z-ai/glm-5.2",
+        session_uid="test",
+        sampling_params=sampling_params,
+        metadata={"gateway_auth_token": "gateway-token"},
+    )
+
+
+def test_stirrup_is_registered_as_a_builtin_agent():
+    assert isinstance(load_agent("stirrup"), StirrupHarness)
+
+
+def test_stirrup_uses_an_isolated_python_and_local_code_backend():
+    harness = StirrupHarness()
+
+    assert "uv venv --python 3.12" in harness.install_script()
+    assert "stirrup==0.1.12" in harness.install_script()
+    assert "LocalCodeExecToolProvider" in _DRIVER_SCRIPT
+    assert "DockerCodeExecToolProvider" not in _DRIVER_SCRIPT
+
+
+def test_stirrup_env_routes_model_through_gateway(monkeypatch):
+    monkeypatch.setenv("BRAVE_API_KEY", "brave-secret")
+    env = StirrupHarness().build_env(_task(), _config(reasoning_effort="xhigh"))
+
+    assert env["OPENAI_BASE_URL"] == "http://gateway/sessions/test/v1"
+    assert env["OPENAI_API_KEY"] == "gateway-token"
+    assert env["RLLM_STIRRUP_MODEL"] == "z-ai/glm-5.2"
+    assert env["RLLM_STIRRUP_REASONING_EFFORT"] == "xhigh"
+    assert json.loads(env["RLLM_STIRRUP_REFERENCE_FILES"]) == ["source.xlsx"]
+    assert env["BRAVE_API_KEY"] == "brave-secret"
+
+
+def test_reasoning_effort_must_be_a_string():
+    with pytest.raises(ValueError, match="must be a string"):
+        StirrupHarness().build_env(_task(), _config(reasoning_effort=3))
+
+
+def test_invocation_runs_stirrup_in_the_existing_sandbox():
+    command = StirrupHarness().build_invocation("task", _task(), _config())
+
+    assert command.startswith("/opt/stirrup-venv/bin/python /opt/stirrup/driver.py")
+    assert "docker" not in command.lower()

--- a/tests/sandbox/test_docker_artifacts.py
+++ b/tests/sandbox/test_docker_artifacts.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import io
+import tarfile
+
+from rllm.sandbox.backends.docker import DockerSandbox
+
+
+def _archive() -> bytes:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as bundle:
+        content = b"workbook"
+        item = tarfile.TarInfo("deliverables/nested/Sample.xlsx")
+        item.size = len(content)
+        bundle.addfile(item, io.BytesIO(content))
+
+        traversal = tarfile.TarInfo("deliverables/../escape.txt")
+        traversal.size = len(content)
+        bundle.addfile(traversal, io.BytesIO(content))
+    return stream.getvalue()
+
+
+def test_download_dir_extracts_regular_files_without_path_traversal(tmp_path):
+    class Container:
+        def get_archive(self, remote_path):
+            assert remote_path == "/home/user/deliverables"
+            return iter([_archive()]), {}
+
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox._container = Container()
+
+    downloaded = sandbox.download_dir("/home/user/deliverables", str(tmp_path))
+
+    expected = tmp_path / "nested" / "Sample.xlsx"
+    assert downloaded == [str(expected)]
+    assert expected.read_bytes() == b"workbook"
+    assert not (tmp_path.parent / "escape.txt").exists()

--- a/tests/sandbox/test_modal_artifacts.py
+++ b/tests/sandbox/test_modal_artifacts.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from rllm.sandbox.backends.modal_backend import ModalSandbox
+
+
+def _archive() -> bytes:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w:gz") as bundle:
+        content = b"presentation"
+        item = tarfile.TarInfo("deliverables/nested/slides.pptx")
+        item.size = len(content)
+        bundle.addfile(item, io.BytesIO(content))
+
+        traversal = tarfile.TarInfo("deliverables/../escape.txt")
+        traversal.size = len(content)
+        bundle.addfile(traversal, io.BytesIO(content))
+    return stream.getvalue()
+
+
+class _Reader:
+    def __init__(self, value: bytes):
+        self.value = value
+
+    def read(self) -> bytes:
+        return self.value
+
+
+class _Process:
+    def __init__(self, stdout: bytes, stderr: bytes = b"", returncode: int = 0):
+        self.stdout = _Reader(stdout)
+        self.stderr = _Reader(stderr)
+        self.returncode = returncode
+        self.waited = False
+
+    def wait(self) -> None:
+        self.waited = True
+
+
+def test_download_dir_streams_binary_tar_and_extracts_safe_files(tmp_path):
+    process = _Process(_archive())
+
+    class Sandbox:
+        def exec(self, *args, **kwargs):
+            assert args == ("tar", "czf", "-", "-C", "/home/user", "deliverables")
+            assert kwargs == {"text": False}
+            return process
+
+    sandbox = ModalSandbox.__new__(ModalSandbox)
+    sandbox.name = "test-modal"
+    sandbox._sandbox = Sandbox()
+
+    downloaded = sandbox.download_dir("/home/user/deliverables/", str(tmp_path))
+
+    expected = tmp_path / "nested" / "slides.pptx"
+    assert downloaded == [str(expected)]
+    assert expected.read_bytes() == b"presentation"
+    assert not (tmp_path.parent / "escape.txt").exists()
+    assert process.waited
+
+
+def test_download_dir_surfaces_modal_tar_failure(tmp_path):
+    process = _Process(b"", stderr=b"tar: deliverables: Cannot stat", returncode=2)
+
+    class Sandbox:
+        def exec(self, *args, **kwargs):
+            return process
+
+    sandbox = ModalSandbox.__new__(ModalSandbox)
+    sandbox.name = "test-modal"
+    sandbox._sandbox = Sandbox()
+
+    with pytest.raises(RuntimeError, match="Cannot stat"):
+        sandbox.download_dir("/home/user/deliverables", str(tmp_path))
+
+
+def test_download_dir_rejects_filesystem_root(tmp_path):
+    sandbox = ModalSandbox.__new__(ModalSandbox)
+
+    with pytest.raises(ValueError, match="other than the filesystem root"):
+        sandbox.download_dir("/", str(tmp_path))

--- a/tests/tasks/test_loader_memory.py
+++ b/tests/tasks/test_loader_memory.py
@@ -37,3 +37,18 @@ def test_vlm_instruction_encodes_images_lazily(tmp_path, monkeypatch):
         {"type": "text", "text": "what?"},
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,ZmFrZQ=="}},
     ]
+
+
+def test_harbor_verifier_env_is_lifted_into_task_metadata(tmp_path):
+    bench = tmp_path / "bench"
+    task_dir = bench / "task-1"
+    task_dir.mkdir(parents=True)
+    (bench / "dataset.toml").write_text('[dataset]\nname = "bench"\ntype = "sandbox"\n')
+    (task_dir / "instruction.md").write_text("do work")
+    (task_dir / "task.toml").write_text(
+        '[task]\nname = "task-1"\n\n[verifier]\nscript = "tests/test.sh"\n\n[verifier.env]\nOPENAI_API_KEY = "${OPENAI_API_KEY}"\n'
+    )
+
+    result = BenchmarkLoader.load(str(bench))
+
+    assert result.tasks[0].metadata["verifier_env"] == {"OPENAI_API_KEY": "${OPENAI_API_KEY}"}


### PR DESCRIPTION
> **WIP:** Reproducing the official GDPval scores as closely as the available environment and evaluation details allow.

## Summary

Add the official OpenAI GDPval benchmark as an rLLM sandbox evaluation with Stirrup as the default solver, hidden human reference deliverables, randomized pairwise LLM judging, Office-file repair reporting, trajectory metrics, and generated-artifact persistence.

This PR contains two deliberately separated layers: reusable rLLM infrastructure required to run the benchmark, and the GDPval-specific builder/verifier.

## Infrastructure changes

- Add verifier-only environment variables so judge credentials are injected after the solver finishes and are never exposed to the solver environment.
- Add Stirrup as a first-party in-sandbox harness routed through the rLLM gateway.
- Capture Stirrup finish metadata, turns, input/answer/reasoning token counts, total tokens, and optional model pricing.
- Return a normal rLLM `Episode`/`Trajectory`, preserving the run in the existing episode/SFT pipeline.
- Add safe recursive artifact export for Docker and Modal sandboxes.
  - Extract regular files only.
  - Reject traversal paths, links, and special files.
  - Persist submitted deliverables under `~/.rllm/agent_outputs/<session_uid>/`.
- Make the Docker Python SDK available to rLLM's built-in default Docker backend.

Existing Modal/Daytona snapshot infrastructure is not modified by this PR. It can already bake the GDPval environment and Stirrup install using `rllm snapshot create`.

## GDPval-specific changes

- Register `gdpval` in the dataset catalog and `stirrup` in the agent registry.
- Materialize `openai/gdpval` rows into Harbor-style task directories containing:
  - `task.toml`
  - `instruction.md`
  - `environment/Dockerfile`
  - staged source files
  - hidden expert deliverables
  - `tests/test.sh` and the generated judge
- Keep expert outputs under the verifier-only test tree so the solver cannot inspect them.
- Repair only recognized malformed Office metadata/relationship patterns and write an audit manifest; unknown defects remain reported rather than silently rewritten.
- Compare the candidate deliverables with the official human expert deliverables using blinded, randomized A/B ordering.
- Normalize `openrouter/<model>` names before calling OpenRouter directly.
- Report `pairwise_win`, `ungraded`, `deliverable_present`, and `expert_reference_present` signals.

## Evaluation semantics

The current GDPval evaluator produces one candidate-vs-human pairwise outcome per task. It does not attempt to reproduce Artificial Analysis's three-judge sampling, cross-model tournament, Bradley-Terry fitting, Elo anchoring, or sandwich confidence intervals. A reusable offline pairwise tournament/Elo layer is a separate follow-up.

## Validation

- `43 passed` across the GDPval builder, Stirrup harness, script evaluator, task loader, and Docker/Modal artifact tests.
- Ruff passes for every touched Python file.
- `git diff --check` passes.
- Live one-task Modal smoke with `z-ai/glm-5.2`, `reasoning_effort=xhigh`:
  - completed end to end with zero infrastructure errors
  - 28 turns
  - candidate deliverable and human reference both detected
  - judge completed with `ungraded=0`
  - generated `Sample v2.xlsx` copied from Modal to the host
  - 729 seconds total on the cold path (`setup=253s`, `agent=440s`, `judge=36s`)

The smoke result was a valid candidate loss (`pairwise_win=0`), not an infrastructure or grading failure. Generated smoke JSON and deliverable files are intentionally not committed.

## Example

```bash
uv sync
uv run rllm dataset pull gdpval

uv run rllm eval gdpval \
  --agent stirrup \
  --model z-ai/glm-5.2 \
  --sandbox-backend docker \
  --concurrency 1 \
  --max-examples 1 \
  --sampling-params reasoning_effort=xhigh \
  --output gdpval-results.json
```

For Modal, install the optional SDK for the invocation and authenticate with Modal first:

```bash
uv run --with modal rllm snapshot create gdpval \
  --sandbox-backend modal \
  --agent stirrup \
  --max-examples 1

uv run --with modal rllm eval gdpval \
  --agent stirrup \
  --model z-ai/glm-5.2 \
  --sandbox-backend modal \
  --concurrency 1 \
  --max-examples 1 \
  --sampling-params reasoning_effort=xhigh \
  --output gdpval-modal-results.json
```

## Out of scope

- New snapshot infrastructure or committed snapshot IDs
- Daytona artifact export
- Cross-model pairwise tournaments and Elo fitting
- Exact reproduction of the Artificial Analysis sandbox and judge pool
- A benchmark-specific GUI or cookbook
