### PR TITLE
eval: RLLM_GATEWAY_PORT for concurrent tunneled evals

### DIFF
--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -24,6 +24,56 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Per-run override for the port the gateway binds behind a tunnel. Sibling to
+#: ``RLLM_GATEWAY_TUNNEL``: whoever supplies the public URL is the only one who
+#: knows which port it forwards to, so the two travel together.
+ENV_GATEWAY_PORT = "RLLM_GATEWAY_PORT"
+
+
+def resolve_gateway_port(tunnel_url: str) -> int:
+    """Port the gateway must bind so *tunnel_url* reaches it.
+
+    A tunnel URL means an already-running forwarder, so the gateway has to bind
+    wherever that forwarder points — a free-port pick would leave the tunnel
+    aimed at nothing.
+
+    Resolution order: ``$RLLM_GATEWAY_PORT`` → the ``rllm tunnel up`` daemon's
+    recorded upstream (only when its URL matches) → the setup config's port.
+
+    The env var comes first because the other two are process-wide: one daemon
+    state file, one config file, one value each. Concurrent evals against
+    remote sandboxes each need their own tunnel on their own port, and without
+    an explicit override they would all read the same number and collide on
+    bind. Local backends never reach here — they need no tunnel, so the gateway
+    picks a free port per run and concurrent evals already coexist.
+    """
+    from rllm.env import env_int
+
+    override = env_int(ENV_GATEWAY_PORT, 0)
+    if override:
+        return override
+
+    from urllib.parse import urlparse
+
+    from rllm.gateway.tunnel import live_tunnel
+
+    state = live_tunnel() or {}
+    upstream = state.get("upstream") if state.get("url") == tunnel_url else None
+    port = urlparse(upstream).port if upstream else None
+    if port is not None:
+        return port
+
+    from rllm.eval.config import load_tunnel_config
+
+    port = int(load_tunnel_config().get("port") or 9090)
+    logger.warning(
+        "Tunnel URL %s has no matching daemon state; binding the gateway to port %d from the tunnel config — it must match the port that URL forwards to. Set %s to override.",
+        tunnel_url,
+        port,
+        ENV_GATEWAY_PORT,
+    )
+    return port
+
 
 async def run_dataset(
     tasks: list,  # list[rllm.types.Task]
@@ -107,27 +157,7 @@ async def run_dataset(
             if tunnel_warning:
                 logger.warning(tunnel_warning)
             if gateway_tunnel.startswith(("http://", "https://")):
-                # A tunnel URL means an already-running forwarder; the gateway
-                # must bind wherever it forwards (a free-port pick would leave
-                # the tunnel pointing at nothing). The daemon's recorded
-                # ``upstream`` is authoritative; a URL supplied some other way
-                # (env var) falls back to the setup config's port.
-                from urllib.parse import urlparse
-
-                from rllm.gateway.tunnel import live_tunnel
-
-                state = live_tunnel() or {}
-                upstream = state.get("upstream") if state.get("url") == gateway_tunnel else None
-                gateway_port = urlparse(upstream).port if upstream else None
-                if gateway_port is None:
-                    from rllm.eval.config import load_tunnel_config
-
-                    gateway_port = int(load_tunnel_config().get("port") or 9090)
-                    logger.warning(
-                        "Tunnel URL %s has no matching daemon state; binding the gateway to port %d from the tunnel config — it must match the port that URL forwards to.",
-                        gateway_tunnel,
-                        gateway_port,
-                    )
+                gateway_port = resolve_gateway_port(gateway_tunnel)
         gateway = EvalGatewayManager(upstream_url=base_url, model=model, tunnel=gateway_tunnel, port=gateway_port)
         gateway.start()
 

--- a/tests/eval/test_gateway_port_resolution.py
+++ b/tests/eval/test_gateway_port_resolution.py
@@ -1,0 +1,116 @@
+"""Port resolution for an eval gateway sitting behind a tunnel.
+
+Concurrent evals against *remote* sandboxes each need their own tunnel on
+their own port. Daemon state and the setup config are both process-wide
+singletons, so without an explicit override every run reads the same port and
+the second one dies on bind. ``RLLM_GATEWAY_PORT`` is that override.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import rllm.eval.runner as runner_mod
+from rllm.eval.runner import ENV_GATEWAY_PORT, resolve_gateway_port
+
+URL = "https://gw.example.test"
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_override(monkeypatch):
+    monkeypatch.delenv(ENV_GATEWAY_PORT, raising=False)
+
+
+def _daemon(monkeypatch, *, url: str, port: int) -> None:
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setattr(tunnel_mod, "live_tunnel", lambda: {"backend": "ngrok", "url": url, "pid": 1, "upstream": f"http://127.0.0.1:{port}"})
+
+
+def _config_port(monkeypatch, port: int) -> None:
+    import rllm.eval.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"port": port})
+
+
+def test_env_override_wins_over_daemon_state(monkeypatch):
+    """The whole point: two runs sharing one daemon still get distinct ports."""
+    _daemon(monkeypatch, url=URL, port=9091)
+    monkeypatch.setenv(ENV_GATEWAY_PORT, "9092")
+
+    assert resolve_gateway_port(URL) == 9092
+
+
+def test_daemon_upstream_used_when_url_matches(monkeypatch):
+    _daemon(monkeypatch, url=URL, port=9091)
+    _config_port(monkeypatch, 4321)
+
+    assert resolve_gateway_port(URL) == 9091
+
+
+def test_daemon_ignored_when_url_differs(monkeypatch):
+    """A daemon forwarding somewhere else says nothing about this tunnel."""
+    _daemon(monkeypatch, url="https://stale.example.test", port=9091)
+    _config_port(monkeypatch, 4321)
+
+    assert resolve_gateway_port(URL) == 4321
+
+
+def test_falls_back_to_config_and_warns(monkeypatch, caplog):
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setattr(tunnel_mod, "live_tunnel", lambda: None)
+    _config_port(monkeypatch, 4321)
+
+    with caplog.at_level("WARNING", logger=runner_mod.__name__):
+        assert resolve_gateway_port(URL) == 4321
+
+    assert ENV_GATEWAY_PORT in caplog.text
+
+
+def test_resolved_port_reaches_the_gateway(monkeypatch):
+    """The resolved port must actually be handed to the gateway.
+
+    Resolution being correct is worthless if ``run_dataset`` drops the value on
+    the way to ``EvalGatewayManager`` — the gateway would then pick a free port
+    and the tunnel would forward to nothing. Guards the wiring against a future
+    refactor, which unit-testing the resolver alone cannot do.
+    """
+    import asyncio
+
+    import rllm.gateway.manager as manager_mod
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setenv(ENV_GATEWAY_PORT, "9137")
+    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: (URL, None))
+    monkeypatch.setattr(tunnel_mod, "is_local_sandbox_backend", lambda name: False)
+    monkeypatch.setattr(runner_mod, "is_local_sandbox_backend", lambda name: False, raising=False)
+
+    seen: dict = {}
+
+    class _Gateway:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+        def start(self):
+            raise _Stop
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr(manager_mod, "EvalGatewayManager", _Gateway)
+    monkeypatch.setattr(runner_mod, "EvalGatewayManager", _Gateway, raising=False)
+
+    with pytest.raises(_Stop):
+        asyncio.run(
+            runner_mod.run_dataset(
+                tasks=[],
+                agent_flow=object(),
+                base_url="http://127.0.0.1:1/v1",
+                model="m",
+                sandbox_backend="modal",
+            )
+        )
+
+    assert seen["port"] == 9137
+    assert seen["tunnel"] == URL


### PR DESCRIPTION
Lets concurrent `rllm eval` runs against remote sandboxes each bind their own gateway port.

## Problem

Behind a tunnel the gateway can't pick a free port — it must bind wherever the tunnel forwards, or the tunnel points at nothing. The port comes only from the `rllm tunnel up` daemon state (`~/.rllm/tunnel.json`) or the setup config (`~/.rllm/config.json`). One file each, one value each, so two concurrent evals read the same port and the second dies with `GatewayPortInUseError` — even when each has its own tunnel.

Local backends are unaffected: no tunnel, so the gateway already picks a free port per run and concurrent evals coexist today. This is the remaining gap from #684.

## Change

`RLLM_GATEWAY_PORT` takes precedence over both, mirroring `RLLM_GATEWAY_TUNNEL` one layer up. Whoever supplies the public URL is the only one who knows which port it forwards to, so the two travel together:

```bash
RLLM_GATEWAY_TUNNEL=https://a.example.com RLLM_GATEWAY_PORT=9091 rllm eval …
RLLM_GATEWAY_TUNNEL=https://b.example.com RLLM_GATEWAY_PORT=9092 rllm eval …
```

Resolution becomes `$RLLM_GATEWAY_PORT` → daemon upstream (only when its URL matches) → config. Unset behaves exactly as before. The config-fallback warning now names the variable.

The logic moves into `resolve_gateway_port()` so it's testable without running an eval; those lines are otherwise unchanged.

## Testing

Five tests. Four cover `resolve_gateway_port` — env beats daemon state, daemon used when its URL matches, daemon ignored when it doesn't, config fallback warns and names the variable. The fifth covers the wiring: it drives `run_dataset` with a stub gateway and asserts the resolved port is what `EvalGatewayManager` receives, since a correct resolver is worthless if the value is dropped on the way.

That wiring test was mutation-checked — discarding the resolved value at the call site fails it and leaves the other four green.

Also verified against a live gateway: with `RLLM_GATEWAY_PORT=9139`, the manager binds 9139, sandboxes are handed `https://<tunnel>/sessions/<id>/v1`, and host-side clients get `http://127.0.0.1:9139/sessions/<id>/v1`.

Two failures on `terminal-rl` predate this change and reproduce with it stashed: `test_loopback_only_listener_still_detected` and `test_lifetime_floor_sized_from_task_budget_when_no_override`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
