### PR TITLE
feat(modal): enforce Harbor network policy

### DIFF
--- a/rllm/eval/_resolution.py
+++ b/rllm/eval/_resolution.py
@@ -543,6 +543,17 @@ def _sandbox_resource_kwargs(task: Task, backend: str, env_override: dict | None
             kw["cpu"] = float(cpus)
         if mem_mb:
             kw["memory"] = int(mem_mb)
+        # Harbor's ``allow_internet = false`` is a runtime isolation contract,
+        # not documentation. A remote CLI agent still needs to call rLLM's
+        # public model gateway, so an explicit domain allowlist takes priority;
+        # without one Modal blocks all outbound traffic. Leave absent/true
+        # declarations unchanged for backward compatibility.
+        if env.get("allow_internet") is False:
+            domain_allowlist = env.get("outbound_domain_allowlist") or []
+            if domain_allowlist:
+                kw["outbound_domain_allowlist"] = [str(value) for value in domain_allowlist]
+            else:
+                kw["block_network"] = True
         kw["timeout"] = lifetime_s  # Modal's hard lifetime, in seconds
     elif backend == "daytona":
         if cpus:

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -263,7 +263,17 @@ class ModalSandbox:
                 create_kwargs["tags"] = run_tags
             else:
                 post_create_tags = run_tags
-            for key in ("secrets", "volumes", "workdir", "gpu", "cpu", "memory"):
+            for key in (
+                "secrets",
+                "volumes",
+                "workdir",
+                "gpu",
+                "cpu",
+                "memory",
+                "block_network",
+                "outbound_cidr_allowlist",
+                "outbound_domain_allowlist",
+            ):
                 if key in kwargs:
                     create_kwargs[key] = kwargs.pop(key)
 

--- a/tests/eval/test_harbor_parity.py
+++ b/tests/eval/test_harbor_parity.py
@@ -117,6 +117,42 @@ def test_modal_resource_kwargs_apply_memory_from_string_form():
     assert "timeout" in kw  # lifetime is always sized for modal
 
 
+def test_modal_resource_kwargs_honor_explicit_offline_environment():
+    def task_with(allow_internet_marker):
+        environment = {}
+        if allow_internet_marker is not None:
+            environment["allow_internet"] = allow_internet_marker
+        return Task(
+            id="t",
+            instruction="",
+            metadata={"environment": environment},
+            dataset_dir=Path("."),
+        )
+
+    offline = task_with(False)
+    online = task_with(True)
+    unspecified = task_with(None)
+
+    assert _sandbox_resource_kwargs(offline, "modal")["block_network"] is True
+    assert "block_network" not in _sandbox_resource_kwargs(online, "modal")
+    assert "block_network" not in _sandbox_resource_kwargs(unspecified, "modal")
+
+    allowlisted = Task(
+        id="t",
+        instruction="",
+        metadata={
+            "environment": {
+                "allow_internet": False,
+                "outbound_domain_allowlist": ["rllm-eval.example.com"],
+            }
+        },
+        dataset_dir=Path("."),
+    )
+    allowlisted_kwargs = _sandbox_resource_kwargs(allowlisted, "modal")
+    assert allowlisted_kwargs["outbound_domain_allowlist"] == ["rllm-eval.example.com"]
+    assert "block_network" not in allowlisted_kwargs
+
+
 def test_daytona_resource_kwargs_convert_mb_to_gb():
     task = Task(
         id="t",


### PR DESCRIPTION
## What changed

- map Harbor's explicit `allow_internet = false` environment contract to Modal network controls
- fully block outbound traffic when no exception is configured
- support an explicit outbound domain allowlist for model-gateway-only access
- forward Modal network-policy arguments into `Sandbox.create`

## Why

Previously, `allow_internet = false` was loaded as task metadata but not enforced by the Modal backend. That made nominally offline evaluations run with unrestricted outbound access.

## Impact

Modal evaluations can now enforce offline benchmark conditions while optionally allowing only the rLLM model gateway.

## Validation

- focused Harbor-parity network-policy test — 1 passed
- `python -m pytest tests/sandbox/test_modal_backend.py -q` — 8 passed
- Ruff lint and formatting checks
- `git diff --check`

