### PR TITLE
fix(eval): non-Anthropic provider compatibility and Anthropic traces

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/data_process.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/data_process.py
@@ -5,6 +5,7 @@ Extracted from ``rllm/sdk/data_process.py``.  No dependency on rLLM's
 dicts and produces ``TraceRecord`` instances.
 """
 
+import json
 import logging
 import time
 import uuid
@@ -13,6 +14,51 @@ from typing import Any
 from rllm_model_gateway.models import TraceRecord
 
 logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# Anthropic /v1/messages shapes
+# ------------------------------------------------------------------
+
+_ANTHROPIC_STREAM_EVENTS = {"message_start", "content_block_start", "content_block_delta", "content_block_stop", "message_delta", "message_stop"}
+
+
+def _is_anthropic_response(response_body: dict[str, Any]) -> bool:
+    """True for Anthropic Messages API responses (no OpenAI ``choices``)."""
+    return response_body.get("type") == "message" and isinstance(response_body.get("content"), list)
+
+
+def _anthropic_tool_call(block: dict[str, Any]) -> dict[str, Any]:
+    """Convert an Anthropic ``tool_use`` block to OpenAI tool_call format."""
+    return {
+        "id": block.get("id", ""),
+        "type": "function",
+        "function": {"name": block.get("name", ""), "arguments": json.dumps(block.get("input") or {})},
+    }
+
+
+def _anthropic_response_message(response_body: dict[str, Any]) -> dict[str, Any]:
+    """Synthesize an OpenAI-style assistant message from an Anthropic response."""
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for block in response_body.get("content") or []:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text" and block.get("text"):
+            text_parts.append(block["text"])
+        elif block.get("type") == "thinking" and block.get("thinking"):
+            reasoning_parts.append(block["thinking"])
+        elif block.get("type") == "tool_use":
+            tool_calls.append(_anthropic_tool_call(block))
+    message: dict[str, Any] = {"role": "assistant"}
+    if text_parts:
+        message["content"] = "".join(text_parts)
+    if reasoning_parts:
+        message["reasoning"] = "".join(reasoning_parts)
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return message
 
 
 # ------------------------------------------------------------------
@@ -207,8 +253,18 @@ def build_trace_record(
     token_counts = {}
     if "prompt_tokens" in usage:
         token_counts["prompt"] = usage["prompt_tokens"]
+    elif "input_tokens" in usage:  # Anthropic Messages API
+        token_counts["prompt"] = usage["input_tokens"]
     if "completion_tokens" in usage:
         token_counts["completion"] = usage["completion_tokens"]
+    elif "output_tokens" in usage:  # Anthropic Messages API
+        token_counts["completion"] = usage["output_tokens"]
+
+    response_message = first_choice.get("message") or first_choice.get("delta") or {}
+    finish_reason = first_choice.get("finish_reason")
+    if _is_anthropic_response(response_body):
+        response_message = _anthropic_response_message(response_body)
+        finish_reason = finish_reason or response_body.get("stop_reason")
 
     # Proxy's fanned-out version wins; the engine-stamped response value is only a fallback.
     # (A multi-worker subprocess's rebuilt engine stamps a stale version that must not override it.)
@@ -222,11 +278,11 @@ def build_trace_record(
         model=request_body.get("model", response_body.get("model", "")),
         messages=request_body.get("messages", []),
         prompt_token_ids=extract_prompt_token_ids(response_body),
-        response_message=first_choice.get("message") or first_choice.get("delta") or {},
+        response_message=response_message,
         completion_token_ids=extract_completion_token_ids(response_body),
         logprobs=extract_logprobs(response_body) or None,
         routing_matrices=extract_routing_matrices(response_body),
-        finish_reason=first_choice.get("finish_reason"),
+        finish_reason=finish_reason,
         weight_version=weight_version,
         latency_ms=latency_ms,
         token_counts=token_counts,
@@ -265,6 +321,21 @@ def build_trace_record_from_chunks(
     finish_reason: str | None = None
     model = request_body.get("model", "")
     usage: dict[str, Any] = {}
+
+    # Anthropic Messages API streams a different event vocabulary
+    # (message_start / content_block_* / message_delta) with no ``choices``.
+    if any(chunk.get("type") in _ANTHROPIC_STREAM_EVENTS for chunk in chunks):
+        return _build_trace_record_from_anthropic_chunks(
+            session_id,
+            request_body,
+            chunks,
+            latency_ms,
+            metadata=metadata,
+            weight_version=weight_version,
+            lineage_id=lineage_id,
+            trace_id=trace_id,
+            capture_raw=capture_raw,
+        )
 
     for i, chunk in enumerate(chunks):
         if i == 0:
@@ -324,4 +395,97 @@ def build_trace_record_from_chunks(
         metadata=metadata or {},
         raw_request=request_body if capture_raw else None,
         raw_response=None,  # Too large for streaming; individual chunks not stored
+    )
+
+
+def _build_trace_record_from_anthropic_chunks(
+    session_id: str,
+    request_body: dict[str, Any],
+    chunks: list[dict[str, Any]],
+    latency_ms: float,
+    *,
+    metadata: dict[str, Any] | None = None,
+    weight_version: int | None = None,
+    lineage_id: str | None = None,
+    trace_id: str | None = None,
+    capture_raw: bool = False,
+) -> TraceRecord:
+    """Assemble a ``TraceRecord`` from Anthropic Messages API SSE events.
+
+    Events: ``message_start`` (message shell + input usage),
+    ``content_block_start``/``content_block_delta``/``content_block_stop``
+    (per-index text / thinking / tool_use assembly), and ``message_delta``
+    (stop_reason + output usage). Token IDs are unavailable on this path —
+    Anthropic-format upstreams don't return them.
+    """
+    model = request_body.get("model", "")
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    finish_reason: str | None = None
+    blocks: dict[int, dict[str, Any]] = {}
+
+    for chunk in chunks:
+        event = chunk.get("type")
+        if event == "message_start":
+            message = chunk.get("message") or {}
+            model = message.get("model", model)
+            start_usage = message.get("usage") or {}
+            if "input_tokens" in start_usage:
+                input_tokens = start_usage["input_tokens"]
+        elif event == "content_block_start":
+            block = dict(chunk.get("content_block") or {})
+            block.setdefault("type", "text")
+            blocks[chunk.get("index", len(blocks))] = block
+        elif event == "content_block_delta":
+            block = blocks.setdefault(chunk.get("index", len(blocks)), {"type": "text"})
+            delta = chunk.get("delta") or {}
+            if delta.get("type") == "text_delta":
+                block["text"] = block.get("text", "") + delta.get("text", "")
+            elif delta.get("type") == "thinking_delta":
+                block["thinking"] = block.get("thinking", "") + delta.get("thinking", "")
+            elif delta.get("type") == "input_json_delta":
+                block["_partial_json"] = block.get("_partial_json", "") + delta.get("partial_json", "")
+        elif event == "content_block_stop":
+            block = blocks.get(chunk.get("index", -1))
+            if block is not None and "_partial_json" in block:
+                raw = block.pop("_partial_json")
+                try:
+                    block["input"] = json.loads(raw or "{}")
+                except ValueError:
+                    block["input"] = {"_raw": raw}
+        elif event == "message_delta":
+            delta = chunk.get("delta") or {}
+            if delta.get("stop_reason"):
+                finish_reason = delta["stop_reason"]
+            delta_usage = chunk.get("usage") or {}
+            if "output_tokens" in delta_usage:
+                output_tokens = delta_usage["output_tokens"]
+
+    content = [blocks[i] for i in sorted(blocks)]
+    response_message = _anthropic_response_message({"type": "message", "content": content})
+
+    token_counts: dict[str, int] = {}
+    if input_tokens is not None:
+        token_counts["prompt"] = input_tokens
+    if output_tokens is not None:
+        token_counts["completion"] = output_tokens
+
+    return TraceRecord(
+        trace_id=trace_id or str(uuid.uuid4()),
+        session_id=session_id,
+        lineage_id=lineage_id,
+        model=model,
+        messages=request_body.get("messages", []),
+        prompt_token_ids=[],
+        response_message=response_message,
+        completion_token_ids=[],
+        logprobs=None,
+        finish_reason=finish_reason,
+        weight_version=weight_version,
+        latency_ms=latency_ms,
+        token_counts=token_counts,
+        timestamp=time.time(),
+        metadata=metadata or {},
+        raw_request=request_body if capture_raw else None,
+        raw_response=None,
     )

--- a/rllm-model-gateway/tests/unit/test_anthropic_traces.py
+++ b/rllm-model-gateway/tests/unit/test_anthropic_traces.py
@@ -1,0 +1,110 @@
+"""Anthropic Messages API shapes in trace building.
+
+Anthropic-protocol agents (claude-code) talk to the gateway via LiteLLM's
+/v1/messages translation, so responses and SSE streams arrive in Anthropic
+format (no ``choices``). The trace builders must still populate
+response_message / finish_reason / token_counts, or rLLM discards the traces
+as empty and misclassifies the rollout as EmptyCompletion.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rllm_model_gateway.data_process import build_trace_record, build_trace_record_from_chunks
+
+
+def _anthropic_response():
+    return {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "z-ai/glm-5.2",
+        "content": [
+            {"type": "thinking", "thinking": "let me think"},
+            {"type": "text", "text": "I will run nmap."},
+            {"type": "tool_use", "id": "toolu_1", "name": "bash", "input": {"command": "nmap -p- target"}},
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 1234, "output_tokens": 56},
+    }
+
+
+def test_build_trace_record_anthropic_response():
+    trace = build_trace_record("s-1", {"model": "z-ai/glm-5.2", "messages": []}, _anthropic_response(), 12.0)
+
+    assert trace.response_message["role"] == "assistant"
+    assert trace.response_message["content"] == "I will run nmap."
+    assert trace.response_message["reasoning"] == "let me think"
+    tool_calls = trace.response_message["tool_calls"]
+    assert tool_calls[0]["function"]["name"] == "bash"
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {"command": "nmap -p- target"}
+    assert trace.finish_reason == "tool_use"
+    assert trace.token_counts == {"prompt": 1234, "completion": 56}
+
+
+def test_build_trace_record_openai_response_unchanged():
+    response = {
+        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+    }
+    trace = build_trace_record("s-1", {"model": "m", "messages": []}, response, 1.0)
+
+    assert trace.response_message == {"role": "assistant", "content": "hi"}
+    assert trace.finish_reason == "stop"
+    assert trace.token_counts == {"prompt": 3, "completion": 2}
+
+
+def test_build_trace_record_from_anthropic_chunks():
+    chunks = [
+        {"type": "message_start", "message": {"model": "z-ai/glm-5.2", "usage": {"input_tokens": 100}}},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " world"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "content_block_start", "index": 1, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "bash"}},
+        {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": '{"command": "ls'}},
+        {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": ' -la"}'}},
+        {"type": "content_block_stop", "index": 1},
+        {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 42}},
+        {"type": "message_stop"},
+    ]
+    trace = build_trace_record_from_chunks("s-1", {"model": "z-ai/glm-5.2", "messages": []}, chunks, 25.0)
+
+    assert trace.response_message["content"] == "Hello world"
+    assert trace.response_message["tool_calls"][0]["function"]["name"] == "bash"
+    assert json.loads(trace.response_message["tool_calls"][0]["function"]["arguments"]) == {"command": "ls -la"}
+    assert trace.finish_reason == "tool_use"
+    assert trace.token_counts == {"prompt": 100, "completion": 42}
+    assert trace.model == "z-ai/glm-5.2"
+
+
+def test_build_trace_record_from_anthropic_chunks_malformed_tool_json():
+    """glm-5.1 sometimes streams tool args that never become valid JSON; the
+    raw text must be preserved instead of crashing the trace builder."""
+    chunks = [
+        {"type": "message_start", "message": {"model": "z-ai/glm-5.1", "usage": {"input_tokens": 10}}},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "bash"}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": '{"command": "grep -rn \\x invalid'}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 5}},
+        {"type": "message_stop"},
+    ]
+    trace = build_trace_record_from_chunks("s-1", {"model": "z-ai/glm-5.1", "messages": []}, chunks, 5.0)
+
+    tool_call = trace.response_message["tool_calls"][0]
+    assert tool_call["function"]["name"] == "bash"
+    assert json.loads(tool_call["function"]["arguments"]) == {"_raw": '{"command": "grep -rn \\x invalid'}
+    assert trace.finish_reason == "tool_use"
+
+
+def test_build_trace_record_from_openai_chunks_unchanged():
+    chunks = [
+        {"choices": [{"delta": {"role": "assistant", "content": "hi"}, "finish_reason": None}]},
+        {"choices": [{"delta": {}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 5, "completion_tokens": 1}},
+    ]
+    trace = build_trace_record_from_chunks("s-1", {"model": "m", "messages": []}, chunks, 1.0)
+
+    assert trace.response_message["content"] == "hi"
+    assert trace.finish_reason == "stop"
+    assert trace.token_counts == {"prompt": 5, "completion": 1}

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -522,10 +522,7 @@ class AgentFlowEngine:
                     _steps = [s for t in (episode.trajectories or []) for s in (t.steps or [])]
                     # A step carrying tool calls is a real completion even when
                     # its text is empty (e.g. claude-code tool_use-only turns).
-                    if _steps and all(
-                        not (s.model_response or "").strip() and not (s.model_output and s.model_output.tool_calls)
-                        for s in _steps
-                    ):
+                    if _steps and all(not (s.model_response or "").strip() and not (s.model_output and s.model_output.tool_calls) for s in _steps):
                         n_empty_rollouts += 1
                         colorful_print(
                             f"[{task_id}:{rollout_idx}] ⚠️  EMPTY COMPLETIONS: all {len(_steps)} LLM calls "

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -520,7 +520,12 @@ class AgentFlowEngine:
                 # run silently produces garbage (every rollout scores 0).
                 if episode is not None:
                     _steps = [s for t in (episode.trajectories or []) for s in (t.steps or [])]
-                    if _steps and all(not (s.model_response or "").strip() for s in _steps):
+                    # A step carrying tool calls is a real completion even when
+                    # its text is empty (e.g. claude-code tool_use-only turns).
+                    if _steps and all(
+                        not (s.model_response or "").strip() and not (s.model_output and s.model_output.tool_calls)
+                        for s in _steps
+                    ):
                         n_empty_rollouts += 1
                         colorful_print(
                             f"[{task_id}:{rollout_idx}] ⚠️  EMPTY COMPLETIONS: all {len(_steps)} LLM calls "

--- a/rllm/engine/trace_converter.py
+++ b/rllm/engine/trace_converter.py
@@ -60,6 +60,12 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
     raw_tool_calls = trace.response_message.get("tool_calls")
     tool_calls = _parse_openai_tool_calls(raw_tool_calls) if raw_tool_calls else None
 
+    # Anthropic-protocol traces (claude-code via LiteLLM /v1/messages) carry no
+    # token ids; fall back to the recorded usage counts so cost metrics work.
+    token_counts = trace.token_counts or {}
+    prompt_length = len(trace.prompt_token_ids) or token_counts.get("prompt", 0)
+    completion_length = len(trace.completion_token_ids) or token_counts.get("completion", 0)
+
     model_output = ModelOutput(
         content=content,
         reasoning=reasoning,
@@ -68,8 +74,8 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
         completion_ids=trace.completion_token_ids,
         logprobs=trace.logprobs or [],
         routing_matrices=trace.routing_matrices,
-        prompt_length=len(trace.prompt_token_ids),
-        completion_length=len(trace.completion_token_ids),
+        prompt_length=prompt_length,
+        completion_length=completion_length,
         finish_reason=trace.finish_reason,
         weight_version=trace.weight_version,
     )

--- a/rllm/eval/_litellm_callbacks.py
+++ b/rllm/eval/_litellm_callbacks.py
@@ -1,0 +1,55 @@
+"""LiteLLM proxy callbacks for eval-time provider quirks.
+
+Registered by ``EvalProxyManager._generate_litellm_config`` via
+``litellm_settings: callbacks`` in the generated proxy config.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from litellm.integrations.custom_logger import CustomLogger
+
+_THINKING_BLOCK_TYPES = ("thinking", "redacted_thinking")
+
+
+class _StripThinkingBlocks(CustomLogger):
+    """Drop reasoning/thinking blocks from assistant messages before the upstream call.
+
+    Anthropic-protocol CLIs (claude-code) echo ``thinking`` blocks back on
+    later turns; litellm's Anthropic-to-chat-completions bridge carries them
+    onto the assistant message as ``thinking_blocks``. Strict
+    OpenAI-compatible providers (Fireworks: "Extra inputs are not permitted,
+    field: 'messages[n].thinking_blocks'") 400 on the unknown field, which
+    kills the agent loop after its first tool call. Anthropic-native
+    downstreams NEED the blocks preserved, so the proxy only registers this
+    callback for providers that don't consume them.
+    """
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: Any,
+        cache: Any,
+        data: dict,
+        call_type: str,
+    ) -> dict:
+        messages = data.get("messages")
+        if isinstance(messages, list):
+            for message in messages:
+                if not isinstance(message, dict) or message.get("role") != "assistant":
+                    continue
+                # OpenAI-shaped (already translated): thinking_blocks field.
+                message.pop("thinking_blocks", None)
+                # Anthropic-shaped (raw /v1/messages body): content blocks.
+                content = message.get("content")
+                if isinstance(content, list):
+                    kept = [
+                        block
+                        for block in content
+                        if not (isinstance(block, dict) and block.get("type") in _THINKING_BLOCK_TYPES)
+                    ]
+                    message["content"] = kept if kept else ""
+        return data
+
+
+strip_thinking_blocks = _StripThinkingBlocks()

--- a/rllm/eval/_litellm_callbacks.py
+++ b/rllm/eval/_litellm_callbacks.py
@@ -43,11 +43,7 @@ class _StripThinkingBlocks(CustomLogger):
                 # Anthropic-shaped (raw /v1/messages body): content blocks.
                 content = message.get("content")
                 if isinstance(content, list):
-                    kept = [
-                        block
-                        for block in content
-                        if not (isinstance(block, dict) and block.get("type") in _THINKING_BLOCK_TYPES)
-                    ]
+                    kept = [block for block in content if not (isinstance(block, dict) and block.get("type") in _THINKING_BLOCK_TYPES)]
                     message["content"] = kept if kept else ""
         return data
 

--- a/rllm/eval/_litellm_server.py
+++ b/rllm/eval/_litellm_server.py
@@ -52,6 +52,15 @@ class _Runtime:
                     litellm.router = None
                 litellm.callbacks = []
 
+            # EvalProxyManager sets this for providers whose downstream rejects
+            # Anthropic thinking blocks (e.g. Fireworks). Registered here rather
+            # than via the config's litellm_settings.callbacks because the proxy
+            # resolves those paths relative to the config file, not sys.path.
+            if os.environ.get("RLLM_EVAL_PROXY_STRIP_THINKING") == "1":
+                from rllm.eval._litellm_callbacks import strip_thinking_blocks
+
+                litellm.callbacks = [strip_thinking_blocks]
+
             os.environ["LITELLM_CONFIG"] = str(target)
             litellm.drop_params = True
             await initialize(config=str(target), telemetry=False)

--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -113,9 +113,16 @@ PROVIDER_REGISTRY: list[ProviderInfo] = [
     ProviderInfo(
         id="openrouter",
         label="OpenRouter",
-        litellm_prefix="openrouter",
+        # Route through the openai/ adapter pinned to OpenRouter's endpoint:
+        # litellm's native openrouter/ provider forwards the prefixed model id
+        # verbatim on the Anthropic /v1/messages path (400 "not a valid model
+        # ID"), which breaks Anthropic-protocol CLIs (claude-code); the openai
+        # adapter strips its prefix on every path. Chat completions verified
+        # to behave identically either way.
+        litellm_prefix="openai",
         env_key="OPENROUTER_API_KEY",
         default_model="anthropic/claude-opus-4-8",
+        base_url="https://openrouter.ai/api/v1",
         models=[
             "anthropic/claude-opus-4-8",
             "anthropic/claude-sonnet-4-6",

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -224,6 +224,13 @@ class EvalProxyManager(_ProxyManagerBase):
             raise RuntimeError("Config snapshot not available. Cannot start proxy.")
 
         env = os.environ.copy()
+        # Anthropic-protocol clients (claude-code) echo thinking blocks back on
+        # later turns; strict OpenAI-compatible providers (Fireworks) 400 on the
+        # translated thinking_blocks field, killing the agent loop after its
+        # first tool call. Anthropic itself needs them, so strip only for
+        # non-Anthropic downstreams. Consumed by rllm.eval._litellm_server.
+        if self.provider != "anthropic":
+            env["RLLM_EVAL_PROXY_STRIP_THINKING"] = "1"
         try:
             import certifi
 

--- a/tests/engine/test_trace_converter.py
+++ b/tests/engine/test_trace_converter.py
@@ -120,6 +120,13 @@ class TestTraceRecordToStep:
         assert step.weight_version == 7
         assert step.model_output.weight_version == 7
 
+    def test_token_count_fallback_when_no_token_ids(self):
+        """Anthropic-protocol traces carry usage counts instead of token ids."""
+        trace = self._make_trace(prompt_token_ids=[], completion_token_ids=[], logprobs=[], token_counts={"prompt": 1234, "completion": 56})
+        step = trace_record_to_step(trace)
+        assert step.model_output.prompt_length == 1234
+        assert step.model_output.completion_length == 56
+
     def test_weight_version_defaults_none(self):
         step = trace_record_to_step(self._make_trace())
         assert step.weight_version is None

--- a/tests/eval/test_litellm_callbacks.py
+++ b/tests/eval/test_litellm_callbacks.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from rllm.eval._litellm_callbacks import strip_thinking_blocks
+
+
+@pytest.mark.asyncio
+async def test_strips_anthropic_thinking_blocks_from_assistant_content():
+    data = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "hmm", "signature": "sig"},
+                    {"type": "text", "text": "answer"},
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            },
+        ]
+    }
+    out = await strip_thinking_blocks.async_pre_call_hook(None, None, data, "anthropic_messages")
+    content = out["messages"][1]["content"]
+    assert [b["type"] for b in content] == ["text", "tool_use"]
+    # user message untouched
+    assert out["messages"][0]["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_strips_openai_shaped_thinking_blocks_field():
+    data = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "thinking_blocks": [{"type": "thinking", "thinking": "hmm", "signature": ""}],
+                "tool_calls": [{"id": "t1", "type": "function", "function": {"name": "Bash", "arguments": "{}"}}],
+            }
+        ]
+    }
+    out = await strip_thinking_blocks.async_pre_call_hook(None, None, data, "acompletion")
+    msg = out["messages"][0]
+    assert "thinking_blocks" not in msg
+    assert msg["tool_calls"]
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_assistant_content_becomes_empty_string():
+    data = {"messages": [{"role": "assistant", "content": [{"type": "thinking", "thinking": "hmm"}]}]}
+    out = await strip_thinking_blocks.async_pre_call_hook(None, None, data, "anthropic_messages")
+    assert out["messages"][0]["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_no_messages_is_passthrough():
+    data = {"prompt": "hello"}
+    out = await strip_thinking_blocks.async_pre_call_hook(None, None, data, "acompletion")
+    assert out == data


### PR DESCRIPTION
## Summary
- Strip echoed `thinking_blocks` in the eval LiteLLM proxy for non-Anthropic providers (Fireworks 400s otherwise), gated by `RLLM_EVAL_PROXY_STRIP_THINKING`.
- Route OpenRouter through the `openai/` adapter + OpenRouter base URL so Anthropic-protocol CLIs (claude-code) do not 400 on prefixed model IDs.
- Build Anthropic-shaped traces in the model gateway (tolerate partial JSON) and count tool-call steps in the agentflow canary.

Independent of the MCP-Atlas / ExploitGym / tunnel PRs.

## Test plan
- [ ] `pytest tests/eval/test_litellm_callbacks.py tests/engine/test_trace_converter.py rllm-model-gateway/tests/unit/test_anthropic_traces.py`
- [ ] Eval a non-Anthropic provider (Fireworks) with an Anthropic-protocol CLI and confirm the second tool-call turn does not 400
- [ ] Confirm Anthropic provider still receives thinking blocks (strip flag is not set)


Made with [Cursor](https://cursor.com)