### PR TITLE
Build the real Dockerfile on Modal instead of replaying RUN steps

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -334,10 +334,8 @@ def _task_dockerfile(task: Task) -> Path | None:
 
 # Remote backends that build images themselves and so can build the *real* Dockerfile
 # (COPY/ENV/WORKDIR/RUN) instead of pulling FROM + replaying RUN. ``docker`` is excluded
-# because it already builds via ``docker build``; ``local`` cannot build. ``modal`` is a
-# tracked follow-up (it accepts a ``modal.Image`` and already keepalive-overrides the
-# entrypoint, but the from_dockerfile path there is untested — see _dockerfile_image).
-_FROM_DOCKERFILE_BACKENDS = ("daytona",)
+# because it already builds via ``docker build``; ``local`` cannot build.
+_FROM_DOCKERFILE_BACKENDS = ("daytona", "modal")
 
 
 def _builds_from_dockerfile(task: Task, backend: str) -> Path | None:
@@ -360,6 +358,18 @@ def _dockerfile_image(backend: str, dockerfile: Path):
         from daytona import Image  # daytona.Image.from_dockerfile bundles the Dockerfile dir as context
 
         return Image.from_dockerfile(str(dockerfile))
+    if backend == "modal":
+        import modal
+
+        # Modal takes the Dockerfile path and its build context separately; daytona
+        # infers the context from the file's directory, so pass the parent explicitly
+        # to keep COPY resolution identical across the two backends.
+        #
+        # WORKDIR is the directive that makes this matter beyond COPY: harbor SWE tasks
+        # (deepswe/uniswe) do `WORKDIR /app` then `git clone <url> .`, so under the
+        # replay path — which drops WORKDIR — the clone lands in the base image's root,
+        # /app never exists, and every `cd /app` in solve.sh and tests/test.sh fails.
+        return modal.Image.from_dockerfile(dockerfile, context_dir=dockerfile.parent)
     raise ValueError(f"from_dockerfile build unsupported for backend {backend!r}")
 
 

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -568,7 +568,9 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
     snapshot keyed on the install must actually contain it.
     """
     from rllm.eval._resolution import (
+        _builds_from_dockerfile,
         _create_base_sandbox,
+        _dockerfile_image,
         _dockerfile_run_commands,
         _replay_dockerfile,
         _should_replay_dockerfile,
@@ -578,17 +580,30 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
         logger.info("modal snapshot %s already live (%s) — reusing", key, prior_ref)
         return prior_ref
 
+    # Mirrors build_daytona_snapshot: when the task builds from its real Dockerfile,
+    # the image already carries every RUN (plus COPY/ENV/WORKDIR), so replaying would
+    # double-apply them — and a snapshotted task must come out identical to a cold-built
+    # one. Only the install script layers on top.
+    dockerfile = _builds_from_dockerfile(task, "modal")
+
     # Size the build sandbox's lifetime to the worst-case replay: each RUN is
     # bounded at 900s (a step that hangs against a prebuilt image burns its
     # full bound), plus the install bound and pull/capture slack — floored at
     # the rollout default. Without this floor, two hung steps killed the
-    # sandbox mid-build.
+    # sandbox mid-build. A from_dockerfile build replays nothing.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
-    n_replay = len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0
+    n_replay = 0 if dockerfile is not None else (len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0)
     build_timeout = max(_default_sandbox_timeout(), 900 * n_replay + install_budget + 600)
-    sb = _create_base_sandbox(task, "modal", name=f"{key}-build", timeout=build_timeout)
+    sb = _create_base_sandbox(
+        task,
+        "modal",
+        image=_dockerfile_image("modal", dockerfile) if dockerfile is not None else None,
+        name=f"{key}-build",
+        timeout=build_timeout,
+    )
     try:
-        _replay_dockerfile(task, sb, "modal")
+        if dockerfile is None:
+            _replay_dockerfile(task, sb, "modal")
         if install_script:
             sb.exec(install_script, timeout=env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900), user="root")
         image = sb._sandbox.snapshot_filesystem()  # noqa: SLF001 — modal.Image

--- a/tests/eval/test_dockerfile_replay.py
+++ b/tests/eval/test_dockerfile_replay.py
@@ -13,7 +13,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from rllm.eval._resolution import _dockerfile_run_commands, _should_replay_dockerfile
+import pytest
+
+from rllm.eval._resolution import (
+    _builds_from_dockerfile,
+    _dockerfile_image,
+    _dockerfile_run_commands,
+    _should_replay_dockerfile,
+)
 from rllm.tasks.loader import _load_task_from_dir
 from rllm.types import Task
 
@@ -82,3 +89,44 @@ def test_replay_flag_read_from_task_toml(tmp_path):
     (tmp_path / "task.toml").write_text('[environment]\ndocker_image = "org/img:t"\nreplay_dockerfile = false\n')
     task = _load_task_from_dir(tmp_path, dataset_dir=tmp_path)
     assert _should_replay_dockerfile(task) is False
+
+
+# ---------------------------------------------------------------------------
+# _builds_from_dockerfile / _dockerfile_image: real-Dockerfile build backends
+# ---------------------------------------------------------------------------
+
+
+def test_modal_builds_from_dockerfile(tmp_path):
+    """Modal builds the real Dockerfile rather than replaying RUN steps.
+
+    Replay drops ``WORKDIR``, so a harbor SWE task doing ``WORKDIR /app`` then
+    ``git clone <url> .`` clones into the base image's root and every later
+    ``cd /app`` fails. Modal must take the from_dockerfile path like daytona.
+    """
+    task = _task_with_dockerfile(tmp_path, "FROM ubuntu:24.04\nWORKDIR /app\nRUN git clone https://example.com/r .\n")
+    assert _builds_from_dockerfile(task, "modal") == tmp_path / "environment" / "Dockerfile"
+    assert _builds_from_dockerfile(task, "daytona") == tmp_path / "environment" / "Dockerfile"
+
+
+def test_replay_only_backends_do_not_build_dockerfile(tmp_path):
+    """docker builds via ``docker build`` already; local cannot build at all."""
+    task = _task_with_dockerfile(tmp_path, "FROM ubuntu:24.04\nRUN echo hi\n")
+    assert _builds_from_dockerfile(task, "docker") is None
+    assert _builds_from_dockerfile(task, "local") is None
+
+
+def test_prebuilt_image_tasks_skip_dockerfile_build_on_modal(tmp_path):
+    """``replay_dockerfile = false`` means the image is complete — boot it as-is."""
+    task = _task_with_dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\nRUN echo hi\n",
+        metadata={"environment": {"docker_image": "prebuilt", "replay_dockerfile": False}},
+    )
+    assert _builds_from_dockerfile(task, "modal") is None
+
+
+def test_dockerfile_image_rejects_unsupported_backend(tmp_path):
+    df = tmp_path / "Dockerfile"
+    df.write_text("FROM ubuntu:24.04\n")
+    with pytest.raises(ValueError, match="unsupported for backend"):
+        _dockerfile_image("e2b", df)


### PR DESCRIPTION
## Summary

Modal was left out of `_FROM_DOCKERFILE_BACKENDS` when the real-Dockerfile build landed for Daytona in 9277e519, whose message noted: *"modal from_dockerfile is a tracked follow-up (untested here; `_FROM_DOCKERFILE_BACKENDS`)."* This finishes that follow-up.

On Modal the cold path pulled the Dockerfile's `FROM` base and replayed only its `RUN` steps, silently dropping `COPY`/`ENV`/`WORKDIR`. `WORKDIR` is what makes this fatal for harbor SWE tasks, whose environments do:

```dockerfile
WORKDIR /app
RUN git clone <url> .
```

Without `WORKDIR`, the clone lands in the base image's root, `/app` never exists, and every `cd /app` in `solution/solve.sh` and `tests/test.sh` fails. The verifier writes no reward file and the trial dies as `grading_error`:

```
Command failed (exit 1) in sandbox rllm-verify-...:
chmod +x /tests/test.sh && cd /app && /tests/test.sh
bash: line 1: cd: /app: No such file or directory
```

Found on a 992-task harbor SWE set where 522 tasks clone into `.` rather than an absolute path — none of them can run on Modal today.

## Why this is small

Modal already had every piece; only the wiring was missing.

| piece | status before |
|---|---|
| `modal.Image.from_dockerfile(path, context_dir=…)` | already in the SDK |
| `ModalSandbox` accepting a `modal.Image` object | already supported |
| `_dockerfile_image()` modal branch | missing — raised `ValueError` |
| `"modal"` in `_FROM_DOCKERFILE_BACKENDS` | missing |

`context_dir=dockerfile.parent` mirrors Daytona, whose `Image.from_dockerfile` infers the context from the file's directory, so `COPY` resolves identically on both.

## Snapshot path

`build_modal_snapshot` now mirrors `build_daytona_snapshot`: a from_dockerfile image already carries every `RUN`, so replaying would double-apply them, and a snapshotted task must come out identical to a cold-built one. Only the install script layers on top, and the replay term drops out of the build timeout.

`env_key` in `rllm/sandbox/snapshot.py` already routes through `_builds_from_dockerfile(task, backend)` generically, so context fingerprinting picks Modal up with no change there.

## Scope

Tasks declaring an explicit `docker_image` resolve `replay_dockerfile` to false and are **unaffected** — they still boot their prebuilt image as-is. Verified against two real tasks:

| task | `docker_image` | `should_replay` | builds Dockerfile on modal |
|---|---|---|---|
| prebuilt-image deepswe | `public.ecr.aws/…:…-v1.1` | `False` | No — unchanged |
| Dockerfile-only harbor task | none (`gcc:13` from `FROM`) | `True` | Yes |

This only changes tasks whose environment *is* their Dockerfile — which previously could not work on Modal at all.

## Tests

Four cases added to `tests/eval/test_dockerfile_replay.py`: Modal and Daytona both take the from_dockerfile path; `docker`/`local` do not; `replay_dockerfile = false` opts out on Modal; unsupported backends still raise.

`tests/eval` + `tests/sandbox`: **605 passed, 1 failed**. The failure is `test_harbor_parity.py::test_lifetime_floor_sized_from_task_budget_when_no_override`, which fails identically on `terminal-rl` without this change — pre-existing and unrelated.

## Not verified

The Modal from_dockerfile path has **not been exercised against live Modal** in this change — same caveat the original commit gave for its own untested Modal path. Static and unit-level verification only. A real `rllm eval --sandbox-backend modal` on a Dockerfile-based harbor task is the remaining check before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)