### PR TITLE
feat(eval): add GLM-5.2 OpenHands reproduction profile

### DIFF
--- a/rllm/harnesses/swebench_pro_openhands_glm52.py
+++ b/rllm/harnesses/swebench_pro_openhands_glm52.py
@@ -25,6 +25,8 @@ from rllm.types import AgentConfig, Episode, Task, TerminationReason
 LLM_STATS_REFERENCE_URL = "https://llm-stats.com/benchmarks/swe-bench-pro"
 LLM_STATS_TARGET_SCORE = 0.621
 TARGET_MODEL = "GLM-5.2"
+OPENROUTER_MODEL_ID = "z-ai/glm-5.2"
+OPENROUTER_PROVIDER_SLUG = "z-ai"
 
 # Public baseline inspected on 2026-08-08. The benchmark repo pins the Agent
 # SDK through a git submodule; both revisions are kept here so an old rLLM run
@@ -67,6 +69,11 @@ REPRODUCTION_PROFILE = {
     "prompt_provenance": "public OpenHands SWE-bench Pro baseline; Z.ai tailored prompt undisclosed",
     "prompt_input": "rLLM official task instruction wrapped by the public OpenHands prompt",
     "workspace": "official task image /app exposed through OpenHands LocalWorkspace",
+    "openrouter_provider_route": {
+        "only": [OPENROUTER_PROVIDER_SLUG],
+        "allow_fallbacks": False,
+        "require_parameters": True,
+    },
 }
 
 _INSTALL_SCRIPT = rf"""
@@ -218,9 +225,19 @@ def _fake_response(conversation):
 
 
 def main():
+    model = os.environ["LLM_MODEL"]
+    provider_route = None
+    if model.startswith("openrouter/"):
+        provider_route = {{
+            "provider": {{
+                "only": ["{OPENROUTER_PROVIDER_SLUG}"],
+                "allow_fallbacks": False,
+                "require_parameters": True,
+            }}
+        }}
     llm = LLM(
         usage_id="agent",
-        model=os.environ["LLM_MODEL"],
+        model=model,
         api_key=os.environ["LLM_API_KEY"],
         base_url=os.environ["LLM_BASE_URL"],
         temperature={TEMPERATURE},
@@ -228,6 +245,7 @@ def main():
         max_input_tokens={CONTEXT_WINDOW_TOKENS},
         max_output_tokens={MAX_OUTPUT_TOKENS},
         disable_vision=True,
+        litellm_extra_body=provider_route or {{}},
     )
     condenser_llm = llm.model_copy(deep=True, update={{"usage_id": "condenser"}})
     public_skills = load_public_skills()
@@ -300,7 +318,13 @@ class SwebenchProOpenHandsGLM52Harness(BaseCliHarness):
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
         if "glm-5.2" not in config.model.lower():
             raise ValueError(f"{self.name} requires a GLM-5.2 model, got {config.model!r}")
-        _, _, qualified = self.ensure_provider_prefix(config.model)
+        if config.model.lower().startswith("z-ai/"):
+            # rLLM's OpenRouter proxy exposes the exact OpenRouter model ID as
+            # its alias. Tell OpenHands/LiteLLM which provider syntax to use,
+            # while preserving that alias in the forwarded request body.
+            qualified = f"openrouter/{config.model}"
+        else:
+            _, _, qualified = self.ensure_provider_prefix(config.model)
         api_key = self.gateway_api_key(config, "OPENAI_API_KEY")
         timeout = int(float(task.metadata.get("agent_timeout") or self.run_timeout))
         workdir = str(task.metadata.get("workdir") or "/app")

--- a/rllm/harnesses/swebench_pro_openhands_glm52.py
+++ b/rllm/harnesses/swebench_pro_openhands_glm52.py
@@ -1,0 +1,344 @@
+"""Best-effort OpenHands profile for the llm-stats GLM-5.2 result.
+
+llm-stats reports a 0.621 resolve rate for GLM-5.2 on SWE-bench Pro, but
+labels every result on that page self-reported and publishes neither code nor
+task-level traces.  Z.ai discloses only that its run used OpenHands, a tailored
+prompt, temperature 1, top-p 1, 32K output tokens, and a 400K context window.
+
+This harness therefore pins the current public OpenHands SWE-bench Pro
+baseline and records the remaining provenance gap.  It is a reproduction
+attempt, not a claim that Z.ai's undisclosed prompt and OpenHands revision have
+been recovered.
+"""
+
+# ruff: noqa: E501 -- the vendored public prompt keeps upstream line breaks.
+
+from __future__ import annotations
+
+import json
+import shlex
+
+from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
+from rllm.types import AgentConfig, Episode, Task, TerminationReason
+
+LLM_STATS_REFERENCE_URL = "https://llm-stats.com/benchmarks/swe-bench-pro"
+LLM_STATS_TARGET_SCORE = 0.621
+TARGET_MODEL = "GLM-5.2"
+
+# Public baseline inspected on 2026-08-08. The benchmark repo pins the Agent
+# SDK through a git submodule; both revisions are kept here so an old rLLM run
+# remains reconstructable even after either upstream default branch moves.
+OPENHANDS_BENCHMARKS_REVISION = "1411fe96666e2c00b958cd30055ad232e2a64ca1"
+OPENHANDS_SDK_REVISION = "43376f1868ffd702746080714a59c16d3f69ec12"
+OPENHANDS_EXTENSIONS_REVISION = "2cfd75e2396ad5111f0e1670a5534a79bbf97a3e"
+
+TEMPERATURE = 1.0
+TOP_P = 1.0
+MAX_OUTPUT_TOKENS = 32_768
+CONTEXT_WINDOW_TOKENS = 400_000
+MAX_ITERATIONS = 500
+CONDENSER_MAX_SIZE = 240
+CONDENSER_KEEP_FIRST = 2
+
+_VENV_DIR = "/opt/rllm/swebench-pro-openhands-glm52"
+_DRIVER_PATH = "/tmp/rllm-swebench-pro-openhands.py"
+_PROMPT_PATH = "/tmp/rllm-swebench-pro-openhands-prompt.txt"
+_SUMMARY_PATH = "/tmp/rllm-swebench-pro-openhands-summary.json"
+_REVISION_FILE = f"{_VENV_DIR}/.sdk-revision"
+_SDK_ARCHIVE = f"https://github.com/OpenHands/software-agent-sdk/archive/{OPENHANDS_SDK_REVISION}.tar.gz"
+_SDK_REQUIREMENT = f"openhands-sdk @ {_SDK_ARCHIVE}#subdirectory=openhands-sdk"
+_TOOLS_REQUIREMENT = f"openhands-tools @ {_SDK_ARCHIVE}#subdirectory=openhands-tools"
+
+REPRODUCTION_PROFILE = {
+    "status": "best_effort",
+    "score_source": LLM_STATS_REFERENCE_URL,
+    "target_model": TARGET_MODEL,
+    "target_score": LLM_STATS_TARGET_SCORE,
+    "score_status": "self_reported_unverified",
+    "openhands_benchmarks_revision": OPENHANDS_BENCHMARKS_REVISION,
+    "openhands_sdk_revision": OPENHANDS_SDK_REVISION,
+    "openhands_extensions_revision": OPENHANDS_EXTENSIONS_REVISION,
+    "temperature": TEMPERATURE,
+    "top_p": TOP_P,
+    "max_output_tokens": MAX_OUTPUT_TOKENS,
+    "context_window_tokens": CONTEXT_WINDOW_TOKENS,
+    "max_iterations": MAX_ITERATIONS,
+    "prompt_provenance": "public OpenHands SWE-bench Pro baseline; Z.ai tailored prompt undisclosed",
+    "prompt_input": "rLLM official task instruction wrapped by the public OpenHands prompt",
+    "workspace": "official task image /app exposed through OpenHands LocalWorkspace",
+}
+
+_INSTALL_SCRIPT = rf"""
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+if ! command -v curl >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates git tmux
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl ca-certificates git tmux bash
+    fi
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    for attempt in 1 2 3 4 5; do
+        if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+            break
+        fi
+        if [ "$attempt" -eq 5 ]; then
+            echo "uv install failed after 5 attempts" >&2
+            exit 1
+        fi
+        sleep $((attempt * 3))
+    done
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+installed_revision="$(cat {_REVISION_FILE} 2>/dev/null || true)"
+if [ "$installed_revision" != "{OPENHANDS_SDK_REVISION}" ]; then
+    uv venv --python 3.12 --clear {_VENV_DIR}
+    uv pip install --python {_VENV_DIR}/bin/python {shlex.quote(_SDK_REQUIREMENT)}
+    uv pip install --python {_VENV_DIR}/bin/python --no-deps {shlex.quote(_TOOLS_REQUIREMENT)}
+    uv pip install --python {_VENV_DIR}/bin/python binaryornot cachetools libtmux func-timeout
+    printf '%s\n' "{OPENHANDS_SDK_REVISION}" > {_REVISION_FILE}
+fi
+"""
+
+
+def _render_prompt(instruction: str, workdir: str, base_commit: str) -> str:
+    """Render the pinned public OpenHands SWE-bench Pro prompt baseline."""
+    return f"""I have access to a code repository in the directory {workdir} . You can explore and modify files using the available tools. Consider the following issue description:
+
+<issue_description>
+{instruction}
+</issue_description>
+
+Can you help me implement the necessary changes to the repository so that the requirements specified in the <issue_description> are met?
+I've already taken care of all changes to any of the test files described in the <issue_description>. This means you DON'T have to modify the testing logic or any of the tests in any way.
+The benchmark image already includes the repository and its baseline dependencies, so prefer using the existing environment and only install missing dependencies when the repository clearly requires it.
+Your task is to make the minimal changes to non-test files in the {workdir} directory to ensure the <issue_description> is satisfied.
+
+Follow these phases to resolve the issue:
+
+Phase 1. READING: read the problem and reword it in clearer terms
+   1.1 If there are code or config snippets, explain any best practices or conventions they imply.
+   1.2 Highlight error messages, method names, variables, file names, stack traces, and technical details.
+   1.3 Explain the problem in clear terms.
+   1.4 Enumerate the steps to reproduce the problem.
+   1.5 Highlight any best practices to take into account when testing and fixing the issue.
+
+Phase 2. RUNNING: understand how the repository is built and tested
+   2.1 Read the repository docs and relevant config files to understand the expected workflow.
+   2.2 Identify the project language, package manager, test runner, and any required services.
+   2.3 Run the most relevant tests or reproduction steps for this issue.
+
+Phase 3. EXPLORATION: find the files that are related to the problem and possible solutions
+   3.1 Use search tools to locate relevant methods, classes, keywords, and error messages.
+   3.2 Identify all files related to the problem statement.
+   3.3 Propose the most likely files and functions to change, and explain why.
+   3.4 Select the best fix location before editing.
+
+Phase 4. TEST CREATION: before implementing any fix, create a script or command sequence to reproduce and verify the issue.
+   4.1 Look at existing tests to understand the expected style and structure.
+   4.2 Create a minimal reproduction that demonstrates the issue.
+   4.3 Run it to confirm you are reproducing the problem.
+   4.4 Refine it as needed.
+
+Phase 5. FIX ANALYSIS: state clearly the problem and how to fix it
+   5.1 State clearly what the problem is.
+   5.2 State clearly where the problem is located.
+   5.3 State clearly how the reproduction proves the issue.
+   5.4 State clearly any best practices to preserve in the fix.
+   5.5 State clearly how you will fix the problem.
+
+Phase 6. FIX IMPLEMENTATION: edit the source code to implement your chosen solution.
+   6.1 Make minimal, focused changes to fix the issue.
+
+Phase 7. VERIFICATION: test your implementation thoroughly.
+   7.1 Re-run your reproduction to verify the fix works.
+   7.2 Add edge cases when useful.
+   7.3 Run existing tests related to the modified code to ensure you have not broken anything else.
+
+Phase 8. FINAL REVIEW: carefully re-read the problem description and compare your changes with the base commit {base_commit}.
+   8.1 Ensure you've fully addressed all requirements.
+   8.2 Run any relevant tests for the issue, the files you modified, and the functions you changed.
+   8.3 If any tests fail, revise your implementation until all relevant tests pass.
+
+Be thorough in your exploration, testing, and reasoning. It is fine if your thinking process is lengthy: quality and completeness are more important than brevity.
+"""
+
+
+_DRIVER_SCRIPT = rf'''"""Pinned local-workspace OpenHands driver for rLLM."""
+
+import json
+import os
+
+from openhands.sdk import Agent, Conversation, LLM
+from openhands.sdk.context import AgentContext
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.event import ActionEvent, MessageEvent
+from openhands.sdk.tool.builtins.finish import FinishAction
+from openhands.sdk.skills import load_public_skills
+from openhands.tools.preset.default import get_default_tools
+
+
+def _finished(events):
+    for event in reversed(events):
+        if isinstance(event, ActionEvent):
+            return isinstance(event.action, FinishAction)
+    return False
+
+
+def _sent_message(events):
+    for event in reversed(events):
+        if isinstance(event, MessageEvent) and event.source == "agent":
+            return True
+        if isinstance(event, ActionEvent):
+            return False
+    return False
+
+
+def _fake_response(conversation):
+    user_messages = [
+        event
+        for event in conversation.state.events
+        if isinstance(event, MessageEvent) and event.source == "user"
+    ]
+    message = (
+        "Please continue working on the task on whatever approach you think is suitable.\n"
+        "When you think you have solved the question, please use the finish tool and "
+        "include your final answer in the message parameter of the finish tool.\n"
+        "IMPORTANT: YOU SHOULD NEVER ASK FOR HUMAN HELP.\n"
+    )
+    if len(user_messages) >= 2:
+        message += 'If you want to give up, use the "finish" tool to finish the interaction.\n'
+    return message
+
+
+def main():
+    llm = LLM(
+        usage_id="agent",
+        model=os.environ["LLM_MODEL"],
+        api_key=os.environ["LLM_API_KEY"],
+        base_url=os.environ["LLM_BASE_URL"],
+        temperature={TEMPERATURE},
+        top_p={TOP_P},
+        max_input_tokens={CONTEXT_WINDOW_TOKENS},
+        max_output_tokens={MAX_OUTPUT_TOKENS},
+        disable_vision=True,
+    )
+    condenser_llm = llm.model_copy(deep=True, update={{"usage_id": "condenser"}})
+    public_skills = load_public_skills()
+    agent_context = AgentContext(skills=public_skills) if public_skills else None
+    agent = Agent(
+        llm=llm,
+        tools=get_default_tools(enable_browser=False),
+        system_prompt_kwargs={{"cli_mode": True}},
+        condenser=LLMSummarizingCondenser(
+            llm=condenser_llm,
+            max_size={CONDENSER_MAX_SIZE},
+            keep_first={CONDENSER_KEEP_FIRST},
+        ),
+        agent_context=agent_context,
+    )
+    conversation = Conversation(
+        agent=agent,
+        workspace=os.environ["RLLM_OPENHANDS_WORKDIR"],
+        max_iteration_per_run={MAX_ITERATIONS},
+        delete_on_close=True,
+    )
+    instruction = open(os.environ["RLLM_OPENHANDS_PROMPT_PATH"], encoding="utf-8").read()
+    conversation.send_message(instruction)
+
+    fake_responses = 0
+    timeout = int(os.environ.get("CONVERSATION_TIMEOUT", "3600"))
+    while True:
+        conversation.run(timeout=timeout)
+        events = list(conversation.state.events)
+        if conversation.state.execution_status != ConversationExecutionStatus.FINISHED:
+            break
+        if _finished(events) or not _sent_message(events) or fake_responses >= 10:
+            break
+        conversation.send_message(_fake_response(conversation))
+        fake_responses += 1
+
+    summary = {{
+        "execution_status": conversation.state.execution_status.value,
+        "events": len(list(conversation.state.events)),
+        "fake_responses": fake_responses,
+        "profile": {json.dumps(REPRODUCTION_PROFILE, sort_keys=True)},
+    }}
+    with open(os.environ["RLLM_OPENHANDS_SUMMARY_PATH"], "w", encoding="utf-8") as stream:
+        json.dump(summary, stream, indent=2, sort_keys=True)
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+class SwebenchProOpenHandsGLM52Harness(BaseCliHarness):
+    """Run the public OpenHands baseline toward llm-stats' GLM-5.2 score."""
+
+    name = "swebench-pro-openhands-glm52"
+    sandbox_backend = "docker"
+    stdout_log_path = "/tmp/swebench-pro-openhands-glm52.log"
+
+    target_score = LLM_STATS_TARGET_SCORE
+    max_iterations = MAX_ITERATIONS
+    temperature = TEMPERATURE
+    top_p = TOP_P
+    max_output_tokens = MAX_OUTPUT_TOKENS
+    context_window_tokens = CONTEXT_WINDOW_TOKENS
+
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        if "glm-5.2" not in config.model.lower():
+            raise ValueError(f"{self.name} requires a GLM-5.2 model, got {config.model!r}")
+        _, _, qualified = self.ensure_provider_prefix(config.model)
+        api_key = self.gateway_api_key(config, "OPENAI_API_KEY")
+        timeout = int(float(task.metadata.get("agent_timeout") or self.run_timeout))
+        workdir = str(task.metadata.get("workdir") or "/app")
+        return {
+            "LLM_MODEL": qualified,
+            "LLM_API_KEY": api_key,
+            "LLM_BASE_URL": config.base_url,
+            "OPENAI_API_KEY": api_key,
+            "OPENAI_API_BASE": config.base_url,
+            "OPENAI_BASE_URL": config.base_url,
+            "OPENHANDS_SUPPRESS_BANNER": "1",
+            "EXTENSIONS_REF": OPENHANDS_EXTENSIONS_REVISION,
+            "LITELLM_LOCAL_MODEL_COST_MAP": "True",
+            "CONVERSATION_TIMEOUT": str(timeout),
+            "RLLM_OPENHANDS_WORKDIR": workdir,
+            "RLLM_OPENHANDS_PROMPT_PATH": _PROMPT_PATH,
+            "RLLM_OPENHANDS_SUMMARY_PATH": _SUMMARY_PATH,
+        }
+
+    def write_configs(self, sandbox: Sandbox, task: Task, config: AgentConfig, env: dict[str, str]) -> None:
+        metadata = task.metadata.get("metadata", {}) or {}
+        base_commit = str(task.metadata.get("base_commit") or metadata.get("base_commit") or "the task base commit")
+        workdir = env["RLLM_OPENHANDS_WORKDIR"]
+        prompt = _render_prompt(str(task.instruction).strip(), workdir, base_commit)
+        self._exec_agent(sandbox, self._heredoc_write(_DRIVER_PATH, _DRIVER_SCRIPT), env=env)
+        self._exec_agent(sandbox, self._heredoc_write(_PROMPT_PATH, prompt), env=env)
+
+    def build_invocation(self, instruction: str, task: Task, config: AgentConfig) -> str:
+        del instruction, task, config
+        return f"set -o pipefail; {_VENV_DIR}/bin/python {shlex.quote(_DRIVER_PATH)} 2>&1 | tee {shlex.quote(self.stdout_log_path)}"
+
+    def _outcome_episode(
+        self,
+        task: Task,
+        termination_reason: TerminationReason | None = None,
+        error: dict | None = None,
+    ) -> Episode:
+        episode = super()._outcome_episode(task, termination_reason, error)
+        episode.metadata = dict(episode.metadata or {})
+        episode.metadata["reproduction_profile"] = dict(REPRODUCTION_PROFILE)
+        return episode

--- a/rllm/harnesses/swebench_pro_openhands_glm52.py
+++ b/rllm/harnesses/swebench_pro_openhands_glm52.py
@@ -16,17 +16,21 @@ been recovered.
 from __future__ import annotations
 
 import json
+import logging
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
 from rllm.sandbox.protocol import Sandbox
 from rllm.types import AgentConfig, Episode, Task, TerminationReason
 
+logger = logging.getLogger(__name__)
+
 LLM_STATS_REFERENCE_URL = "https://llm-stats.com/benchmarks/swe-bench-pro"
 LLM_STATS_TARGET_SCORE = 0.621
 TARGET_MODEL = "GLM-5.2"
 OPENROUTER_MODEL_ID = "z-ai/glm-5.2"
 OPENROUTER_PROVIDER_SLUG = "z-ai"
+FIREWORKS_MODEL_ID = "accounts/fireworks/models/glm-5p2"
 
 # Public baseline inspected on 2026-08-08. The benchmark repo pins the Agent
 # SDK through a git submodule; both revisions are kept here so an old rLLM run
@@ -34,6 +38,12 @@ OPENROUTER_PROVIDER_SLUG = "z-ai"
 OPENHANDS_BENCHMARKS_REVISION = "1411fe96666e2c00b958cd30055ad232e2a64ca1"
 OPENHANDS_SDK_REVISION = "43376f1868ffd702746080714a59c16d3f69ec12"
 OPENHANDS_EXTENSIONS_REVISION = "2cfd75e2396ad5111f0e1670a5534a79bbf97a3e"
+# Resolved by the SDK repository's uv.lock at OPENHANDS_SDK_REVISION. The
+# tools package only declares ``libtmux>=0.53.0``; installing that range today
+# selects newer releases whose tmux parser is incompatible with some official
+# SWE-bench Pro images (notably internetarchive/openlibrary).
+OPENHANDS_LIBTMUX_VERSION = "0.53.0"
+OPENHANDS_LOCALE = "C.UTF-8"
 
 TEMPERATURE = 1.0
 TOP_P = 1.0
@@ -47,7 +57,9 @@ _VENV_DIR = "/opt/rllm/swebench-pro-openhands-glm52"
 _DRIVER_PATH = "/tmp/rllm-swebench-pro-openhands.py"
 _PROMPT_PATH = "/tmp/rllm-swebench-pro-openhands-prompt.txt"
 _SUMMARY_PATH = "/tmp/rllm-swebench-pro-openhands-summary.json"
+_OUTCOME_PATH = "/tmp/rllm-swebench-pro-openhands-outcome.json"
 _REVISION_FILE = f"{_VENV_DIR}/.sdk-revision"
+_INSTALL_REVISION = f"{OPENHANDS_SDK_REVISION}:libtmux=={OPENHANDS_LIBTMUX_VERSION}"
 _SDK_ARCHIVE = f"https://github.com/OpenHands/software-agent-sdk/archive/{OPENHANDS_SDK_REVISION}.tar.gz"
 _SDK_REQUIREMENT = f"openhands-sdk @ {_SDK_ARCHIVE}#subdirectory=openhands-sdk"
 _TOOLS_REQUIREMENT = f"openhands-tools @ {_SDK_ARCHIVE}#subdirectory=openhands-tools"
@@ -61,6 +73,8 @@ REPRODUCTION_PROFILE = {
     "openhands_benchmarks_revision": OPENHANDS_BENCHMARKS_REVISION,
     "openhands_sdk_revision": OPENHANDS_SDK_REVISION,
     "openhands_extensions_revision": OPENHANDS_EXTENSIONS_REVISION,
+    "libtmux_version": OPENHANDS_LIBTMUX_VERSION,
+    "locale": OPENHANDS_LOCALE,
     "temperature": TEMPERATURE,
     "top_p": TOP_P,
     "max_output_tokens": MAX_OUTPUT_TOKENS,
@@ -72,7 +86,12 @@ REPRODUCTION_PROFILE = {
     "openrouter_provider_route": {
         "only": [OPENROUTER_PROVIDER_SLUG],
         "allow_fallbacks": False,
-        "require_parameters": True,
+        # OpenHands/LiteLLM includes auxiliary request fields that Z.AI does
+        # not advertise even though it supports the disclosed benchmark
+        # settings and tools.  Requiring every field would exclude Z.AI before
+        # the request reaches it; with this false, unsupported extras are
+        # ignored while routing remains pinned to Z.AI.
+        "require_parameters": False,
     },
 }
 
@@ -103,12 +122,12 @@ fi
 export PATH="$HOME/.local/bin:$PATH"
 
 installed_revision="$(cat {_REVISION_FILE} 2>/dev/null || true)"
-if [ "$installed_revision" != "{OPENHANDS_SDK_REVISION}" ]; then
+if [ "$installed_revision" != "{_INSTALL_REVISION}" ]; then
     uv venv --python 3.12 --clear {_VENV_DIR}
     uv pip install --python {_VENV_DIR}/bin/python {shlex.quote(_SDK_REQUIREMENT)}
     uv pip install --python {_VENV_DIR}/bin/python --no-deps {shlex.quote(_TOOLS_REQUIREMENT)}
-    uv pip install --python {_VENV_DIR}/bin/python binaryornot cachetools libtmux func-timeout
-    printf '%s\n' "{OPENHANDS_SDK_REVISION}" > {_REVISION_FILE}
+    uv pip install --python {_VENV_DIR}/bin/python binaryornot cachetools libtmux=={OPENHANDS_LIBTMUX_VERSION} func-timeout
+    printf '%s\n' "{_INSTALL_REVISION}" > {_REVISION_FILE}
 fi
 """
 
@@ -180,6 +199,7 @@ _DRIVER_SCRIPT = rf'''"""Pinned local-workspace OpenHands driver for rLLM."""
 
 import json
 import os
+import traceback
 
 from openhands.sdk import Agent, Conversation, LLM
 from openhands.sdk.context import AgentContext
@@ -224,72 +244,118 @@ def _fake_response(conversation):
     return message
 
 
-def main():
-    model = os.environ["LLM_MODEL"]
-    provider_route = None
-    if model.startswith("openrouter/"):
-        provider_route = {{
-            "provider": {{
-                "only": ["{OPENROUTER_PROVIDER_SLUG}"],
-                "allow_fallbacks": False,
-                "require_parameters": True,
-            }}
-        }}
-    llm = LLM(
-        usage_id="agent",
-        model=model,
-        api_key=os.environ["LLM_API_KEY"],
-        base_url=os.environ["LLM_BASE_URL"],
-        temperature={TEMPERATURE},
-        top_p={TOP_P},
-        max_input_tokens={CONTEXT_WINDOW_TOKENS},
-        max_output_tokens={MAX_OUTPUT_TOKENS},
-        disable_vision=True,
-        litellm_extra_body=provider_route or {{}},
-    )
-    condenser_llm = llm.model_copy(deep=True, update={{"usage_id": "condenser"}})
-    public_skills = load_public_skills()
-    agent_context = AgentContext(skills=public_skills) if public_skills else None
-    agent = Agent(
-        llm=llm,
-        tools=get_default_tools(enable_browser=False),
-        system_prompt_kwargs={{"cli_mode": True}},
-        condenser=LLMSummarizingCondenser(
-            llm=condenser_llm,
-            max_size={CONDENSER_MAX_SIZE},
-            keep_first={CONDENSER_KEEP_FIRST},
-        ),
-        agent_context=agent_context,
-    )
-    conversation = Conversation(
-        agent=agent,
-        workspace=os.environ["RLLM_OPENHANDS_WORKDIR"],
-        max_iteration_per_run={MAX_ITERATIONS},
-        delete_on_close=True,
-    )
-    instruction = open(os.environ["RLLM_OPENHANDS_PROMPT_PATH"], encoding="utf-8").read()
-    conversation.send_message(instruction)
+class ConversationIncompleteError(RuntimeError):
+    pass
 
+
+def _write_json(path, data):
+    temporary = f"{{path}}.tmp.{{os.getpid()}}"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        json.dump(data, stream, indent=2, sort_keys=True)
+    os.replace(temporary, path)
+
+
+def main():
+    conversation = None
+    failure = None
+    failure_traceback = None
     fake_responses = 0
-    timeout = int(os.environ.get("CONVERSATION_TIMEOUT", "3600"))
-    while True:
-        conversation.run(timeout=timeout)
-        events = list(conversation.state.events)
-        if conversation.state.execution_status != ConversationExecutionStatus.FINISHED:
-            break
-        if _finished(events) or not _sent_message(events) or fake_responses >= 10:
-            break
-        conversation.send_message(_fake_response(conversation))
-        fake_responses += 1
+    try:
+        model = os.environ["LLM_MODEL"]
+        provider_route = None
+        if model.startswith("openrouter/"):
+            provider_route = {{
+                "provider": {{
+                    "only": ["{OPENROUTER_PROVIDER_SLUG}"],
+                    "allow_fallbacks": False,
+                    "require_parameters": False,
+                }}
+            }}
+        llm = LLM(
+            usage_id="agent",
+            model=model,
+            api_key=os.environ["LLM_API_KEY"],
+            base_url=os.environ["LLM_BASE_URL"],
+            temperature={TEMPERATURE},
+            top_p={TOP_P},
+            max_input_tokens={CONTEXT_WINDOW_TOKENS},
+            max_output_tokens={MAX_OUTPUT_TOKENS},
+            disable_vision=True,
+            litellm_extra_body=provider_route or {{}},
+        )
+        condenser_llm = llm.model_copy(deep=True, update={{"usage_id": "condenser"}})
+        public_skills = load_public_skills()
+        agent_context = AgentContext(skills=public_skills) if public_skills else None
+        agent = Agent(
+            llm=llm,
+            tools=get_default_tools(enable_browser=False),
+            system_prompt_kwargs={{"cli_mode": True}},
+            condenser=LLMSummarizingCondenser(
+                llm=condenser_llm,
+                max_size={CONDENSER_MAX_SIZE},
+                keep_first={CONDENSER_KEEP_FIRST},
+            ),
+            agent_context=agent_context,
+        )
+        conversation = Conversation(
+            agent=agent,
+            workspace=os.environ["RLLM_OPENHANDS_WORKDIR"],
+            max_iteration_per_run={MAX_ITERATIONS},
+            delete_on_close=True,
+        )
+        instruction = open(os.environ["RLLM_OPENHANDS_PROMPT_PATH"], encoding="utf-8").read()
+        conversation.send_message(instruction)
+
+        while True:
+            conversation.run()
+            events = list(conversation.state.events)
+            if conversation.state.execution_status != ConversationExecutionStatus.FINISHED:
+                break
+            if _finished(events) or not _sent_message(events) or fake_responses >= 10:
+                break
+            conversation.send_message(_fake_response(conversation))
+            fake_responses += 1
+    except BaseException as exc:
+        # OpenHands can raise while processing the terminal FinishAction. Keep
+        # the typed event authoritative, but record every pre-finish failure.
+        failure = exc
+        failure_traceback = traceback.format_exc()
+
+    events = list(conversation.state.events) if conversation is not None else []
+    finished = _finished(events)
+    execution_status = None
+    if conversation is not None:
+        status = conversation.state.execution_status
+        execution_status = getattr(status, "value", str(status))
+    if not finished and failure is None:
+        failure = ConversationIncompleteError(
+            f"OpenHands stopped without FinishAction (execution_status={{execution_status}})"
+        )
 
     summary = {{
-        "execution_status": conversation.state.execution_status.value,
-        "events": len(list(conversation.state.events)),
+        "execution_status": execution_status,
+        "events": len(events),
         "fake_responses": fake_responses,
-        "profile": {json.dumps(REPRODUCTION_PROFILE, sort_keys=True)},
+        "finished": finished,
+        "profile": {REPRODUCTION_PROFILE!r},
     }}
-    with open(os.environ["RLLM_OPENHANDS_SUMMARY_PATH"], "w", encoding="utf-8") as stream:
-        json.dump(summary, stream, indent=2, sort_keys=True)
+    try:
+        _write_json(os.environ["RLLM_OPENHANDS_SUMMARY_PATH"], summary)
+    except BaseException as exc:
+        if failure is None:
+            failure = exc
+            failure_traceback = traceback.format_exc()
+
+    outcome = {{
+        "finished": finished,
+        "execution_status": execution_status,
+        "exception_type": None if finished else type(failure).__name__,
+        "message": "" if failure is None else str(failure),
+        "traceback": None if finished else failure_traceback,
+    }}
+    # Write the authoritative sentinel last. Once it exists, the harness can
+    # classify the run even when the backend loses the exec completion.
+    _write_json(os.environ["RLLM_OPENHANDS_OUTCOME_PATH"], outcome)
     print(json.dumps(summary, sort_keys=True))
 
 
@@ -316,17 +382,26 @@ class SwebenchProOpenHandsGLM52Harness(BaseCliHarness):
         return _INSTALL_SCRIPT
 
     def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
-        if "glm-5.2" not in config.model.lower():
+        model_lower = config.model.lower()
+        if "glm-5.2" not in model_lower and model_lower != FIREWORKS_MODEL_ID:
             raise ValueError(f"{self.name} requires a GLM-5.2 model, got {config.model!r}")
-        if config.model.lower().startswith("z-ai/"):
+        if model_lower.startswith("z-ai/"):
             # rLLM's OpenRouter proxy exposes the exact OpenRouter model ID as
             # its alias. Tell OpenHands/LiteLLM which provider syntax to use,
             # while preserving that alias in the forwarded request body.
             qualified = f"openrouter/{config.model}"
+        elif model_lower == FIREWORKS_MODEL_ID:
+            # The sandbox talks to rLLM's OpenAI-compatible gateway, not
+            # Fireworks directly. Preserve Fireworks' full account-scoped model
+            # alias in the forwarded request body while using LiteLLM's OpenAI
+            # adapter for the gateway hop.
+            qualified = f"openai/{config.model}"
         else:
             _, _, qualified = self.ensure_provider_prefix(config.model)
-        api_key = self.gateway_api_key(config, "OPENAI_API_KEY")
-        timeout = int(float(task.metadata.get("agent_timeout") or self.run_timeout))
+        # The sandbox talks only to rLLM's gateway; the real OpenRouter key
+        # remains in the host-side proxy.  Use a harness-specific fallback so
+        # an unrelated host OPENAI_API_KEY is never copied into the sandbox.
+        api_key = self.gateway_api_key(config, "RLLM_GATEWAY_API_KEY")
         workdir = str(task.metadata.get("workdir") or "/app")
         return {
             "LLM_MODEL": qualified,
@@ -338,10 +413,43 @@ class SwebenchProOpenHandsGLM52Harness(BaseCliHarness):
             "OPENHANDS_SUPPRESS_BANNER": "1",
             "EXTENSIONS_REF": OPENHANDS_EXTENSIONS_REVISION,
             "LITELLM_LOCAL_MODEL_COST_MAP": "True",
-            "CONVERSATION_TIMEOUT": str(timeout),
+            # The pinned OpenHands agent-layer Dockerfile requires this UTF-8
+            # locale so tmux preserves libtmux's Unicode field separator.
+            "LC_ALL": OPENHANDS_LOCALE,
+            "LANG": OPENHANDS_LOCALE,
             "RLLM_OPENHANDS_WORKDIR": workdir,
             "RLLM_OPENHANDS_PROMPT_PATH": _PROMPT_PATH,
             "RLLM_OPENHANDS_SUMMARY_PATH": _SUMMARY_PATH,
+            "RLLM_OPENHANDS_OUTCOME_PATH": _OUTCOME_PATH,
+        }
+
+    def _read_outcome(self, sandbox: Sandbox) -> dict | None:
+        try:
+            raw = sandbox.exec(
+                f"cat {shlex.quote(_OUTCOME_PATH)} 2>/dev/null || true",
+                timeout=15,
+                user=self.agent_user,
+            ).strip()
+        except Exception as exc:
+            logger.debug("SWE-bench Pro OpenHands outcome read failed: %s", exc)
+            return None
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except Exception as exc:
+            logger.debug("SWE-bench Pro OpenHands outcome parse failed: %s", exc)
+            return None
+        if data.get("finished") is True:
+            return {}
+        message = data.get("message", "")
+        failure_traceback = data.get("traceback")
+        if failure_traceback:
+            message = f"{message}\n\n{failure_traceback}" if message else failure_traceback
+        return {
+            "exception_type": data.get("exception_type") or "ConversationIncompleteError",
+            "message": message,
+            "traceback": failure_traceback,
         }
 
     def write_configs(self, sandbox: Sandbox, task: Task, config: AgentConfig, env: dict[str, str]) -> None:
@@ -354,7 +462,8 @@ class SwebenchProOpenHandsGLM52Harness(BaseCliHarness):
 
     def build_invocation(self, instruction: str, task: Task, config: AgentConfig) -> str:
         del instruction, task, config
-        return f"set -o pipefail; {_VENV_DIR}/bin/python {shlex.quote(_DRIVER_PATH)} 2>&1 | tee {shlex.quote(self.stdout_log_path)}"
+        log = shlex.quote(self.stdout_log_path)
+        return f"set -o pipefail; {_VENV_DIR}/bin/python {shlex.quote(_DRIVER_PATH)} 2>&1 | tee {log}"
 
     def _outcome_episode(
         self,

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -26,6 +26,11 @@
       "function": "MiniSweAgentHarness",
       "description": "Run mini-swe-agent inside the sandbox."
     },
+    "swebench-pro-openhands-glm52": {
+      "module": "rllm.harnesses.swebench_pro_openhands_glm52",
+      "function": "SwebenchProOpenHandsGLM52Harness",
+      "description": "Best-effort OpenHands reproduction profile for llm-stats' GLM-5.2 SWE-bench Pro score (0.621)."
+    },
     "terminus2": {
       "module": "rllm.harnesses.terminus2",
       "function": "Terminus2Harness",

--- a/tests/harnesses/test_swebench_pro_openhands_glm52.py
+++ b/tests/harnesses/test_swebench_pro_openhands_glm52.py
@@ -2,19 +2,27 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from dataclasses import dataclass, field
+from enum import Enum
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 from rllm.eval.agent_loader import load_agent
 from rllm.harnesses.swebench_pro_openhands_glm52 import (
     _DRIVER_SCRIPT,
+    _OUTCOME_PATH,
     CONTEXT_WINDOW_TOKENS,
+    FIREWORKS_MODEL_ID,
     LLM_STATS_TARGET_SCORE,
     MAX_ITERATIONS,
     MAX_OUTPUT_TOKENS,
     OPENHANDS_BENCHMARKS_REVISION,
     OPENHANDS_EXTENSIONS_REVISION,
+    OPENHANDS_LIBTMUX_VERSION,
+    OPENHANDS_LOCALE,
     OPENHANDS_SDK_REVISION,
     OPENROUTER_MODEL_ID,
     OPENROUTER_PROVIDER_SLUG,
@@ -22,17 +30,31 @@ from rllm.harnesses.swebench_pro_openhands_glm52 import (
     SwebenchProOpenHandsGLM52Harness,
     _render_prompt,
 )
-from rllm.types import AgentConfig, Task
+from rllm.sandbox.protocol import SandboxCommandTimeout
+from rllm.types import AgentConfig, Task, TerminationReason
 
 
 @dataclass
 class FakeSandbox:
     calls: list[str] = field(default_factory=list)
+    outcome: str | None = None
+    fail_invocation: bool = False
+    timeout_invocation: bool = False
 
     def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
         del timeout, user
         self.calls.append(command)
+        if command.startswith(f"cat {_OUTCOME_PATH}"):
+            return self.outcome or ""
+        if "/bin/python /tmp/rllm-swebench-pro-openhands.py" in command:
+            if self.timeout_invocation:
+                raise SandboxCommandTimeout("agent timed out")
+            if self.fail_invocation:
+                raise RuntimeError("driver exited non-zero")
         return "OK"
+
+    def is_alive(self) -> bool:
+        return True
 
 
 def _task() -> Task:
@@ -61,6 +83,8 @@ def test_profile_records_public_baseline_and_disclosure_gap():
     assert len(OPENHANDS_BENCHMARKS_REVISION) == 40
     assert len(OPENHANDS_SDK_REVISION) == 40
     assert len(OPENHANDS_EXTENSIONS_REVISION) == 40
+    assert OPENHANDS_LIBTMUX_VERSION == "0.53.0"
+    assert OPENHANDS_LOCALE == "C.UTF-8"
     assert REPRODUCTION_PROFILE["status"] == "best_effort"
     assert REPRODUCTION_PROFILE["score_status"] == "self_reported_unverified"
     assert "undisclosed" in REPRODUCTION_PROFILE["prompt_provenance"]
@@ -68,7 +92,7 @@ def test_profile_records_public_baseline_and_disclosure_gap():
     assert REPRODUCTION_PROFILE["openrouter_provider_route"] == {
         "only": [OPENROUTER_PROVIDER_SLUG],
         "allow_fallbacks": False,
-        "require_parameters": True,
+        "require_parameters": False,
     }
 
 
@@ -79,7 +103,8 @@ def test_install_script_pins_sdk_and_uses_minimal_tool_dependencies():
     assert "#subdirectory=openhands-sdk" in script
     assert "#subdirectory=openhands-tools" in script
     assert "--no-deps" in script
-    assert "binaryornot cachetools libtmux func-timeout" in script
+    assert f"binaryornot cachetools libtmux=={OPENHANDS_LIBTMUX_VERSION} func-timeout" in script
+    assert f"{OPENHANDS_SDK_REVISION}:libtmux=={OPENHANDS_LIBTMUX_VERSION}" in script
     assert "tmux" in script
 
 
@@ -97,6 +122,14 @@ def test_driver_is_valid_and_encodes_disclosed_sampling_settings():
     assert "agent_context=agent_context" in _DRIVER_SCRIPT
     assert 'model.startswith("openrouter/")' in _DRIVER_SCRIPT
     assert '"allow_fallbacks": False' in _DRIVER_SCRIPT
+    assert '"require_parameters": False' in _DRIVER_SCRIPT
+    assert "conversation.run()" in _DRIVER_SCRIPT
+    assert "conversation.run(timeout=" not in _DRIVER_SCRIPT
+    assert "finished = _finished(events)" in _DRIVER_SCRIPT
+    assert '"exception_type": None if finished else type(failure).__name__' in _DRIVER_SCRIPT
+    assert "failure_traceback = traceback.format_exc()" in _DRIVER_SCRIPT
+    assert '"traceback": None if finished else failure_traceback' in _DRIVER_SCRIPT
+    assert "os.replace(temporary, path)" in _DRIVER_SCRIPT
 
 
 def test_build_env_routes_openhands_through_the_rllm_gateway():
@@ -107,8 +140,11 @@ def test_build_env_routes_openhands_through_the_rllm_gateway():
     assert env["LLM_BASE_URL"] == "http://gateway/sessions/test/v1"
     assert env["OPENAI_API_KEY"] == "gateway-token"
     assert env["EXTENSIONS_REF"] == OPENHANDS_EXTENSIONS_REVISION
-    assert env["CONVERSATION_TIMEOUT"] == "3600"
+    assert env["LC_ALL"] == OPENHANDS_LOCALE
+    assert env["LANG"] == OPENHANDS_LOCALE
+    assert "CONVERSATION_TIMEOUT" not in env
     assert env["RLLM_OPENHANDS_WORKDIR"] == "/app"
+    assert env["RLLM_OPENHANDS_OUTCOME_PATH"] == _OUTCOME_PATH
 
 
 def test_profile_rejects_non_glm52_models():
@@ -120,6 +156,23 @@ def test_build_env_preserves_openrouter_model_alias():
     env = SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config(OPENROUTER_MODEL_ID))
 
     assert env["LLM_MODEL"] == f"openrouter/{OPENROUTER_MODEL_ID}"
+
+
+def test_build_env_preserves_fireworks_model_alias_through_gateway():
+    env = SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config(FIREWORKS_MODEL_ID))
+
+    assert env["LLM_MODEL"] == f"openai/{FIREWORKS_MODEL_ID}"
+
+
+def test_build_env_does_not_fall_back_to_a_host_provider_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "host-provider-secret")
+    config = _config()
+    config.metadata = {}
+
+    env = SwebenchProOpenHandsGLM52Harness().build_env(_task(), config)
+
+    assert env["LLM_API_KEY"] == "sk-rllm-gateway"
+    assert env["OPENAI_API_KEY"] == "sk-rllm-gateway"
 
 
 def test_write_configs_materializes_driver_and_public_prompt():
@@ -148,6 +201,200 @@ def test_prompt_and_invocation_use_the_existing_rllm_task_workspace():
     assert invocation.startswith("set -o pipefail;")
     assert "/opt/rllm/swebench-pro-openhands-glm52/bin/python" in invocation
     assert "tee /tmp/swebench-pro-openhands-glm52.log" in invocation
+    assert "grep" not in invocation
+
+
+def _run_driver_with_fake_openhands(monkeypatch, tmp_path, *, finish_before_error: bool) -> dict:
+    class ExecutionStatus(Enum):
+        FINISHED = "finished"
+
+    class FinishAction:
+        pass
+
+    class ActionEvent:
+        def __init__(self, action):
+            self.action = action
+
+    class MessageEvent:
+        def __init__(self, source):
+            self.source = source
+
+    class LLM:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def model_copy(self, **kwargs):
+            del kwargs
+            return self
+
+    class AcceptsKeywords:
+        def __init__(self, **kwargs):
+            del kwargs
+
+    class Conversation:
+        def __init__(self, **kwargs):
+            del kwargs
+            self.state = SimpleNamespace(events=[], execution_status=ExecutionStatus.FINISHED)
+
+        def send_message(self, message):
+            del message
+
+        def run(self):
+            if finish_before_error:
+                self.state.events.append(ActionEvent(FinishAction()))
+                raise RuntimeError("cleanup failed after finish")
+            raise RuntimeError("gateway unavailable")
+
+    modules = {
+        name: ModuleType(name)
+        for name in (
+            "openhands",
+            "openhands.sdk",
+            "openhands.sdk.context",
+            "openhands.sdk.context.condenser",
+            "openhands.sdk.conversation",
+            "openhands.sdk.conversation.state",
+            "openhands.sdk.event",
+            "openhands.sdk.tool",
+            "openhands.sdk.tool.builtins",
+            "openhands.sdk.tool.builtins.finish",
+            "openhands.sdk.skills",
+            "openhands.tools",
+            "openhands.tools.preset",
+            "openhands.tools.preset.default",
+        )
+    }
+    modules["openhands.sdk"].Agent = AcceptsKeywords
+    modules["openhands.sdk"].Conversation = Conversation
+    modules["openhands.sdk"].LLM = LLM
+    modules["openhands.sdk.context"].AgentContext = AcceptsKeywords
+    modules["openhands.sdk.context.condenser"].LLMSummarizingCondenser = AcceptsKeywords
+    modules["openhands.sdk.conversation.state"].ConversationExecutionStatus = ExecutionStatus
+    modules["openhands.sdk.event"].ActionEvent = ActionEvent
+    modules["openhands.sdk.event"].MessageEvent = MessageEvent
+    modules["openhands.sdk.tool.builtins.finish"].FinishAction = FinishAction
+    modules["openhands.sdk.skills"].load_public_skills = lambda: []
+    modules["openhands.tools.preset.default"].get_default_tools = lambda **kwargs: []
+    for name, module in modules.items():
+        if name.rsplit(".", 1)[-1] not in {"condenser", "state", "event", "finish", "skills", "default"}:
+            module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    prompt_path = tmp_path / "prompt.txt"
+    summary_path = tmp_path / "summary.json"
+    outcome_path = tmp_path / "outcome.json"
+    prompt_path.write_text("Fix it")
+    env = {
+        "LLM_MODEL": "openrouter/z-ai/glm-5.2",
+        "LLM_API_KEY": "test-key",
+        "LLM_BASE_URL": "http://gateway/v1",
+        "RLLM_OPENHANDS_WORKDIR": "/app",
+        "RLLM_OPENHANDS_PROMPT_PATH": str(prompt_path),
+        "RLLM_OPENHANDS_SUMMARY_PATH": str(summary_path),
+        "RLLM_OPENHANDS_OUTCOME_PATH": str(outcome_path),
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    namespace = {"__name__": "test_openhands_driver"}
+    exec(compile(_DRIVER_SCRIPT, "<openhands-driver>", "exec"), namespace)
+    namespace["main"]()
+    return json.loads(outcome_path.read_text())
+
+
+def test_driver_treats_typed_finish_as_authoritative_after_cleanup_error(monkeypatch, tmp_path):
+    outcome = _run_driver_with_fake_openhands(monkeypatch, tmp_path, finish_before_error=True)
+
+    assert outcome == {
+        "execution_status": "finished",
+        "exception_type": None,
+        "finished": True,
+        "message": "cleanup failed after finish",
+        "traceback": None,
+    }
+
+
+def test_driver_records_gateway_failure_when_no_typed_finish_exists(monkeypatch, tmp_path):
+    outcome = _run_driver_with_fake_openhands(monkeypatch, tmp_path, finish_before_error=False)
+
+    assert {key: value for key, value in outcome.items() if key != "traceback"} == {
+        "execution_status": "finished",
+        "exception_type": "RuntimeError",
+        "finished": False,
+        "message": "gateway unavailable",
+    }
+    assert "RuntimeError: gateway unavailable" in outcome["traceback"]
+
+
+def test_read_outcome_uses_typed_finish_not_reward_or_stdout():
+    sandbox = FakeSandbox(outcome=json.dumps({"finished": True, "reward": 0, "message": "cleanup failed"}))
+
+    assert SwebenchProOpenHandsGLM52Harness()._read_outcome(sandbox) == {}
+
+
+def test_run_maps_typed_finish_to_env_done():
+    sandbox = FakeSandbox(
+        outcome=json.dumps(
+            {
+                "finished": True,
+                "execution_status": "finished",
+                "exception_type": None,
+                "message": "cleanup failed after finish",
+            }
+        )
+    )
+
+    episode = SwebenchProOpenHandsGLM52Harness().run(_task(), _config(), env=sandbox)
+
+    assert episode.termination_reason is None
+    assert "error" not in episode.metadata
+
+
+def test_run_maps_structured_failure_without_finish_to_error():
+    sandbox = FakeSandbox(
+        outcome=json.dumps(
+            {
+                "finished": False,
+                "execution_status": "error",
+                "exception_type": "RuntimeError",
+                "message": "gateway unavailable",
+                "traceback": "Traceback (most recent call last):\n  driver.py, line 1\nRuntimeError: gateway unavailable\n",
+            }
+        )
+    )
+
+    episode = SwebenchProOpenHandsGLM52Harness().run(_task(), _config(), env=sandbox)
+
+    assert episode.termination_reason == TerminationReason.ERROR
+    assert episode.metadata["error"] == {
+        "error_type": "RuntimeError",
+        "message": "gateway unavailable\n\nTraceback (most recent call last):\n  driver.py, line 1\nRuntimeError: gateway unavailable\n",
+    }
+
+
+def test_run_maps_structured_timeout_without_finish_to_timeout():
+    sandbox = FakeSandbox(
+        outcome=json.dumps(
+            {
+                "finished": False,
+                "exception_type": "AgentTimeoutError",
+                "message": "agent timed out",
+            }
+        ),
+        timeout_invocation=True,
+    )
+
+    episode = SwebenchProOpenHandsGLM52Harness().run(_task(), _config(), env=sandbox)
+
+    assert episode.termination_reason == TerminationReason.TIMEOUT
+
+
+def test_run_keeps_nonzero_without_sentinel_as_error():
+    sandbox = FakeSandbox(fail_invocation=True)
+
+    episode = SwebenchProOpenHandsGLM52Harness().run(_task(), _config(), env=sandbox)
+
+    assert episode.termination_reason == TerminationReason.ERROR
 
 
 def test_registry_loads_profile_and_episode_records_provenance():

--- a/tests/harnesses/test_swebench_pro_openhands_glm52.py
+++ b/tests/harnesses/test_swebench_pro_openhands_glm52.py
@@ -1,0 +1,143 @@
+"""Offline tests for the SWE-bench Pro OpenHands GLM-5.2 profile."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from rllm.eval.agent_loader import load_agent
+from rllm.harnesses.swebench_pro_openhands_glm52 import (
+    _DRIVER_SCRIPT,
+    CONTEXT_WINDOW_TOKENS,
+    LLM_STATS_TARGET_SCORE,
+    MAX_ITERATIONS,
+    MAX_OUTPUT_TOKENS,
+    OPENHANDS_BENCHMARKS_REVISION,
+    OPENHANDS_EXTENSIONS_REVISION,
+    OPENHANDS_SDK_REVISION,
+    REPRODUCTION_PROFILE,
+    SwebenchProOpenHandsGLM52Harness,
+    _render_prompt,
+)
+from rllm.types import AgentConfig, Task
+
+
+@dataclass
+class FakeSandbox:
+    calls: list[str] = field(default_factory=list)
+
+    def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
+        del timeout, user
+        self.calls.append(command)
+        return "OK"
+
+
+def _task() -> Task:
+    return Task(
+        id="task-1",
+        instruction="Fix the issue.\n\nRequirements:\nKeep the API stable.",
+        metadata={
+            "workdir": "/app",
+            "agent_timeout": 3600.0,
+            "metadata": {"base_commit": "a" * 40},
+        },
+    )
+
+
+def _config(model: str = "openai/glm-5.2") -> AgentConfig:
+    return AgentConfig(
+        base_url="http://gateway/sessions/test/v1",
+        model=model,
+        session_uid="test",
+        metadata={"gateway_auth_token": "gateway-token"},
+    )
+
+
+def test_profile_records_public_baseline_and_disclosure_gap():
+    assert LLM_STATS_TARGET_SCORE == 0.621
+    assert len(OPENHANDS_BENCHMARKS_REVISION) == 40
+    assert len(OPENHANDS_SDK_REVISION) == 40
+    assert len(OPENHANDS_EXTENSIONS_REVISION) == 40
+    assert REPRODUCTION_PROFILE["status"] == "best_effort"
+    assert REPRODUCTION_PROFILE["score_status"] == "self_reported_unverified"
+    assert "undisclosed" in REPRODUCTION_PROFILE["prompt_provenance"]
+    assert REPRODUCTION_PROFILE["max_iterations"] == 500
+
+
+def test_install_script_pins_sdk_and_uses_minimal_tool_dependencies():
+    script = SwebenchProOpenHandsGLM52Harness().install_script()
+
+    assert OPENHANDS_SDK_REVISION in script
+    assert "#subdirectory=openhands-sdk" in script
+    assert "#subdirectory=openhands-tools" in script
+    assert "--no-deps" in script
+    assert "binaryornot cachetools libtmux func-timeout" in script
+    assert "tmux" in script
+
+
+def test_driver_is_valid_and_encodes_disclosed_sampling_settings():
+    compile(_DRIVER_SCRIPT, "<openhands-driver>", "exec")
+
+    assert f"temperature={1.0}" in _DRIVER_SCRIPT
+    assert f"top_p={1.0}" in _DRIVER_SCRIPT
+    assert f"max_input_tokens={CONTEXT_WINDOW_TOKENS}" in _DRIVER_SCRIPT
+    assert f"max_output_tokens={MAX_OUTPUT_TOKENS}" in _DRIVER_SCRIPT
+    assert f"max_iteration_per_run={MAX_ITERATIONS}" in _DRIVER_SCRIPT
+    assert "get_default_tools(enable_browser=False)" in _DRIVER_SCRIPT
+    assert "LLMSummarizingCondenser" in _DRIVER_SCRIPT
+    assert "load_public_skills()" in _DRIVER_SCRIPT
+    assert "agent_context=agent_context" in _DRIVER_SCRIPT
+
+
+def test_build_env_routes_openhands_through_the_rllm_gateway():
+    env = SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config())
+
+    assert env["LLM_MODEL"] == "openai/glm-5.2"
+    assert env["LLM_API_KEY"] == "gateway-token"
+    assert env["LLM_BASE_URL"] == "http://gateway/sessions/test/v1"
+    assert env["OPENAI_API_KEY"] == "gateway-token"
+    assert env["EXTENSIONS_REF"] == OPENHANDS_EXTENSIONS_REVISION
+    assert env["CONVERSATION_TIMEOUT"] == "3600"
+    assert env["RLLM_OPENHANDS_WORKDIR"] == "/app"
+
+
+def test_profile_rejects_non_glm52_models():
+    with pytest.raises(ValueError, match="requires a GLM-5.2 model"):
+        SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config("openai/gpt-5.4"))
+
+
+def test_write_configs_materializes_driver_and_public_prompt():
+    harness = SwebenchProOpenHandsGLM52Harness()
+    sandbox = FakeSandbox()
+    task = _task()
+    config = _config()
+    env = harness.build_env(task, config)
+
+    harness.write_configs(sandbox, task, config, env)
+
+    assert len(sandbox.calls) == 2
+    assert "Pinned local-workspace OpenHands driver" in sandbox.calls[0]
+    assert "<issue_description>" in sandbox.calls[1]
+    assert "Keep the API stable." in sandbox.calls[1]
+    assert "a" * 40 in sandbox.calls[1]
+    assert "make the minimal changes to non-test files in the /app directory" in sandbox.calls[1]
+
+
+def test_prompt_and_invocation_use_the_existing_rllm_task_workspace():
+    prompt = _render_prompt("Fix it", "/app", "b" * 40)
+    invocation = SwebenchProOpenHandsGLM52Harness().build_invocation("Fix it", _task(), _config())
+
+    assert "code repository in the directory /app" in prompt
+    assert "b" * 40 in prompt
+    assert invocation.startswith("set -o pipefail;")
+    assert "/opt/rllm/swebench-pro-openhands-glm52/bin/python" in invocation
+    assert "tee /tmp/swebench-pro-openhands-glm52.log" in invocation
+
+
+def test_registry_loads_profile_and_episode_records_provenance():
+    harness = load_agent("swebench-pro-openhands-glm52")
+    episode = harness._outcome_episode(_task())
+
+    assert isinstance(harness, SwebenchProOpenHandsGLM52Harness)
+    assert episode.metadata["reproduction_profile"] == REPRODUCTION_PROFILE

--- a/tests/harnesses/test_swebench_pro_openhands_glm52.py
+++ b/tests/harnesses/test_swebench_pro_openhands_glm52.py
@@ -16,6 +16,8 @@ from rllm.harnesses.swebench_pro_openhands_glm52 import (
     OPENHANDS_BENCHMARKS_REVISION,
     OPENHANDS_EXTENSIONS_REVISION,
     OPENHANDS_SDK_REVISION,
+    OPENROUTER_MODEL_ID,
+    OPENROUTER_PROVIDER_SLUG,
     REPRODUCTION_PROFILE,
     SwebenchProOpenHandsGLM52Harness,
     _render_prompt,
@@ -63,6 +65,11 @@ def test_profile_records_public_baseline_and_disclosure_gap():
     assert REPRODUCTION_PROFILE["score_status"] == "self_reported_unverified"
     assert "undisclosed" in REPRODUCTION_PROFILE["prompt_provenance"]
     assert REPRODUCTION_PROFILE["max_iterations"] == 500
+    assert REPRODUCTION_PROFILE["openrouter_provider_route"] == {
+        "only": [OPENROUTER_PROVIDER_SLUG],
+        "allow_fallbacks": False,
+        "require_parameters": True,
+    }
 
 
 def test_install_script_pins_sdk_and_uses_minimal_tool_dependencies():
@@ -88,6 +95,8 @@ def test_driver_is_valid_and_encodes_disclosed_sampling_settings():
     assert "LLMSummarizingCondenser" in _DRIVER_SCRIPT
     assert "load_public_skills()" in _DRIVER_SCRIPT
     assert "agent_context=agent_context" in _DRIVER_SCRIPT
+    assert 'model.startswith("openrouter/")' in _DRIVER_SCRIPT
+    assert '"allow_fallbacks": False' in _DRIVER_SCRIPT
 
 
 def test_build_env_routes_openhands_through_the_rllm_gateway():
@@ -105,6 +114,12 @@ def test_build_env_routes_openhands_through_the_rllm_gateway():
 def test_profile_rejects_non_glm52_models():
     with pytest.raises(ValueError, match="requires a GLM-5.2 model"):
         SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config("openai/gpt-5.4"))
+
+
+def test_build_env_preserves_openrouter_model_alias():
+    env = SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config(OPENROUTER_MODEL_ID))
+
+    assert env["LLM_MODEL"] == f"openrouter/{OPENROUTER_MODEL_ID}"
 
 
 def test_write_configs_materializes_driver_and_public_prompt():


### PR DESCRIPTION
## What changed

- add a best-effort OpenHands profile for reproducing the published GLM-5.2 SWE-bench Pro result
- pin the disclosed OpenHands SDK, extensions, and compatible `libtmux` revisions
- preserve the published sampling and context settings
- route GLM-5.2 through rLLM's gateway using either OpenRouter or Fireworks model aliases
- record structured finish, failure, and traceback outcomes so infrastructure failures are distinguishable from task failures

## Why

The generic SWE-bench Pro builder does not define the model-specific OpenHands setup used for the published GLM-5.2 result. Keeping this profile separate makes the benchmark support reusable and makes reproduction assumptions explicit.

This PR intentionally contains only the GLM-5.2/OpenHands reproduction profile. General SWE-bench Pro task construction and Modal fixes are separate PRs.

## Validation

- `python -m pytest tests/harnesses/test_swebench_pro_openhands_glm52.py -q` — 18 passed
- Ruff lint and formatting checks
- `git diff --check`

