### PR TITLE
feat(eval): AgentFlow run lifecycle and resume

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -9,8 +9,13 @@ configuration from ``rllm setup`` (stored in ``~/.rllm/config.json``).
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import subprocess
+from collections.abc import Mapping
+from importlib.metadata import PackageNotFoundError, version
+from urllib.parse import urlsplit, urlunsplit
 
 import click
 from rich.status import Status
@@ -22,6 +27,63 @@ from rllm.cli._ui import console, fail, info_panel, not_found, parse_index_spec
 from rllm.types import Task
 
 logger = logging.getLogger(__name__)
+
+
+def _load_agent_config(source: str | None) -> dict:
+    if not source:
+        return {}
+    path = source[1:] if source.startswith("@") else source
+    expanded = os.path.expanduser(path)
+    if not os.path.isfile(expanded):
+        raise FileNotFoundError(f"agent-config file not found: {path}")
+    with open(expanded, encoding="utf-8") as fh:
+        text = fh.read()
+    try:
+        import yaml
+
+        value = yaml.safe_load(text)
+    except ImportError:
+        value = json.loads(text)
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError("agent-config must contain a mapping at the top level")
+    return dict(value)
+
+
+def _redact_config(value):
+    if isinstance(value, dict):
+        return {key: ("<redacted>" if any(part in str(key).lower() for part in ("api_key", "token", "secret", "password")) else _redact_config(item)) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_config(item) for item in value]
+    return value
+
+
+def _sanitize_endpoint(endpoint: str) -> str:
+    """Retain endpoint routing information without credentials or query data."""
+    parsed = urlsplit(endpoint)
+    hostname = parsed.hostname or ""
+    if parsed.port is not None:
+        hostname = f"{hostname}:{parsed.port}"
+    return urlunsplit((parsed.scheme, hostname, parsed.path, "", ""))
+
+
+def _rllm_build_metadata() -> dict[str, str | None]:
+    try:
+        package_version = version("rllm")
+    except PackageNotFoundError:
+        package_version = "unknown"
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        commit = None
+    return {"version": package_version, "commit": commit}
 
 
 def _suggest_benchmarks(name: str, catalog_names: list[str], max_suggestions: int = 3) -> list[str]:
@@ -114,6 +176,26 @@ def _dict_rows_to_tasks(rows: list[dict]) -> list[Task]:
     return tasks
 
 
+def _apply_agent_task_filter(dataset, agent):
+    """Apply an optional agent-owned task filter and return its metadata."""
+    filter_fn = getattr(agent, "filter_eval_tasks", None)
+    if not callable(filter_fn):
+        return dataset, {}
+    filtered = filter_fn(list(dataset.data))
+    if filtered is None:
+        filtered = list(dataset.data)
+    from rllm.data.dataset import Dataset
+
+    result = Dataset(data=list(filtered), name=dataset.name, split=dataset.split)
+    metadata_fn = getattr(agent, "eval_task_filter_metadata", None)
+    metadata = metadata_fn() if callable(metadata_fn) else {}
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, Mapping):
+        raise TypeError("eval_task_filter_metadata() must return a mapping")
+    return result, dict(metadata)
+
+
 def _run_eval(
     benchmark: str,
     agent_name: str,
@@ -133,6 +215,8 @@ def _run_eval(
     warm_queue_size: int = 0,
     sampling_config=None,
     attempts: int = 1,
+    resume_run: str | None = None,
+    provider_name: str = "direct",
 ):
     """Core eval logic, extracted for clean proxy lifecycle management."""
     from rllm.data import DatasetRegistry
@@ -374,7 +458,16 @@ def _run_eval(
             tasks = _dict_rows_to_tasks(list(dataset.data))
             dataset = Dataset(data=tasks, name=benchmark, split=split)
 
-    # Filter to specific task indices if requested
+    # Specialized agents may define a run cohort (for example a family
+    # filter). This happens before explicit
+    # indices/max-examples and, critically, before lifecycle/model calls.
+    try:
+        dataset, task_filter_metadata = _apply_agent_task_filter(dataset, agent)
+    except (TypeError, ValueError, RuntimeError) as e:
+        fail(f"Could not apply agent task filter: {e}")
+
+    # Filter to specific task indices if requested. Indices address the
+    # agent-filtered cohort when a task filter is active.
     if task_indices is not None:
         out_of_range = [i for i in task_indices if i < 0 or i >= len(dataset)]
         if out_of_range:
@@ -382,6 +475,8 @@ def _run_eval(
         dataset = dataset.select(task_indices)
     elif max_examples is not None and max_examples < len(dataset):
         dataset = dataset.select(range(max_examples))
+    if task_filter_metadata:
+        task_filter_metadata["evaluated_task_count"] = len(dataset)
 
     # Resolve agent description
     agent_desc = ""
@@ -407,6 +502,8 @@ def _run_eval(
         rows.append(("Snapshots", "[dim]disabled (--no-snapshot, cold start)[/]"))
     if sampling_config is not None and not sampling_config.is_empty:
         rows.append(("Sampling", f"[dim]{sampling_config.as_dict()} (gateway-enforced)[/]"))
+    if task_filter_metadata:
+        rows.append(("Task filter", f"[dim]{task_filter_metadata.get('name', 'agent')} ({len(dataset)} selected)[/]"))
     console.print()
     console.print(info_panel(rows, border="brand"))
     console.print()
@@ -423,28 +520,67 @@ def _run_eval(
     #     episodes/        — populated only when save_episodes is True
     from rllm.eval.episode_store import EvalEpisodeStore
 
-    if episodes_dir is not None:
+    if resume_run is not None and episodes_dir is not None:
+        fail("--resume-run cannot be combined with --episodes-dir.")
+    if resume_run is not None:
+        run_dir = os.path.expanduser(resume_run)
+    elif episodes_dir is not None:
         run_dir = os.path.expanduser(episodes_dir)
     else:
         model_safe = model.replace("/", "_").replace("\\", "_")
         bench_safe = benchmark.replace("/", "_").replace("\\", "_")
         run_dir = paths.rllm_path("eval_results", f"{bench_safe}_{model_safe}_{timestamp}")
     run_store = EvalEpisodeStore(run_dir)
-    run_store.write_meta(
-        {
-            "benchmark": benchmark,
-            "model": model,
-            "agent": agent_name,
-            "split": split,
-            "timestamp": timestamp,
-            "attempts": attempts,
-        }
-    )
+    task_ids_for_manifest = [str(getattr(task, "id", None) or idx) for idx, task in enumerate(dataset.data)]
+    run_meta = {
+        "manifest_version": 1,
+        "benchmark": benchmark,
+        "model": model,
+        "provider": provider_name,
+        "agent": agent_name,
+        "split": split,
+        "timestamp": timestamp,
+        "attempts": attempts,
+        "concurrency": concurrency,
+        "upstream_endpoint": _sanitize_endpoint(base_url),
+        "rllm": _rllm_build_metadata(),
+        "sampling_params": _redact_config(sampling_config.as_dict() if sampling_config is not None else {}),
+        "agent_config": _redact_config(agent_metadata or {}),
+        "task_filter": _redact_config(task_filter_metadata),
+        "task_ids": task_ids_for_manifest,
+    }
+    resume_items = []
+    if resume_run is not None:
+        previous_meta = run_store.read_meta()
+        if not previous_meta:
+            fail(f"--resume-run has no meta.json: {run_dir}")
+        manifest_keys = (
+            "manifest_version",
+            "benchmark",
+            "model",
+            "provider",
+            "agent",
+            "split",
+            "attempts",
+            "rllm",
+            "sampling_params",
+            "agent_config",
+            "task_filter",
+            "task_ids",
+        )
+        mismatches = [key for key in manifest_keys if previous_meta.get(key) != run_meta.get(key)]
+        if mismatches:
+            fail(f"Resume manifest mismatch for: {', '.join(mismatches)}")
+        timestamp = str(previous_meta.get("timestamp") or timestamp)
+        run_meta = previous_meta
+        resume_items = run_store.load_completed_items(successful_only=True)
+        console.print(f"  [dim]Resuming {len(resume_items)} completed rollout(s) from {run_dir}[/]")
+    else:
+        run_store.write_meta(run_meta)
     episode_store = run_store if save_episodes else None
 
     # Create UI logger before run for progressive episode uploads
     ui_logger = None
-    on_episode_complete = None
     _flush_episode_buffer = None
     _ui_callback = None
     if enable_ui:
@@ -480,17 +616,20 @@ def _run_eval(
                 if batch:
                     ui_logger.log(data={}, step=0, episodes=batch)
 
-    # Wrap UI streaming and per-file dump into a single callback.
-    if episode_store is not None or _ui_callback is not None:
-
-        def on_episode_complete(idx, episode):
-            if episode_store is not None:
-                try:
-                    episode_store.write(idx, episode)
-                except Exception:
-                    logger.debug("episode_store.write failed", exc_info=True)
-            if _ui_callback is not None:
-                _ui_callback(episode)
+    # Progress is always written so --resume-run also works with
+    # --no-save-episodes and --no-ui.
+    def on_episode_complete(flat_idx, task_idx, attempt, episode):
+        try:
+            run_store.write_progress(flat_idx, task_idx, attempt, episode, task_id=task_ids_for_manifest[task_idx])
+        except Exception:
+            logger.debug("progress write failed", exc_info=True)
+        if episode_store is not None:
+            try:
+                episode_store.write(flat_idx, episode)
+            except Exception:
+                logger.debug("episode_store.write failed", exc_info=True)
+        if _ui_callback is not None:
+            _ui_callback(episode)
 
     # Single execution path: every Task goes through ``AgentFlowEngine``
     # via ``SandboxTaskHooks``. The engine fronts every LLM call with the rLLM
@@ -500,24 +639,37 @@ def _run_eval(
     # otherwise ``SandboxTaskHooks`` reads each Task's [verifier] config.
     from rllm.eval.runner import run_dataset
 
-    result, episodes = asyncio.run(
-        run_dataset(
-            tasks=list(dataset.data),
-            agent_flow=agent,
-            base_url=base_url,
-            model=model,
-            concurrency=concurrency,
-            sandbox_backend=(agent_metadata or {}).get("sandbox_backend"),
-            use_snapshot=use_snapshot,
-            warm_queue_size=warm_queue_size,
-            agent_name=agent_name,
-            dataset_name=getattr(dataset, "name", benchmark) or benchmark,
-            on_episode_complete=on_episode_complete,
-            evaluator=evaluator,
-            sampling_params=(sampling_config.as_dict() if sampling_config is not None else None),
-            attempts=attempts,
+    try:
+        result, episodes = asyncio.run(
+            run_dataset(
+                tasks=list(dataset.data),
+                agent_flow=agent,
+                base_url=base_url,
+                model=model,
+                concurrency=concurrency,
+                sandbox_backend=(agent_metadata or {}).get("sandbox_backend"),
+                use_snapshot=use_snapshot,
+                warm_queue_size=warm_queue_size,
+                agent_name=agent_name,
+                dataset_name=getattr(dataset, "name", benchmark) or benchmark,
+                on_episode_complete=on_episode_complete,
+                evaluator=evaluator,
+                sampling_params=(sampling_config.as_dict() if sampling_config is not None else None),
+                attempts=attempts,
+                run_dir=run_dir,
+                resume_items=resume_items,
+            )
         )
-    )
+    finally:
+        run_metadata_fn = getattr(agent, "eval_run_metadata", None)
+        if callable(run_metadata_fn):
+            try:
+                dynamic_meta = run_metadata_fn() or {}
+                if isinstance(dynamic_meta, dict):
+                    run_meta.update(_redact_config(dynamic_meta))
+                    run_store.write_meta(run_meta)
+            except Exception:
+                logger.warning("Could not collect agent eval metadata", exc_info=True)
 
     # Flush remaining buffered episodes BEFORE posting eval result / finishing
     # session.  The flush enqueues episodes onto the UILogger background
@@ -623,6 +775,8 @@ def _run_eval(
 @click.option("--save-episodes/--no-save-episodes", "save_episodes", default=True, help="Save each Episode as its own JSON file for later visualization (default: enabled).")
 @click.option("--episodes-dir", "episodes_dir", default=None, help="Directory to write the episode JSONs into. Default: ~/.rllm/eval_results/<bench>_<model>_<timestamp>/.")
 @click.option("--sampling-params", "sampling_params", default=None, help=_SAMPLING_PARAMS_HELP)
+@click.option("--agent-config", "agent_config", default=None, help="Agent-specific JSON/YAML mapping, as @file or file path.")
+@click.option("--resume-run", "resume_run", default=None, help="Resume a compatible run directory, rerunning only missing/error rollouts.")
 @click.option("--temperature", default=None, type=float, help="Sampling temperature (shortcut for --sampling-params temperature=...).")
 @click.option("--top-p", "top_p", default=None, type=float, help="Nucleus sampling top_p (shortcut for --sampling-params top_p=...).")
 @click.option("--max-tokens", "max_tokens", default=None, type=int, help="Max generated tokens per call (shortcut for --sampling-params max_tokens=...).")
@@ -658,6 +812,8 @@ def eval_cmd(
     save_episodes: bool,
     episodes_dir: str | None,
     sampling_params: str | None,
+    agent_config: str | None,
+    resume_run: str | None,
     temperature: float | None,
     top_p: float | None,
     max_tokens: int | None,
@@ -670,6 +826,10 @@ def eval_cmd(
         sampling_config = resolve_eval_sampling(sampling_params, temperature, top_p, max_tokens)
     except (ValueError, FileNotFoundError, TypeError) as e:
         fail(f"Invalid --sampling-params: {e}")
+    try:
+        agent_config_values = _load_agent_config(agent_config)
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as e:
+        fail(f"Invalid --agent-config: {e}")
     if attempts < 1:
         fail("--attempts must be >= 1.")
     # Auto-detect UI logging: enable if user is logged in (has ui_api_key or RLLM_API_KEY)
@@ -686,6 +846,7 @@ def eval_cmd(
         console.print("  [blue]Tip: Try rllm UI for live monitoring! Run [bold]rllm login[/bold] to get started.[/]")
 
     proxy_manager = None
+    provider_name = "direct"
 
     if base_url is not None:
         # Direct mode: user provided --base-url, require --model too
@@ -712,12 +873,14 @@ def eval_cmd(
             if not api_key:
                 fail("tinker:// checkpoint models require TINKER_API_KEY in the environment.\n\n  Export your Tinker key and re-run, e.g.:\n    export TINKER_API_KEY=<your-tinker-key>")
             provider = "tinker"
+            provider_name = provider
             model = resolved_model
             console.print("  [success]tinker:// checkpoint detected[/] → routing through the Tinker OAI endpoint")
         else:
             if not config.is_configured():
                 fail("No configuration found. Run `rllm setup` first to configure your provider and API key.")
             provider = config.provider
+            provider_name = provider
             api_key = config.api_key
             # --model overrides configured model
             if model is None:
@@ -753,7 +916,7 @@ def eval_cmd(
             console.print(f"  [success]Proxy ready[/] at [dim]{base_url}[/]")
 
     # Build agent metadata from CLI options
-    agent_metadata = {}
+    agent_metadata = dict(agent_config_values)
     if sandbox_backend:
         agent_metadata["sandbox_backend"] = sandbox_backend
     if sandbox_concurrency is not None:
@@ -792,6 +955,8 @@ def eval_cmd(
             warm_queue_size=warm_queue_size,
             sampling_config=sampling_config,
             attempts=attempts,
+            resume_run=resume_run,
+            provider_name=provider_name,
         )
     finally:
         if proxy_manager is not None:

--- a/rllm/eval/episode_store.py
+++ b/rllm/eval/episode_store.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from rllm.eval.results import EvalItem
-from rllm.types import Episode
+from rllm.types import INFRA_ERROR_REASONS, Episode
 from rllm.workflows.workflow import TerminationReason
 
 
@@ -123,7 +123,10 @@ class EvalEpisodeStore:
     @staticmethod
     def item_from_episode(idx: int, attempt: int, episode: Episode, *, task_id: str | None = None) -> EvalItem:
         error = None
-        if episode.termination_reason in {TerminationReason.ERROR, TerminationReason.TIMEOUT}:
+        # Infra failures (model/proxy/sandbox/grading breakdowns) are not real
+        # attempts: mark them as errors so a resumed run re-executes them instead
+        # of treating the empty rollout as a completed result.
+        if episode.termination_reason in INFRA_ERROR_REASONS or episode.termination_reason == TerminationReason.TIMEOUT:
             raw_error = (episode.metadata or {}).get("error") or {}
             error = raw_error.get("message") if isinstance(raw_error, dict) else str(raw_error)
             error = error or "episode terminated with an error"

--- a/rllm/eval/episode_store.py
+++ b/rllm/eval/episode_store.py
@@ -23,7 +23,9 @@ import json
 from pathlib import Path
 from typing import Any
 
+from rllm.eval.results import EvalItem
 from rllm.types import Episode
+from rllm.workflows.workflow import TerminationReason
 
 
 def _sanitize(s: str) -> str:
@@ -69,6 +71,7 @@ class EvalEpisodeStore:
 
     META_FILENAME = "meta.json"
     EPISODES_SUBDIR = "episodes"
+    PROGRESS_SUBDIR = "progress"
 
     def __init__(self, run_dir: str | Path) -> None:
         self.run_dir = Path(run_dir).expanduser()
@@ -77,13 +80,25 @@ class EvalEpisodeStore:
         # callers that only need ``write_meta()`` (e.g. ``--no-save-episodes``)
         # don't leave an empty subdirectory behind.
         self.episodes_dir = self.run_dir / self.EPISODES_SUBDIR
+        self.progress_dir = self.run_dir / self.PROGRESS_SUBDIR
 
     def write_meta(self, meta: dict[str, Any]) -> Path:
         """Write run-level metadata to ``<run_dir>/meta.json``."""
         path = self.run_dir / self.META_FILENAME
-        with open(path, "w", encoding="utf-8") as f:
+        temporary = path.with_suffix(".json.tmp")
+        with open(temporary, "w", encoding="utf-8") as f:
             json.dump(meta, f, indent=2, default=_json_default)
+            f.write("\n")
+        temporary.replace(path)
         return path
+
+    def read_meta(self) -> dict[str, Any]:
+        path = self.run_dir / self.META_FILENAME
+        if not path.is_file():
+            return {}
+        with path.open(encoding="utf-8") as fh:
+            value = json.load(fh)
+        return value if isinstance(value, dict) else {}
 
     def episode_path(self, idx: int, episode: Episode) -> Path:
         """Compute the file path for ``episode`` at index ``idx``."""
@@ -104,3 +119,56 @@ class EvalEpisodeStore:
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, default=_json_default)
         return path
+
+    @staticmethod
+    def item_from_episode(idx: int, attempt: int, episode: Episode, *, task_id: str | None = None) -> EvalItem:
+        error = None
+        if episode.termination_reason in {TerminationReason.ERROR, TerminationReason.TIMEOUT}:
+            raw_error = (episode.metadata or {}).get("error") or {}
+            error = raw_error.get("message") if isinstance(raw_error, dict) else str(raw_error)
+            error = error or "episode terminated with an error"
+        trajectory = episode.trajectories[0] if episode.trajectories else None
+        reward = float(trajectory.reward or 0.0) if trajectory is not None else 0.0
+        signals = dict(trajectory.signals or {}) if trajectory is not None else {}
+        task = episode.task
+        if task_id is None:
+            task_id = getattr(task, "id", None)
+            if task_id is None and isinstance(task, dict):
+                task_id = task.get("id") or task.get("TASK") or task.get("task_id")
+        return EvalItem(
+            idx=idx,
+            attempt=attempt,
+            task_id=str(task_id) if task_id is not None else None,
+            reward=reward,
+            is_correct=bool(episode.is_correct),
+            error=error,
+            signals=signals,
+        )
+
+    def write_progress(self, flat_idx: int, idx: int, attempt: int, episode: Episode, *, task_id: str | None = None) -> Path:
+        """Atomically persist a compact completed-rollout record."""
+        self.progress_dir.mkdir(parents=True, exist_ok=True)
+        item = self.item_from_episode(idx, attempt, episode, task_id=task_id)
+        path = self.progress_dir / f"item_{flat_idx:06d}.json"
+        temporary = path.with_suffix(".json.tmp")
+        temporary.write_text(json.dumps(item.__dict__, indent=2, default=_json_default) + "\n", encoding="utf-8")
+        temporary.replace(path)
+        return path
+
+    def load_completed_items(self, *, successful_only: bool = True) -> list[EvalItem]:
+        items: list[EvalItem] = []
+        if not self.progress_dir.is_dir():
+            return items
+        seen: set[tuple[int, int]] = set()
+        for path in sorted(self.progress_dir.glob("item_*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                item = EvalItem(**data)
+            except (OSError, ValueError, TypeError):
+                continue
+            key = (item.idx, item.attempt)
+            if key in seen or (successful_only and item.error is not None):
+                continue
+            seen.add(key)
+            items.append(item)
+        return items

--- a/rllm/eval/lifecycle.py
+++ b/rllm/eval/lifecycle.py
@@ -1,0 +1,39 @@
+"""Optional run-scoped lifecycle hooks for eval AgentFlows."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class EvalRunContext:
+    dataset_name: str
+    agent_name: str
+    model: str
+    base_url: str
+    task_count: int
+    concurrency: int
+    attempts: int
+    sampling_params: dict[str, Any] = field(default_factory=dict)
+    run_dir: Path | None = None
+    tasks: tuple[Any, ...] = field(default_factory=tuple, repr=False)
+
+
+async def call_eval_lifecycle(obj: object, method_name: str, *args) -> Any:
+    """Call an optional sync or async lifecycle method without blocking the loop."""
+    method = getattr(obj, method_name, None)
+    if not callable(method):
+        return None
+    if inspect.iscoroutinefunction(method):
+        return await method(*args)
+    result = await asyncio.to_thread(method, *args)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+__all__ = ["EvalRunContext", "call_eval_lifecycle"]

--- a/rllm/eval/results.py
+++ b/rllm/eval/results.py
@@ -26,6 +26,7 @@ class EvalItem:
     # "verifier_timeout", "grading_error". Lets the report break failures down by
     # cause — agent timeouts vs infra/grading errors vs genuine wrong answers.
     termination_reason: str | None = None
+    task_id: str | None = None
 
 
 def _pass_at_k(per_task_counts: list[tuple[int, int]], k: int) -> float:
@@ -173,6 +174,7 @@ class EvalResult:
                 {
                     "idx": item.idx,
                     "attempt": item.attempt,
+                    "task_id": item.task_id,
                     "reward": item.reward,
                     "is_correct": item.is_correct,
                     "error": item.error,
@@ -203,6 +205,7 @@ class EvalResult:
                 signals=item.get("signals", {}),
                 attempt=item.get("attempt", 0),
                 termination_reason=item.get("termination_reason"),
+                task_id=item.get("task_id"),
             )
             for item in data["items"]
         ]

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -222,10 +222,7 @@ async def run_dataset(
         # downstream consumer wants it) is stable; the engine's session uid
         # becomes f"{task.id}:0" which matches training's convention.
         if resume_items:
-            task_ids = [
-                f"{getattr(task, 'id', None) or task_idx}~attempt-{attempt}"
-                for task, (task_idx, attempt) in zip(tasks, rollout_map, strict=True)
-            ]
+            task_ids = [f"{getattr(task, 'id', None) or task_idx}~attempt-{attempt}" for task, (task_idx, attempt) in zip(tasks, rollout_map, strict=True)]
         else:
             task_ids = [getattr(t, "id", None) or str(idx) for idx, t in enumerate(tasks)]
 

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -12,7 +12,9 @@ traces, exactly as they do at training time.
 
 from __future__ import annotations
 
+import inspect
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rllm.eval.results import EvalItem, EvalResult
@@ -23,6 +25,16 @@ if TYPE_CHECKING:
     from rllm.gateway.manager import GatewayManager
 
 logger = logging.getLogger(__name__)
+
+
+def _notify_episode_complete(callback, flat_idx: int, task_idx: int, attempt: int, episode) -> None:
+    """Call the extended callback while preserving the historical two-arg API."""
+    try:
+        inspect.signature(callback).bind(flat_idx, task_idx, attempt, episode)
+    except (TypeError, ValueError):
+        callback(flat_idx, episode)
+    else:
+        callback(flat_idx, task_idx, attempt, episode)
 
 
 async def run_dataset(
@@ -42,6 +54,8 @@ async def run_dataset(
     gateway: GatewayManager | None = None,
     sampling_params: dict | None = None,
     attempts: int = 1,
+    run_dir: str | Path | None = None,
+    resume_items: list[EvalItem] | None = None,
 ) -> tuple[EvalResult, list]:
     """Run a list of :class:`rllm.types.Task` objects through :class:`AgentFlowEngine`.
 
@@ -74,13 +88,36 @@ async def run_dataset(
     # import (rllm.eval.__init__ → rllm.eval.runner → here). Importing
     # them inside the function breaks the cycle.
     from rllm.engine.agentflow_engine import AgentFlowEngine
+    from rllm.eval.lifecycle import EvalRunContext, call_eval_lifecycle
     from rllm.gateway.manager import EvalGatewayManager
     from rllm.gateway.tunnel import is_local_sandbox_backend
 
-    # pass@k: expose each task as `attempts` adjacent rollouts while reusing
-    # the same Task objects.
-    if attempts > 1:
-        tasks = [task for task in tasks for _ in range(attempts)]
+    original_tasks = list(tasks)
+    full_rollout_map = [(task_idx, attempt) for task_idx in range(len(original_tasks)) for attempt in range(attempts)]
+    valid_rollouts = set(full_rollout_map)
+    seen_resume_rollouts: set[tuple[int, int]] = set()
+    for item in resume_items or []:
+        key = (item.idx, item.attempt)
+        if key not in valid_rollouts:
+            raise ValueError(f"Resume item is outside this run manifest: task={item.idx}, attempt={item.attempt}")
+        if key in seen_resume_rollouts:
+            raise ValueError(f"Duplicate resume item: task={item.idx}, attempt={item.attempt}")
+        seen_resume_rollouts.add(key)
+        expected_task_id = str(getattr(original_tasks[item.idx], "id", None) or item.idx)
+        if item.task_id is not None and item.task_id != expected_task_id:
+            raise ValueError(f"Resume task ID mismatch at index {item.idx}: expected {expected_task_id}, got {item.task_id}")
+    successful_resume_items = [item for item in (resume_items or []) if item.error is None]
+    rollout_map = list(full_rollout_map)
+    if resume_items:
+        completed = {(item.idx, item.attempt) for item in successful_resume_items}
+        rollout_map = [key for key in rollout_map if key not in completed]
+        tasks = [original_tasks[task_idx] for task_idx, _attempt in rollout_map]
+    elif attempts > 1:
+        tasks = [task for task in original_tasks for _ in range(attempts)]
+
+    if not rollout_map:
+        items = sorted(successful_resume_items, key=lambda item: (item.idx, item.attempt))
+        return EvalResult.from_items(dataset_name, model, agent_name, items, attempts=attempts), []
 
     # Cap concurrency by the agent flow's hint, if any. The engine's
     # internal semaphore enforces this on the rollout side.
@@ -127,6 +164,28 @@ async def run_dataset(
         gateway = EvalGatewayManager(upstream_url=base_url, model=model, tunnel=gateway_tunnel, port=gateway_port)
         gateway.start()
 
+    lifecycle_context = EvalRunContext(
+        dataset_name=dataset_name,
+        agent_name=agent_name,
+        model=model,
+        base_url=base_url,
+        task_count=len(original_tasks) * attempts,
+        concurrency=effective_concurrency,
+        attempts=attempts,
+        sampling_params=dict(sampling_params or {}),
+        run_dir=Path(run_dir).expanduser() if run_dir is not None else None,
+        tasks=tuple(tasks),
+    )
+    try:
+        await call_eval_lifecycle(agent_flow, "prepare_eval", lifecycle_context)
+    except BaseException as exc:
+        try:
+            await call_eval_lifecycle(agent_flow, "finalize_eval", lifecycle_context, exc)
+        finally:
+            if owned_gateway:
+                gateway.stop()
+        raise
+
     hooks = SandboxTaskHooks(evaluation=FixedEvaluation(evaluator) if evaluator is not None else None, sandbox_backend=sandbox_backend, use_snapshot=use_snapshot)
 
     engine = AgentFlowEngine(
@@ -145,6 +204,7 @@ async def run_dataset(
     )
 
     warm_queue = None
+    run_error: BaseException | None = None
     try:
         # Warm queue: prefetch this run's next sandboxes ahead of consumption.
         # Negative size means "match concurrency"; it only helps when sandboxes
@@ -161,8 +221,29 @@ async def run_dataset(
         # task_ids carry the original Task.id so GRPO-style grouping (if a
         # downstream consumer wants it) is stable; the engine's session uid
         # becomes f"{task.id}:0" which matches training's convention.
-        task_ids = [getattr(t, "id", None) or str(idx) for idx, t in enumerate(tasks)]
-        episodes = await engine.execute_tasks(tasks, task_ids=task_ids, is_validation=True, on_episode_complete=on_episode_complete)
+        if resume_items:
+            task_ids = [
+                f"{getattr(task, 'id', None) or task_idx}~attempt-{attempt}"
+                for task, (task_idx, attempt) in zip(tasks, rollout_map, strict=True)
+            ]
+        else:
+            task_ids = [getattr(t, "id", None) or str(idx) for idx, t in enumerate(tasks)]
+
+        def _stream_episode(result_idx, episode):
+            if on_episode_complete is None:
+                return
+            task_idx, attempt = rollout_map[result_idx]
+            _notify_episode_complete(on_episode_complete, task_idx * attempts + attempt, task_idx, attempt, episode)
+
+        episodes = await engine.execute_tasks(
+            tasks,
+            task_ids=task_ids,
+            is_validation=True,
+            on_episode_complete=_stream_episode if on_episode_complete is not None else None,
+        )
+    except BaseException as exc:
+        run_error = exc
+        raise
     finally:
         if warm_queue is not None:
             warm_queue.shutdown()
@@ -172,15 +253,22 @@ async def run_dataset(
                 gateway.stop()
             except Exception:
                 logger.exception("gateway.stop() raised; suppressing")
+        try:
+            await call_eval_lifecycle(agent_flow, "finalize_eval", lifecycle_context, run_error)
+        except Exception:
+            if run_error is None:
+                raise
+            logger.exception("agent finalize_eval raised while handling another error; suppressing")
 
     # Aggregate per-rollout EvalItems for the report; with attempts > 1 the
     # expanded index folds back to (task index, attempt).
-    items: list[EvalItem] = []
+    items: list[EvalItem] = list(successful_resume_items)
     surviving_episodes: list = []
     for idx, episode in enumerate(episodes):
-        task_idx, attempt = divmod(idx, attempts) if attempts > 1 else (idx, 0)
+        task_idx, attempt = rollout_map[idx]
+        task_id = str(getattr(original_tasks[task_idx], "id", None) or task_idx)
         if episode is None:
-            items.append(EvalItem(idx=task_idx, attempt=attempt, reward=0.0, is_correct=False, error="missing episode"))
+            items.append(EvalItem(idx=task_idx, attempt=attempt, task_id=task_id, reward=0.0, is_correct=False, error="missing episode"))
             continue
 
         # An infra/grading failure (sandbox/setup/verifier/grading) means the
@@ -212,6 +300,7 @@ async def run_dataset(
             EvalItem(
                 idx=task_idx,
                 attempt=attempt,
+                task_id=task_id,
                 reward=reward,
                 is_correct=bool(episode.is_correct),
                 signals=signals,
@@ -222,4 +311,5 @@ async def run_dataset(
         if error_msg is None:
             surviving_episodes.append(episode)
 
+    items.sort(key=lambda item: (item.idx, item.attempt))
     return (EvalResult.from_items(dataset_name, model, agent_name, items, attempts=attempts), surviving_episodes)

--- a/rllm/utils/tracking.py
+++ b/rllm/utils/tracking.py
@@ -602,7 +602,18 @@ class UILogger:
                 "correct": result.correct,
                 "errors": result.errors,
                 "signal_averages": result.signal_averages,
-                "items": [{"idx": item.idx, "reward": item.reward, "is_correct": item.is_correct, "error": item.error, "signals": item.signals} for item in result.items],
+                "items": [
+                    {
+                        "idx": item.idx,
+                        "attempt": item.attempt,
+                        "task_id": item.task_id,
+                        "reward": item.reward,
+                        "is_correct": item.is_correct,
+                        "error": item.error,
+                        "signals": item.signals,
+                    }
+                    for item in result.items
+                ],
             }
             payload_json = json.loads(json.dumps(payload, default=self._json_serializer))
             response = self.client.post("/api/eval-results", json=payload_json)

--- a/tests/cli/test_eval_command.py
+++ b/tests/cli/test_eval_command.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from rllm.cli.eval import _apply_agent_task_filter, _load_agent_config, _redact_config, _sanitize_endpoint
 from rllm.cli.main import cli
 from rllm.eval.config import RllmConfig
 from rllm.eval.types import EvalOutput, Signal
@@ -77,6 +78,36 @@ def test_eval_base_url_requires_model(runner, tmp_rllm_home):
     result = runner.invoke(cli, ["eval", "gsm8k", "--base-url", "http://localhost:8000/v1"])
     assert result.exit_code != 0
     assert "--model is required" in result.output
+
+
+def test_agent_config_loading_redaction_and_endpoint_sanitization(tmp_path):
+    config_path = tmp_path / "agent.json"
+    config_path.write_text('{"preflight":"strict","nested":{"api_key":"secret"}}')
+
+    config = _load_agent_config(f"@{config_path}")
+
+    assert config["preflight"] == "strict"
+    assert _redact_config(config)["nested"]["api_key"] == "<redacted>"
+    assert _sanitize_endpoint("https://user:pass@example.test/v1?token=secret") == "https://example.test/v1"
+
+
+def test_optional_agent_task_filter_preserves_dataset_identity():
+    from rllm.data.dataset import Dataset
+
+    class FilterAgent:
+        def filter_eval_tasks(self, tasks):
+            return tasks[1:]
+
+        def eval_task_filter_metadata(self):
+            return {"name": "test", "selected_task_count": 2}
+
+    source = Dataset(data=[1, 2, 3], name="bench", split="public")
+    filtered, metadata = _apply_agent_task_filter(source, FilterAgent())
+
+    assert filtered.data == [2, 3]
+    assert filtered.name == "bench"
+    assert filtered.split == "public"
+    assert metadata == {"name": "test", "selected_task_count": 2}
 
 
 def test_eval_with_proxy_mode(runner, tmp_rllm_home, mock_dataset):

--- a/tests/eval/test_eval_resume.py
+++ b/tests/eval/test_eval_resume.py
@@ -42,6 +42,29 @@ def test_progress_records_are_atomic_and_errors_are_rerun(tmp_path):
     assert not list(store.progress_dir.glob("*.tmp"))
 
 
+@pytest.mark.parametrize(
+    "reason",
+    [
+        TerminationReason.MODEL_ERROR,
+        TerminationReason.SANDBOX_ERROR,
+        TerminationReason.GRADING_ERROR,
+        TerminationReason.AGENT_SETUP_TIMEOUT,
+        TerminationReason.ENV_START_TIMEOUT,
+        TerminationReason.VERIFIER_TIMEOUT,
+    ],
+)
+def test_infra_terminated_rollouts_are_rerun_on_resume(tmp_path, reason):
+    store = EvalEpisodeStore(tmp_path / "run")
+    store.write_progress(0, 0, 0, _episode(_task("a")))
+    broken = _episode(_task("b"), reward=0.0)
+    broken.termination_reason = reason
+    store.write_progress(1, 1, 0, broken)
+
+    successful = store.load_completed_items(successful_only=True)
+
+    assert [(item.idx, item.attempt, item.task_id) for item in successful] == [(0, 0, "a")]
+
+
 def test_fully_resumed_run_does_not_start_agent_lifecycle():
     class Agent:
         def prepare_eval(self, context):

--- a/tests/eval/test_eval_resume.py
+++ b/tests/eval/test_eval_resume.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from rllm.eval.episode_store import EvalEpisodeStore
+from rllm.eval.results import EvalItem
+from rllm.eval.runner import run_dataset
+from rllm.eval.types import EvalOutput, Signal
+from rllm.types import AgentConfig, Episode, Task, Trajectory
+from rllm.workflows.workflow import TerminationReason
+
+
+def _task(task_id: str) -> Task:
+    return Task(id=task_id, instruction="prompt", metadata={}, dataset_dir=Path("."))
+
+
+def _episode(task: Task, *, reward: float = 1.0, error: str | None = None) -> Episode:
+    trajectory = Trajectory(uid=f"traj-{task.id}", task=task.id, output="answer", reward=reward, signals={"coverage": reward})
+    return Episode(
+        id=f"episode-{task.id}",
+        task=task,
+        trajectories=[trajectory],
+        is_correct=reward == 1.0,
+        termination_reason=TerminationReason.ERROR if error else None,
+        metadata={"error": {"message": error}} if error else {},
+    )
+
+
+def test_progress_records_are_atomic_and_errors_are_rerun(tmp_path):
+    store = EvalEpisodeStore(tmp_path / "run")
+    store.write_progress(0, 0, 0, _episode(_task("a")))
+    store.write_progress(1, 1, 0, _episode(_task("b"), reward=0.0, error="transient"))
+
+    successful = store.load_completed_items(successful_only=True)
+    all_items = store.load_completed_items(successful_only=False)
+
+    assert [(item.idx, item.attempt, item.task_id) for item in successful] == [(0, 0, "a")]
+    assert [(item.idx, item.error) for item in all_items] == [(0, None), (1, "transient")]
+    assert not list(store.progress_dir.glob("*.tmp"))
+
+
+def test_fully_resumed_run_does_not_start_agent_lifecycle():
+    class Agent:
+        def prepare_eval(self, context):
+            raise AssertionError("completed resume must not prepare services")
+
+    items = [
+        EvalItem(idx=1, attempt=0, task_id="b", reward=0.0, is_correct=False),
+        EvalItem(idx=0, attempt=0, task_id="a", reward=1.0, is_correct=True),
+    ]
+    result, episodes = asyncio.run(
+        run_dataset(
+            [_task("a"), _task("b")],
+            Agent(),
+            "http://unused",
+            "model",
+            dataset_name="dataset",
+            agent_name="agent",
+            resume_items=items,
+        )
+    )
+
+    assert episodes == []
+    assert [(item.idx, item.task_id) for item in result.items] == [(0, "a"), (1, "b")]
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [EvalItem(idx=0, attempt=0, task_id="wrong", reward=1.0, is_correct=True)],
+        [
+            EvalItem(idx=0, attempt=0, task_id="a", reward=1.0, is_correct=True),
+            EvalItem(idx=0, attempt=0, task_id="a", reward=1.0, is_correct=True),
+        ],
+        [EvalItem(idx=0, attempt=1, task_id="a", reward=1.0, is_correct=True)],
+    ],
+)
+def test_resume_rejects_task_id_duplicates_and_invalid_attempts(items):
+    with pytest.raises(ValueError):
+        asyncio.run(
+            run_dataset(
+                [_task("a")],
+                object(),
+                "http://unused",
+                "model",
+                attempts=1,
+                resume_items=items,
+            )
+        )
+
+
+class _Gateway:
+    async def acreate_session(self, session_id, is_validation=False, sampling_params=None):
+        return session_id
+
+    def get_session_url(self, session_id, public=True):
+        return f"http://gateway/sessions/{session_id}/v1"
+
+    async def aget_traces(self, session_id):
+        return []
+
+    async def adelete_session(self, session_id):
+        return 1
+
+    async def adelete_sessions(self, session_ids):
+        return len(session_ids)
+
+
+class _Evaluator:
+    def evaluate(self, task, episode):
+        return EvalOutput(reward=1.0, is_correct=True, signals=[Signal(name="coverage", value=1.0)])
+
+
+def test_lifecycle_wraps_run_and_legacy_callback_still_works(tmp_path):
+    calls = []
+    callback_calls = []
+
+    class Agent:
+        def prepare_eval(self, context):
+            calls.append(("prepare", context.task_count, len(context.tasks), context.run_dir))
+
+        def finalize_eval(self, context, error):
+            calls.append(("finalize", error))
+
+        def run(self, task: Task, config: AgentConfig):
+            return _episode(task)
+
+    def legacy_callback(idx, episode):
+        callback_calls.append((idx, getattr(episode.task, "id", episode.task)))
+
+    result, _episodes = asyncio.run(
+        run_dataset(
+            [_task("a")],
+            Agent(),
+            "http://unused",
+            "model",
+            dataset_name="dataset",
+            agent_name="agent",
+            gateway=_Gateway(),
+            evaluator=_Evaluator(),
+            run_dir=tmp_path,
+            on_episode_complete=legacy_callback,
+        )
+    )
+
+    assert calls == [("prepare", 1, 1, tmp_path), ("finalize", None)]
+    assert len(callback_calls) == 1
+    assert callback_calls[0][0] == 0
+    assert result.items[0].task_id == "a"
+    assert result.items[0].signals == {"coverage": 1.0}
+
+
+def test_completion_callback_streams_before_slowest_task_finishes():
+    async def scenario():
+        release_slow = asyncio.Event()
+        first_saved = asyncio.Event()
+        completed = []
+
+        class Agent:
+            async def arun(self, task: Task, config: AgentConfig):
+                if task.id == "slow":
+                    await release_slow.wait()
+                return _episode(task)
+
+        def callback(flat_idx, task_idx, attempt, episode):
+            completed.append((flat_idx, task_idx, attempt))
+            first_saved.set()
+
+        running = asyncio.create_task(
+            run_dataset(
+                [_task("fast"), _task("slow")],
+                Agent(),
+                "http://unused",
+                "model",
+                dataset_name="dataset",
+                agent_name="agent",
+                gateway=_Gateway(),
+                evaluator=_Evaluator(),
+                concurrency=2,
+                on_episode_complete=callback,
+            )
+        )
+        await asyncio.wait_for(first_saved.wait(), timeout=2)
+        assert completed == [(0, 0, 0)]
+        assert not running.done()
+        release_slow.set()
+        result, _episodes = await running
+        assert result.total == 2
+        assert completed == [(0, 0, 0), (1, 1, 0)]
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- Custom eval harnesses can `filter_eval_tasks`, `prepare_eval` / `finalize_eval` shared services, and attach `eval_run_metadata`.
- Compact progress records enable `--resume-run`; infra failures (`MODEL_ERROR`, sandbox/grading errors, timeouts) are rerun instead of treated as completed.

Generic eval plumbing only — no MCP-Atlas or ExploitGym code.

## Test plan
- [ ] `pytest tests/eval/test_eval_resume.py tests/cli/test_eval_command.py`
- [ ] Confirm `rllm eval --help` shows `--resume-run`


Made with [Cursor](https://cursor.com)