### PR TITLE
infra: forward sampling params litellm would silently drop

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -737,6 +737,10 @@ def eval_cmd(
                 model_name=model,
                 api_key=api_key,
                 proxy_port=proxy_port,
+                # Non-core sampling params (reasoning_effort, …) the proxy must
+                # forward instead of dropping. The gateway enforces them per
+                # call; this keeps litellm from deleting them en route.
+                sampling_extra=sampling_config.extra if sampling_config else None,
             )
             with Status(f"[dim]Starting LiteLLM proxy for [bold]{provider}/{model}[/bold]...[/]", console=console):
                 try:

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -143,12 +143,23 @@ class EvalProxyManager(_ProxyManagerBase):
         api_key: str,
         proxy_host: str = "127.0.0.1",
         proxy_port: int | None = None,
+        sampling_extra: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(proxy_host=proxy_host, proxy_port=proxy_port)
         self.provider = provider
         self.model_name = model_name
         self.api_key = api_key
+        self.sampling_extra = sampling_extra or {}
         self._stderr_path: str | None = None
+
+    def _litellm_supported(self, prefix: str) -> set[str]:
+        """Params litellm will forward top-level for this provider (empty if it can't say)."""
+        try:
+            import litellm
+
+            return set(litellm.get_supported_openai_params(self.model_name, custom_llm_provider=prefix) or ())
+        except Exception:  # unknown provider, litellm API drift — treat everything as passthrough
+            return set()
 
     def _generate_litellm_config(self) -> dict[str, Any]:
         from rllm.eval.config import get_provider_info
@@ -166,6 +177,18 @@ class EvalProxyManager(_ProxyManagerBase):
         # through the ``openai/`` adapter pinned to their ``api_base``.
         if info and info.base_url:
             litellm_params["api_base"] = info.base_url
+
+        # ``drop_params`` below deletes any param outside litellm's per-provider
+        # allowlist — including ones the provider really does support, since the
+        # allowlists lag (fireworks_ai has no ``reasoning_effort`` entry, yet
+        # Fireworks honours it and 400s on a bad value). Silently dropping it
+        # yields a run at the model's default effort that still looks valid, so
+        # route the unrecognised params through ``extra_body``, which litellm
+        # forwards verbatim. Params litellm does know stay top-level so it can
+        # still validate and translate them.
+        passthrough = {k: v for k, v in self.sampling_extra.items() if k not in self._litellm_supported(prefix)}
+        if passthrough:
+            litellm_params["extra_body"] = passthrough
 
         return {
             "model_list": [

--- a/tests/eval/test_eval_proxy.py
+++ b/tests/eval/test_eval_proxy.py
@@ -110,14 +110,12 @@ class TestSamplingExtraPassthrough:
         params = pm.build_proxy_config()["model_list"][0]["litellm_params"]
         assert params["extra_body"] == {"reasoning_effort": "max"}
 
-    def test_supported_param_stays_top_level(self):
-        """litellm knows ``top_k`` for fireworks_ai, so it must not be diverted —
-        top-level params still get validated and translated per provider."""
+    def test_supported_param_is_not_diverted_to_extra_body(self):
+        """litellm-known params must not be duplicated into ``extra_body``."""
         pm = EvalProxyManager(provider="fireworks", model_name=self.FIREWORKS_MODEL, api_key="fw-key", sampling_extra={"top_k": 20, "reasoning_effort": "max"})
 
         params = pm.build_proxy_config()["model_list"][0]["litellm_params"]
         assert params["extra_body"] == {"reasoning_effort": "max"}
-        assert "top_k" not in params["extra_body"]
 
     def test_no_extra_body_key_without_extras(self):
         """Runs that pass no extras must generate the same config as before."""

--- a/tests/eval/test_eval_proxy.py
+++ b/tests/eval/test_eval_proxy.py
@@ -94,3 +94,33 @@ class TestEvalProxyManager:
         r = repr(pm)
         assert "minimax" in r
         assert "MiniMax-M2.7" in r
+
+
+class TestSamplingExtraPassthrough:
+    """``drop_params`` deletes params outside litellm's per-provider allowlist,
+    even ones the provider honours (fireworks_ai has no ``reasoning_effort``
+    entry). Those must ride in ``extra_body``, which litellm forwards verbatim,
+    or the run silently uses the model's default and still looks valid."""
+
+    FIREWORKS_MODEL = "accounts/fireworks/models/deepseek-v4-flash-0731"
+
+    def test_unsupported_param_moves_to_extra_body(self):
+        pm = EvalProxyManager(provider="fireworks", model_name=self.FIREWORKS_MODEL, api_key="fw-key", sampling_extra={"reasoning_effort": "max"})
+
+        params = pm.build_proxy_config()["model_list"][0]["litellm_params"]
+        assert params["extra_body"] == {"reasoning_effort": "max"}
+
+    def test_supported_param_stays_top_level(self):
+        """litellm knows ``top_k`` for fireworks_ai, so it must not be diverted —
+        top-level params still get validated and translated per provider."""
+        pm = EvalProxyManager(provider="fireworks", model_name=self.FIREWORKS_MODEL, api_key="fw-key", sampling_extra={"top_k": 20, "reasoning_effort": "max"})
+
+        params = pm.build_proxy_config()["model_list"][0]["litellm_params"]
+        assert params["extra_body"] == {"reasoning_effort": "max"}
+        assert "top_k" not in params["extra_body"]
+
+    def test_no_extra_body_key_without_extras(self):
+        """Runs that pass no extras must generate the same config as before."""
+        pm = EvalProxyManager(provider="fireworks", model_name=self.FIREWORKS_MODEL, api_key="fw-key")
+
+        assert "extra_body" not in pm.build_proxy_config()["model_list"][0]["litellm_params"]

--- a/tests/integration/test_reasoning_effort_passthrough.py
+++ b/tests/integration/test_reasoning_effort_passthrough.py
@@ -10,7 +10,6 @@ Requires FIREWORKS_API_KEY.
 
 import json
 import os
-import time
 import urllib.request
 
 import pytest
@@ -37,16 +36,10 @@ def _reasoning_chars(effort: str) -> int:
     try:
         url = pm.get_proxy_url().rstrip("/") + "/chat/completions"
         body = json.dumps({"model": MODEL, "messages": [{"role": "user", "content": PROMPT}], "max_tokens": 6000}).encode()
-        deadline = time.time() + 180
-        while True:
-            try:
-                req = urllib.request.Request(url, data=body, method="POST", headers={"Content-Type": "application/json", "Authorization": "Bearer sk-placeholder"})
-                payload = json.loads(urllib.request.urlopen(req, timeout=300).read())
-                return len(payload["choices"][0]["message"].get("reasoning_content") or "")
-            except Exception:
-                if time.time() > deadline:
-                    raise
-                time.sleep(3)  # proxy still booting
+        req = urllib.request.Request(url, data=body, method="POST", headers={"Content-Type": "application/json", "Authorization": "Bearer sk-placeholder"})
+        with urllib.request.urlopen(req, timeout=300) as response:
+            payload = json.loads(response.read())
+        return len(payload["choices"][0]["message"].get("reasoning_content") or "")
     finally:
         pm.shutdown_proxy()
 

--- a/tests/integration/test_reasoning_effort_passthrough.py
+++ b/tests/integration/test_reasoning_effort_passthrough.py
@@ -1,0 +1,66 @@
+"""Live check that sampling params litellm doesn't recognise still reach the provider.
+
+The unit tests in ``tests/eval/test_eval_proxy.py`` only assert the generated
+config carries ``extra_body``. They would keep passing if litellm stopped
+forwarding it — which is the exact silent-drop this passthrough exists to
+prevent, so the guarantee needs one test that talks to a real provider.
+
+Requires FIREWORKS_API_KEY.
+"""
+
+import json
+import os
+import time
+import urllib.request
+
+import pytest
+
+from rllm.eval.proxy import EvalProxyManager
+
+FIREWORKS_API_KEY = os.environ.get("FIREWORKS_API_KEY")
+
+requires_fireworks = pytest.mark.skipif(
+    not FIREWORKS_API_KEY,
+    reason="FIREWORKS_API_KEY env var required",
+)
+
+MODEL = "accounts/fireworks/models/deepseek-v4-flash-0731"
+# Hard enough that effort actually changes how much the model thinks; a trivial
+# prompt reasons about the same amount at every level and the assert goes flaky.
+PROMPT = "Prove that for every positive integer n, 2^(2n)+1 has no prime factor congruent to 3 mod 4. Show full reasoning."
+
+
+def _reasoning_chars(effort: str) -> int:
+    """Round-trip one completion through a proxy configured for *effort*."""
+    pm = EvalProxyManager(provider="fireworks", model_name=MODEL, api_key=FIREWORKS_API_KEY, sampling_extra={"reasoning_effort": effort})
+    pm.start_proxy_subprocess(pm.build_proxy_config())
+    try:
+        url = pm.get_proxy_url().rstrip("/") + "/chat/completions"
+        body = json.dumps({"model": MODEL, "messages": [{"role": "user", "content": PROMPT}], "max_tokens": 6000}).encode()
+        deadline = time.time() + 180
+        while True:
+            try:
+                req = urllib.request.Request(url, data=body, method="POST", headers={"Content-Type": "application/json", "Authorization": "Bearer sk-placeholder"})
+                payload = json.loads(urllib.request.urlopen(req, timeout=300).read())
+                return len(payload["choices"][0]["message"].get("reasoning_content") or "")
+            except Exception:
+                if time.time() > deadline:
+                    raise
+                time.sleep(3)  # proxy still booting
+    finally:
+        pm.shutdown_proxy()
+
+
+@requires_fireworks
+def test_reasoning_effort_reaches_the_provider():
+    """``max`` must visibly out-think ``low``.
+
+    Fireworks honours ``reasoning_effort`` but litellm's fireworks_ai allowlist
+    has no entry for it, so without the ``extra_body`` passthrough both calls
+    silently run at the model's default and come back the same size. Observed
+    ~3.9x; asserting 2x leaves room for sampling variance.
+    """
+    low = _reasoning_chars("low")
+    high = _reasoning_chars("max")
+
+    assert high > 2 * low, f"reasoning_effort looks dropped: low={low} chars, max={high} chars"


### PR DESCRIPTION
## The bug

`--sampling-params reasoning_effort=max` is accepted by the eval CLI today. It parses, lands in `SamplingConfig.extra`, and the gateway enforces it on every call:

```python
>>> resolve_eval_sampling('reasoning_effort=max', None, None, None)
SamplingConfig(temperature=1.0, top_p=1.0, extra={'reasoning_effort': 'max'})
>>> .as_dict()   # what the gateway enforces
{'temperature': 1.0, 'top_p': 1.0, 'reasoning_effort': 'max'}
```

Then the LiteLLM proxy deletes it. `drop_params: True` strips anything outside litellm's per-provider allowlist, and those allowlists lag the providers:

```python
>>> litellm.get_supported_openai_params(model, custom_llm_provider="fireworks_ai")
[... 'temperature', 'tools', 'top_k', 'top_p', 'user']     # no reasoning_effort
>>> get_optional_params(..., reasoning_effort="max", drop_params=True)
{'stream': False, 'max_tokens': 100, 'extra_body': {}}      # gone
```

Fireworks genuinely honours the param — a bad value 400s with `Input should be 'low', 'medium', 'high', 'xhigh', 'max', 'none' or 'adaptive'` — so this is purely litellm's map being out of date.

Nothing errors. The run completes at the model's default effort and reports a number that looks legitimate. That matters for benchmarking: the public DeepSWE leaderboard reports models at `[max]` / `[xhigh]` / `[high]`, and there is currently no way to reproduce those settings through `rllm eval` — you get the default and no indication you didn't get what you asked for.

## The fix

Route params litellm doesn't recognise through `extra_body`, which it forwards verbatim; leave the ones it knows top-level so they still get validated and translated per provider.

The split is computed from litellm's own support map, not a hardcoded list — so when litellm adds `reasoning_effort` to `fireworks_ai`, the param returns to top-level on its own and `extra_body` empties out.

## Verification

End-to-end against a live LiteLLM proxy started from the generated config, identical prompt and `max_tokens`:

| `reasoning_effort` | reasoning_content | completion_tokens |
|---|---|---|
| unset (default) | 3,334 ch | 1,875 |
| `low` | 4,474 ch | 2,096 |
| `max` | **17,339 ch** | **6,000** (hit cap) |

**5.2× the default at `max`.** This also closes the one real design risk — that the proxy *server* might not honour `extra_body` from config YAML. It does.

Config generation, by case:

```
extra=None                          -> {'model': 'fireworks_ai/…'}
extra={'reasoning_effort':'max'}    -> {'model': …, 'extra_body': {'reasoning_effort': 'max'}}
extra={'reasoning_effort':'max',
       'top_k': 20}                 -> extra_body carries only reasoning_effort; top_k stays top-level
```

Runs that pass no extras generate a **byte-identical** config, so existing behaviour is untouched.

## Scope

**+27 lines of code, +30 of tests**, in one module plus one call site. No harness changes, no gateway changes — the gateway already forwards the param correctly; it only died at the last hop.

`tests/eval`, `tests/cli`, `tests/harnesses`: 682 passed. The one failure (`test_harbor_parity::test_lifetime_floor_sized_from_task_budget_when_no_override`) is pre-existing and fails identically on a clean `terminal-rl` — verified via `git stash`. ruff check + format clean.

## Follow-up, not in this PR

The effort is fixed per proxy, so it is one setting per run. That suits eval (one model per run) but would not support per-task variation. A per-request path would have to live in the gateway, which is a separate package.

Worth considering separately: **warn when a sampling param is dropped**. Even with this fix, an unsupported param aimed at a provider whose allowlist litellm *does* cover would still vanish quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)