### PR TITLE
eval: isolate LiteLLM proxy state per run

### DIFF
--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -211,7 +211,15 @@ class EvalProxyManager(_ProxyManagerBase):
             logger.warning("Proxy subprocess already running")
             return ""
 
-        snapshot_path = self._snapshot_config_to_file(config, directory=kwargs.get("snapshot_directory"))
+        state_dir = os.getenv("LITELLM_PROXY_STATE_DIR")
+        if state_dir:
+            state_dir = os.path.abspath(os.path.expanduser(state_dir))
+        else:
+            state_root = os.path.join(os.getcwd(), ".litellm_proxy")
+            os.makedirs(state_root, exist_ok=True)
+            state_dir = tempfile.mkdtemp(prefix="rllm_", dir=state_root)
+
+        snapshot_path = self._snapshot_config_to_file(config, directory=kwargs.get("snapshot_directory") or os.getenv("RLLM_PROXY_CONFIG_DIR") or state_dir)
         if not snapshot_path or not os.path.exists(snapshot_path):
             raise RuntimeError("Config snapshot not available. Cannot start proxy.")
 
@@ -247,6 +255,8 @@ class EvalProxyManager(_ProxyManagerBase):
                 self.proxy_host,
                 "--port",
                 str(self.proxy_port),
+                "--state-dir",
+                state_dir,
             ]
 
             # Fresh stderr capture per attempt so a death leaves a readable trail.

--- a/tests/eval/test_eval_proxy.py
+++ b/tests/eval/test_eval_proxy.py
@@ -1,9 +1,74 @@
-"""Tests for EvalProxyManager config generation."""
+"""Tests for EvalProxyManager config generation and process isolation."""
 
+from pathlib import Path
+from unittest.mock import Mock
+
+import rllm.eval.proxy as proxy_module
 from rllm.eval.proxy import EvalProxyManager
 
 
+def _mock_proxy_startup(monkeypatch):
+    commands = []
+    monkeypatch.delenv("RLLM_PROXY_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("LITELLM_PROXY_STATE_DIR", raising=False)
+
+    def fake_popen(cmd, **kwargs):
+        commands.append(cmd)
+        return Mock(pid=1000, returncode=None, poll=Mock(return_value=None), wait=Mock(return_value=0))
+
+    monkeypatch.setattr(proxy_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(EvalProxyManager, "_wait_for_proxy", lambda self, timeout: None)
+    monkeypatch.setattr(EvalProxyManager, "reload_proxy_config", lambda self, config: {"status": "ok"})
+    monkeypatch.setattr(EvalProxyManager, "_start_proxy_monitor", lambda self: None)
+    monkeypatch.setattr(proxy_module.atexit, "register", lambda callback: None)
+    return commands
+
+
+def _state_dir(command):
+    return Path(command[command.index("--state-dir") + 1])
+
+
 class TestEvalProxyManager:
+    def test_concurrent_managers_use_unique_state_dirs(self, monkeypatch, tmp_path):
+        commands = _mock_proxy_startup(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+
+        first = EvalProxyManager(provider="openai", model_name="model-a", api_key="key-a", proxy_port=5001)
+        second = EvalProxyManager(provider="openai", model_name="model-b", api_key="key-b", proxy_port=5002)
+        first_snapshot = Path(first.start_proxy_subprocess(first.build_proxy_config()))
+        second_snapshot = Path(second.start_proxy_subprocess(second.build_proxy_config()))
+
+        first_state = _state_dir(commands[0])
+        second_state = _state_dir(commands[1])
+        assert first_snapshot.parent != second_snapshot.parent
+        assert first_state != second_state
+        assert first_state == first_snapshot.parent
+        assert second_state == second_snapshot.parent
+        assert first_state.parent == second_state.parent == tmp_path / ".litellm_proxy"
+
+        first.shutdown_proxy()
+        second.shutdown_proxy()
+        assert first_state.exists()
+        assert second_state.exists()
+
+    def test_explicit_config_and_state_dirs_keep_exact_paths(self, monkeypatch, tmp_path):
+        commands = _mock_proxy_startup(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        config_dir = tmp_path / "config"
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        monkeypatch.setenv("RLLM_PROXY_CONFIG_DIR", str(config_dir))
+        monkeypatch.setenv("LITELLM_PROXY_STATE_DIR", str(state_dir))
+        manager = EvalProxyManager(provider="openai", model_name="model-a", api_key="key-a", proxy_port=5001)
+
+        snapshot = Path(manager.start_proxy_subprocess(manager.build_proxy_config()))
+        assert snapshot == config_dir / "litellm_proxy_config_autogen.yaml"
+        assert _state_dir(commands[0]) == state_dir
+
+        manager.shutdown_proxy()
+        assert snapshot.exists()
+        assert not (tmp_path / ".litellm_proxy").exists()
+
     def test_build_proxy_config_openai(self):
         pm = EvalProxyManager(provider="openai", model_name="gpt-4o", api_key="sk-test")
         config = pm.build_proxy_config()


### PR DESCRIPTION
## Summary

- Create one atomic `.litellm_proxy/rllm_<random>/` directory for each automatically managed eval proxy.
- Use that directory for the config snapshot and pass it to the child through the existing `--state-dir` argument.
- Preserve exact `RLLM_PROXY_CONFIG_DIR`, `snapshot_directory`, and `LITELLM_PROXY_STATE_DIR` overrides.

The production change is 11 added lines and one replacement in `rllm/eval/proxy.py`. Per-run directories intentionally remain after shutdown for inspection; this PR adds no cleanup lifecycle.

## Why

Concurrent `rllm eval` processes already select different proxy ports, but their LiteLLM children defaulted to the same `.litellm_proxy/litellm_proxy_config_autogen.yaml`. Two same-directory evals could therefore overwrite the file while LiteLLM was initializing and load the other run's model, provider, or API key.

`tempfile.mkdtemp` allocates distinct directories atomically, so each eval reads and writes only its own LiteLLM state. The generated run directories are mode `0700`.

## Scope and training impact

This is provider-independent for every external-provider eval that uses `EvalProxyManager`. It does not change `rllm train`: training uses `GatewayManager`, not the eval LiteLLM sidecar. Remote train tunnel and gateway isolation is handled separately by #827.

Explicit shared config or state-directory overrides remain an intentional opt-out from automatic isolation.

## Validation

- 27 focused proxy and eval CLI tests passed.
- 513 broader eval tests passed; one unrelated pre-existing sandbox lifetime assertion was excluded.
- Ruff, formatting, pre-commit, and `git diff --check` passed.
- Two real LiteLLM proxy subprocesses started concurrently with distinct ports and `.litellm_proxy/rllm_*` directories, loaded their own model configs, and retained both directories after shutdown.
