### PR TITLE
feat(eval): native Terminal-Bench 3 runtime — Compose environments, Harbor 0.20, verifier contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,8 @@ code-tools = [
 ]
 
 harbor = [
-    "harbor==0.3.0 ; python_version >= '3.12'",
+    "harbor==0.20.0 ; python_version >= '3.12'",
+    "docker>=7.0.0 ; python_version >= '3.12'",
 ]
 
 [tool.uv.sources]

--- a/rllm/cli/_pull.py
+++ b/rllm/cli/_pull.py
@@ -225,14 +225,14 @@ def resolve_harbor_catalog_entry(name: str) -> dict | None:
     a pre-registered entry in ``datasets.json``.
     """
     try:
-        from harbor.registry.client.factory import RegistryClientFactory
+        from rllm.integrations.harbor.dataset_loader import get_harbor_dataset_client
     except ImportError:
         return None
 
     import asyncio
 
     async def _probe():
-        client = RegistryClientFactory.create()
+        client = get_harbor_dataset_client(name)
         try:
             metadata = await client.get_dataset_metadata(name)
             return metadata

--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -185,6 +185,7 @@ def _resolve_evaluator(
             reward_file_override=verifier_config.get("reward_file"),
             git_heads=_capture_git_heads(task, sandbox),
             verifier_sandbox_factory=(lambda: _create_verifier_sandbox(task, task.metadata.get("sandbox_backend"))) if separate else None,
+            verifier_tests_baked=bool(separate and _verifier_dockerfile(task)),
             collect_commands=task.metadata.get("verifier_collect") if separate else None,
             artifacts=task.metadata.get("artifacts") if separate else None,
         )
@@ -403,6 +404,28 @@ def _create_sandbox_for_task(
     prebuilt-image tasks that set ``replay_dockerfile = false``).
     """
     backend = _resolve_backend(task, sandbox_backend)
+    compose_file = _task_compose_file(task)
+    if compose_file is not None:
+        if name is None:
+            safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
+            name = f"rllm-{safe_id}-{uuid.uuid4().hex[:6]}"
+        env = env_override if env_override is not None else (task.metadata.get("environment", {}) or {})
+        compose_kwargs = {
+            "name": name,
+            "environment_dir": compose_file.parent,
+            "compose_file": compose_file,
+            "resources": env,
+            "build_timeout": float(env.get("build_timeout_sec") or 600.0),
+        }
+        if backend == "docker":
+            from rllm.sandbox.backends.docker_compose import DockerComposeSandbox
+
+            return DockerComposeSandbox(**compose_kwargs)
+        if backend == "modal":
+            from rllm.sandbox.backends.modal_compose import ModalComposeSandbox
+
+            return ModalComposeSandbox(**compose_kwargs, **_sandbox_resource_kwargs(task, "modal", env_override))
+        raise RuntimeError(f"task {task.id!r} requires Docker Compose, which rLLM supports with --sandbox-backend docker or modal")
     dockerfile = _builds_from_dockerfile(task, backend)
     if dockerfile is not None:
         return _create_base_sandbox(task, backend, image=_dockerfile_image(backend, dockerfile), name=name, env_override=env_override)
@@ -441,22 +464,60 @@ def _verifier_env_section(task: Task) -> dict:
     return {**(task.metadata.get("environment") or {}), **(task.metadata.get("verifier_environment") or {})}
 
 
+def _verifier_dockerfile(task: Task) -> Path | None:
+    """Locate the Dockerfile whose build context is the task's tests directory."""
+    for base in (task.task_dir, task.dataset_dir):
+        dockerfile = base / "tests" / "Dockerfile"
+        if dockerfile.exists():
+            return dockerfile
+    return None
+
+
 def _create_verifier_sandbox(task: Task, sandbox_backend: str | None) -> Sandbox:
     """A fresh container to grade a separate-mode task in.
 
-    Harbor builds this image from ``tests/`` as the build context — deepswe's
-    ``tests/Dockerfile`` is "the pinned task image with the hidden tests baked
-    in". Creating from the task's own image reproduces it, because
-    :class:`~rllm.eval.script_evaluator.ShellScriptEvaluator` uploads ``tests/``
-    to ``/tests`` regardless. Resources come from the verifier's own section.
+    Harbor builds this image from ``tests/`` as the build context. The verifier
+    Dockerfile may install dependencies or transform files, so uploading the
+    raw tests into the agent image is not equivalent.
     """
+    backend = _resolve_backend(task, sandbox_backend)
+    dockerfile = _verifier_dockerfile(task)
+    if dockerfile is None:
+        # Preserve legacy separate-verifier tasks that predate Harbor's
+        # tests/Dockerfile contract.
+        safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
+        return _create_sandbox_for_task(
+            task,
+            backend,
+            name=f"rllm-verify-{safe_id}-{uuid.uuid4().hex[:6]}",
+            env_override=_verifier_env_section(task),
+        )
+    if backend == "docker":
+        image = _build_docker_image(dockerfile.parent, f"{task.id}-verifier")
+    elif backend == "daytona":
+        image = _dockerfile_image(backend, dockerfile)
+    elif backend == "modal":
+        import modal
+
+        image = modal.Image.from_dockerfile(str(dockerfile), context_dir=str(dockerfile.parent))
+    else:
+        raise RuntimeError(f"building tests/Dockerfile is not supported by the {backend!r} sandbox backend")
     safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "-", task.id)
-    return _create_sandbox_for_task(
+    sandbox = _create_base_sandbox(
         task,
-        sandbox_backend,
+        backend,
+        image=image,
         name=f"rllm-verify-{safe_id}-{uuid.uuid4().hex[:6]}",
         env_override=_verifier_env_section(task),
     )
+    verifier_env = {
+        **(_verifier_env_section(task).get("env") or {}),
+        **(task.metadata.get("verifier_env_vars") or {}),
+    }
+    set_env = getattr(sandbox, "set_env", None)
+    if verifier_env and callable(set_env):
+        set_env(verifier_env)
+    return sandbox
 
 
 def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None = None) -> dict:
@@ -465,7 +526,8 @@ def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None
     Harbor task.toml declares ``cpus`` / ``memory_mb`` / ``storage_mb``; without
     these a remote sandbox runs at the backend default (Daytona: 1 GiB), which
     OOM-kills compile-heavy graders (e.g. ``go test ./...``). Modal takes memory
-    in MB; Daytona takes memory/disk in GB. Docker/local ignore the values.
+    in MB; Daytona takes memory/disk in GB. Docker applies CPU and memory
+    limits directly; local has no resource-isolation primitive.
 
     Those per-task values are baked into ``task.toml`` at dataset-build time, so
     an over-provisioned default can only be shrunk by rebuilding the dataset.
@@ -498,6 +560,8 @@ def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None
 
     env = env_override if env_override is not None else (task.metadata.get("environment", {}) or {})
     cpus, mem_mb, disk_mb = env.get("cpus"), env.get("memory_mb"), env.get("storage_mb")
+    gpus = env.get("gpus")
+    gpu_types = env.get("gpu_types") or []
 
     # Operator caps clamp the baked-in task.toml values down (see docstring):
     # shrink an over-provisioned sandbox at runtime without rebuilding. A cap
@@ -538,11 +602,21 @@ def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None
     lifetime_s = max(lifetime_s, sandbox_timeout_override_s())
 
     kw: dict = {}
-    if backend == "modal":
+    if backend == "docker":
+        if cpus:
+            kw["cpus"] = float(cpus)
+        if mem_mb:
+            kw["memory"] = int(mem_mb) * 1024 * 1024
+        if gpus:
+            kw["gpus"] = int(gpus)
+    elif backend == "modal":
         if cpus:
             kw["cpu"] = float(cpus)
         if mem_mb:
             kw["memory"] = int(mem_mb)
+        if gpus:
+            gpu_type = str(gpu_types[0]) if gpu_types else "any"
+            kw["gpu"] = f"{gpu_type}:{int(gpus)}" if int(gpus) > 1 else gpu_type
         kw["timeout"] = lifetime_s  # Modal's hard lifetime, in seconds
     elif backend == "daytona":
         if cpus:
@@ -551,6 +625,8 @@ def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None
             kw["memory"] = max(1, round(mem_mb / 1024))
         if disk_mb:
             kw["disk"] = max(1, round(disk_mb / 1024))
+        if gpus:
+            kw["gpu"] = int(gpus)
         # First boot of a from-image sandbox includes the registry pull, which
         # for multi-GB SWE images routinely exceeds the SDK's 120s default.
         # Honor the task's declared build timeout, with a pull-friendly floor.
@@ -625,6 +701,24 @@ def _resolve_image(task: Task, backend: str) -> str:
     if dockerfile.exists() and backend == "docker":
         return _build_docker_image(dockerfile.parent, task.id)
     return configured
+
+
+def _task_compose_file(task: Task) -> Path | None:
+    """Locate a Harbor-style Docker Compose overlay for the task environment."""
+    for base in (task.task_dir, task.dataset_dir):
+        for name in ("docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml"):
+            path = base / "environment" / name
+            if path.exists():
+                return path
+    return None
+
+
+def _validate_task_runtime(task: Task, backend: str) -> None:
+    """Fail before agent execution when a task needs an unsupported capability."""
+    if _task_compose_file(task) is not None and backend not in {"docker", "modal"}:
+        raise RuntimeError(f"task {task.id!r} requires Docker Compose; select --sandbox-backend docker or modal")
+    if task.metadata.get("verifier_mode") == "separate" and _verifier_dockerfile(task) is not None and backend not in {"docker", "daytona", "modal"}:
+        raise RuntimeError(f"task {task.id!r} requires a verifier image build unsupported by backend {backend!r}")
 
 
 def _build_docker_image(context_dir: Path, task_id: str) -> str:

--- a/rllm/eval/script_evaluator.py
+++ b/rllm/eval/script_evaluator.py
@@ -13,9 +13,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shlex
+import tarfile
 import tempfile
+import uuid
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 from rllm.eval.types import EvalOutput, Signal
@@ -44,6 +48,41 @@ _RESERVED_REWARD_KEYS = frozenset({"reward", "rewards", "is_correct", "signals",
 _VERIFIER_STDOUT_TAIL_CHARS = 8000
 
 
+@dataclass(frozen=True)
+class ArtifactSpec:
+    """The TB3-relevant subset of Harbor's artifact declaration."""
+
+    source: str
+    service: str = "main"
+    exclude: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CollectedArtifact:
+    spec: ArtifactSpec
+    local_path: Path
+    is_dir: bool
+
+
+def normalize_artifacts(entries: list[str | dict] | None) -> list[ArtifactSpec]:
+    """Normalize Harbor's string and object artifact forms."""
+    artifacts: list[ArtifactSpec] = []
+    for entry in entries or []:
+        if isinstance(entry, str):
+            artifacts.append(ArtifactSpec(source=entry))
+            continue
+        if not isinstance(entry, dict) or not entry.get("source"):
+            raise ValueError(f"invalid artifact declaration: {entry!r}")
+        artifacts.append(
+            ArtifactSpec(
+                source=str(entry["source"]),
+                service=str(entry.get("service") or "main"),
+                exclude=tuple(str(pattern) for pattern in (entry.get("exclude") or [])),
+            )
+        )
+    return artifacts
+
+
 class ShellScriptEvaluator:
     """Run a verifier script inside the sandbox, parse the reward file.
 
@@ -61,8 +100,9 @@ class ShellScriptEvaluator:
         reward_file_override: str | None = None,
         git_heads: dict[str, str] | None = None,
         verifier_sandbox_factory: Callable[[], Sandbox] | None = None,
+        verifier_tests_baked: bool = False,
         collect_commands: list[dict] | None = None,
-        artifacts: list[str] | None = None,
+        artifacts: list[str | dict] | None = None,
     ):
         self.sandbox = sandbox
         self.script_path = script_path  # relative to the task's directory
@@ -75,8 +115,9 @@ class ShellScriptEvaluator:
         # grading then runs in a container this builds, not the agent's. See
         # :meth:`_grading_sandbox`.
         self.verifier_sandbox_factory = verifier_sandbox_factory
+        self.verifier_tests_baked = verifier_tests_baked
         self.collect_commands = collect_commands or []
-        self.artifacts = artifacts or []
+        self.artifacts = normalize_artifacts(artifacts)
 
     @property
     def separate_env(self) -> bool:
@@ -108,27 +149,28 @@ class ShellScriptEvaluator:
         # produced reaches it as collected artifacts. Own it for the duration so
         # the box can't outlive the grade.
         grading_sandbox = self.sandbox
-        collected: dict[str, bytes] = {}
-        if self.separate_env:
-            collected = self._run_collect(task, v_user)
-            try:
-                grading_sandbox = self.verifier_sandbox_factory()  # type: ignore[misc]
-            except Exception as e:
-                logger.warning("Could not create verifier sandbox for %s: %s", task.id, e)
-                return EvalOutput(
-                    reward=0.0,
-                    is_correct=False,
-                    error="VerifierEnvironmentError",
-                    metadata={"error": f"failed to create separate verifier environment: {e}"},
-                )
-        try:
-            return self._grade_in(grading_sandbox, task, tests_dir, script_name, v_user, collected)
-        finally:
-            if grading_sandbox is not self.sandbox:
+        with tempfile.TemporaryDirectory(prefix="rllm-artifacts-") as staging:
+            collected: list[CollectedArtifact] = []
+            if self.separate_env:
+                collected = self._run_collect(task, v_user, Path(staging))
                 try:
-                    grading_sandbox.close()
-                except Exception:
-                    logger.debug("Verifier sandbox teardown failed for %s", task.id, exc_info=True)
+                    grading_sandbox = self.verifier_sandbox_factory()  # type: ignore[misc]
+                except Exception as e:
+                    logger.warning("Could not create verifier sandbox for %s: %s", task.id, e)
+                    return EvalOutput(
+                        reward=0.0,
+                        is_correct=False,
+                        error="VerifierEnvironmentError",
+                        metadata={"error": f"failed to create separate verifier environment: {e}"},
+                    )
+            try:
+                return self._grade_in(grading_sandbox, task, tests_dir, script_name, v_user, collected)
+            finally:
+                if grading_sandbox is not self.sandbox:
+                    try:
+                        grading_sandbox.close()
+                    except Exception:
+                        logger.debug("Verifier sandbox teardown failed for %s", task.id, exc_info=True)
 
     def _grade_in(
         self,
@@ -137,7 +179,7 @@ class ShellScriptEvaluator:
         tests_dir: Path,
         script_name: str,
         v_user: str | None,
-        collected: dict[str, bytes],
+        collected: list[CollectedArtifact],
     ) -> EvalOutput:
         """Upload the tests (and any collected artifacts), run the verifier, read the reward."""
         # Prepare reward directories
@@ -149,31 +191,39 @@ class ShellScriptEvaluator:
         # Upload to /tests/ (Harbor convention — scripts may reference /tests/*.py).
         # A failed upload means the verifier can't run — a grading-infra failure,
         # not a task score; tag it so the engine doesn't read it as reward 0.
-        try:
-            sandbox.upload_dir(str(tests_dir), "/tests")
-        except Exception as e:
-            logger.warning("Failed to upload tests dir for %s: %s", task.id, e)
-            return EvalOutput(
-                reward=0.0,
-                is_correct=False,
-                error="AddTestsDirError",
-                metadata={"error": f"failed to upload tests dir: {e}"},
-            )
+        if not self.verifier_tests_baked:
+            try:
+                sandbox.upload_dir(str(tests_dir), "/tests")
+            except Exception as e:
+                logger.warning("Failed to upload tests dir for %s: %s", task.id, e)
+                return EvalOutput(
+                    reward=0.0,
+                    is_correct=False,
+                    error="AddTestsDirError",
+                    metadata={"error": f"failed to upload tests dir: {e}"},
+                )
 
         # Re-materialise what the collect step snapshotted, at the same paths it
         # wrote them to — the verifier image doesn't pre-create those dirs.
-        for path, blob in collected.items():
+        for artifact in collected:
             try:
-                _write_remote_file(sandbox, path, blob, user=v_user)
+                target_dir = artifact.spec.source if artifact.is_dir else str(PurePosixPath(artifact.spec.source).parent)
+                sandbox.exec(
+                    f"mkdir -p {shlex.quote(target_dir)} && chmod 777 {shlex.quote(target_dir)}",
+                    timeout=30,
+                    user=v_user,
+                )
+                if artifact.is_dir:
+                    sandbox.upload_dir(str(artifact.local_path), artifact.spec.source)
+                else:
+                    sandbox.upload_file(str(artifact.local_path), artifact.spec.source)
             except Exception as e:
-                logger.warning("Could not upload artifact %s for %s: %s", path, task.id, e)
+                logger.warning("Could not upload artifact %s for %s: %s", artifact.spec.source, task.id, e)
 
-        # Only ``cd`` when the task explicitly declared a workdir.
-        # Otherwise the Dockerfile's WORKDIR wins — required for swesmith
-        # and similar harbor task families whose verifier scripts run
-        # ``git`` and ``pytest`` against ``/testbed`` (the image WORKDIR)
-        # and silently collect zero tests when forced into ``/workspace``.
-        workdir = task.metadata.get("workdir")
+        # A task workdir belongs to the agent image. A separate verifier image
+        # must retain its own Dockerfile WORKDIR; the agent path may not exist
+        # there, which would prevent the verifier script from running at all.
+        workdir = task.metadata.get("workdir") if sandbox is self.sandbox else None
         cd_prefix = f"cd {workdir} && " if workdir else ""
 
         # Only meaningful in the agent's own container; a fresh verifier box is
@@ -223,7 +273,7 @@ class ShellScriptEvaluator:
             out.metadata["verifier_stdout_tail"] = verifier_stdout[-_VERIFIER_STDOUT_TAIL_CHARS:]
         return out
 
-    def _run_collect(self, task: Task, user: str | None) -> dict[str, bytes]:
+    def _run_collect(self, task: Task, user: str | None, staging: Path) -> list[CollectedArtifact]:
         """Run ``[[verifier.collect]]`` in the agent's box and pull the artifacts out.
 
         Harbor's separate-mode contract: the agent's container is the only place
@@ -233,24 +283,75 @@ class ShellScriptEvaluator:
         collect step that fails leaves that artifact missing, which the verifier
         reports as an unsubmitted patch rather than a grading crash.
         """
-        for entry in self.collect_commands:
+        main_hooks = [entry for entry in self.collect_commands if _entry_service(entry) == "main"]
+        sidecar_hooks = [entry for entry in self.collect_commands if _entry_service(entry) != "main"]
+        main_artifacts = [artifact for artifact in self.artifacts if artifact.service == "main"]
+        sidecar_artifacts = [artifact for artifact in self.artifacts if artifact.service != "main"]
+
+        self._run_collect_hooks(task, main_hooks, user)
+        collected = self._collect_artifacts(task, main_artifacts, staging, user)
+
+        if sidecar_hooks or sidecar_artifacts:
+            stop_service = getattr(self.sandbox, "stop_service", None)
+            if not callable(stop_service):
+                raise RuntimeError(f"task {task.id!r} declares sidecar artifacts but its sandbox is not service-capable")
+            stop_service("main")
+            self._run_collect_hooks(task, sidecar_hooks, user)
+            collected.extend(self._collect_artifacts(task, sidecar_artifacts, staging, user, offset=len(collected)))
+        return collected
+
+    def _run_collect_hooks(self, task: Task, entries: list[dict], user: str | None) -> None:
+        for entry in entries:
             command = entry.get("command") if isinstance(entry, dict) else str(entry)
             if not command:
                 continue
+            service = _entry_service(entry)
             try:
-                self.sandbox.exec(command, timeout=float((entry or {}).get("timeout_sec", 300.0)), user=user)
+                _service_exec(self.sandbox, service, command, timeout=float((entry or {}).get("timeout_sec", 300.0)), user=user)
             except Exception as e:
-                logger.warning("collect step failed for %s (%s): %s", task.id, command[:80], e)
+                logger.warning("collect step failed for %s in %s (%s): %s", task.id, service, command[:80], e)
 
-        collected: dict[str, bytes] = {}
-        for path in self.artifacts:
+    def _collect_artifacts(
+        self,
+        task: Task,
+        artifacts: list[ArtifactSpec],
+        staging: Path,
+        user: str | None,
+        *,
+        offset: int = 0,
+    ) -> list[CollectedArtifact]:
+        collected: list[CollectedArtifact] = []
+        for index, artifact in enumerate(artifacts, start=offset):
+            target = staging / str(index)
             try:
-                blob = _read_remote_file(self.sandbox, str(path))
+                kind = _service_exec(
+                    self.sandbox,
+                    artifact.service,
+                    f"if [ -d {shlex.quote(artifact.source)} ]; then echo directory; elif [ -f {shlex.quote(artifact.source)} ]; then echo file; else echo missing; fi",
+                    timeout=30,
+                    user=user,
+                ).strip()
+                if kind.endswith("directory"):
+                    local_path = _download_directory(self.sandbox, artifact, target, user=user)
+                    collected.append(CollectedArtifact(artifact, local_path, True))
+                elif kind.endswith("file"):
+                    target.mkdir(parents=True, exist_ok=True)
+                    local_path = target / (PurePosixPath(artifact.source.rstrip("/")).name or "artifact")
+                    local_path.write_bytes(_service_download_file(self.sandbox, artifact.service, artifact.source))
+                    mode = _remote_file_mode(self.sandbox, artifact, user=user)
+                    if mode is not None:
+                        os.chmod(local_path, mode)
+                    collected.append(CollectedArtifact(artifact, local_path, False))
+                else:
+                    # Compatibility for simple Sandbox test doubles and older
+                    # providers that cannot answer the shell type probe but can
+                    # still download a regular file.
+                    target.mkdir(parents=True, exist_ok=True)
+                    local_path = target / (PurePosixPath(artifact.source.rstrip("/")).name or "artifact")
+                    local_path.write_bytes(_service_download_file(self.sandbox, artifact.service, artifact.source))
+                    collected.append(CollectedArtifact(artifact, local_path, False))
             except Exception as e:
-                logger.warning("Could not collect artifact %s for %s: %s", path, task.id, e)
-                continue
-            if blob is not None:
-                collected[str(path)] = blob
+                logger.warning("Could not collect artifact %s from %s for %s: %s", artifact.source, artifact.service, task.id, e)
         return collected
 
     def _restore_git_heads(self, user: str | None) -> None:
@@ -283,35 +384,95 @@ class ShellScriptEvaluator:
 # ---------------------------------------------------------------------------
 
 
-def _read_remote_file(sandbox: Sandbox, path: str) -> bytes | None:
-    """Read a file out of a sandbox, or ``None`` when it isn't there.
+def _entry_service(entry: dict | str) -> str:
+    return str(entry.get("service") or "main") if isinstance(entry, dict) else "main"
 
-    Uses the backend's native transfer (:meth:`Sandbox.download_file`) rather
-    than shelling out: ``git diff --binary`` output is not text-safe, and routing
-    binary through ``exec`` stdout costs a base64 round-trip and holds the whole
-    payload as a string on both ends.
-    """
-    try:
+
+def _service_exec(
+    sandbox: Sandbox,
+    service: str,
+    command: str,
+    *,
+    timeout: float | None = None,
+    user: str | None = None,
+) -> str:
+    if service == "main":
+        return sandbox.exec(command, timeout=timeout, user=user)
+    execute = getattr(sandbox, "service_exec", None)
+    if not callable(execute):
+        raise RuntimeError(f"sandbox cannot execute in sidecar service {service!r}")
+    return execute(service, command, timeout=timeout, user=user)
+
+
+def _service_download_file(sandbox: Sandbox, service: str, path: str) -> bytes:
+    if service == "main":
         return sandbox.download_file(path)
-    except FileNotFoundError:
+    download = getattr(sandbox, "service_download_file", None)
+    if not callable(download):
+        raise RuntimeError(f"sandbox cannot download from sidecar service {service!r}")
+    return download(service, path)
+
+
+def _remote_file_mode(
+    sandbox: Sandbox,
+    artifact: ArtifactSpec,
+    *,
+    user: str | None = None,
+) -> int | None:
+    """Read a regular artifact's permission bits so executables stay executable."""
+    path = shlex.quote(artifact.source)
+    command = f"stat -c '%a' {path} 2>/dev/null || stat -f '%Lp' {path} 2>/dev/null"
+    try:
+        raw = _service_exec(sandbox, artifact.service, command, timeout=30, user=user).strip().splitlines()[-1]
+        return int(raw, 8) & 0o7777
+    except (IndexError, TypeError, ValueError, RuntimeError):
         return None
 
 
-def _write_remote_file(sandbox: Sandbox, path: str, blob: bytes, user: str | None = None) -> None:
-    """Write bytes into a sandbox at *path*, creating parent directories.
-
-    Staged through a temp file so the backend's native ``upload_file`` carries
-    the bytes; the protocol has no "write these bytes" primitive.
-    """
-    parent = shlex.quote(str(PurePosixPath(path).parent))
+def _download_directory(
+    sandbox: Sandbox,
+    artifact: ArtifactSpec,
+    target: Path,
+    *,
+    user: str | None = None,
+) -> Path:
+    """Download a remote directory as one filtered tar archive."""
+    source = PurePosixPath(artifact.source.rstrip("/"))
+    if not source.name:
+        raise ValueError("artifact directory source must not be filesystem root")
+    archive_path = f"/tmp/.rllm-artifact-{uuid.uuid4().hex}.tgz"
+    excludes = " ".join(shlex.quote(f"--exclude={pattern}") for pattern in artifact.exclude)
+    command = " ".join(
+        part
+        for part in (
+            "tar czf",
+            shlex.quote(archive_path),
+            excludes,
+            "-C",
+            shlex.quote(str(source.parent)),
+            shlex.quote(source.name),
+        )
+        if part
+    )
     try:
-        sandbox.exec(f"mkdir -p {parent}", timeout=30, user=user)
-    except Exception:
-        pass
-    with tempfile.NamedTemporaryFile() as tmp:
-        tmp.write(blob)
-        tmp.flush()
-        sandbox.upload_file(tmp.name, path)
+        _service_exec(sandbox, artifact.service, command, timeout=600, user=user)
+        archive = _service_download_file(sandbox, artifact.service, archive_path)
+    finally:
+        try:
+            _service_exec(sandbox, artifact.service, f"rm -f {shlex.quote(archive_path)}", timeout=30, user=user)
+        except Exception:
+            pass
+
+    target.mkdir(parents=True, exist_ok=True)
+    local_archive = target / "artifact.tgz"
+    local_archive.write_bytes(archive)
+    with tarfile.open(local_archive, mode="r:gz") as tar:
+        tar.extractall(target, filter="data")
+    local_archive.unlink()
+    local_path = target / source.name
+    if not local_path.is_dir():
+        raise FileNotFoundError(f"downloaded artifact archive did not contain {source.name!r}")
+    return local_path
 
 
 # ---------------------------------------------------------------------------

--- a/rllm/harnesses/claude_code.py
+++ b/rllm/harnesses/claude_code.py
@@ -22,6 +22,7 @@ Two facts are load-bearing:
 
 from __future__ import annotations
 
+import json
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
@@ -144,6 +145,45 @@ class ClaudeCodeHarness(BaseCliHarness):
             "CLAUDE_CODE_SUBAGENT_MODEL": model,
         }
         return env
+
+    def write_configs(
+        self,
+        sandbox,
+        task: Task,
+        config: AgentConfig,  # noqa: ARG002
+        env: dict[str, str],  # noqa: ARG002
+    ) -> None:
+        """Register task-declared MCP servers and skills with Claude Code."""
+        environment = task.metadata.get("environment", {}) or {}
+        mcp_servers = environment.get("mcp_servers") or []
+        skills_dir = environment.get("skills_dir")
+        commands = [f"mkdir -p {shlex.quote(_CLAUDE_CONFIG_DIR)}/skills"]
+
+        if skills_dir:
+            commands.append(f"cp -r {shlex.quote(str(skills_dir))}/. {shlex.quote(_CLAUDE_CONFIG_DIR)}/skills/ 2>/dev/null || true")
+
+        if mcp_servers:
+            servers: dict[str, dict] = {}
+            for server in mcp_servers:
+                name = str(server["name"])
+                transport = str(server.get("transport") or "stdio")
+                if transport == "stdio":
+                    servers[name] = {
+                        "type": "stdio",
+                        "command": server["command"],
+                        "args": server.get("args") or [],
+                        **({"env": server["env"]} if server.get("env") else {}),
+                    }
+                else:
+                    servers[name] = {
+                        "type": "http" if transport == "streamable-http" else transport,
+                        "url": server["url"],
+                    }
+            payload = shlex.quote(json.dumps({"mcpServers": servers}))
+            commands.append(f"printf '%s' {payload} > {shlex.quote(_CLAUDE_CONFIG_DIR)}/.claude.json")
+
+        if len(commands) > 1:
+            sandbox.exec(" && ".join(commands), timeout=60, user=self.agent_user)
 
     def build_invocation(
         self,

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -244,7 +244,7 @@ class SandboxTaskHooks:
 
     def setup(self, task: Task, agent_flow: AgentFlow, uid: str) -> TaskContext:
         from rllm.engine.agentflow_engine import TaskContext
-        from rllm.eval._resolution import _resolve_backend, _run_healthcheck, _setup_task_environment
+        from rllm.eval._resolution import _resolve_backend, _run_healthcheck, _setup_task_environment, _validate_task_runtime
 
         plan = resolve_rollout_plan(task, agent_flow, self.evaluation)
 
@@ -256,6 +256,7 @@ class SandboxTaskHooks:
                 from rllm.sandbox.snapshot import get_sandbox, install_script_for
 
                 install = install_script_for(agent_flow)
+                _validate_task_runtime(task, _resolve_backend(task, self.sandbox_backend))
                 sandbox = self.warm_queue.pop(task) if self.warm_queue is not None else get_sandbox(task, self.sandbox_backend, self._registry, install)
                 env_backend = _resolve_backend(task, self.sandbox_backend)
                 # Record the backend this task actually got, so anything resolved

--- a/rllm/integrations/harbor/dataset_loader.py
+++ b/rllm/integrations/harbor/dataset_loader.py
@@ -15,6 +15,24 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def get_harbor_dataset_client(identifier: str):
+    """Return the Harbor registry client appropriate for a dataset identifier.
+
+    Harbor 0.20 uses ``org/name@ref`` for Hub packages and ``name@version``
+    for datasets in the legacy registry. This mirrors Harbor's own CLI
+    dispatch so both forms remain supported by rLLM.
+    """
+    dataset_name = identifier.split("@", 1)[0]
+    if "/" in dataset_name:
+        from harbor.registry.client.package import PackageDatasetClient
+
+        return PackageDatasetClient()
+
+    from harbor.registry.client.factory import RegistryClientFactory
+
+    return RegistryClientFactory.create()
+
+
 def harbor_task_to_row(task_dir: Path, task_name: str | None = None, task_digest: str | None = None) -> dict | None:
     """Convert a single Harbor task directory into a flat dict row.
 
@@ -121,10 +139,9 @@ def load_harbor_dataset_from_registry(identifier: str) -> list[dict]:
     Returns:
         List of task row dicts.
     """
-    from harbor.registry.client.factory import RegistryClientFactory
 
     async def _download():
-        client = RegistryClientFactory.create()
+        client = get_harbor_dataset_client(identifier)
         items = await client.download_dataset(identifier)
         return items
 

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -62,6 +62,16 @@
       "train_split": "train",
       "default_agent": "terminus-2"
     },
+    "terminal-bench-3": {
+      "description": "Terminal-Bench 3.0: 74 frontier-level terminal-agent tasks across software engineering, scientific computing, cybersecurity, data science, infrastructure, build systems, and games.",
+      "source": "harbor:terminal-bench/terminal-bench@3.0.0",
+      "category": "agentic",
+      "splits": [
+        "default"
+      ],
+      "eval_split": "default",
+      "default_agent": "claude-code"
+    },
     "gsm8k": {
       "description": "Grade school math word problems (8.5K train, 1.3K test)",
       "source": "openai/gsm8k",

--- a/rllm/sandbox/backends/docker.py
+++ b/rllm/sandbox/backends/docker.py
@@ -26,14 +26,45 @@ class DockerSandbox:
         self.name = name
         self.image = image
         self._client = docker.from_env()
+        self._persistent_env: dict[str, str] = {}
+        self._owns_container = True
+        run_kwargs: dict = {}
+        cpus = kwargs.pop("cpus", None)
+        memory = kwargs.pop("memory", None)
+        gpus = kwargs.pop("gpus", None)
+        if cpus:
+            run_kwargs["nano_cpus"] = int(float(cpus) * 1_000_000_000)
+        if memory:
+            run_kwargs["mem_limit"] = int(memory)
+        if gpus:
+            run_kwargs["device_requests"] = [docker.types.DeviceRequest(count=int(gpus), capabilities=[["gpu"]])]
         self._container = self._client.containers.run(
             image,
             command="sleep infinity",
             name=f"rllm-sandbox-{name}",
             detach=True,
             remove=False,
+            **run_kwargs,
         )
         logger.info("DockerSandbox %s created (container: %s, image: %s)", name, self._container.short_id, image)
+
+    @classmethod
+    def from_container(cls, name: str, container, client=None) -> DockerSandbox:
+        """Attach the Sandbox file/exec API to a Compose-owned container."""
+        import docker
+
+        instance = cls.__new__(cls)
+        instance.name = name
+        instance.image = container.image.tags[0] if getattr(container.image, "tags", None) else "<compose>"
+        instance._client = client or docker.from_env()
+        instance._container = container
+        instance._persistent_env = {}
+        instance._owns_container = False
+        return instance
+
+    def set_env(self, env: dict[str, str]) -> None:
+        """Inject task environment variables into every subsequent exec."""
+        self._persistent_env.update({str(k): str(v) for k, v in env.items()})
 
     def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
         """Execute a command inside the container.
@@ -45,11 +76,24 @@ class DockerSandbox:
                 Maps to ``docker exec --user``. If ``None``, runs as the
                 container's default user.
         """
+        return self.exec_with_shell(command, shell="bash", timeout=timeout, user=user)
+
+    def exec_with_shell(
+        self,
+        command: str,
+        *,
+        shell: str,
+        timeout: float | None = None,  # noqa: ARG002
+        user: str | None = None,
+    ) -> str:
+        """Execute with an explicit shell; sidecars commonly provide only ``sh``."""
         kwargs: dict = {"demux": True}
         if user is not None:
             kwargs["user"] = user
+        if self._persistent_env:
+            kwargs["environment"] = self._persistent_env
         exit_code, output = self._container.exec_run(
-            ["bash", "-c", command],
+            [shell, "-c", command],
             **kwargs,
         )
         stdout = (output[0] or b"").decode("utf-8", errors="replace")
@@ -125,6 +169,8 @@ class DockerSandbox:
 
     def close(self) -> None:
         """Stop and remove the container."""
+        if not self._owns_container:
+            return
         try:
             self._container.stop(timeout=5)
         except Exception:

--- a/rllm/sandbox/backends/docker_compose.py
+++ b/rllm/sandbox/backends/docker_compose.py
@@ -1,0 +1,172 @@
+"""Docker Compose-backed sandbox for multi-service benchmark tasks."""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from rllm.sandbox.backends.docker import DockerSandbox
+
+logger = logging.getLogger(__name__)
+
+
+class DockerComposeSandbox:
+    """Expose a Compose project's ``main`` service through the Sandbox API.
+
+    Task-authored Compose files are overlays: rLLM supplies the base ``main``
+    build and keepalive command, while the task adds sidecars, networking,
+    healthchecks, volumes, and any main-service overrides.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        environment_dir: Path,
+        compose_file: Path,
+        resources: dict | None = None,
+        build_timeout: float = 600.0,
+    ) -> None:
+        import docker
+
+        self.name = name
+        self.image = "<docker-compose>"
+        self._environment_dir = environment_dir.resolve()
+        self._compose_file = compose_file.resolve()
+        self._client = docker.from_env()
+        self._handles: dict[str, DockerSandbox] = {}
+        self._closed = False
+        self._tempdir = tempfile.TemporaryDirectory(prefix="rllm-compose-")
+        self._base_file = Path(self._tempdir.name) / "compose.base.yaml"
+        self._project = _compose_project_name(name)
+        self._write_base(resources or {})
+        try:
+            self._run_compose(
+                "up",
+                "--build",
+                "--wait",
+                "--wait-timeout",
+                str(max(1, int(build_timeout))),
+                timeout=build_timeout,
+            )
+            self._handle("main")
+        except BaseException:
+            self.close()
+            raise
+
+    def _write_base(self, resources: dict) -> None:
+        main: dict = {
+            "build": {"context": str(self._environment_dir), "dockerfile": "Dockerfile"},
+            "command": ["sleep", "infinity"],
+        }
+        cpus = resources.get("cpus")
+        memory_mb = resources.get("memory_mb")
+        env = resources.get("env")
+        if cpus:
+            main["cpus"] = float(cpus)
+        if memory_mb:
+            main["mem_limit"] = f"{int(memory_mb)}m"
+        if env:
+            main["environment"] = {str(k): str(v) for k, v in env.items()}
+        self._base_file.write_text(yaml.safe_dump({"services": {"main": main}}, sort_keys=False))
+
+    def _command(self, *args: str) -> list[str]:
+        return [
+            "docker",
+            "compose",
+            "--project-name",
+            self._project,
+            "--project-directory",
+            str(self._environment_dir),
+            "-f",
+            str(self._base_file),
+            "-f",
+            str(self._compose_file),
+            *args,
+        ]
+
+    def _run_compose(self, *args: str, timeout: float | None = None, check: bool = True) -> str:
+        result = subprocess.run(
+            self._command(*args),
+            cwd=str(self._environment_dir),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if check and result.returncode != 0:
+            detail = (result.stderr or result.stdout)[-4000:]
+            raise RuntimeError(f"docker compose {' '.join(args)} failed for {self.name}:\n{detail}")
+        return result.stdout
+
+    def _handle(self, service: str) -> DockerSandbox:
+        cached = self._handles.get(service)
+        if cached is not None:
+            return cached
+        container_id = self._run_compose("ps", "-q", service).strip()
+        if not container_id:
+            raise RuntimeError(f"Docker Compose service {service!r} is not running for {self.name}")
+        container = self._client.containers.get(container_id)
+        handle = DockerSandbox.from_container(f"{self.name}:{service}", container, self._client)
+        self._handles[service] = handle
+        return handle
+
+    def set_env(self, env: dict[str, str]) -> None:
+        self._handle("main").set_env(env)
+
+    def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
+        return self.service_exec("main", command, timeout=timeout, user=user)
+
+    def service_exec(
+        self,
+        service: str,
+        command: str,
+        timeout: float | None = None,
+        user: str | None = None,
+    ) -> str:
+        handle = self._handle(service)
+        if service == "main":
+            return handle.exec(command, timeout=timeout, user=user)
+        return handle.exec_with_shell(command, shell="sh", timeout=timeout, user=user)
+
+    def upload_file(self, local_path: str, remote_path: str) -> None:
+        self._handle("main").upload_file(local_path, remote_path)
+
+    def upload_dir(self, local_path: str, remote_path: str) -> None:
+        self._handle("main").upload_dir(local_path, remote_path)
+
+    def download_file(self, remote_path: str) -> bytes:
+        return self.service_download_file("main", remote_path)
+
+    def service_download_file(self, service: str, remote_path: str) -> bytes:
+        return self._handle(service).download_file(remote_path)
+
+    def stop_service(self, service: str) -> None:
+        self._run_compose("stop", "--timeout", "10", service, timeout=30)
+
+    def is_alive(self) -> bool:
+        try:
+            return self._handle("main").is_alive()
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._run_compose("down", "--volumes", "--remove-orphans", "--timeout", "10", timeout=60, check=False)
+        finally:
+            self._handles.clear()
+            self._tempdir.cleanup()
+        logger.info("DockerComposeSandbox %s closed", self.name)
+
+
+def _compose_project_name(name: str) -> str:
+    """Return an isolated, Compose-safe project name."""
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", name.lower()).strip("-_")
+    return (normalized or "rllm")[:63]

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -217,6 +217,8 @@ class ModalSandbox:
     - ``gpu``: GPU spec (e.g. ``"T4"``, ``"A10G"``).
     - ``cpu``: CPU count (float).
     - ``memory``: Memory in MB (int).
+    - ``shell``: Shell used for exec calls (default: ``"bash"``).
+    - ``experimental_options``: Options forwarded to ``modal.Sandbox.create``.
     """
 
     def __init__(self, name: str, image: str = "python:3.11-slim", **kwargs):
@@ -230,6 +232,7 @@ class ModalSandbox:
         # sandboxes (set RLLM_RUN_ID; else a random per-process id). Pass an
         # explicit app_name to override.
         self._app_name = kwargs.pop("app_name", None) or f"rllm-sandbox-{rllm_run_id()}"
+        self._shell = kwargs.pop("shell", "bash")
         # Env exported into every exec (populated via set_env); see exec().
         self._persistent_env: dict[str, str] = {}
 
@@ -263,7 +266,7 @@ class ModalSandbox:
                 create_kwargs["tags"] = run_tags
             else:
                 post_create_tags = run_tags
-            for key in ("secrets", "volumes", "workdir", "gpu", "cpu", "memory"):
+            for key in ("secrets", "volumes", "workdir", "gpu", "cpu", "memory", "experimental_options", "block_network"):
                 if key in kwargs:
                     create_kwargs[key] = kwargs.pop(key)
 
@@ -275,7 +278,7 @@ class ModalSandbox:
 
             # Pace creates under Modal's account-wide rate cap (see _CreateRateLimiter).
             _CREATE_LIMITER.acquire()
-            self._sandbox = modal.Sandbox.create(*entrypoint, **create_kwargs)
+            self._sandbox = modal.Sandbox.create(*(entrypoint or ()), **create_kwargs)
         except modal.exception.NotFoundError as e:
             if from_snapshot:
                 raise SnapshotNotFound(f"modal snapshot {image} no longer exists") from e
@@ -322,7 +325,7 @@ class ModalSandbox:
 
         run = _build_exec_command(command, self._persistent_env, user)
         start = time.monotonic()
-        process = self._sandbox.exec("bash", "-c", run, **exec_kwargs)
+        process = self._sandbox.exec(self._shell, "-c", run, **exec_kwargs)
 
         stdout = process.stdout.read()
         stderr = process.stderr.read()

--- a/rllm/sandbox/backends/modal_compose.py
+++ b/rllm/sandbox/backends/modal_compose.py
@@ -1,0 +1,223 @@
+"""Docker Compose-backed sandbox running inside one Modal VM Sandbox."""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import yaml
+
+from rllm.sandbox.backends.docker_compose import _compose_project_name
+from rllm.sandbox.backends.modal_backend import ModalSandbox
+
+logger = logging.getLogger(__name__)
+
+_REMOTE_ROOT = "/rllm"
+_REMOTE_ENVIRONMENT = f"{_REMOTE_ROOT}/environment"
+_REMOTE_COMPOSE = f"{_REMOTE_ROOT}/compose"
+
+
+class ModalComposeSandbox:
+    """Expose a nested Compose project's ``main`` service as an rLLM Sandbox.
+
+    One Modal VM Sandbox runs Docker-in-Docker; the task's ``main`` container
+    and sidecars live in a normal Compose bridge network inside that VM. This
+    follows Harbor's Modal DinD topology while retaining rLLM's small Sandbox
+    interface.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        environment_dir: Path,
+        compose_file: Path,
+        resources: dict | None = None,
+        build_timeout: float = 600.0,
+        dind_image: str = "docker:28.3.3-dind",
+        **modal_kwargs,
+    ) -> None:
+        self.name = name
+        self.image = "<modal-compose>"
+        self._environment_dir = environment_dir.resolve()
+        self._compose_file = compose_file.resolve()
+        self._project = _compose_project_name(name)
+        self._persistent_env: dict[str, str] = {}
+        self._closed = False
+
+        if modal_kwargs.get("gpu"):
+            raise RuntimeError("Modal VM Sandboxes do not support GPUs; Compose tasks must use CPU resources")
+
+        modal_kwargs.pop("gpu", None)
+        self._outer = ModalSandbox(
+            name=name,
+            image=dind_image,
+            entrypoint=None,
+            shell="sh",
+            experimental_options={"vm_runtime": True},
+            block_network=False,
+            **modal_kwargs,
+        )
+        try:
+            self._wait_for_docker()
+            self._stage_project(resources or {})
+            self._run_compose(
+                "up",
+                "--build",
+                "--wait",
+                "--wait-timeout",
+                str(max(1, int(build_timeout))),
+                timeout=build_timeout,
+            )
+            self.service_exec("main", "true", timeout=30)
+        except BaseException:
+            self.close()
+            raise
+
+    def _wait_for_docker(self) -> None:
+        last_error: Exception | None = None
+        for _ in range(30):
+            try:
+                self._outer.exec("docker info >/dev/null", timeout=10)
+                return
+            except Exception as exc:
+                last_error = exc
+                time.sleep(2)
+        raise RuntimeError(f"Docker daemon did not become ready in Modal sandbox {self.name}: {last_error}")
+
+    def _stage_project(self, resources: dict) -> None:
+        self._outer.upload_dir(str(self._environment_dir), _REMOTE_ENVIRONMENT)
+        base = {
+            "services": {
+                "main": {
+                    "build": {"context": _REMOTE_ENVIRONMENT, "dockerfile": "Dockerfile"},
+                    "command": ["sleep", "infinity"],
+                }
+            }
+        }
+        main = base["services"]["main"]
+        if resources.get("cpus"):
+            main["cpus"] = float(resources["cpus"])
+        if resources.get("memory_mb"):
+            main["mem_limit"] = f"{int(resources['memory_mb'])}m"
+        if resources.get("env"):
+            main["environment"] = {str(k): str(v) for k, v in resources["env"].items()}
+
+        with tempfile.TemporaryDirectory(prefix="rllm-modal-compose-") as tempdir:
+            base_file = Path(tempdir) / "compose.base.yaml"
+            base_file.write_text(yaml.safe_dump(base, sort_keys=False))
+            self._outer.upload_file(str(base_file), f"{_REMOTE_COMPOSE}/compose.base.yaml")
+
+    def _compose_parts(self, *args: str) -> list[str]:
+        return [
+            "docker",
+            "compose",
+            "--project-name",
+            self._project,
+            "--project-directory",
+            _REMOTE_ENVIRONMENT,
+            "-f",
+            f"{_REMOTE_COMPOSE}/compose.base.yaml",
+            "-f",
+            f"{_REMOTE_ENVIRONMENT}/{self._compose_file.name}",
+            *args,
+        ]
+
+    def _compose_command(self, *args: str) -> str:
+        return shlex.join(self._compose_parts(*args))
+
+    def _run_compose(self, *args: str, timeout: float | None = None, check: bool = True) -> str:
+        command = self._compose_command(*args)
+        try:
+            return self._outer.exec(command, timeout=timeout)
+        except RuntimeError:
+            if check:
+                raise
+            return ""
+
+    def _host_exec_unchecked(self, command: str) -> None:
+        try:
+            self._outer.exec(command, timeout=30)
+        except RuntimeError:
+            pass
+
+    def set_env(self, env: dict[str, str]) -> None:
+        self._persistent_env.update({str(k): str(v) for k, v in (env or {}).items()})
+
+    def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
+        return self.service_exec("main", command, timeout=timeout, user=user)
+
+    def service_exec(
+        self,
+        service: str,
+        command: str,
+        timeout: float | None = None,
+        user: str | None = None,
+    ) -> str:
+        args = ["exec", "-T"]
+        if user is not None:
+            args.extend(["--user", str(user)])
+        for key, value in self._persistent_env.items():
+            args.extend(["--env", f"{key}={value}"])
+        shell = "bash" if service == "main" else "sh"
+        args.extend([service, shell, "-c", command])
+        return self._run_compose(*args, timeout=timeout)
+
+    def _stage_path(self) -> str:
+        return f"/tmp/.rllm-compose-{uuid.uuid4().hex}"
+
+    def upload_file(self, local_path: str, remote_path: str) -> None:
+        staged = self._stage_path()
+        try:
+            self._outer.upload_file(local_path, staged)
+            parent = str(Path(remote_path).parent)
+            self.service_exec("main", f"mkdir -p {shlex.quote(parent)}", timeout=30, user="root")
+            self._run_compose("cp", staged, f"main:{remote_path}", timeout=300)
+        finally:
+            self._host_exec_unchecked(f"rm -f {shlex.quote(staged)}")
+
+    def upload_dir(self, local_path: str, remote_path: str) -> None:
+        staged = self._stage_path()
+        try:
+            self._outer.upload_dir(local_path, staged)
+            self.service_exec("main", f"mkdir -p {shlex.quote(remote_path)}", timeout=30, user="root")
+            self._run_compose("cp", f"{staged}/.", f"main:{remote_path}", timeout=600)
+        finally:
+            self._host_exec_unchecked(f"rm -rf {shlex.quote(staged)}")
+
+    def download_file(self, remote_path: str) -> bytes:
+        return self.service_download_file("main", remote_path)
+
+    def service_download_file(self, service: str, remote_path: str) -> bytes:
+        staged = self._stage_path()
+        try:
+            self._run_compose("cp", f"{service}:{remote_path}", staged, timeout=300)
+            return self._outer.download_file(staged)
+        finally:
+            self._host_exec_unchecked(f"rm -f {shlex.quote(staged)}")
+
+    def stop_service(self, service: str) -> None:
+        self._run_compose("stop", "--timeout", "10", service, timeout=30)
+
+    def is_alive(self) -> bool:
+        if not self._outer.is_alive():
+            return False
+        try:
+            self.service_exec("main", "true", timeout=10)
+            return True
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._run_compose("down", "--volumes", "--remove-orphans", "--timeout", "10", timeout=60, check=False)
+        finally:
+            self._outer.close()
+        logger.info("ModalComposeSandbox %s closed", self.name)

--- a/rllm/sandbox/snapshot.py
+++ b/rllm/sandbox/snapshot.py
@@ -99,12 +99,12 @@ def install_script_for(agent_flow: object) -> str:
 
 def keys_for_tasks(tasks: list[Task], backend: str | None, install_script: str = "") -> dict[str, Task]:
     """Map distinct env_keys to a representative task (used by ``rllm snapshot create``)."""
-    from rllm.eval._resolution import _resolve_backend
+    from rllm.eval._resolution import _resolve_backend, _task_compose_file
 
     out: dict[str, Task] = {}
     for task in tasks:
         eff = _resolve_backend(task, backend)
-        if eff in _NO_SNAPSHOT_BACKENDS:
+        if eff in _NO_SNAPSHOT_BACKENDS or _task_compose_file(task) is not None:
             continue
         out.setdefault(env_key_for(task, eff, install_script), task)
     return out
@@ -145,10 +145,14 @@ def get_sandbox(task: Task, backend: str | None, registry: SnapshotRegistry | No
     but the caller must still install at runtime). Cold sandboxes leave the
     attribute unset.
     """
-    from rllm.eval._resolution import _create_base_sandbox, _create_sandbox_for_task, _resolve_backend
+    from rllm.eval._resolution import _create_base_sandbox, _create_sandbox_for_task, _resolve_backend, _task_compose_file
     from rllm.sandbox.protocol import SnapshotNotFound
 
     backend = _resolve_backend(task, backend)
+    # A Compose task is a VM plus a set of nested images, networks, and volumes;
+    # a normal single-image backend snapshot cannot represent that topology.
+    if _task_compose_file(task) is not None:
+        return _create_sandbox_for_task(task, backend)
     if registry is not None and backend not in _NO_SNAPSHOT_BACKENDS:
         key = env_key_for(task, backend, install_script)
         candidates = [key]

--- a/rllm/tasks/loader.py
+++ b/rllm/tasks/loader.py
@@ -273,6 +273,7 @@ def _lift_verifier_contract(raw: dict, into: dict) -> None:
     into["verifier_mode"] = _resolve_verifier_mode(verifier_section)
     into["verifier_environment"] = verifier_section.get("environment")
     into["verifier_collect"] = verifier_section.get("collect", []) or []
+    into["verifier_env_vars"] = verifier_section.get("env", {}) or {}
     into["verifier_network_mode"] = verifier_section.get("network_mode")
     # Top-level ``artifacts``: paths the collect step produces, which a separate
     # verifier container needs re-materialised at their original locations.

--- a/tests/cli/test_terminal_bench_3.py
+++ b/tests/cli/test_terminal_bench_3.py
@@ -1,0 +1,52 @@
+"""Tests for the first-class Terminal-Bench 3 catalog entry."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from rllm.cli._pull import load_dataset_catalog, pull_dataset
+from rllm.integrations.harbor.dataset_loader import get_harbor_dataset_client
+
+HARBOR_DATASET_ID = "terminal-bench/terminal-bench@3.0.0"
+
+
+def test_terminal_bench_3_catalog_entry_uses_harbor_registry() -> None:
+    entry = load_dataset_catalog()["datasets"]["terminal-bench-3"]
+
+    assert entry["source"] == f"harbor:{HARBOR_DATASET_ID}"
+    assert entry["splits"] == ["default"]
+    assert entry["eval_split"] == "default"
+    assert entry["default_agent"] == "claude-code"
+    assert not entry["default_agent"].startswith("harbor:")
+    assert "reward_fn" not in entry
+    assert "builder" not in entry
+
+
+def test_terminal_bench_3_uses_hub_package_client() -> None:
+    pytest.importorskip("harbor")
+    from harbor.registry.client.package import PackageDatasetClient
+
+    assert isinstance(get_harbor_dataset_client(HARBOR_DATASET_ID), PackageDatasetClient)
+
+
+def test_terminal_bench_3_pull_uses_exact_versioned_identifier() -> None:
+    entry = load_dataset_catalog()["datasets"]["terminal-bench-3"]
+    rows = [{"task_id": "example", "task_path": "/tmp/example"}]
+
+    with (
+        patch("rllm.integrations.harbor.dataset_loader.load_harbor_dataset", return_value=rows) as load_harbor,
+        patch("rllm.data.DatasetRegistry.register_dataset") as register_dataset,
+    ):
+        pull_dataset("terminal-bench-3", entry)
+
+    load_harbor.assert_called_once_with(HARBOR_DATASET_ID)
+    register_dataset.assert_called_once_with(
+        name="terminal-bench-3",
+        data=rows,
+        split="default",
+        source=f"harbor:{HARBOR_DATASET_ID}",
+        description=entry["description"],
+        category="agentic",
+    )

--- a/tests/eval/test_terminal_bench_3_runtime.py
+++ b/tests/eval/test_terminal_bench_3_runtime.py
@@ -1,0 +1,269 @@
+"""Focused native-runtime coverage for Terminal-Bench 3 contracts."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from rllm.eval._resolution import _create_sandbox_for_task, _create_verifier_sandbox, _sandbox_resource_kwargs, _validate_task_runtime
+from rllm.eval.script_evaluator import ShellScriptEvaluator, normalize_artifacts
+from rllm.types import Episode, Task, Trajectory
+
+
+class _Sandbox:
+    def __init__(self, *, reward: str | None = None):
+        self.reward = reward
+        self.execs: list[str] = []
+        self.uploaded_files: list[tuple[str, str]] = []
+        self.uploaded_dirs: list[tuple[str, str]] = []
+        self.closed = False
+
+    def exec(self, command, timeout=None, user=None):  # noqa: ARG002
+        self.execs.append(command)
+        if command.startswith("test -f /logs/verifier/reward.txt"):
+            return "yes" if self.reward is not None else "no"
+        if command.startswith("cat /logs/verifier/reward.txt"):
+            return self.reward or ""
+        if command.startswith("if [ -d "):
+            return "directory"
+        return ""
+
+    def upload_file(self, local_path, remote_path):
+        self.uploaded_files.append((local_path, remote_path))
+
+    def upload_dir(self, local_path, remote_path):
+        self.uploaded_dirs.append((local_path, remote_path))
+
+    def download_file(self, remote_path):  # noqa: ARG002
+        raise FileNotFoundError(remote_path)
+
+    def close(self):
+        self.closed = True
+
+
+class _ComposeSandbox(_Sandbox):
+    def __init__(self):
+        super().__init__()
+        self.events: list[tuple[str, str]] = []
+
+    def service_exec(self, service, command, timeout=None, user=None):  # noqa: ARG002
+        self.events.append(("exec", service))
+        if command.startswith("if [ -d "):
+            return "file"
+        return ""
+
+    def service_download_file(self, service, remote_path):
+        self.events.append(("download", service))
+        return b"sidecar evidence"
+
+    def stop_service(self, service):
+        self.events.append(("stop", service))
+
+
+class _ExecutableArtifactSandbox(_Sandbox):
+    def exec(self, command, timeout=None, user=None):  # noqa: ARG002
+        if command.startswith("if [ -d /tmp/tool"):
+            return "file"
+        if command.startswith("stat -c"):
+            return "755\n"
+        return super().exec(command, timeout=timeout, user=user)
+
+    def download_file(self, remote_path):  # noqa: ARG002
+        return b"#!/bin/sh\n"
+
+
+def _task(tmp_path: Path) -> Task:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text("#!/bin/sh\n")
+    (tests / "Dockerfile").write_text("FROM python:3.12-slim\nCOPY . /tests\n")
+    return Task(
+        id="tb3",
+        instruction="solve",
+        metadata={"environment": {}, "verifier_mode": "separate"},
+        dataset_dir=tmp_path,
+    )
+
+
+def _episode() -> Episode:
+    return Episode(task="tb3", trajectories=[Trajectory(name="agent", steps=[])])
+
+
+def test_artifact_declarations_normalize_to_one_shape():
+    specs = normalize_artifacts(
+        [
+            "/tmp/result.json",
+            {"source": "/workspace/app", "exclude": ["node_modules"], "service": "main"},
+            {"source": "/tmp/db.dump", "service": "postgres"},
+        ]
+    )
+    assert [(spec.source, spec.service, spec.exclude) for spec in specs] == [
+        ("/tmp/result.json", "main", ()),
+        ("/workspace/app", "main", ("node_modules",)),
+        ("/tmp/db.dump", "postgres", ()),
+    ]
+
+
+def test_directory_artifact_is_uploaded_at_original_path(tmp_path, monkeypatch):
+    import rllm.eval.script_evaluator as module
+
+    agent = _Sandbox()
+    verifier = _Sandbox(reward="1.0")
+
+    def fake_download_directory(sandbox, artifact, target, user=None):  # noqa: ARG001
+        path = target / "app"
+        path.mkdir(parents=True)
+        (path / "solution.py").write_text("pass\n")
+        return path
+
+    monkeypatch.setattr(module, "_download_directory", fake_download_directory)
+    evaluator = ShellScriptEvaluator(
+        sandbox=agent,
+        verifier_sandbox_factory=lambda: verifier,
+        verifier_tests_baked=True,
+        artifacts=[{"source": "/workspace/app", "exclude": ["node_modules"]}],
+    )
+
+    output = evaluator.evaluate(_task(tmp_path), _episode())
+
+    assert output.reward == 1.0
+    assert verifier.uploaded_dirs[0][1] == "/workspace/app"
+    assert "mkdir -p /workspace/app && chmod 777 /workspace/app" in verifier.execs
+    assert verifier.closed is True
+
+
+def test_separate_verifier_does_not_inherit_agent_workdir(tmp_path):
+    task = _task(tmp_path)
+    task.metadata["workdir"] = "/app"
+    agent = _Sandbox()
+    verifier = _Sandbox(reward="1.0")
+    evaluator = ShellScriptEvaluator(
+        sandbox=agent,
+        verifier_sandbox_factory=lambda: verifier,
+        verifier_tests_baked=True,
+    )
+
+    output = evaluator.evaluate(task, _episode())
+
+    assert output.reward == 1.0
+    verifier_command = next(command for command in verifier.execs if "/tests/test.sh" in command)
+    assert "cd /app" not in verifier_command
+
+
+def test_regular_artifact_preserves_executable_mode(tmp_path):
+    agent = _ExecutableArtifactSandbox()
+    verifier = _Sandbox(reward="1.0")
+    uploaded_mode = None
+
+    def capture_upload(local_path, remote_path):
+        nonlocal uploaded_mode
+        uploaded_mode = stat.S_IMODE(Path(local_path).stat().st_mode)
+        verifier.uploaded_files.append((local_path, remote_path))
+
+    verifier.upload_file = capture_upload
+    evaluator = ShellScriptEvaluator(
+        sandbox=agent,
+        verifier_sandbox_factory=lambda: verifier,
+        verifier_tests_baked=True,
+        artifacts=["/tmp/tool"],
+    )
+
+    output = evaluator.evaluate(_task(tmp_path), _episode())
+
+    assert output.reward == 1.0
+    assert uploaded_mode == 0o755
+
+
+def test_verifier_build_uses_tests_dockerfile(tmp_path, monkeypatch):
+    import rllm.eval._resolution as module
+
+    task = _task(tmp_path)
+    built: dict = {}
+    sandbox = _Sandbox()
+
+    def fake_build(context, task_id):
+        built.update(context=context, task_id=task_id)
+        return "verifier:image"
+
+    def fake_create(task, backend, **kwargs):  # noqa: ARG001
+        built.update(backend=backend, image=kwargs["image"])
+        return sandbox
+
+    monkeypatch.setattr(module, "_build_docker_image", fake_build)
+    monkeypatch.setattr(module, "_create_base_sandbox", fake_create)
+
+    assert _create_verifier_sandbox(task, "docker") is sandbox
+    assert built["context"] == tmp_path / "tests"
+    assert built["image"] == "verifier:image"
+
+
+def test_sidecar_collection_stops_main_before_collecting(tmp_path):
+    agent = _ComposeSandbox()
+    verifier = _Sandbox(reward="1.0")
+    evaluator = ShellScriptEvaluator(
+        sandbox=agent,
+        verifier_sandbox_factory=lambda: verifier,
+        verifier_tests_baked=True,
+        collect_commands=[{"service": "api", "command": "snapshot", "timeout_sec": 10}],
+        artifacts=[{"source": "/tmp/evidence.json", "service": "api"}],
+    )
+
+    output = evaluator.evaluate(_task(tmp_path), _episode())
+
+    assert output.reward == 1.0
+    assert agent.events.index(("stop", "main")) < agent.events.index(("exec", "api"))
+    assert ("download", "api") in agent.events
+    assert verifier.uploaded_files[0][1] == "/tmp/evidence.json"
+
+
+def test_compose_task_accepts_modal_but_rejects_unsupported_backend(tmp_path):
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    (environment / "docker-compose.yaml").write_text("services:\n  main:\n    image: python:3.12\n")
+    task = Task(id="compose", instruction="", metadata={}, dataset_dir=tmp_path)
+
+    _validate_task_runtime(task, "modal")
+    with pytest.raises(RuntimeError, match="requires Docker Compose"):
+        _validate_task_runtime(task, "daytona")
+
+
+def test_compose_task_routes_to_modal_vm_backend(tmp_path, monkeypatch):
+    import rllm.sandbox.backends.modal_compose as module
+
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    compose = environment / "docker-compose.yaml"
+    compose.write_text("services:\n  main:\n    image: python:3.12\n")
+    task = Task(
+        id="compose",
+        instruction="",
+        metadata={"environment": {"cpus": 2, "memory_mb": 4096, "build_timeout_sec": 75}},
+        dataset_dir=tmp_path,
+    )
+    captured = {}
+
+    class FakeModalCompose:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(module, "ModalComposeSandbox", FakeModalCompose)
+    sandbox = _create_sandbox_for_task(task, "modal", name="trial")
+
+    assert isinstance(sandbox, FakeModalCompose)
+    assert captured["compose_file"] == compose
+    assert captured["build_timeout"] == 75.0
+    assert captured["cpu"] == 2.0
+    assert captured["memory"] == 4096
+
+
+def test_gpu_requirements_reach_docker_and_modal():
+    task = Task(
+        id="gpu",
+        instruction="",
+        metadata={"environment": {"gpus": 1, "gpu_types": ["H100"]}},
+        dataset_dir=Path("."),
+    )
+    assert _sandbox_resource_kwargs(task, "docker")["gpus"] == 1
+    assert _sandbox_resource_kwargs(task, "modal")["gpu"] == "H100"

--- a/tests/harnesses/test_claude_code_tb3.py
+++ b/tests/harnesses/test_claude_code_tb3.py
@@ -1,0 +1,47 @@
+"""TB3 task configuration passed to the native Claude Code harness."""
+
+from pathlib import Path
+
+from rllm.harnesses.claude_code import ClaudeCodeHarness
+from rllm.types import AgentConfig, Task
+
+
+class _Sandbox:
+    def __init__(self):
+        self.commands: list[str] = []
+
+    def exec(self, command, timeout=None, user=None):  # noqa: ARG002
+        self.commands.append(command)
+        return ""
+
+
+def test_task_mcp_and_skills_are_registered_for_claude_code():
+    task = Task(
+        id="tb3",
+        instruction="",
+        dataset_dir=Path("."),
+        metadata={
+            "environment": {
+                "skills_dir": "/app/.agents/skills",
+                "mcp_servers": [
+                    {
+                        "name": "playwright",
+                        "transport": "sse",
+                        "url": "http://playwright-mcp:3080/sse",
+                    }
+                ],
+            }
+        },
+    )
+    sandbox = _Sandbox()
+    ClaudeCodeHarness().write_configs(
+        sandbox,
+        task,
+        AgentConfig(base_url="http://gateway/v1", model="model", session_uid="s"),
+        {},
+    )
+    command = sandbox.commands[0]
+    assert "/app/.agents/skills/." in command
+    assert '"mcpServers"' in command
+    assert '"playwright"' in command
+    assert '"type": "sse"' in command

--- a/tests/sandbox/test_docker_compose.py
+++ b/tests/sandbox/test_docker_compose.py
@@ -1,0 +1,72 @@
+"""Unit tests for the native Docker Compose sandbox."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import yaml
+
+from rllm.sandbox.backends.docker_compose import DockerComposeSandbox, _compose_project_name
+
+
+class _Container:
+    def __init__(self):
+        self.image = SimpleNamespace(tags=["task:image"])
+        self.status = "running"
+
+    def reload(self):
+        return None
+
+
+class _Containers:
+    def __init__(self):
+        self.items = {"cid-main": _Container(), "cid-api": _Container()}
+
+    def get(self, container_id):
+        return self.items[container_id]
+
+
+def test_compose_sandbox_layers_task_file_and_uses_unique_project(tmp_path, monkeypatch):
+    import rllm.sandbox.backends.docker_compose as module
+
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    overlay = environment / "docker-compose.yaml"
+    overlay.write_text("services:\n  main:\n    depends_on:\n      api:\n        condition: service_started\n  api:\n    image: nginx\n")
+
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):  # noqa: ARG001
+        calls.append(command)
+        if "ps" in command:
+            service = command[-1]
+            return SimpleNamespace(returncode=0, stdout=f"cid-{service}\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    client = SimpleNamespace(containers=_Containers())
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setitem(sys.modules, "docker", SimpleNamespace(from_env=lambda: client))
+
+    sandbox = DockerComposeSandbox(
+        name="TB3/Trial 1",
+        environment_dir=environment,
+        compose_file=overlay,
+        resources={"cpus": 2, "memory_mb": 4096},
+    )
+    base = yaml.safe_load(sandbox._base_file.read_text())
+    assert base["services"]["main"]["build"]["context"] == str(environment.resolve())
+    assert base["services"]["main"]["cpus"] == 2.0
+    assert any("up" in call and "--wait" in call for call in calls)
+    assert sandbox._handle("api").name.endswith(":api")
+    sandbox.stop_service("main")
+    sandbox.close()
+    assert any("stop" in call for call in calls)
+    assert any("down" in call and "--volumes" in call for call in calls)
+
+
+def test_compose_project_name_is_safe_and_bounded():
+    name = _compose_project_name("TB3 / Weird Task ! " + "x" * 100)
+    assert name.startswith("tb3-weird-task-")
+    assert len(name) <= 63

--- a/tests/sandbox/test_modal_backend.py
+++ b/tests/sandbox/test_modal_backend.py
@@ -8,6 +8,9 @@ needing a live Modal sandbox.
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 from rllm.sandbox.backends.modal_backend import _build_exec_command
 
 
@@ -78,3 +81,54 @@ def test_attach_run_tags_swallows_set_tags_failure():
 
     _attach_run_tags(Ok(), {"rllm_run_id": "x"}, "sb")
     assert seen == {"rllm_run_id": "x"}
+
+
+def test_constructor_forwards_vm_options_and_inherits_image_entrypoint(monkeypatch):
+    import rllm.sandbox.backends.modal_backend as module
+
+    created = {}
+
+    class Container:
+        object_id = "sb-1"
+
+        def set_tags(self, tags):  # noqa: ARG002
+            return None
+
+        def terminate(self):
+            return None
+
+        def detach(self):
+            return None
+
+    class SandboxApi:
+        @staticmethod
+        def create(*args, tags=None, **kwargs):
+            created.update(args=args, tags=tags, kwargs=kwargs)
+            return Container()
+
+    fake_modal = SimpleNamespace(
+        App=SimpleNamespace(lookup=lambda *args, **kwargs: object()),
+        Image=SimpleNamespace(from_registry=lambda image: f"modal:{image}"),
+        Sandbox=SandboxApi,
+        exception=SimpleNamespace(NotFoundError=type("NotFoundError", (Exception,), {})),
+    )
+    monkeypatch.setitem(sys.modules, "modal", fake_modal)
+    monkeypatch.setattr(module._CREATE_LIMITER, "acquire", lambda: None)
+    module._APP_CACHE.clear()
+
+    sandbox = module.ModalSandbox(
+        name="compose",
+        image="docker:28.3.3-dind",
+        entrypoint=None,
+        shell="sh",
+        experimental_options={"vm_runtime": True},
+        block_network=False,
+    )
+    try:
+        assert created["args"] == ()
+        assert created["kwargs"]["experimental_options"] == {"vm_runtime": True}
+        assert created["kwargs"]["block_network"] is False
+        assert sandbox._shell == "sh"
+    finally:
+        sandbox.close()
+        module._APP_CACHE.clear()

--- a/tests/sandbox/test_modal_compose.py
+++ b/tests/sandbox/test_modal_compose.py
@@ -1,0 +1,145 @@
+"""Unit tests for Docker Compose running inside one Modal VM Sandbox."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from rllm.sandbox.backends.modal_compose import ModalComposeSandbox
+
+
+class _OuterSandbox:
+    instances: list[_OuterSandbox] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.commands: list[tuple[str, float | None]] = []
+        self.uploaded_dirs: list[tuple[str, str]] = []
+        self.uploaded_files: list[tuple[str, str]] = []
+        self.base_compose: dict | None = None
+        self.closed = False
+        self.alive = True
+        self.__class__.instances.append(self)
+
+    def exec(self, command: str, timeout: float | None = None, user=None):  # noqa: ARG002
+        self.commands.append((command, timeout))
+        return ""
+
+    def upload_dir(self, local_path: str, remote_path: str):
+        self.uploaded_dirs.append((local_path, remote_path))
+
+    def upload_file(self, local_path: str, remote_path: str):
+        self.uploaded_files.append((local_path, remote_path))
+        if remote_path.endswith("compose.base.yaml"):
+            self.base_compose = yaml.safe_load(Path(local_path).read_text())
+
+    def download_file(self, remote_path: str):
+        return f"downloaded:{remote_path}".encode()
+
+    def is_alive(self):
+        return self.alive
+
+    def close(self):
+        self.closed = True
+
+
+def _environment(tmp_path: Path) -> tuple[Path, Path]:
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    compose = environment / "docker-compose.yaml"
+    compose.write_text("services:\n  main: {}\n  api:\n    image: nginx\n")
+    return environment, compose
+
+
+def _sandbox(tmp_path: Path, monkeypatch) -> tuple[ModalComposeSandbox, _OuterSandbox]:
+    import rllm.sandbox.backends.modal_compose as module
+
+    _OuterSandbox.instances.clear()
+    monkeypatch.setattr(module, "ModalSandbox", _OuterSandbox)
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    environment, compose = _environment(tmp_path)
+    sandbox = ModalComposeSandbox(
+        name="TB3 / Modal Trial",
+        environment_dir=environment,
+        compose_file=compose,
+        resources={"cpus": 2, "memory_mb": 4096},
+        build_timeout=90,
+        cpu=2,
+        memory=4096,
+        timeout=1200,
+    )
+    return sandbox, _OuterSandbox.instances[-1]
+
+
+def test_modal_compose_starts_dind_vm_and_remote_project(tmp_path, monkeypatch):
+    sandbox, outer = _sandbox(tmp_path, monkeypatch)
+
+    assert outer.kwargs["image"] == "docker:28.3.3-dind"
+    assert outer.kwargs["entrypoint"] is None
+    assert outer.kwargs["shell"] == "sh"
+    assert outer.kwargs["experimental_options"] == {"vm_runtime": True}
+    assert outer.kwargs["block_network"] is False
+    assert outer.kwargs["cpu"] == 2
+    assert outer.kwargs["memory"] == 4096
+    assert outer.uploaded_dirs[0][1] == "/rllm/environment"
+    assert outer.base_compose["services"]["main"]["build"]["context"] == "/rllm/environment"
+    assert outer.base_compose["services"]["main"]["cpus"] == 2.0
+    assert any("docker compose" in command and "up --build --wait" in command for command, _ in outer.commands)
+    sandbox.close()
+
+
+def test_exec_targets_main_and_sidecar_with_user_and_env(tmp_path, monkeypatch):
+    sandbox, outer = _sandbox(tmp_path, monkeypatch)
+    sandbox.set_env({"API_KEY": "secret value"})
+
+    sandbox.exec("echo main", timeout=12, user="agent")
+    sandbox.service_exec("api", "echo sidecar", timeout=13, user="root")
+
+    main = next(command for command, _ in outer.commands if "echo main" in command)
+    sidecar = next(command for command, _ in outer.commands if "echo sidecar" in command)
+    assert "exec -T --user agent --env 'API_KEY=secret value' main bash -c 'echo main'" in main
+    assert "exec -T --user root --env 'API_KEY=secret value' api sh -c 'echo sidecar'" in sidecar
+    sandbox.close()
+
+
+def test_file_transfers_bridge_outer_vm_and_nested_services(tmp_path, monkeypatch):
+    sandbox, outer = _sandbox(tmp_path, monkeypatch)
+    local_file = tmp_path / "input.txt"
+    local_file.write_text("hello")
+    local_dir = tmp_path / "tests"
+    local_dir.mkdir()
+    (local_dir / "test.sh").write_text("true\n")
+
+    sandbox.upload_file(str(local_file), "/workspace/input.txt")
+    sandbox.upload_dir(str(local_dir), "/tests")
+    result = sandbox.service_download_file("api", "/tmp/evidence.json")
+
+    assert result.startswith(b"downloaded:/tmp/.rllm-compose-")
+    commands = [command for command, _ in outer.commands]
+    assert any("cp /tmp/.rllm-compose-" in command and "main:/workspace/input.txt" in command for command in commands)
+    assert any("main:/tests" in command for command in commands)
+    assert any("api:/tmp/evidence.json" in command for command in commands)
+    sandbox.close()
+
+
+def test_close_stops_compose_and_modal_vm_once(tmp_path, monkeypatch):
+    sandbox, outer = _sandbox(tmp_path, monkeypatch)
+
+    sandbox.stop_service("main")
+    sandbox.close()
+    sandbox.close()
+
+    commands = [command for command, _ in outer.commands]
+    assert any("stop --timeout 10 main" in command for command in commands)
+    assert sum("down --volumes --remove-orphans" in command for command in commands) == 1
+    assert outer.closed is True
+
+
+def test_is_alive_requires_outer_vm_and_main_service(tmp_path, monkeypatch):
+    sandbox, outer = _sandbox(tmp_path, monkeypatch)
+    assert sandbox.is_alive() is True
+    outer.alive = False
+    assert sandbox.is_alive() is False
+    sandbox.close()

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -85,6 +85,21 @@ def test_keys_for_tasks_dedups_envs_and_skips_local_backends():
     assert keys_for_tasks([_task(backend="docker")], "docker") == {}  # no snapshots for docker
 
 
+def test_compose_tasks_skip_single_image_snapshots(tmp_path, monkeypatch):
+    import rllm.eval._resolution as res
+
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    (environment / "docker-compose.yaml").write_text("services:\n  main:\n    image: python:3.12\n")
+    task = Task(id="compose", instruction="", metadata={}, dataset_dir=tmp_path)
+    registry = SnapshotRegistry(str(tmp_path / "snapshots.json"))
+
+    assert keys_for_tasks([task], "modal") == {}
+    monkeypatch.setattr(res, "_create_base_sandbox", lambda *a, **k: pytest.fail("compose attempted a single-image snapshot boot"))
+    monkeypatch.setattr(res, "_create_sandbox_for_task", lambda task, backend: _FakeSandbox())
+    assert isinstance(get_sandbox(task, "modal", registry), _FakeSandbox)
+
+
 # --------------------------------------------------------------------------
 # get_sandbox — two gates + self-heal + no-live-call-on-miss
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Runs Terminal-Bench 3 natively in rLLM's own sandbox/eval stack, with fidelity to Harbor's task contract, rather than delegating to Harbor's runner.

Stacked on #820 (gateway Anthropic traces) — see *Dependency* below.

## Harbor 0.20 / TB3 packaging

TB3 ships as a Hub package (`terminal-bench/terminal-bench@3.0.0`, the `org/name@ref` form) rather than a legacy `name@version` dataset. `get_harbor_dataset_client()` dispatches between `PackageDatasetClient` and `RegistryClientFactory`, mirroring Harbor's own CLI, so both forms keep working. Bumps the `harbor` extra 0.3.0 → 0.20.0 and adds `docker>=7.0.0`.

## Dataset registration

Adds `terminal-bench-3` to the registry — 74 tasks, `default_agent: claude-code`.

## Docker Compose environments

Some TB3 tasks ship `environment/docker-compose.yaml` with multiple services, which no existing backend can run. Adds `DockerComposeSandbox` and `ModalComposeSandbox`; `_create_sandbox_for_task` routes to them when a task has a compose file and raises a clear error on backends that cannot.

Snapshotting is skipped for compose tasks — a VM plus nested images, networks, and volumes has no single-image snapshot representation.

The sandbox-backend edits here are **prerequisites, not standalone cleanups**, which is why they aren't in #820:

- `docker_compose` needs `DockerSandbox.from_container()` to attach the Sandbox file/exec API to a Compose-owned container
- `modal_compose` needs `shell`, `experimental_options`, and `block_network` on `ModalSandbox`

`DockerSandbox` also gains cpu/memory/gpu limits from the task's environment section.

## Verifier contract fidelity

Harbor builds the verifier image *from* `tests/` as build context, and that Dockerfile may install dependencies or transform files — uploading raw `tests/` into the agent image is not equivalent. `_create_verifier_sandbox` now builds `tests/Dockerfile` per backend (docker/modal/daytona), with `verifier_tests_baked` and `verifier_env_vars` plumbed through. Tasks predating the `tests/Dockerfile` contract keep the old path.

## Testing

58 passed across the new and touched suites (`test_docker_compose`, `test_modal_compose`, `test_snapshot`, `test_modal_backend`, `test_terminal_bench_3`, `test_terminal_bench_3_runtime`, `test_claude_code_tb3`).

One pre-existing failure, `test_snapshot.py::test_daytona_ref_absent_reads_enum_or_string_state`, fails identically on `terminal-rl` without this branch — the optional `daytona` dep isn't installed. Untouched by this PR.

End-to-end, both task shapes:

| task | compose | turns | outcome |
|---|---|---|---|
| `freight-dispatch-shift` | ✅ | 176 | artifact collected, verifier graded 132/232 diagnostic points |
| `html-js-filter` | ❌ | 60 | 1 of 2 verifier tests passed |

Each task's native `task.toml` budgets were honoured without `--agent-timeout` — 7200s/300s and 3600s/1800s respectively.

## Dependency

Scoring is correct without #820, but trajectories from the `claude-code` harness are empty until the gateway can parse Anthropic responses. Merge #820 first for non-empty training data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
