### PR TITLE
fix(modal): clear registry image entrypoints

### DIFF
--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -70,6 +70,17 @@ def _attach_run_tags(sandbox, tags: dict[str, str], name: str) -> None:
         logger.debug("could not tag sandbox %s", name, exc_info=True)
 
 
+def _registry_image(modal_module, reference: str):
+    """Import a registry image without retaining its Docker ``ENTRYPOINT``.
+
+    Modal appends the positional arguments passed to ``Sandbox.create`` to a
+    registry image's entrypoint. rLLM supplies its own keepalive command, so a
+    task image with ``ENTRYPOINT [\"/bin/bash\"]`` would otherwise try to parse
+    the keepalive executable as a shell script and exit immediately.
+    """
+    return modal_module.Image.from_registry(reference).entrypoint([])
+
+
 # Modal caps an exec's total argv at 64 KiB (ARG_MAX); payloads above this go
 # through a chunked temp-file path instead of being inlined in the command.
 _B64_ARGV_LIMIT = 50_000
@@ -246,7 +257,7 @@ class ModalSandbox:
             if from_snapshot:
                 modal_image = modal.Image.from_id(image)
             elif isinstance(image, str):
-                modal_image = modal.Image.from_registry(image)
+                modal_image = _registry_image(modal, image)
             else:
                 modal_image = image  # already a modal.Image
 

--- a/tests/sandbox/test_modal_backend.py
+++ b/tests/sandbox/test_modal_backend.py
@@ -78,3 +78,28 @@ def test_attach_run_tags_swallows_set_tags_failure():
 
     _attach_run_tags(Ok(), {"rllm_run_id": "x"}, "sb")
     assert seen == {"rllm_run_id": "x"}
+
+
+def test_registry_image_clears_docker_entrypoint():
+    from rllm.sandbox.backends.modal_backend import _registry_image
+
+    seen = {}
+
+    class Image:
+        def entrypoint(self, command):
+            seen["entrypoint"] = command
+            return self
+
+    class Images:
+        @staticmethod
+        def from_registry(reference):
+            seen["reference"] = reference
+            return Image()
+
+    class Modal:
+        Image = Images
+
+    image = _registry_image(Modal, "example/task:latest")
+
+    assert isinstance(image, Image)
+    assert seen == {"reference": "example/task:latest", "entrypoint": []}


### PR DESCRIPTION
## What changed

- clear the inherited Docker `ENTRYPOINT` when importing registry images into Modal
- retain rLLM's own sandbox keepalive command
- add a focused unit test for registry-image construction

## Root cause

Modal appends the positional command passed to `Sandbox.create` to a registry image's entrypoint. Images such as SWE-bench Pro images use `ENTRYPOINT ["/bin/bash"]`, causing rLLM's keepalive command to be interpreted as a shell script path and the sandbox to exit immediately.

## Impact

Registry-backed task images can start reliably on Modal regardless of their Docker entrypoint.

## Validation

- `python -m pytest tests/sandbox/test_modal_backend.py -q` — 9 passed
- Ruff lint and formatting checks
- `git diff --check`

