### PR TITLE
infra: route Fireworks-hosted models by host, not by author name

### DIFF
--- a/rllm/harnesses/cli_harness.py
+++ b/rllm/harnesses/cli_harness.py
@@ -159,8 +159,18 @@ class BaseCliHarness(SandboxedAgentFlow):
         Returns the lowercase provider slug. Defaults to ``openai`` for
         unknown patterns — works for ``gpt-*``/``o1``/``o3`` and routes
         cleanly through any OpenAI-compatible proxy.
+
+        A Fireworks model id names its *author*, not its host
+        (``accounts/fireworks/models/deepseek-v4-pro``), so the vendor
+        keywords below would match the wrong thing: litellm would resolve
+        ``deepseek/`` against api.deepseek.com and ignore the
+        ``OPENAI_API_BASE`` the harness points at the gateway, sending every
+        call out of the sandbox. Match the host first — Fireworks is
+        OpenAI-shaped.
         """
         name = model_name.lower()
+        if "fireworks" in name:
+            return "openai"
         if any(k in name for k in ("claude", "haiku", "sonnet", "opus")):
             return "anthropic"
         if "gemini" in name or "gemma" in name:

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -355,6 +355,13 @@ def test_opencode_invocation_uses_custom_provider_prefix_and_detaches_stdin():
         ("gemini-1.5-pro", "google", "google/gemini-1.5-pro"),
         ("deepseek-coder", "deepseek", "deepseek/deepseek-coder"),
         ("mistral-large", "mistral", "mistral/mistral-large"),
+        # A Fireworks id names the model's author, not its host. The host wins:
+        # anything else routes the sandbox to that vendor's own endpoint
+        # instead of the gateway (litellm ignores OPENAI_API_BASE for a
+        # non-openai slug), which zeroes the whole run.
+        ("accounts/fireworks/models/deepseek-v4-pro", "openai", "openai/fireworks/models/deepseek-v4-pro"),
+        ("accounts/fireworks/models/kimi-k3", "openai", "openai/fireworks/models/kimi-k3"),
+        ("accounts/fireworks/routers/kimi-k3-fast", "openai", "openai/fireworks/routers/kimi-k3-fast"),
         # Pre-qualified names round-trip unchanged.
         ("openai/gpt-4o", "openai", "openai/gpt-4o"),
         ("anthropic/claude-opus-4-1", "anthropic", "anthropic/claude-opus-4-1"),


### PR DESCRIPTION
## The bug

`BaseCliHarness.infer_provider` maps a model name to a litellm provider slug by substring-matching. But a Fireworks id names the model's **author**, not its host — `accounts/fireworks/models/deepseek-v4-pro` matched `deepseek`, so the harness wrote `deepseek/…` into the sandbox.

litellm resolves that slug against `api.deepseek.com` and ignores the `OPENAI_API_BASE` the harness points at the gateway. Every call left the sandbox and failed auth.

A 10-task `deepswe` smoke died this way, ~10s per task, with zero steps and zero traces:

```
[datacurve/…] Rewards: [mini-swe-agent: 0.0] in 33s (agentflow=11s), Termination: TerminationReason.MODEL_ERROR
Accuracy 0.0% (0/10) · Errors 10 · Terminations model_error 10
```

Reproduced directly — the sandbox's exact model string vs. the corrected one, with `OPENAI_API_BASE` pointed at a stub gateway:

| model string | where the request actually went |
|---|---|
| `deepseek/fireworks/models/deepseek-v4-pro` | `DeepseekException - Authentication Fails` ← **api.deepseek.com** |
| `openai/fireworks/models/deepseek-v4-pro` | connection error to the stub ← correctly targeted |

Models that worked (`glm-5p2`, `kimi-k3`, `qwen3p7-plus`, `minimax-m3`, `nemotron-3-ultra`) did so only because their names happen to contain no vendor keyword and fell through to the `openai` default.

## The fix

Match the **host** before the author keywords:

```python
name = model_name.lower()
if "fireworks" in name:
    return "openai"
```

Fireworks is OpenAI-shaped, and its ids always carry the `accounts/fireworks/…` path — litellm's `fireworks_ai` adapter requires the full path upstream — so this covers every model and router form:

```
accounts/fireworks/models/deepseek-v4-pro  -> openai/fireworks/models/deepseek-v4-pro
accounts/fireworks/routers/kimi-k3-fast    -> openai/fireworks/routers/kimi-k3-fast
```

Nothing else changes: `claude-*` → `anthropic`, bare `deepseek-coder` → `deepseek`, `gemini-1.5-pro` → `google`, all unchanged.

## Not a workaround: passing `openai/…` yourself

`--model` reaches `EvalProxyManager` verbatim, which would build `fireworks_ai/openai/accounts/fireworks/models/deepseek-v4-pro`. Confirmed against the Fireworks API:

```
HTTP 404 {'message': 'Model not found, inaccessible, and/or not deployed', 'code': 'NOT_FOUND'}
```

It fixes the sandbox side and breaks the proxy side.

## Verification

Same smoke, same 10 task indices, after the fix — 10/10 real rollouts, 57–136 steps each, **all `env_done`, 0 errors**:

```
Accuracy 10.0% (1/10) · Errors 0 · Terminations env_done 10
```

(The 1/10 is DeepSeek V4 Pro's own result on those tasks — mean f2p 0.775, chronically a test or two short. Kimi K3 gets 9/10 on the same set. A model outcome, not infra.)

`tests/harnesses` 69 passed; ruff check + format clean. Three Fireworks cases added to `test_provider_inference`.

## Known gap, deliberately not fixed here

The same mismatch exists for other OpenAI-compatible hosts whose model ids carry an author name — `together_ai/deepseek-ai/DeepSeek-V3`, `groq/mistral-saba-24b`, `openrouter/x-ai/grok-4` — because the harness only ever redirects `OPENAI_API_BASE` and `ANTHROPIC_BASE_URL`, so any other inferred slug bypasses the gateway. Those are unchanged from today's behavior, not regressions.

The durable form of this would be to derive the slug from the set of base URLs `build_env` actually redirects (and fail loudly on anything outside it) rather than from the model name, but that touches six harnesses and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)