### PR TITLE
tunnels: isolate eval and train routes per run

### DIFF
--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -502,7 +502,7 @@ def _describe_sandbox_routing(
             gateway_note = f"{tunnel_backend} tunnel (auto-spawn)"
         else:
             # No explicit tunnel: show what auto-resolution will actually use
-            # ($RLLM_GATEWAY_TUNNEL / `rllm tunnel up` daemon / cloudflared).
+            # ($RLLM_GATEWAY_TUNNEL / configured wildcard / cloudflared).
             from rllm.gateway.tunnel import resolve_auto_tunnel
 
             resolved, _ = resolve_auto_tunnel()

--- a/rllm/cli/tunnel.py
+++ b/rllm/cli/tunnel.py
@@ -97,7 +97,10 @@ def tunnel_setup():
             except subprocess.CalledProcessError as e:
                 detail = (e.stderr or e.stdout or "").strip() or f"ngrok exited with status {e.returncode}"
                 detail = detail.replace(api_key, "***") if api_key else detail
-                fail(f"ngrok could not reserve {domain}: {detail}")
+                if "ERR_NGROK_413" in detail:
+                    console.print(f"  [success]✓[/] [val]{domain}[/] is already reserved on this account.")
+                else:
+                    fail(f"ngrok could not reserve {domain}: {detail}")
     else:
         if not CloudflaredTunnel.is_available():
             fail(f"cloudflared not found on PATH. {CloudflaredTunnel.install_hint}")

--- a/rllm/cli/tunnel.py
+++ b/rllm/cli/tunnel.py
@@ -167,8 +167,8 @@ def tunnel_up(backend, port):
     write_tunnel_state(backend=resolved_backend, url=url, pid=pid, upstream=upstream, log_path=log_path)
     console.print(f"  [success]✓ Tunnel up:[/] [val]{url}[/] [muted](pid {pid})[/]")
     console.print(f"  [label]logs[/] {log_path}")
-        console.print(f"  To reuse it, set [key]RLLM_GATEWAY_TUNNEL[/] to this URL and [key]rllm.gateway.port={resolved_port}[/].")
-        console.print("  Stop it with [key]rllm tunnel down[/].")
+    console.print(f"  To reuse it, set [key]RLLM_GATEWAY_TUNNEL[/] to this URL and [key]rllm.gateway.port={resolved_port}[/].")
+    console.print("  Stop it with [key]rllm tunnel down[/].")
 
 
 @tunnel.command("status")

--- a/rllm/cli/tunnel.py
+++ b/rllm/cli/tunnel.py
@@ -1,14 +1,15 @@
 """rLLM CLI: set up and run the public tunnel that lets remote sandboxes reach the gateway.
 
-``rllm tunnel setup`` records a backend + credentials in ``~/.rllm/config.json``
-(per-user, so nothing personal lands in shared train scripts). ``rllm tunnel up``
-runs that backend as a background daemon and writes its live URL to a state file;
-training auto-discovers it (see :func:`rllm.gateway.tunnel.resolve_auto_tunnel`),
-so no ``rllm.gateway.tunnel=...`` is needed in the run command.
+``rllm tunnel setup`` records a backend in ``~/.rllm/config.json`` (per-user,
+so nothing personal lands in shared train scripts). A configured ngrok wildcard
+creates an owned endpoint for each eval/train run. Legacy fixed domains and
+cloudflared may instead run as a background daemon via ``rllm tunnel up``.
 """
 
 from __future__ import annotations
 
+import json
+import secrets
 import subprocess
 
 import click
@@ -17,26 +18,51 @@ import click
 DEFAULT_PORT = 9090
 
 
+def _ngrok_reserved_domain_exists(domain: str) -> bool:
+    """Return whether the authenticated ngrok account already owns ``domain``."""
+    result = subprocess.run(
+        [
+            "ngrok",
+            "api",
+            "reserved-domains",
+            "list",
+            "--limit",
+            "1",
+            "--filter",
+            f'obj.domain == "{domain}"',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload_start = result.stdout.find("{")
+    if payload_start < 0:
+        raise ValueError("ngrok returned no JSON payload")
+    payload = json.loads(result.stdout[payload_start:])
+    return any(entry.get("domain") == domain for entry in payload.get("reserved_domains", []))
+
+
 @click.group("tunnel")
 def tunnel():
     """Set up and run the public tunnel to the model gateway.
 
     Remote sandboxes (Daytona / Modal / Fireworks runtimes) reach the local
-    gateway through this tunnel. Run `rllm tunnel setup` once, then
-    `rllm tunnel up`; training auto-discovers the live URL with no per-run config.
+    gateway through this tunnel. Run `rllm tunnel setup` once. An ngrok
+    wildcard is allocated per eval/train run; fixed domains and cloudflared can
+    still be run as a background daemon with `rllm tunnel up`.
     """
 
 
 @tunnel.command("setup")
 def tunnel_setup():
-    """Configure a stable tunnel backend (ngrok or cloudflared) for this machine."""
+    """Configure a tunnel backend (ngrok or cloudflared) for this machine."""
     from rllm.cli._ui import _select_from_menu, abort, console, fail
     from rllm.eval.config import load_tunnel_config, save_tunnel_config
-    from rllm.gateway.tunnel import CloudflaredTunnel, NgrokTunnel
+    from rllm.gateway.tunnel import CloudflaredTunnel, NgrokTunnel, is_ngrok_wildcard_domain
 
     existing = load_tunnel_config()
     backends = [
-        ("ngrok", "ngrok — stable reserved domain, needs a (free) account  [recommended]"),
+        ("ngrok", "ngrok — per-run wildcard (Pay-as-you-go) or fixed reserved domain  [recommended]"),
         ("cloudflared", "cloudflared — free quick tunnel, zero setup, shared & rate-limited"),
     ]
     cursor = next((i for i, (b, _) in enumerate(backends) if b == existing.get("backend")), 0)
@@ -46,6 +72,7 @@ def tunnel_setup():
     backend = backends[idx][0]
 
     domain: str | None = None
+    per_run = False
     if backend == "ngrok":
         if not NgrokTunnel.is_available():
             fail(f"ngrok not found on PATH. {NgrokTunnel.install_hint}")
@@ -60,30 +87,114 @@ def tunnel_setup():
                 subprocess.run(["ngrok", "config", "add-authtoken", token], check=True, capture_output=True, text=True)
                 console.print("  [success]✓[/] ngrok authtoken saved.")
             except subprocess.CalledProcessError as e:
-                fail(f"ngrok rejected the authtoken: {(e.stderr or '').strip() or e}")
-        domain = (
-            click.prompt(
-                "  Reserved domain (e.g. you.ngrok.dev; blank for an ephemeral *.ngrok-free.app URL)",
-                default=existing.get("domain", ""),
-                show_default=bool(existing.get("domain")),
+                detail = (e.stderr or "").strip() or f"exit code {e.returncode}"
+                fail(f"ngrok rejected the authtoken: {detail}")
+
+        existing_domain = str(existing.get("domain") or "")
+        domain_modes = [
+            "Create a persistent wildcard with the ngrok API  [recommended]",
+            "Use an existing wildcard",
+            "Use a fixed reserved domain  [one run at a time]",
+        ]
+        mode_cursor = 1 if is_ngrok_wildcard_domain(existing_domain) else (2 if existing_domain else 0)
+        mode = _select_from_menu("ngrok domain", domain_modes, mode_cursor)
+        if mode is None:
+            abort()
+
+        if mode in (0, 1):
+            per_run = True
+            default_domain = existing_domain if is_ngrok_wildcard_domain(existing_domain) else f"*.rllm-{secrets.token_hex(4)}.ngrok.app"
+            domain = click.prompt(
+                "  Wildcard domain (for example *.rllm-team.ngrok.app)",
+                default=default_domain,
             ).strip()
-            or None
-        )
+            if not is_ngrok_wildcard_domain(domain):
+                fail("An ngrok wildcard must be a valid DNS wildcard such as '*.rllm-team.ngrok.app'.")
+
+            if mode == 0:
+                api_key = click.prompt(
+                    "  ngrok API key (https://dashboard.ngrok.com/api-keys; blank if already configured)",
+                    default="",
+                    hide_input=True,
+                    show_default=False,
+                ).strip()
+                if api_key:
+                    try:
+                        subprocess.run(["ngrok", "config", "add-api-key", api_key], check=True, capture_output=True, text=True)
+                        console.print("  [success]✓[/] ngrok API key saved.")
+                    except subprocess.CalledProcessError as e:
+                        detail = (e.stderr or "").strip() or f"exit code {e.returncode}"
+                        fail(f"ngrok rejected the API key: {detail}")
+                try:
+                    already_reserved = _ngrok_reserved_domain_exists(domain)
+                except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as e:
+                    detail = ((e.stderr or e.stdout or "").strip() if isinstance(e, subprocess.CalledProcessError) else str(e)) or str(e)
+                    fail(f"ngrok could not check {domain}: {detail}")
+                if already_reserved:
+                    console.print(f"  [success]✓[/] [val]{domain}[/] is already reserved on this ngrok account.")
+                else:
+                    try:
+                        subprocess.run(
+                            [
+                                "ngrok",
+                                "api",
+                                "reserved-domains",
+                                "create",
+                                "--domain",
+                                domain,
+                                "--description",
+                                "rLLM per-run gateway tunnels",
+                            ],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                        )
+                        console.print(f"  [success]✓[/] Reserved [val]{domain}[/] with ngrok.")
+                    except subprocess.CalledProcessError as e:
+                        # A second setup process may have won the race between
+                        # our list and create calls. Verify ownership once more
+                        # before treating the create failure as fatal.
+                        try:
+                            created_by_peer = _ngrok_reserved_domain_exists(domain)
+                        except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError):
+                            created_by_peer = False
+                        if created_by_peer:
+                            console.print(f"  [success]✓[/] [val]{domain}[/] is already reserved on this ngrok account.")
+                        else:
+                            detail = (e.stderr or e.stdout or "").strip() or str(e)
+                            fail(f"ngrok could not reserve {domain}: {detail}")
+        else:
+            domain = click.prompt(
+                "  Fixed reserved domain (for example gateway.ngrok.app)",
+                default=existing_domain,
+                show_default=bool(existing_domain),
+            ).strip()
+            if not domain:
+                fail("A fixed ngrok domain is required for this mode.")
+            if "*" in domain:
+                fail("A fixed ngrok domain cannot contain '*'; choose the wildcard mode for per-run endpoints.")
+            console.print("  [muted]A fixed domain can point to only one gateway at a time; concurrent runs need a wildcard.[/]")
     else:
         if not CloudflaredTunnel.is_available():
             fail(f"cloudflared not found on PATH. {CloudflaredTunnel.install_hint}")
         console.print("  [muted]cloudflared quick tunnels are shared and rate-limited (HTTP 429); fine for smoke tests.[/]")
 
-    port = click.prompt(
-        "  Gateway port (must match rllm.gateway.port in training)",
-        default=int(existing.get("port") or DEFAULT_PORT),
-        type=int,
-    )
+    port: int | None = None
+    if not per_run:
+        port = click.prompt(
+            "  Gateway port (must match rllm.gateway.port in training)",
+            default=int(existing.get("port") or DEFAULT_PORT),
+            type=int,
+        )
 
-    save_tunnel_config(backend, domain=domain, port=int(port))
+    save_tunnel_config(backend, domain=domain, port=port)
     summary = backend + (f":{domain}" if domain else "")
-    console.print(f"\n  [success]✓ Tunnel configured:[/] [val]{summary}[/] [muted](gateway port {port})[/]")
-    console.print("  Start it with [key]rllm tunnel up[/]; training picks up the URL automatically.")
+    if per_run:
+        console.print(f"\n  [success]✓ Tunnel configured:[/] [val]{summary}[/]")
+        console.print("  Each remote eval/train run now creates its own ngrok hostname and gateway port automatically.")
+    else:
+        console.print(f"\n  [success]✓ Tunnel configured:[/] [val]{summary}[/] [muted](gateway port {port})[/]")
+        console.print("  Start it with [key]rllm tunnel up[/]; training picks up the URL automatically.")
 
 
 @tunnel.command("up")
@@ -96,6 +207,7 @@ def tunnel_up(backend, port):
     from rllm.gateway.tunnel import (
         TunnelStartError,
         create_tunnel,
+        is_ngrok_wildcard_spec,
         pid_alive,
         read_tunnel_state,
         spawn_detached,
@@ -115,6 +227,8 @@ def tunnel_up(backend, port):
     # Fold a configured reserved domain into a bare "ngrok" spec.
     if resolved_backend == "ngrok" and cfg.get("domain"):
         resolved_backend = f"ngrok:{cfg['domain']}"
+    if is_ngrok_wildcard_spec(resolved_backend):
+        fail("ngrok wildcards are created per eval/train run; run eval or train directly instead of `rllm tunnel up`.")
     resolved_port = port or cfg.get("port") or DEFAULT_PORT
     upstream = f"http://127.0.0.1:{resolved_port}"
 

--- a/rllm/cli/tunnel.py
+++ b/rllm/cli/tunnel.py
@@ -1,15 +1,14 @@
 """rLLM CLI: set up and run the public tunnel that lets remote sandboxes reach the gateway.
 
-``rllm tunnel setup`` records a backend in ``~/.rllm/config.json`` (per-user,
-so nothing personal lands in shared train scripts). A configured ngrok wildcard
-creates an owned endpoint for each eval/train run. Legacy fixed domains and
-cloudflared may instead run as a background daemon via ``rllm tunnel up``.
+``rllm tunnel setup`` records backend settings in ``~/.rllm/config.json``
+(per-user, so nothing personal lands in shared train scripts). ``rllm tunnel up``
+runs that backend as a background daemon and writes its live URL to a state file;
+set ``RLLM_GATEWAY_TUNNEL`` to reuse that URL. Wildcard setups instead create
+an owned tunnel per eval/train run.
 """
 
 from __future__ import annotations
 
-import json
-import secrets
 import subprocess
 
 import click
@@ -18,51 +17,26 @@ import click
 DEFAULT_PORT = 9090
 
 
-def _ngrok_reserved_domain_exists(domain: str) -> bool:
-    """Return whether the authenticated ngrok account already owns ``domain``."""
-    result = subprocess.run(
-        [
-            "ngrok",
-            "api",
-            "reserved-domains",
-            "list",
-            "--limit",
-            "1",
-            "--filter",
-            f'obj.domain == "{domain}"',
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    payload_start = result.stdout.find("{")
-    if payload_start < 0:
-        raise ValueError("ngrok returned no JSON payload")
-    payload = json.loads(result.stdout[payload_start:])
-    return any(entry.get("domain") == domain for entry in payload.get("reserved_domains", []))
-
-
 @click.group("tunnel")
 def tunnel():
     """Set up and run the public tunnel to the model gateway.
 
     Remote sandboxes (Daytona / Modal / Fireworks runtimes) reach the local
-    gateway through this tunnel. Run `rllm tunnel setup` once. An ngrok
-    wildcard is allocated per eval/train run; fixed domains and cloudflared can
-    still be run as a background daemon with `rllm tunnel up`.
+    gateway through this tunnel. A wildcard ngrok setup creates one tunnel per
+    run; fixed domains use `rllm tunnel up` as before.
     """
 
 
 @tunnel.command("setup")
 def tunnel_setup():
-    """Configure a tunnel backend (ngrok or cloudflared) for this machine."""
+    """Configure a stable tunnel backend (ngrok or cloudflared) for this machine."""
     from rllm.cli._ui import _select_from_menu, abort, console, fail
     from rllm.eval.config import load_tunnel_config, save_tunnel_config
-    from rllm.gateway.tunnel import CloudflaredTunnel, NgrokTunnel, is_ngrok_wildcard_domain
+    from rllm.gateway.tunnel import CloudflaredTunnel, NgrokTunnel
 
     existing = load_tunnel_config()
     backends = [
-        ("ngrok", "ngrok — per-run wildcard (Pay-as-you-go) or fixed reserved domain  [recommended]"),
+        ("ngrok", "ngrok — reserved domain or wildcard (wildcards need Pay-as-you-go)  [recommended]"),
         ("cloudflared", "cloudflared — free quick tunnel, zero setup, shared & rate-limited"),
     ]
     cursor = next((i for i, (b, _) in enumerate(backends) if b == existing.get("backend")), 0)
@@ -72,7 +46,6 @@ def tunnel_setup():
     backend = backends[idx][0]
 
     domain: str | None = None
-    per_run = False
     if backend == "ngrok":
         if not NgrokTunnel.is_available():
             fail(f"ngrok not found on PATH. {NgrokTunnel.install_hint}")
@@ -87,100 +60,51 @@ def tunnel_setup():
                 subprocess.run(["ngrok", "config", "add-authtoken", token], check=True, capture_output=True, text=True)
                 console.print("  [success]✓[/] ngrok authtoken saved.")
             except subprocess.CalledProcessError as e:
-                detail = (e.stderr or "").strip() or f"exit code {e.returncode}"
-                fail(f"ngrok rejected the authtoken: {detail}")
-
-        existing_domain = str(existing.get("domain") or "")
-        domain_modes = [
-            "Create a persistent wildcard with the ngrok API  [recommended]",
-            "Use an existing wildcard",
-            "Use a fixed reserved domain  [one run at a time]",
-        ]
-        mode_cursor = 1 if is_ngrok_wildcard_domain(existing_domain) else (2 if existing_domain else 0)
-        mode = _select_from_menu("ngrok domain", domain_modes, mode_cursor)
-        if mode is None:
-            abort()
-
-        if mode in (0, 1):
-            per_run = True
-            default_domain = existing_domain if is_ngrok_wildcard_domain(existing_domain) else f"*.rllm-{secrets.token_hex(4)}.ngrok.app"
-            domain = click.prompt(
-                "  Wildcard domain (for example *.rllm-team.ngrok.app)",
-                default=default_domain,
+                fail(f"ngrok rejected the authtoken: {(e.stderr or '').strip() or e}")
+        domain = (
+            click.prompt(
+                "  Reserved domain or wildcard (e.g. gateway.ngrok.app or *.rllm-team.ngrok.app)",
+                default=existing.get("domain", ""),
+                show_default=bool(existing.get("domain")),
             ).strip()
-            if not is_ngrok_wildcard_domain(domain):
-                fail("An ngrok wildcard must be a valid DNS wildcard such as '*.rllm-team.ngrok.app'.")
-
-            if mode == 0:
-                api_key = click.prompt(
-                    "  ngrok API key (https://dashboard.ngrok.com/api-keys; blank if already configured)",
-                    default="",
-                    hide_input=True,
-                    show_default=False,
-                ).strip()
+            or None
+        )
+        if (
+            domain
+            and domain.startswith("*.")
+            and click.confirm(
+                "  Reserve this wildcard with the ngrok API now?",
+                default=domain != existing.get("domain"),
+            )
+        ):
+            api_key = click.prompt(
+                "  ngrok API key (used once, not saved; blank uses existing config; https://dashboard.ngrok.com/api)",
+                default="",
+                hide_input=True,
+                show_default=False,
+            ).strip()
+            try:
+                command = ["ngrok", "api", "reserved-domains", "create", "--domain", domain, "--description", "rLLM per-run gateway tunnels"]
                 if api_key:
-                    try:
-                        subprocess.run(["ngrok", "config", "add-api-key", api_key], check=True, capture_output=True, text=True)
-                        console.print("  [success]✓[/] ngrok API key saved.")
-                    except subprocess.CalledProcessError as e:
-                        detail = (e.stderr or "").strip() or f"exit code {e.returncode}"
-                        fail(f"ngrok rejected the API key: {detail}")
-                try:
-                    already_reserved = _ngrok_reserved_domain_exists(domain)
-                except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as e:
-                    detail = ((e.stderr or e.stdout or "").strip() if isinstance(e, subprocess.CalledProcessError) else str(e)) or str(e)
-                    fail(f"ngrok could not check {domain}: {detail}")
-                if already_reserved:
-                    console.print(f"  [success]✓[/] [val]{domain}[/] is already reserved on this ngrok account.")
-                else:
-                    try:
-                        subprocess.run(
-                            [
-                                "ngrok",
-                                "api",
-                                "reserved-domains",
-                                "create",
-                                "--domain",
-                                domain,
-                                "--description",
-                                "rLLM per-run gateway tunnels",
-                            ],
-                            check=True,
-                            capture_output=True,
-                            text=True,
-                        )
-                        console.print(f"  [success]✓[/] Reserved [val]{domain}[/] with ngrok.")
-                    except subprocess.CalledProcessError as e:
-                        # A second setup process may have won the race between
-                        # our list and create calls. Verify ownership once more
-                        # before treating the create failure as fatal.
-                        try:
-                            created_by_peer = _ngrok_reserved_domain_exists(domain)
-                        except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError):
-                            created_by_peer = False
-                        if created_by_peer:
-                            console.print(f"  [success]✓[/] [val]{domain}[/] is already reserved on this ngrok account.")
-                        else:
-                            detail = (e.stderr or e.stdout or "").strip() or str(e)
-                            fail(f"ngrok could not reserve {domain}: {detail}")
-        else:
-            domain = click.prompt(
-                "  Fixed reserved domain (for example gateway.ngrok.app)",
-                default=existing_domain,
-                show_default=bool(existing_domain),
-            ).strip()
-            if not domain:
-                fail("A fixed ngrok domain is required for this mode.")
-            if "*" in domain:
-                fail("A fixed ngrok domain cannot contain '*'; choose the wildcard mode for per-run endpoints.")
-            console.print("  [muted]A fixed domain can point to only one gateway at a time; concurrent runs need a wildcard.[/]")
+                    command.extend(["--api-key", api_key])
+                subprocess.run(
+                    command,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                console.print(f"  [success]✓[/] Reserved [val]{domain}[/] with ngrok.")
+            except subprocess.CalledProcessError as e:
+                detail = (e.stderr or e.stdout or "").strip() or f"ngrok exited with status {e.returncode}"
+                detail = detail.replace(api_key, "***") if api_key else detail
+                fail(f"ngrok could not reserve {domain}: {detail}")
     else:
         if not CloudflaredTunnel.is_available():
             fail(f"cloudflared not found on PATH. {CloudflaredTunnel.install_hint}")
         console.print("  [muted]cloudflared quick tunnels are shared and rate-limited (HTTP 429); fine for smoke tests.[/]")
 
     port: int | None = None
-    if not per_run:
+    if not (backend == "ngrok" and domain and domain.startswith("*.")):
         port = click.prompt(
             "  Gateway port (must match rllm.gateway.port in training)",
             default=int(existing.get("port") or DEFAULT_PORT),
@@ -189,12 +113,12 @@ def tunnel_setup():
 
     save_tunnel_config(backend, domain=domain, port=port)
     summary = backend + (f":{domain}" if domain else "")
-    if per_run:
+    if port is None:
         console.print(f"\n  [success]✓ Tunnel configured:[/] [val]{summary}[/]")
-        console.print("  Each remote eval/train run now creates its own ngrok hostname and gateway port automatically.")
+        console.print("  Remote eval/train runs create a unique hostname and gateway port automatically.")
     else:
         console.print(f"\n  [success]✓ Tunnel configured:[/] [val]{summary}[/] [muted](gateway port {port})[/]")
-        console.print("  Start it with [key]rllm tunnel up[/]; training picks up the URL automatically.")
+        console.print("  Start it with [key]rllm tunnel up[/]; set its URL explicitly to reuse this fixed route.")
 
 
 @tunnel.command("up")
@@ -207,7 +131,6 @@ def tunnel_up(backend, port):
     from rllm.gateway.tunnel import (
         TunnelStartError,
         create_tunnel,
-        is_ngrok_wildcard_spec,
         pid_alive,
         read_tunnel_state,
         spawn_detached,
@@ -227,8 +150,6 @@ def tunnel_up(backend, port):
     # Fold a configured reserved domain into a bare "ngrok" spec.
     if resolved_backend == "ngrok" and cfg.get("domain"):
         resolved_backend = f"ngrok:{cfg['domain']}"
-    if is_ngrok_wildcard_spec(resolved_backend):
-        fail("ngrok wildcards are created per eval/train run; run eval or train directly instead of `rllm tunnel up`.")
     resolved_port = port or cfg.get("port") or DEFAULT_PORT
     upstream = f"http://127.0.0.1:{resolved_port}"
 
@@ -246,7 +167,8 @@ def tunnel_up(backend, port):
     write_tunnel_state(backend=resolved_backend, url=url, pid=pid, upstream=upstream, log_path=log_path)
     console.print(f"  [success]✓ Tunnel up:[/] [val]{url}[/] [muted](pid {pid})[/]")
     console.print(f"  [label]logs[/] {log_path}")
-    console.print("  Training runs forward through this automatically. Stop it with [key]rllm tunnel down[/].")
+        console.print(f"  To reuse it, set [key]RLLM_GATEWAY_TUNNEL[/] to this URL and [key]rllm.gateway.port={resolved_port}[/].")
+        console.print("  Stop it with [key]rllm tunnel down[/].")
 
 
 @tunnel.command("status")

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -13,6 +13,7 @@ traces, exactly as they do at training time.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from rllm.eval.results import EvalItem, EvalResult
@@ -23,6 +24,24 @@ if TYPE_CHECKING:
     from rllm.gateway.manager import GatewayManager
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_eval_tunnel() -> str:
+    """Resolve the tunnel for one remote eval invocation.
+
+    Eval gateways are single-run services, so their tunnels must be single-run
+    too: reusing the ``rllm tunnel up`` daemon would force every concurrent eval
+    onto that daemon's one fixed origin port. An explicit environment override
+    still wins; otherwise use a Cloudflare quick tunnel, whose URL is unique per
+    process. Configured persistent backends are deliberately ignored because
+    they may own a singleton endpoint (for example, an ngrok reserved or
+    account-assigned domain). A backend spec makes the gateway choose a free
+    port and own the tunnel lifecycle.
+    """
+    from rllm.gateway.tunnel import ENV_TUNNEL
+
+    explicit = os.getenv(ENV_TUNNEL)
+    return explicit if explicit else "cloudflared"
 
 
 async def run_dataset(
@@ -92,20 +111,14 @@ async def run_dataset(
     # and tear down one ourselves (single-shot).
     owned_gateway = gateway is None
     if owned_gateway:
-        # Auto-tunnel for off-host sandboxes (same predicate AgentTrainer uses).
-        # Resolve like training does: $RLLM_GATEWAY_TUNNEL → a running
-        # `rllm tunnel up` daemon → cloudflared quick-tunnel fallback. Quick
-        # tunnels enforce a 120s origin read timeout, which kills slow
-        # non-streaming LLM calls (CF 524) — a configured ngrok tunnel avoids
-        # that, so eval must honor it, not just training.
+        # Auto-tunnel for off-host sandboxes. Unlike training, each eval owns a
+        # tunnel backed by its own free gateway port; it must not auto-discover
+        # the singleton `rllm tunnel up` daemon and collide on that daemon's
+        # fixed origin port. Explicit URL/backend overrides remain supported.
         gateway_tunnel: str | None = None
         gateway_port: int | None = None
         if not is_local_sandbox_backend(sandbox_backend):
-            from rllm.gateway.tunnel import resolve_auto_tunnel
-
-            gateway_tunnel, tunnel_warning = resolve_auto_tunnel()
-            if tunnel_warning:
-                logger.warning(tunnel_warning)
+            gateway_tunnel = _resolve_eval_tunnel()
             if gateway_tunnel.startswith(("http://", "https://")):
                 # A tunnel URL means an already-running forwarder; the gateway
                 # must bind wherever it forwards (a free-port pick would leave

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -13,7 +13,6 @@ traces, exactly as they do at training time.
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
 from rllm.eval.results import EvalItem, EvalResult
@@ -24,33 +23,6 @@ if TYPE_CHECKING:
     from rllm.gateway.manager import GatewayManager
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_eval_tunnel() -> str:
-    """Resolve the tunnel for one remote eval invocation.
-
-    Eval gateways are single-run services, so their tunnels must be single-run
-    too: reusing the ``rllm tunnel up`` daemon would force every concurrent eval
-    onto that daemon's one fixed origin port. An explicit environment override
-    still wins. A configured ngrok wildcard is safe because each process expands
-    it to a unique child hostname; fixed configured domains remain ignored.
-    Otherwise use a Cloudflare quick tunnel, whose URL is unique per process. A
-    backend spec makes the gateway choose a free port and own the tunnel
-    lifecycle.
-    """
-    from rllm.gateway.tunnel import ENV_TUNNEL, is_ngrok_wildcard_domain
-
-    explicit = os.getenv(ENV_TUNNEL)
-    if explicit:
-        return explicit
-
-    from rllm.eval.config import load_tunnel_config
-
-    configured = load_tunnel_config()
-    domain = configured.get("domain")
-    if configured.get("backend") == "ngrok" and is_ngrok_wildcard_domain(domain):
-        return f"ngrok:{domain}"
-    return "cloudflared"
 
 
 async def run_dataset(
@@ -120,14 +92,16 @@ async def run_dataset(
     # and tear down one ourselves (single-shot).
     owned_gateway = gateway is None
     if owned_gateway:
-        # Auto-tunnel for off-host sandboxes. Unlike training, each eval owns a
-        # tunnel backed by its own free gateway port; it must not auto-discover
-        # the singleton `rllm tunnel up` daemon and collide on that daemon's
-        # fixed origin port. Explicit URL/backend overrides remain supported.
+        # Each remote eval owns its tunnel instead of reusing the singleton
+        # `rllm tunnel up` daemon and its fixed origin port.
         gateway_tunnel: str | None = None
         gateway_port: int | None = None
         if not is_local_sandbox_backend(sandbox_backend):
-            gateway_tunnel = _resolve_eval_tunnel()
+            from rllm.gateway.tunnel import resolve_auto_tunnel
+
+            gateway_tunnel, tunnel_warning = resolve_auto_tunnel()
+            if tunnel_warning:
+                logger.warning(tunnel_warning)
             if gateway_tunnel.startswith(("http://", "https://")):
                 # A tunnel URL means an already-running forwarder; the gateway
                 # must bind wherever it forwards (a free-port pick would leave

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -32,16 +32,25 @@ def _resolve_eval_tunnel() -> str:
     Eval gateways are single-run services, so their tunnels must be single-run
     too: reusing the ``rllm tunnel up`` daemon would force every concurrent eval
     onto that daemon's one fixed origin port. An explicit environment override
-    still wins; otherwise use a Cloudflare quick tunnel, whose URL is unique per
-    process. Configured persistent backends are deliberately ignored because
-    they may own a singleton endpoint (for example, an ngrok reserved or
-    account-assigned domain). A backend spec makes the gateway choose a free
-    port and own the tunnel lifecycle.
+    still wins. A configured ngrok wildcard is safe because each process expands
+    it to a unique child hostname; fixed configured domains remain ignored.
+    Otherwise use a Cloudflare quick tunnel, whose URL is unique per process. A
+    backend spec makes the gateway choose a free port and own the tunnel
+    lifecycle.
     """
-    from rllm.gateway.tunnel import ENV_TUNNEL
+    from rllm.gateway.tunnel import ENV_TUNNEL, is_ngrok_wildcard_domain
 
     explicit = os.getenv(ENV_TUNNEL)
-    return explicit if explicit else "cloudflared"
+    if explicit:
+        return explicit
+
+    from rllm.eval.config import load_tunnel_config
+
+    configured = load_tunnel_config()
+    domain = configured.get("domain")
+    if configured.get("backend") == "ngrok" and is_ngrok_wildcard_domain(domain):
+        return f"ngrok:{domain}"
+    return "cloudflared"
 
 
 async def run_dataset(

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -191,17 +191,17 @@ class GatewayManager:
         gw_cfg = config.rllm.get("gateway", {})
         configured_host = gw_cfg.get("host", None)
         self.host: str = configured_host if configured_host else _get_routable_ip()
+        from rllm.gateway.tunnel import parse_tunnel
+
+        self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
         configured_port = gw_cfg.get("port", None)
-        self.port: int = int(configured_port) if configured_port is not None else DEFAULT_GATEWAY_PORT
+        self.port: int = int(configured_port) if configured_port is not None else (_find_free_port() if self.tunnel_backend else DEFAULT_GATEWAY_PORT)
         self.store: str = gw_cfg.get("store", "memory")
         self.db_path: str | None = gw_cfg.get("db_path", None)
         if self.store not in ("memory", "sqlite"):
             raise ValueError(f"rllm.gateway.store must be 'memory' or 'sqlite', got {self.store!r}")
         if self.store == "memory" and self.db_path:
             raise ValueError("rllm.gateway.db_path is set but store='memory'; set store='sqlite' or clear db_path")
-        from rllm.gateway.tunnel import parse_tunnel
-
-        self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
         _model_cfg = config.get("model", {})
         self.model: str | None = _model_cfg.get("tokenizer_model") or _model_cfg.get("name", None)
 

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -191,7 +191,8 @@ class GatewayManager:
         gw_cfg = config.rllm.get("gateway", {})
         configured_host = gw_cfg.get("host", None)
         self.host: str = configured_host if configured_host else _get_routable_ip()
-        self.port: int = gw_cfg.get("port", DEFAULT_GATEWAY_PORT)
+        configured_port = gw_cfg.get("port", None)
+        self.port: int = int(configured_port) if configured_port is not None else DEFAULT_GATEWAY_PORT
         self.store: str = gw_cfg.get("store", "memory")
         self.db_path: str | None = gw_cfg.get("db_path", None)
         if self.store not in ("memory", "sqlite"):

--- a/rllm/gateway/tunnel.py
+++ b/rllm/gateway/tunnel.py
@@ -7,19 +7,19 @@ backends ship:
 * :class:`CloudflaredTunnel` — ``cloudflared tunnel --url`` →
   ``*.trycloudflare.com``. Zero-setup, but a shared, rate-limited (HTTP 429)
   quick tunnel; fine for smoke tests, not for high-concurrency training.
-* :class:`NgrokTunnel` — ``ngrok http`` → ``*.ngrok-free.app`` or your own
-  reserved domain. Needs a one-time ``rllm tunnel setup`` (authtoken) but is
-  stable across restarts.
+* :class:`NgrokTunnel` — ``ngrok http`` using an account endpoint, a fixed
+  reserved domain, or a unique child of a configured wildcard. Needs a one-time
+  ``rllm tunnel setup`` (authtoken).
 
 :class:`GatewayManager` plumbs the chosen tunnel's :attr:`public_url` into
 :class:`AgentConfig.base_url`. It builds a tunnel from the
 ``rllm.gateway.tunnel`` config via :func:`create_tunnel`.
 
-The ``rllm tunnel`` CLI runs a backend as a *detached daemon*
+The ``rllm tunnel`` CLI can run a fixed backend as a *detached daemon*
 (:func:`spawn_detached`) whose live URL is written to a state file
-(:func:`write_tunnel_state`). Training then auto-discovers that URL via
-:func:`resolve_auto_tunnel` with no per-run config — set
-``rllm.gateway.tunnel`` explicitly only to override.
+(:func:`write_tunnel_state`). Configured ngrok wildcards instead resolve to an
+owned backend per run. Training selects either path via
+:func:`resolve_auto_tunnel`; set ``rllm.gateway.tunnel`` explicitly to override.
 """
 
 from __future__ import annotations
@@ -33,6 +33,7 @@ import signal
 import subprocess
 import threading
 import time
+import uuid
 
 from rich.console import Console
 
@@ -50,6 +51,24 @@ LOCAL_SANDBOX_BACKENDS: frozenset[str] = frozenset({"docker", "local", "apple-co
 # :func:`resolve_auto_tunnel`). Either a backend name ("cloudflared",
 # "ngrok", "ngrok:<domain>") or an explicit http(s):// URL.
 ENV_TUNNEL = "RLLM_GATEWAY_TUNNEL"
+
+
+def is_ngrok_wildcard_domain(domain: str | None) -> bool:
+    """Whether ``domain`` is a valid wildcard hostname template."""
+    if not domain or len(domain) > 253 or not domain.startswith("*."):
+        return False
+    labels = domain[2:].split(".")
+    if len(labels) < 2:
+        return False
+    return all(1 <= len(label) <= 63 and label[0].isalnum() and label[-1].isalnum() and all(char.isascii() and (char.isalnum() or char == "-") for char in label) for label in labels)
+
+
+def is_ngrok_wildcard_spec(value: str | None) -> bool:
+    """Whether a tunnel backend spec requests a per-run ngrok wildcard child."""
+    if not value:
+        return False
+    name, sep, domain = value.partition(":")
+    return bool(sep and name.strip().lower() == "ngrok" and is_ngrok_wildcard_domain(domain.strip()))
 
 
 def is_local_sandbox_backend(name: str | None) -> bool:
@@ -321,9 +340,11 @@ class CloudflaredTunnel(_Tunnel):
 class NgrokTunnel(_Tunnel):
     """Run ``ngrok http <upstream>`` and surface the assigned ngrok URL.
 
-    Pass ``domain`` to pin a reserved domain (e.g. ``rllm.ngrok.dev``);
-    otherwise ngrok assigns an ephemeral ``*.ngrok-free.app`` URL. ngrok needs
-    an authtoken — run ``rllm tunnel setup`` or ``ngrok config add-authtoken``.
+    Pass a fixed ``domain`` to pin one reserved endpoint, or a wildcard template
+    (for example ``*.rllm.example.ngrok.app``) to allocate a unique child
+    hostname for this tunnel instance. Without a domain, ngrok uses the
+    account-assigned endpoint. ngrok needs an authtoken — run
+    ``rllm tunnel setup`` or ``ngrok config add-authtoken``.
     """
 
     name = "ngrok"
@@ -333,7 +354,10 @@ class NgrokTunnel(_Tunnel):
 
     def __init__(self, upstream_url: str, *, domain: str | None = None, **kwargs) -> None:
         super().__init__(upstream_url, **kwargs)
-        self.domain = domain.strip() if domain else None
+        configured_domain = domain.strip() if domain else None
+        if is_ngrok_wildcard_domain(configured_domain):
+            configured_domain = f"rllm-{uuid.uuid4().hex}.{configured_domain[2:]}"
+        self.domain = configured_domain
 
     def _command(self) -> list[str]:
         # ngrok http takes a local addr/port; strip the scheme so we pass
@@ -550,17 +574,15 @@ def live_tunnel_url() -> str | None:
 def resolve_auto_tunnel() -> tuple[str, str | None]:
     """Decide ``rllm.gateway.tunnel`` when it is unset.
 
-    Resolution order: ``$RLLM_GATEWAY_TUNNEL`` → a running ``rllm tunnel up``
-    daemon → a free Cloudflare quick tunnel. Returns ``(value, warning)`` where
-    ``warning`` is a ready-to-log message when falling back to the quick tunnel
-    (and ``None`` otherwise).
+    Resolution order: ``$RLLM_GATEWAY_TUNNEL`` → a configured ngrok wildcard
+    (owned by this run) → a running ``rllm tunnel up`` daemon → a free
+    Cloudflare quick tunnel. Returns ``(value, warning)`` where ``warning`` is a
+    ready-to-log message when falling back to the quick tunnel (and ``None``
+    otherwise).
     """
     env = os.getenv(ENV_TUNNEL)
     if env:
         return env, None
-    live = live_tunnel_url()
-    if live:
-        return live, None
 
     try:
         from rllm.eval.config import load_tunnel_config
@@ -568,6 +590,14 @@ def resolve_auto_tunnel() -> tuple[str, str | None]:
         cfg = load_tunnel_config()
     except Exception:
         cfg = {}
+    configured_domain = cfg.get("domain")
+    if cfg.get("backend") == "ngrok" and is_ngrok_wildcard_domain(configured_domain):
+        return f"ngrok:{configured_domain}", None
+
+    live = live_tunnel_url()
+    if live:
+        return live, None
+
     if cfg.get("backend"):
         warning = (
             f"Tunnel backend {cfg['backend']!r} is configured but no tunnel is running — "

--- a/rllm/gateway/tunnel.py
+++ b/rllm/gateway/tunnel.py
@@ -7,19 +7,18 @@ backends ship:
 * :class:`CloudflaredTunnel` — ``cloudflared tunnel --url`` →
   ``*.trycloudflare.com``. Zero-setup, but a shared, rate-limited (HTTP 429)
   quick tunnel; fine for smoke tests, not for high-concurrency training.
-* :class:`NgrokTunnel` — ``ngrok http`` using an account endpoint, a fixed
-  reserved domain, or a unique child of a configured wildcard. Needs a one-time
-  ``rllm tunnel setup`` (authtoken).
+* :class:`NgrokTunnel` — ``ngrok http`` → ``*.ngrok-free.app`` or your own
+  reserved domain. Needs a one-time ``rllm tunnel setup`` (authtoken) but is
+  stable across restarts.
 
 :class:`GatewayManager` plumbs the chosen tunnel's :attr:`public_url` into
 :class:`AgentConfig.base_url`. It builds a tunnel from the
 ``rllm.gateway.tunnel`` config via :func:`create_tunnel`.
 
-The ``rllm tunnel`` CLI can run a fixed backend as a *detached daemon*
+The ``rllm tunnel`` CLI can also run a backend as a *detached daemon*
 (:func:`spawn_detached`) whose live URL is written to a state file
-(:func:`write_tunnel_state`). Configured ngrok wildcards instead resolve to an
-owned backend per run. Training selects either path via
-:func:`resolve_auto_tunnel`; set ``rllm.gateway.tunnel`` explicitly to override.
+(:func:`write_tunnel_state`). Callers choose whether to reuse that route via
+:func:`resolve_auto_tunnel`; eval and train default to owned per-run tunnels.
 """
 
 from __future__ import annotations
@@ -47,28 +46,10 @@ _status = Console()
 # Sandbox backends that share network with the gateway host.
 LOCAL_SANDBOX_BACKENDS: frozenset[str] = frozenset({"docker", "local", "apple-container"})
 
-# Environment override consulted before the daemon state file (see
+# Environment override consulted before setup config and daemon state (see
 # :func:`resolve_auto_tunnel`). Either a backend name ("cloudflared",
 # "ngrok", "ngrok:<domain>") or an explicit http(s):// URL.
 ENV_TUNNEL = "RLLM_GATEWAY_TUNNEL"
-
-
-def is_ngrok_wildcard_domain(domain: str | None) -> bool:
-    """Whether ``domain`` is a valid wildcard hostname template."""
-    if not domain or len(domain) > 253 or not domain.startswith("*."):
-        return False
-    labels = domain[2:].split(".")
-    if len(labels) < 2:
-        return False
-    return all(1 <= len(label) <= 63 and label[0].isalnum() and label[-1].isalnum() and all(char.isascii() and (char.isalnum() or char == "-") for char in label) for label in labels)
-
-
-def is_ngrok_wildcard_spec(value: str | None) -> bool:
-    """Whether a tunnel backend spec requests a per-run ngrok wildcard child."""
-    if not value:
-        return False
-    name, sep, domain = value.partition(":")
-    return bool(sep and name.strip().lower() == "ngrok" and is_ngrok_wildcard_domain(domain.strip()))
 
 
 def is_local_sandbox_backend(name: str | None) -> bool:
@@ -340,10 +321,8 @@ class CloudflaredTunnel(_Tunnel):
 class NgrokTunnel(_Tunnel):
     """Run ``ngrok http <upstream>`` and surface the assigned ngrok URL.
 
-    Pass a fixed ``domain`` to pin one reserved endpoint, or a wildcard template
-    (for example ``*.rllm.example.ngrok.app``) to allocate a unique child
-    hostname for this tunnel instance. Without a domain, ngrok uses the
-    account-assigned endpoint. ngrok needs an authtoken — run
+    Pass ``domain`` to pin a reserved domain. A wildcard creates a unique child
+    hostname per tunnel instance. ngrok needs an authtoken — run
     ``rllm tunnel setup`` or ``ngrok config add-authtoken``.
     """
 
@@ -354,10 +333,9 @@ class NgrokTunnel(_Tunnel):
 
     def __init__(self, upstream_url: str, *, domain: str | None = None, **kwargs) -> None:
         super().__init__(upstream_url, **kwargs)
-        configured_domain = domain.strip() if domain else None
-        if is_ngrok_wildcard_domain(configured_domain):
-            configured_domain = f"rllm-{uuid.uuid4().hex}.{configured_domain[2:]}"
-        self.domain = configured_domain
+        self.domain = domain.strip() if domain else None
+        if self.domain and self.domain.startswith("*."):
+            self.domain = f"rllm-{uuid.uuid4().hex}.{self.domain[2:]}"
 
     def _command(self) -> list[str]:
         # ngrok http takes a local addr/port; strip the scheme so we pass
@@ -521,7 +499,7 @@ def tunnel_state_path() -> str:
 
 
 def write_tunnel_state(*, backend: str, url: str, pid: int, upstream: str, log_path: str | None = None) -> str:
-    """Record the running daemon tunnel so training can auto-discover its URL."""
+    """Record the running daemon tunnel so callers can explicitly reuse its URL."""
     path = tunnel_state_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
@@ -571,14 +549,12 @@ def live_tunnel_url() -> str | None:
     return state["url"] if state else None
 
 
-def resolve_auto_tunnel() -> tuple[str, str | None]:
+def resolve_auto_tunnel(*, reuse_daemon: bool = False) -> tuple[str, str | None]:
     """Decide ``rllm.gateway.tunnel`` when it is unset.
 
     Resolution order: ``$RLLM_GATEWAY_TUNNEL`` → a configured ngrok wildcard
-    (owned by this run) → a running ``rllm tunnel up`` daemon → a free
-    Cloudflare quick tunnel. Returns ``(value, warning)`` where ``warning`` is a
-    ready-to-log message when falling back to the quick tunnel (and ``None``
-    otherwise).
+    → a running ``rllm tunnel up`` daemon (when ``reuse_daemon``) → a free
+    Cloudflare quick tunnel.
     """
     env = os.getenv(ENV_TUNNEL)
     if env:
@@ -591,14 +567,15 @@ def resolve_auto_tunnel() -> tuple[str, str | None]:
     except Exception:
         cfg = {}
     configured_domain = cfg.get("domain")
-    if cfg.get("backend") == "ngrok" and is_ngrok_wildcard_domain(configured_domain):
+    if cfg.get("backend") == "ngrok" and str(configured_domain).startswith("*."):
         return f"ngrok:{configured_domain}", None
 
-    live = live_tunnel_url()
-    if live:
-        return live, None
+    if reuse_daemon:
+        live = live_tunnel_url()
+        if live:
+            return live, None
 
-    if cfg.get("backend"):
+    if cfg.get("backend") and reuse_daemon:
         warning = (
             f"Tunnel backend {cfg['backend']!r} is configured but no tunnel is running — "
             "run `rllm tunnel up` for a stable tunnel. "
@@ -606,8 +583,9 @@ def resolve_auto_tunnel() -> tuple[str, str | None]:
         )
     else:
         warning = (
-            "No gateway tunnel configured — falling back to a free Cloudflare quick tunnel "
+            "No isolated gateway tunnel configured — falling back to a free Cloudflare quick tunnel "
             "(*.trycloudflare.com): shared infra, rate-limited (HTTP 429) and unsuitable for "
-            "high-concurrency training. Run `rllm tunnel setup` then `rllm tunnel up` for a stable tunnel."
+            "high-concurrency training. Configure an ngrok wildcard with `rllm tunnel setup` "
+            "for an isolated per-run tunnel."
         )
     return "cloudflared", warning

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -344,31 +344,22 @@ def enable_gateway_tunnel(config: DictConfig) -> DictConfig:
     Callers decide *when* (sandboxes run off-host — see
     :func:`scan_env_requirements`); this helper resolves *what*. An explicit
     ``rllm.gateway.tunnel`` always wins; otherwise resolution falls to
-    ``$RLLM_GATEWAY_TUNNEL`` → a configured ngrok wildcard → a running
-    ``rllm tunnel up`` daemon → a free Cloudflare quick tunnel (with a warning) — see
+    ``$RLLM_GATEWAY_TUNNEL`` → a configured ngrok wildcard → a fresh
+    Cloudflare quick tunnel (with a warning) — see
     :func:`rllm.gateway.tunnel.resolve_auto_tunnel`.
     """
     gw = config.rllm.get("gateway", {}) or {}
     if gw.get("tunnel"):
         return config
 
-    from rllm.gateway.tunnel import parse_tunnel, resolve_auto_tunnel
+    from rllm.gateway.tunnel import resolve_auto_tunnel
 
     value, warning = resolve_auto_tunnel()
     if warning:
         logger.warning(warning)
-    gateway_config: dict[str, object] = {"tunnel": value}
-    _, owned_backend = parse_tunnel(value)
-    if owned_backend and gw.get("port") is None:
-        # An owned tunnel needs a run-local origin port unless the caller
-        # explicitly pinned one. This happens before UnifiedTrainer's port
-        # preflight and GatewayManager construction.
-        from rllm.gateway.manager import _find_free_port
-
-        gateway_config["port"] = _find_free_port()
     return OmegaConf.merge(
         config,
-        OmegaConf.create({"rllm": {"gateway": gateway_config}}),
+        OmegaConf.create({"rllm": {"gateway": {"tunnel": value}}}),
     )
 
 

--- a/rllm/hooks.py
+++ b/rllm/hooks.py
@@ -344,22 +344,31 @@ def enable_gateway_tunnel(config: DictConfig) -> DictConfig:
     Callers decide *when* (sandboxes run off-host — see
     :func:`scan_env_requirements`); this helper resolves *what*. An explicit
     ``rllm.gateway.tunnel`` always wins; otherwise resolution falls to
-    ``$RLLM_GATEWAY_TUNNEL`` → a running ``rllm tunnel up`` daemon → a free
-    Cloudflare quick tunnel (with a warning) — see
+    ``$RLLM_GATEWAY_TUNNEL`` → a configured ngrok wildcard → a running
+    ``rllm tunnel up`` daemon → a free Cloudflare quick tunnel (with a warning) — see
     :func:`rllm.gateway.tunnel.resolve_auto_tunnel`.
     """
     gw = config.rllm.get("gateway", {}) or {}
     if gw.get("tunnel"):
         return config
 
-    from rllm.gateway.tunnel import resolve_auto_tunnel
+    from rllm.gateway.tunnel import parse_tunnel, resolve_auto_tunnel
 
     value, warning = resolve_auto_tunnel()
     if warning:
         logger.warning(warning)
+    gateway_config: dict[str, object] = {"tunnel": value}
+    _, owned_backend = parse_tunnel(value)
+    if owned_backend and gw.get("port") is None:
+        # An owned tunnel needs a run-local origin port unless the caller
+        # explicitly pinned one. This happens before UnifiedTrainer's port
+        # preflight and GatewayManager construction.
+        from rllm.gateway.manager import _find_free_port
+
+        gateway_config["port"] = _find_free_port()
     return OmegaConf.merge(
         config,
-        OmegaConf.create({"rllm": {"gateway": {"tunnel": value}}}),
+        OmegaConf.create({"rllm": {"gateway": gateway_config}}),
     )
 
 

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -161,7 +161,7 @@ remote_runtime:
 
 # Gateway Configuration (model gateway for AgentFlow-based training)
 gateway:
-  port: 9090
+  port: null          # Auto-select for an owned tunnel; otherwise defaults to 9090. Set an integer to pin it.
   host: null          # Auto-detects routable IP; set explicitly to override
   num_workers: 0      # 0 = gateway runs in a trainer thread (shares the trainer's GIL).
                       # 1 = run it in its own process (own event loop/GIL; recommended when the
@@ -170,9 +170,10 @@ gateway:
                       # session-sharding front on `port`, to spread the gateway's per-request CPU
                       # across cores. Use when one gateway process still saturates its core.
   tunnel: null        # Reach the gateway from remote sandboxes. When null and a run uses remote
-                      # sandboxes, it auto-resolves: $RLLM_GATEWAY_TUNNEL -> a running `rllm tunnel up`
-                      # daemon -> a free Cloudflare quick tunnel (shared/rate-limited; warns). Or set
-                      # explicitly to a backend to auto-spawn ("cloudflared", "ngrok", "ngrok:<domain>")
+                      # sandboxes, it auto-resolves: $RLLM_GATEWAY_TUNNEL -> a configured ngrok wildcard
+                      # -> a running `rllm tunnel up` daemon -> a free Cloudflare quick tunnel
+                      # (shared/rate-limited; warns). Or set explicitly to a backend to auto-spawn
+                      # ("cloudflared", "ngrok", "ngrok:<domain>").
                       # or an http(s):// URL reachable from the sandbox (tailscale IP, bore/frp, etc.).
                       # For a stable tunnel with no per-run config: `rllm tunnel setup` then `rllm tunnel up`.
   store: memory       # "memory" (non-persistent) | "sqlite" (writes traces to disk)

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -161,7 +161,7 @@ remote_runtime:
 
 # Gateway Configuration (model gateway for AgentFlow-based training)
 gateway:
-  port: null          # Auto-select for an owned tunnel; otherwise defaults to 9090. Set an integer to pin it.
+  port: null          # Owned tunnels auto-select; otherwise defaults to 9090
   host: null          # Auto-detects routable IP; set explicitly to override
   num_workers: 0      # 0 = gateway runs in a trainer thread (shares the trainer's GIL).
                       # 1 = run it in its own process (own event loop/GIL; recommended when the
@@ -170,12 +170,11 @@ gateway:
                       # session-sharding front on `port`, to spread the gateway's per-request CPU
                       # across cores. Use when one gateway process still saturates its core.
   tunnel: null        # Reach the gateway from remote sandboxes. When null and a run uses remote
-                      # sandboxes, it auto-resolves: $RLLM_GATEWAY_TUNNEL -> a configured ngrok wildcard
-                      # -> a running `rllm tunnel up` daemon -> a free Cloudflare quick tunnel
-                      # (shared/rate-limited; warns). Or set explicitly to a backend to auto-spawn
-                      # ("cloudflared", "ngrok", "ngrok:<domain>").
+                      # sandboxes, it auto-resolves: $RLLM_GATEWAY_TUNNEL -> a configured ngrok
+                      # wildcard -> a fresh Cloudflare quick tunnel (shared/rate-limited; warns). Or set
+                      # explicitly to a backend to auto-spawn ("cloudflared", "ngrok", "ngrok:<domain>")
                       # or an http(s):// URL reachable from the sandbox (tailscale IP, bore/frp, etc.).
-                      # For a stable tunnel with no per-run config: `rllm tunnel setup` then `rllm tunnel up`.
+                      # `rllm tunnel setup` can reserve a wildcard for isolated per-run ngrok URLs.
   store: memory       # "memory" (non-persistent) | "sqlite" (writes traces to disk)
   db_path: null       # Only used when store=sqlite; null → auto-resolved path (logged at startup)
   # Sampling params attached to a session overwrite those keys on every LLM call;

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -170,7 +170,8 @@ class UnifiedTrainer:
             # check the port here so a conflict fails before any of that.
             from rllm.gateway.manager import DEFAULT_GATEWAY_PORT, preflight_gateway_port
 
-            preflight_gateway_port((config.rllm.get("gateway", {}) or {}).get("port", DEFAULT_GATEWAY_PORT))
+            configured_port = (config.rllm.get("gateway", {}) or {}).get("port", None)
+            preflight_gateway_port(int(configured_port) if configured_port is not None else DEFAULT_GATEWAY_PORT)
 
         self.workflow_class = workflow_class
         self.workflow_args = workflow_args or {}

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -169,9 +169,13 @@ class UnifiedTrainer:
             # the backend has provisioned rollout infra (minutes on Fireworks) —
             # check the port here so a conflict fails before any of that.
             from rllm.gateway.manager import DEFAULT_GATEWAY_PORT, preflight_gateway_port
+            from rllm.gateway.tunnel import parse_tunnel
 
-            configured_port = (config.rllm.get("gateway", {}) or {}).get("port", None)
-            preflight_gateway_port(int(configured_port) if configured_port is not None else DEFAULT_GATEWAY_PORT)
+            gateway = config.rllm.get("gateway", {}) or {}
+            configured_port = gateway.get("port", None)
+            _, owned_backend = parse_tunnel(gateway.get("tunnel", None))
+            if configured_port is not None or not owned_backend:
+                preflight_gateway_port(int(configured_port) if configured_port is not None else DEFAULT_GATEWAY_PORT)
 
         self.workflow_class = workflow_class
         self.workflow_args = workflow_args or {}

--- a/tests/cli/test_tunnel_command.py
+++ b/tests/cli/test_tunnel_command.py
@@ -49,6 +49,17 @@ def test_setup_can_use_existing_wildcard_without_api_call(monkeypatch):
     assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.existing.ngrok.app"}
 
 
+def test_setup_accepts_already_reserved_wildcard(monkeypatch):
+    error = subprocess.CalledProcessError(1, ["ngrok"], stderr="This domain is already reserved. [ERR_NGROK_413]")
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(error))
+
+    result = CliRunner().invoke(cli, ["tunnel", "setup"], input="1\n\n*.existing.ngrok.app\ny\n\n")
+
+    assert result.exit_code == 0, result.output
+    assert "already reserved" in result.output
+    assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.existing.ngrok.app"}
+
+
 def test_fixed_domain_keeps_configured_port(monkeypatch):
     monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected ngrok call")))
 

--- a/tests/cli/test_tunnel_command.py
+++ b/tests/cli/test_tunnel_command.py
@@ -1,0 +1,151 @@
+"""Tests for one-time gateway tunnel setup."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from rllm.cli.main import cli
+from rllm.eval.config import load_tunnel_config, save_tunnel_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("RLLM_HOME", str(tmp_path / ".rllm"))
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _ngrok_available(monkeypatch):
+    from rllm.gateway.tunnel import NgrokTunnel
+
+    monkeypatch.setattr(NgrokTunnel, "is_available", classmethod(lambda cls: True))
+
+
+def test_setup_creates_and_saves_wildcard_without_port_or_secrets(runner, monkeypatch):
+    calls: list[list[str]] = []
+
+    def _run(command, **kwargs):
+        calls.append(command)
+        if command[1:4] == ["api", "reserved-domains", "list"]:
+            return subprocess.CompletedProcess(command, 0, stdout='200 OK\n{"reserved_domains": []}', stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="201 Created\n{}", stderr="")
+
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _run)
+
+    result = runner.invoke(
+        cli,
+        ["tunnel", "setup"],
+        input="1\n\n1\n*.rllm-team.ngrok.app\napi-secret\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls[0][:3] == ["ngrok", "config", "add-api-key"]
+    assert calls[1][1:4] == ["api", "reserved-domains", "list"]
+    assert calls[2] == [
+        "ngrok",
+        "api",
+        "reserved-domains",
+        "create",
+        "--domain",
+        "*.rllm-team.ngrok.app",
+        "--description",
+        "rLLM per-run gateway tunnels",
+    ]
+    assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.rllm-team.ngrok.app"}
+    assert "api-secret" not in result.output
+    assert "own ngrok hostname and gateway port" in result.output
+
+
+def test_setup_uses_existing_wildcard_without_api_call(runner, monkeypatch):
+    def _unexpected_run(*args, **kwargs):
+        raise AssertionError("existing wildcard setup must not call ngrok")
+
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _unexpected_run)
+
+    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n2\n*.existing.ngrok.app\n")
+
+    assert result.exit_code == 0, result.output
+    assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.existing.ngrok.app"}
+
+
+def test_setup_keeps_fixed_domain_and_port_with_warning(runner, monkeypatch):
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0))
+
+    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n3\ngateway.ngrok.app\n9191\n")
+
+    assert result.exit_code == 0, result.output
+    assert load_tunnel_config() == {"backend": "ngrok", "domain": "gateway.ngrok.app", "port": 9191}
+    assert "only one gateway at a time" in result.output
+
+
+def test_failed_wildcard_reservation_preserves_existing_config(runner, monkeypatch):
+    save_tunnel_config("cloudflared", port=9090)
+
+    def _fail(command, **kwargs):
+        if command[1:4] == ["api", "reserved-domains", "list"]:
+            return subprocess.CompletedProcess(command, 0, stdout='200 OK\n{"reserved_domains": []}', stderr="")
+        raise subprocess.CalledProcessError(1, command, stderr="ERR_NGROK_419 plan does not support wildcards")
+
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _fail)
+
+    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n1\n*.new.ngrok.app\n\n")
+
+    assert result.exit_code == 1
+    assert "ERR_NGROK_419" in result.output
+    assert load_tunnel_config() == {"backend": "cloudflared", "port": 9090}
+
+
+def test_create_mode_is_idempotent_for_owned_wildcard(runner, monkeypatch):
+    calls: list[list[str]] = []
+
+    def _run(command, **kwargs):
+        calls.append(command)
+        payload = '{"reserved_domains": [{"domain": "*.existing.ngrok.app"}]}'
+        return subprocess.CompletedProcess(command, 0, stdout=f"200 OK\n{payload}", stderr="")
+
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _run)
+
+    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n1\n*.existing.ngrok.app\n\n")
+
+    assert result.exit_code == 0, result.output
+    assert [command[1:4] for command in calls] == [["api", "reserved-domains", "list"]]
+    assert "already reserved" in result.output
+    assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.existing.ngrok.app"}
+
+
+def test_wildcard_mode_rejects_fixed_domain_before_api_call(runner, monkeypatch):
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must validate first")))
+
+    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n2\nnot-a-wildcard.ngrok.app\n")
+
+    assert result.exit_code == 1
+    assert "valid DNS wildcard" in result.output
+
+
+@pytest.mark.parametrize(
+    "domain",
+    ["*.", "*.single-label", "*.https://bad.example", "*.bad/example.com", "*.bad example.com", "*.bad:443.example.com"],
+)
+def test_wildcard_mode_rejects_invalid_hostnames(runner, monkeypatch, domain):
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must validate first")))
+
+    result = runner.invoke(cli, ["tunnel", "setup"], input=f"1\n\n2\n{domain}\n")
+
+    assert result.exit_code == 1
+    assert "ngrok wildcard" in result.output
+
+
+def test_tunnel_up_rejects_per_run_wildcard(runner):
+    save_tunnel_config("ngrok", domain="*.rllm-team.ngrok.app")
+
+    result = runner.invoke(cli, ["tunnel", "up"])
+
+    assert result.exit_code == 1
+    assert "created per eval/train run" in result.output

--- a/tests/cli/test_tunnel_command.py
+++ b/tests/cli/test_tunnel_command.py
@@ -1,4 +1,4 @@
-"""Tests for one-time gateway tunnel setup."""
+"""Focused tests for ngrok wildcard setup."""
 
 from __future__ import annotations
 
@@ -12,140 +12,47 @@ from rllm.eval.config import load_tunnel_config, save_tunnel_config
 
 
 @pytest.fixture(autouse=True)
-def _isolated_home(monkeypatch, tmp_path):
+def _setup(monkeypatch, tmp_path):
     monkeypatch.setenv("RLLM_HOME", str(tmp_path / ".rllm"))
+    monkeypatch.setattr("rllm.gateway.tunnel.NgrokTunnel.is_available", classmethod(lambda cls: True))
 
 
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture(autouse=True)
-def _ngrok_available(monkeypatch):
-    from rllm.gateway.tunnel import NgrokTunnel
-
-    monkeypatch.setattr(NgrokTunnel, "is_available", classmethod(lambda cls: True))
-
-
-def test_setup_creates_and_saves_wildcard_without_port_or_secrets(runner, monkeypatch):
-    calls: list[list[str]] = []
+def test_setup_can_reserve_wildcard_without_saving_api_key(monkeypatch):
+    calls = []
 
     def _run(command, **kwargs):
-        calls.append(command)
-        if command[1:4] == ["api", "reserved-domains", "list"]:
-            return subprocess.CompletedProcess(command, 0, stdout='200 OK\n{"reserved_domains": []}', stderr="")
-        return subprocess.CompletedProcess(command, 0, stdout="201 Created\n{}", stderr="")
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout="201 Created", stderr="")
 
     monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _run)
-
-    result = runner.invoke(
+    result = CliRunner().invoke(
         cli,
         ["tunnel", "setup"],
-        input="1\n\n1\n*.rllm-team.ngrok.app\napi-secret\n",
+        input="1\n\n*.rllm-team.ngrok.app\ny\napi-secret\n",
     )
 
     assert result.exit_code == 0, result.output
-    assert calls[0][:3] == ["ngrok", "config", "add-api-key"]
-    assert calls[1][1:4] == ["api", "reserved-domains", "list"]
-    assert calls[2] == [
-        "ngrok",
-        "api",
-        "reserved-domains",
-        "create",
-        "--domain",
-        "*.rllm-team.ngrok.app",
-        "--description",
-        "rLLM per-run gateway tunnels",
-    ]
-    assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.rllm-team.ngrok.app"}
+    command, kwargs = calls[0]
+    assert command[:4] == ["ngrok", "api", "reserved-domains", "create"]
+    assert command[-2:] == ["--api-key", "api-secret"]
     assert "api-secret" not in result.output
-    assert "own ngrok hostname and gateway port" in result.output
+    assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.rllm-team.ngrok.app"}
 
 
-def test_setup_uses_existing_wildcard_without_api_call(runner, monkeypatch):
-    def _unexpected_run(*args, **kwargs):
-        raise AssertionError("existing wildcard setup must not call ngrok")
+def test_setup_can_use_existing_wildcard_without_api_call(monkeypatch):
+    save_tunnel_config("ngrok", domain="*.existing.ngrok.app")
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected ngrok call")))
 
-    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _unexpected_run)
-
-    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n2\n*.existing.ngrok.app\n")
+    result = CliRunner().invoke(cli, ["tunnel", "setup"], input="1\n\n\n\n")
 
     assert result.exit_code == 0, result.output
     assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.existing.ngrok.app"}
 
 
-def test_setup_keeps_fixed_domain_and_port_with_warning(runner, monkeypatch):
-    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0))
+def test_fixed_domain_keeps_configured_port(monkeypatch):
+    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected ngrok call")))
 
-    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n3\ngateway.ngrok.app\n9191\n")
+    result = CliRunner().invoke(cli, ["tunnel", "setup"], input="1\n\ngateway.ngrok.app\n9191\n")
 
     assert result.exit_code == 0, result.output
     assert load_tunnel_config() == {"backend": "ngrok", "domain": "gateway.ngrok.app", "port": 9191}
-    assert "only one gateway at a time" in result.output
-
-
-def test_failed_wildcard_reservation_preserves_existing_config(runner, monkeypatch):
-    save_tunnel_config("cloudflared", port=9090)
-
-    def _fail(command, **kwargs):
-        if command[1:4] == ["api", "reserved-domains", "list"]:
-            return subprocess.CompletedProcess(command, 0, stdout='200 OK\n{"reserved_domains": []}', stderr="")
-        raise subprocess.CalledProcessError(1, command, stderr="ERR_NGROK_419 plan does not support wildcards")
-
-    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _fail)
-
-    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n1\n*.new.ngrok.app\n\n")
-
-    assert result.exit_code == 1
-    assert "ERR_NGROK_419" in result.output
-    assert load_tunnel_config() == {"backend": "cloudflared", "port": 9090}
-
-
-def test_create_mode_is_idempotent_for_owned_wildcard(runner, monkeypatch):
-    calls: list[list[str]] = []
-
-    def _run(command, **kwargs):
-        calls.append(command)
-        payload = '{"reserved_domains": [{"domain": "*.existing.ngrok.app"}]}'
-        return subprocess.CompletedProcess(command, 0, stdout=f"200 OK\n{payload}", stderr="")
-
-    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", _run)
-
-    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n1\n*.existing.ngrok.app\n\n")
-
-    assert result.exit_code == 0, result.output
-    assert [command[1:4] for command in calls] == [["api", "reserved-domains", "list"]]
-    assert "already reserved" in result.output
-    assert load_tunnel_config() == {"backend": "ngrok", "domain": "*.existing.ngrok.app"}
-
-
-def test_wildcard_mode_rejects_fixed_domain_before_api_call(runner, monkeypatch):
-    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must validate first")))
-
-    result = runner.invoke(cli, ["tunnel", "setup"], input="1\n\n2\nnot-a-wildcard.ngrok.app\n")
-
-    assert result.exit_code == 1
-    assert "valid DNS wildcard" in result.output
-
-
-@pytest.mark.parametrize(
-    "domain",
-    ["*.", "*.single-label", "*.https://bad.example", "*.bad/example.com", "*.bad example.com", "*.bad:443.example.com"],
-)
-def test_wildcard_mode_rejects_invalid_hostnames(runner, monkeypatch, domain):
-    monkeypatch.setattr("rllm.cli.tunnel.subprocess.run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must validate first")))
-
-    result = runner.invoke(cli, ["tunnel", "setup"], input=f"1\n\n2\n{domain}\n")
-
-    assert result.exit_code == 1
-    assert "ngrok wildcard" in result.output
-
-
-def test_tunnel_up_rejects_per_run_wildcard(runner):
-    save_tunnel_config("ngrok", domain="*.rllm-team.ngrok.app")
-
-    result = runner.invoke(cli, ["tunnel", "up"])
-
-    assert result.exit_code == 1
-    assert "created per eval/train run" in result.output

--- a/tests/engine/test_gateway_tunnel.py
+++ b/tests/engine/test_gateway_tunnel.py
@@ -1,0 +1,113 @@
+"""Tunnel backend templates and automatic train-side wiring."""
+
+from __future__ import annotations
+
+from omegaconf import OmegaConf
+
+from rllm.gateway.tunnel import NgrokTunnel, create_tunnel
+
+
+def test_ngrok_wildcard_expands_once_per_tunnel():
+    first = create_tunnel("ngrok:*.rllm.example.ngrok.app", "http://127.0.0.1:9101")
+    second = create_tunnel("ngrok:*.rllm.example.ngrok.app", "http://127.0.0.1:9102")
+
+    assert isinstance(first, NgrokTunnel)
+    assert isinstance(second, NgrokTunnel)
+    first_url = first._command()[first._command().index("--url") + 1]
+    second_url = second._command()[second._command().index("--url") + 1]
+    assert first_url.startswith("https://rllm-")
+    assert first_url.endswith(".rllm.example.ngrok.app")
+    assert first_url != second_url
+    assert first._command()[first._command().index("--url") + 1] == first_url
+
+
+def test_fixed_ngrok_domain_is_unchanged():
+    tunnel = create_tunnel("ngrok:gateway.example.ngrok.app", "http://127.0.0.1:9090")
+
+    command = tunnel._command()
+    assert command[command.index("--url") + 1] == "https://gateway.example.ngrok.app"
+
+
+def test_unset_gateway_port_keeps_legacy_9090_without_auto_wiring():
+    from rllm.gateway.manager import GatewayManager
+
+    config = OmegaConf.create({"rllm": {"gateway": {"port": None}}, "model": {"name": "probe"}})
+
+    assert GatewayManager(config).port == 9090
+
+
+def test_train_auto_resolution_prefers_configured_wildcard(monkeypatch):
+    import rllm.eval.config as config_mod
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.delenv(tunnel_mod.ENV_TUNNEL, raising=False)
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"backend": "ngrok", "domain": "*.rllm.example.ngrok.app"})
+    monkeypatch.setattr(tunnel_mod, "live_tunnel_url", lambda: (_ for _ in ()).throw(AssertionError("daemon must not win")))
+
+    assert tunnel_mod.resolve_auto_tunnel() == ("ngrok:*.rllm.example.ngrok.app", None)
+
+
+def test_train_wildcard_gets_automatic_gateway_port(monkeypatch):
+    import rllm.gateway.manager as manager_mod
+    import rllm.gateway.tunnel as tunnel_mod
+    import rllm.hooks as hooks_mod
+
+    config = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": None}}})
+    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: ("ngrok:*.rllm.example.ngrok.app", None))
+    monkeypatch.setattr(manager_mod, "_find_free_port", lambda: 49123)
+
+    resolved = hooks_mod.enable_gateway_tunnel(config)
+
+    assert resolved.rllm.gateway.tunnel == "ngrok:*.rllm.example.ngrok.app"
+    assert resolved.rllm.gateway.port == 49123
+
+
+def test_train_wildcard_preserves_explicit_gateway_port(monkeypatch):
+    import rllm.gateway.tunnel as tunnel_mod
+    import rllm.hooks as hooks_mod
+
+    config = OmegaConf.create({"rllm": {"gateway": {"port": 9191, "tunnel": None}}})
+    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: ("ngrok:*.rllm.example.ngrok.app", None))
+
+    resolved = hooks_mod.enable_gateway_tunnel(config)
+
+    assert resolved.rllm.gateway.tunnel == "ngrok:*.rllm.example.ngrok.app"
+    assert resolved.rllm.gateway.port == 9191
+
+
+def test_train_cloudflared_default_gets_automatic_gateway_port(monkeypatch):
+    import rllm.gateway.manager as manager_mod
+    import rllm.gateway.tunnel as tunnel_mod
+    import rllm.hooks as hooks_mod
+
+    config = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": None}}})
+    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: ("cloudflared", None))
+    monkeypatch.setattr(manager_mod, "_find_free_port", lambda: 49124)
+
+    resolved = hooks_mod.enable_gateway_tunnel(config)
+
+    assert resolved.rllm.gateway.tunnel == "cloudflared"
+    assert resolved.rllm.gateway.port == 49124
+
+
+def test_train_environment_wildcard_gets_automatic_gateway_port(monkeypatch):
+    import rllm.gateway.manager as manager_mod
+    import rllm.gateway.tunnel as tunnel_mod
+    import rllm.hooks as hooks_mod
+
+    config = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": None}}})
+    monkeypatch.setenv(tunnel_mod.ENV_TUNNEL, "ngrok:*.env.example.ngrok.app")
+    monkeypatch.setattr(manager_mod, "_find_free_port", lambda: 49125)
+
+    resolved = hooks_mod.enable_gateway_tunnel(config)
+
+    assert resolved.rllm.gateway.tunnel == "ngrok:*.env.example.ngrok.app"
+    assert resolved.rllm.gateway.port == 49125
+
+
+def test_explicit_train_tunnel_and_port_are_unchanged():
+    from rllm.hooks import enable_gateway_tunnel
+
+    config = OmegaConf.create({"rllm": {"gateway": {"port": 9191, "tunnel": "ngrok:fixed.example.ngrok.app"}}})
+
+    assert enable_gateway_tunnel(config) is config

--- a/tests/engine/test_gateway_tunnel.py
+++ b/tests/engine/test_gateway_tunnel.py
@@ -1,42 +1,30 @@
-"""Tunnel backend templates and automatic train-side wiring."""
+"""Focused tests for owned tunnel isolation."""
 
 from __future__ import annotations
 
 from omegaconf import OmegaConf
 
-from rllm.gateway.tunnel import NgrokTunnel, create_tunnel
+from rllm.gateway.tunnel import create_tunnel
+
+
+def _ngrok_url(tunnel) -> str:
+    command = tunnel._command()
+    return command[command.index("--url") + 1]
 
 
 def test_ngrok_wildcard_expands_once_per_tunnel():
     first = create_tunnel("ngrok:*.rllm.example.ngrok.app", "http://127.0.0.1:9101")
     second = create_tunnel("ngrok:*.rllm.example.ngrok.app", "http://127.0.0.1:9102")
+    first_url = _ngrok_url(first)
 
-    assert isinstance(first, NgrokTunnel)
-    assert isinstance(second, NgrokTunnel)
-    first_url = first._command()[first._command().index("--url") + 1]
-    second_url = second._command()[second._command().index("--url") + 1]
     assert first_url.startswith("https://rllm-")
     assert first_url.endswith(".rllm.example.ngrok.app")
-    assert first_url != second_url
-    assert first._command()[first._command().index("--url") + 1] == first_url
+    assert first_url != _ngrok_url(second)
+    assert first_url == _ngrok_url(first)
+    assert _ngrok_url(create_tunnel("ngrok:fixed.ngrok.app", "http://127.0.0.1:9090")) == "https://fixed.ngrok.app"
 
 
-def test_fixed_ngrok_domain_is_unchanged():
-    tunnel = create_tunnel("ngrok:gateway.example.ngrok.app", "http://127.0.0.1:9090")
-
-    command = tunnel._command()
-    assert command[command.index("--url") + 1] == "https://gateway.example.ngrok.app"
-
-
-def test_unset_gateway_port_keeps_legacy_9090_without_auto_wiring():
-    from rllm.gateway.manager import GatewayManager
-
-    config = OmegaConf.create({"rllm": {"gateway": {"port": None}}, "model": {"name": "probe"}})
-
-    assert GatewayManager(config).port == 9090
-
-
-def test_train_auto_resolution_prefers_configured_wildcard(monkeypatch):
+def test_configured_wildcard_precedes_daemon(monkeypatch):
     import rllm.eval.config as config_mod
     import rllm.gateway.tunnel as tunnel_mod
 
@@ -47,67 +35,47 @@ def test_train_auto_resolution_prefers_configured_wildcard(monkeypatch):
     assert tunnel_mod.resolve_auto_tunnel() == ("ngrok:*.rllm.example.ngrok.app", None)
 
 
-def test_train_wildcard_gets_automatic_gateway_port(monkeypatch):
-    import rllm.gateway.manager as manager_mod
+def test_environment_override_precedes_wildcard(monkeypatch):
+    import rllm.eval.config as config_mod
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setenv(tunnel_mod.ENV_TUNNEL, "ngrok")
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"backend": "ngrok", "domain": "*.rllm.example.ngrok.app"})
+
+    assert tunnel_mod.resolve_auto_tunnel() == ("ngrok", None)
+
+
+def test_default_resolution_skips_daemon(monkeypatch):
+    import rllm.eval.config as config_mod
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.delenv(tunnel_mod.ENV_TUNNEL, raising=False)
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {})
+    monkeypatch.setattr(tunnel_mod, "live_tunnel_url", lambda: "https://daemon.example")
+
+    value, _ = tunnel_mod.resolve_auto_tunnel()
+    assert value == "cloudflared"
+    assert tunnel_mod.resolve_auto_tunnel(reuse_daemon=True) == ("https://daemon.example", None)
+
+
+def test_train_resolution_skips_daemon(monkeypatch):
     import rllm.gateway.tunnel as tunnel_mod
     import rllm.hooks as hooks_mod
 
-    config = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": None}}})
-    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: ("ngrok:*.rllm.example.ngrok.app", None))
-    monkeypatch.setattr(manager_mod, "_find_free_port", lambda: 49123)
-
-    resolved = hooks_mod.enable_gateway_tunnel(config)
-
-    assert resolved.rllm.gateway.tunnel == "ngrok:*.rllm.example.ngrok.app"
-    assert resolved.rllm.gateway.port == 49123
-
-
-def test_train_wildcard_preserves_explicit_gateway_port(monkeypatch):
-    import rllm.gateway.tunnel as tunnel_mod
-    import rllm.hooks as hooks_mod
-
-    config = OmegaConf.create({"rllm": {"gateway": {"port": 9191, "tunnel": None}}})
-    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: ("ngrok:*.rllm.example.ngrok.app", None))
-
-    resolved = hooks_mod.enable_gateway_tunnel(config)
-
-    assert resolved.rllm.gateway.tunnel == "ngrok:*.rllm.example.ngrok.app"
-    assert resolved.rllm.gateway.port == 9191
-
-
-def test_train_cloudflared_default_gets_automatic_gateway_port(monkeypatch):
-    import rllm.gateway.manager as manager_mod
-    import rllm.gateway.tunnel as tunnel_mod
-    import rllm.hooks as hooks_mod
-
-    config = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": None}}})
     monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: ("cloudflared", None))
-    monkeypatch.setattr(manager_mod, "_find_free_port", lambda: 49124)
+    config = OmegaConf.create({"rllm": {"gateway": {"tunnel": None}}})
 
-    resolved = hooks_mod.enable_gateway_tunnel(config)
-
-    assert resolved.rllm.gateway.tunnel == "cloudflared"
-    assert resolved.rllm.gateway.port == 49124
+    assert hooks_mod.enable_gateway_tunnel(config).rllm.gateway.tunnel == "cloudflared"
 
 
-def test_train_environment_wildcard_gets_automatic_gateway_port(monkeypatch):
+def test_owned_tunnel_gets_free_port_unless_explicit(monkeypatch):
     import rllm.gateway.manager as manager_mod
-    import rllm.gateway.tunnel as tunnel_mod
-    import rllm.hooks as hooks_mod
 
-    config = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": None}}})
-    monkeypatch.setenv(tunnel_mod.ENV_TUNNEL, "ngrok:*.env.example.ngrok.app")
-    monkeypatch.setattr(manager_mod, "_find_free_port", lambda: 49125)
+    monkeypatch.setattr(manager_mod, "_find_free_port", lambda: 49123)
+    automatic = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": "cloudflared"}}, "model": {"name": "probe"}})
+    explicit = OmegaConf.create({"rllm": {"gateway": {"port": 9191, "tunnel": "cloudflared"}}, "model": {"name": "probe"}})
+    local = OmegaConf.create({"rllm": {"gateway": {"port": None, "tunnel": None}}, "model": {"name": "probe"}})
 
-    resolved = hooks_mod.enable_gateway_tunnel(config)
-
-    assert resolved.rllm.gateway.tunnel == "ngrok:*.env.example.ngrok.app"
-    assert resolved.rllm.gateway.port == 49125
-
-
-def test_explicit_train_tunnel_and_port_are_unchanged():
-    from rllm.hooks import enable_gateway_tunnel
-
-    config = OmegaConf.create({"rllm": {"gateway": {"port": 9191, "tunnel": "ngrok:fixed.example.ngrok.app"}}})
-
-    assert enable_gateway_tunnel(config) is config
+    assert manager_mod.GatewayManager(automatic).port == 49123
+    assert manager_mod.GatewayManager(explicit).port == 9191
+    assert manager_mod.GatewayManager(local).port == 9090

--- a/tests/eval/test_eval_tunnel_resolution.py
+++ b/tests/eval/test_eval_tunnel_resolution.py
@@ -1,4 +1,4 @@
-"""Eval-specific tunnel selection and gateway wiring."""
+"""Eval-owned tunnel wiring."""
 
 from __future__ import annotations
 
@@ -7,58 +7,16 @@ import asyncio
 import pytest
 
 import rllm.eval.runner as runner_mod
-from rllm.gateway.tunnel import ENV_TUNNEL
 
 
-@pytest.fixture(autouse=True)
-def _no_tunnel_override(monkeypatch):
-    monkeypatch.delenv(ENV_TUNNEL, raising=False)
-
-
-@pytest.mark.parametrize("override", ["ngrok", "https://gateway.example.test"])
-def test_explicit_environment_override_wins(monkeypatch, override):
-    monkeypatch.setenv(ENV_TUNNEL, override)
-
-    assert runner_mod._resolve_eval_tunnel() == override
-
-
-def test_configured_ngrok_wildcard_is_owned_by_eval(monkeypatch):
-    import rllm.eval.config as config_mod
-
-    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"backend": "ngrok", "domain": "*.rllm.example.ngrok.app"})
-
-    assert runner_mod._resolve_eval_tunnel() == "ngrok:*.rllm.example.ngrok.app"
-
-
-def test_fixed_ngrok_domain_is_not_reused_by_eval(monkeypatch):
-    import rllm.eval.config as config_mod
-
-    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"backend": "ngrok", "domain": "gateway.example.ngrok.app"})
-
-    assert runner_mod._resolve_eval_tunnel() == "cloudflared"
-
-
-def test_persistent_daemon_is_not_consulted(monkeypatch):
-    import rllm.eval.config as config_mod
-    import rllm.gateway.tunnel as tunnel_mod
-
-    def _unexpected_daemon_lookup():
-        raise AssertionError("eval tunnel resolution must not inspect the persistent daemon")
-
-    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {})
-    monkeypatch.setattr(tunnel_mod, "live_tunnel_url", _unexpected_daemon_lookup)
-
-    assert runner_mod._resolve_eval_tunnel() == "cloudflared"
-
-
-def test_remote_eval_passes_owned_backend_with_automatic_port(monkeypatch):
+def test_remote_eval_skips_daemon_and_uses_automatic_port(monkeypatch):
     import rllm.gateway.manager as manager_mod
     import rllm.gateway.tunnel as tunnel_mod
 
-    monkeypatch.setattr(runner_mod, "_resolve_eval_tunnel", lambda: "cloudflared")
-    monkeypatch.setattr(tunnel_mod, "is_local_sandbox_backend", lambda _: False)
+    seen = {}
 
-    seen: dict = {}
+    def _resolve():
+        return "cloudflared", None
 
     class _Stop(Exception):
         pass
@@ -70,6 +28,8 @@ def test_remote_eval_passes_owned_backend_with_automatic_port(monkeypatch):
         def start(self):
             raise _Stop
 
+    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", _resolve)
+    monkeypatch.setattr(tunnel_mod, "is_local_sandbox_backend", lambda _: False)
     monkeypatch.setattr(manager_mod, "EvalGatewayManager", _Gateway)
 
     with pytest.raises(_Stop):

--- a/tests/eval/test_eval_tunnel_resolution.py
+++ b/tests/eval/test_eval_tunnel_resolution.py
@@ -22,23 +22,30 @@ def test_explicit_environment_override_wins(monkeypatch, override):
     assert runner_mod._resolve_eval_tunnel() == override
 
 
-def test_default_is_cloudflared_even_when_ngrok_is_configured(monkeypatch):
+def test_configured_ngrok_wildcard_is_owned_by_eval(monkeypatch):
     import rllm.eval.config as config_mod
 
-    def _unexpected_config_lookup():
-        raise AssertionError("eval must not reuse persistent tunnel configuration")
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"backend": "ngrok", "domain": "*.rllm.example.ngrok.app"})
 
-    monkeypatch.setattr(config_mod, "load_tunnel_config", _unexpected_config_lookup)
+    assert runner_mod._resolve_eval_tunnel() == "ngrok:*.rllm.example.ngrok.app"
+
+
+def test_fixed_ngrok_domain_is_not_reused_by_eval(monkeypatch):
+    import rllm.eval.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"backend": "ngrok", "domain": "gateway.example.ngrok.app"})
 
     assert runner_mod._resolve_eval_tunnel() == "cloudflared"
 
 
 def test_persistent_daemon_is_not_consulted(monkeypatch):
+    import rllm.eval.config as config_mod
     import rllm.gateway.tunnel as tunnel_mod
 
     def _unexpected_daemon_lookup():
         raise AssertionError("eval tunnel resolution must not inspect the persistent daemon")
 
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {})
     monkeypatch.setattr(tunnel_mod, "live_tunnel_url", _unexpected_daemon_lookup)
 
     assert runner_mod._resolve_eval_tunnel() == "cloudflared"

--- a/tests/eval/test_eval_tunnel_resolution.py
+++ b/tests/eval/test_eval_tunnel_resolution.py
@@ -1,0 +1,80 @@
+"""Eval-specific tunnel selection and gateway wiring."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import rllm.eval.runner as runner_mod
+from rllm.gateway.tunnel import ENV_TUNNEL
+
+
+@pytest.fixture(autouse=True)
+def _no_tunnel_override(monkeypatch):
+    monkeypatch.delenv(ENV_TUNNEL, raising=False)
+
+
+@pytest.mark.parametrize("override", ["ngrok", "https://gateway.example.test"])
+def test_explicit_environment_override_wins(monkeypatch, override):
+    monkeypatch.setenv(ENV_TUNNEL, override)
+
+    assert runner_mod._resolve_eval_tunnel() == override
+
+
+def test_default_is_cloudflared_even_when_ngrok_is_configured(monkeypatch):
+    import rllm.eval.config as config_mod
+
+    def _unexpected_config_lookup():
+        raise AssertionError("eval must not reuse persistent tunnel configuration")
+
+    monkeypatch.setattr(config_mod, "load_tunnel_config", _unexpected_config_lookup)
+
+    assert runner_mod._resolve_eval_tunnel() == "cloudflared"
+
+
+def test_persistent_daemon_is_not_consulted(monkeypatch):
+    import rllm.gateway.tunnel as tunnel_mod
+
+    def _unexpected_daemon_lookup():
+        raise AssertionError("eval tunnel resolution must not inspect the persistent daemon")
+
+    monkeypatch.setattr(tunnel_mod, "live_tunnel_url", _unexpected_daemon_lookup)
+
+    assert runner_mod._resolve_eval_tunnel() == "cloudflared"
+
+
+def test_remote_eval_passes_owned_backend_with_automatic_port(monkeypatch):
+    import rllm.gateway.manager as manager_mod
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setattr(runner_mod, "_resolve_eval_tunnel", lambda: "cloudflared")
+    monkeypatch.setattr(tunnel_mod, "is_local_sandbox_backend", lambda _: False)
+
+    seen: dict = {}
+
+    class _Stop(Exception):
+        pass
+
+    class _Gateway:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+        def start(self):
+            raise _Stop
+
+    monkeypatch.setattr(manager_mod, "EvalGatewayManager", _Gateway)
+
+    with pytest.raises(_Stop):
+        asyncio.run(
+            runner_mod.run_dataset(
+                tasks=[],
+                agent_flow=object(),
+                base_url="http://127.0.0.1:1/v1",
+                model="probe-model",
+                sandbox_backend="modal",
+            )
+        )
+
+    assert seen["tunnel"] == "cloudflared"
+    assert seen["port"] is None


### PR DESCRIPTION
## Summary

- Make automatic remote eval and train routing create a fresh owned tunnel instead of reusing the singleton `rllm tunnel up` daemon.
- Auto-select a gateway port for owned tunnel backends while preserving explicit ports and URL routes.
- Let ngrok setup reserve a wildcard once; each run expands it to a unique UUID hostname.

## Design

The shared resolver is now:

1. `RLLM_GATEWAY_TUNNEL` when explicitly set.
2. A configured ngrok wildcard, expanded per tunnel instance.
3. A fresh Cloudflare quick tunnel.

`GatewayManager` selects an OS-free port only when the route is an owned backend and no port was supplied. This keeps eval and train on the same path. Fixed external URLs and explicit ports retain their existing behavior.

A detached `rllm tunnel up` route remains available, but reuse is explicit: set `RLLM_GATEWAY_TUNNEL` to its URL and use its matching gateway port.

## Setup

`rllm tunnel setup` keeps the existing domain prompt. Entering a wildcard adds one optional reservation step through the ngrok API. The API key is used for that command only and is not stored in rLLM config. Re-running setup with the saved wildcard defaults to using the existing reservation; ngrok `ERR_NGROK_413` is also accepted as confirmation that the wildcard already belongs to the account.

## Validation

- 145 passed, 1 deselected across CLI, eval tunnel, gateway, and remote-runtime tests. The deselected macOS loopback-preflight test is pre-existing and unrelated.
- Ruff, Ruff format, pre-commit, YAML parse, diff checks, and GitHub pre-commit pass.
- Real two-process eval acceptance using two simultaneous `rllm eval` CLI subprocesses and local marked OpenAI-compatible upstreams:
  - distinct automatic gateway ports (`63050`, `63051`);
  - distinct wildcard child hostnames;
  - each public route returned only its own marker (`A` or `B`);
  - both requests waited on a barrier, proving the routes were live concurrently;
  - both evals exited 0 with 100% results;
  - all owned ngrok processes, listeners, sessions, and endpoints were removed afterward.
- Production training-path acceptance (`AgentTrainer` -> shared resolver -> `GatewayManager`) against the saved wildcard:
  - resolved `ngrok:*.rllm-tianhao.ngrok.app` with `port: null`;
  - selected distinct gateway ports (`63131`, `63132`) and child hostnames;
  - routed independent markers correctly;
  - stopping gateway A left gateway B publicly healthy;
  - cleanup restored the account to its pre-test session/endpoint baseline.

## Scope

This isolates tunnel routes and gateway ports. The live eval acceptance used explicit local `--base-url` upstreams to avoid paid model calls. LiteLLM per-process state-directory isolation is a separate issue and is intentionally not included in this minimal PR.