### PR TITLE
fix(data): preserve nested Parquet containers

### DIFF
--- a/rllm/data/dataset.py
+++ b/rllm/data/dataset.py
@@ -163,9 +163,12 @@ class Dataset:
 
             data = pd.read_csv(path).to_dict("records")
         elif file_ext == ".parquet":
-            import pandas as pd
+            import pyarrow.parquet as pq
 
-            data = pd.read_parquet(path).to_dict("records")
+            # pandas materializes nested list columns as ``numpy.ndarray``
+            # objects. Conversation and tool schemas require ordinary Python
+            # lists, and PyArrow preserves that shape directly.
+            data = pq.read_table(path).to_pylist()
         elif file_ext == ".arrow":
             data = DatasetRegistry._load_arrow_ipc(path)
         else:

--- a/tests/data/test_arrow_ipc.py
+++ b/tests/data/test_arrow_ipc.py
@@ -253,3 +253,37 @@ class TestDatasetLoadDataArrow:
         ds = Dataset.load_data(path)
         assert len(ds) == 1
         assert ds[0]["img"] == b"\x89PNG_data"
+
+
+class TestDatasetLoadDataParquet:
+    def test_nested_columns_are_python_lists(self, tmp_path):
+        """Direct SFT files must not leak pandas/NumPy container types."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        rows = [
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi"},
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            }
+        ]
+        path = tmp_path / "nested.parquet"
+        pq.write_table(pa.Table.from_pylist(rows), path)
+
+        row = Dataset.load_data(str(path))[0]
+
+        assert isinstance(row["messages"], list)
+        assert isinstance(row["messages"][0], dict)
+        assert isinstance(row["tools"], list)
+        assert isinstance(row["tools"][0], dict)


### PR DESCRIPTION
Part 1 of 11 in the draft stack replacing #809.

Base: `terminal-rl`
Next: #842

## Change

Deserialize Parquet rows through PyArrow into native Python containers. Nested message and tool columns therefore remain ordinary lists and dictionaries instead of pandas/NumPy container values.

## Verification

- `pytest tests/data/test_arrow_ipc.py -q`
- full stacked tip: 152 passed, 22 skipped

This PR is intentionally limited to Parquet row deserialization.