### PR TITLE
fix(sft): reject ambiguous inline thinking

### DIFF
--- a/rllm/data/sft_bridges.py
+++ b/rllm/data/sft_bridges.py
@@ -45,6 +45,7 @@ from rllm.data.sft_schema import (
     SFTMessage,
     SFTRow,
     SFTSchemaError,
+    _has_structural_inline_thinking,
     normalize_message_dict,
     normalize_rows,
 )
@@ -58,6 +59,7 @@ _THINK_RE = re.compile(r"\s*<think>(.*?)</think>(.*)", re.DOTALL)
 # Sibling fields carrying chain-of-thought next to ``content`` in the
 # OpenAI-compatible reasoning-model wire shape, in precedence order.
 _REASONING_KEYS = ("reasoning_content", "reasoning")
+_PART_PAYLOAD = {"text": "text", "thinking": "thinking"}
 
 
 # --- source-shape normalization ----------------------------------------------
@@ -121,6 +123,9 @@ def _normalize_source_message(msg: Any) -> Any:
     reasoning = reasoning_values[0][1] if reasoning_values else ""
     if reasoning:
         content = out.get("content")
+        if _has_structural_inline_thinking(content):
+            fields = ", ".join(key for key, _ in reasoning_values)
+            raise SFTSchemaError(f"sibling reasoning field ({fields}) conflicts with structural inline <think>...</think> content; choose one reasoning representation.")
         parts: list = [{"type": "thinking", "thinking": reasoning}]
         if isinstance(content, str):
             if content:
@@ -133,7 +138,28 @@ def _normalize_source_message(msg: Any) -> Any:
     return out
 
 
+def _payload_of(part: Any, kind: str | None = None) -> str | None:
+    if not isinstance(part, dict):
+        return None
+    part_type = part.get("type")
+    if kind is not None and part_type != kind:
+        return None
+    key = _PART_PAYLOAD.get(part_type) if isinstance(part_type, str) else None
+    value = part.get(key) if key else None
+    return value if isinstance(value, str) else None
+
+
 # --- shared helpers ----------------------------------------------------------
+
+
+def _split_think_tag(text: str) -> list[dict]:
+    match = _THINK_RE.match(text)
+    if not match:
+        return [{"type": "text", "text": text}]
+    return [
+        {"type": "thinking", "thinking": match.group(1).strip()},
+        {"type": "text", "text": match.group(2).lstrip()},
+    ]
 
 
 def _content_to_parts(role: str, content: Any) -> list[dict]:
@@ -146,19 +172,19 @@ def _content_to_parts(role: str, content: Any) -> list[dict]:
     does, so this bridge tolerates partially-structured inputs too.
     """
     if isinstance(content, str):
-        if role == "assistant":
-            m = _THINK_RE.match(content)
-            if m:
-                return [
-                    {"type": "thinking", "thinking": m.group(1).strip()},
-                    {"type": "text", "text": m.group(2).lstrip()},
-                ]
-        return [{"type": "text", "text": content}]
+        return _split_think_tag(content) if role == "assistant" else [{"type": "text", "text": content}]
     if content is None:
         return [{"type": "text", "text": ""}]
     if isinstance(content, list):
-        # Reuse the schema's part cleanup (drops ``None`` cross-keys).
-        return list(normalize_message_dict({"role": role, "content": content}).get("content", []))
+        parts = list(normalize_message_dict({"role": role, "content": content}).get("content", []))
+        if role != "assistant":
+            return parts
+        for index, part in enumerate(parts):
+            if _payload_of(part, "text") is None:
+                continue
+            split = _split_think_tag(part["text"])
+            return parts[:index] + split + parts[index + 1 :] if len(split) > 1 else parts
+        return parts
     raise SFTSchemaError(f"unsupported content type {type(content).__name__} for role {role!r}.")
 
 

--- a/rllm/data/sft_schema.py
+++ b/rllm/data/sft_schema.py
@@ -16,15 +16,17 @@ which builds tinker's structured ``ToolCall`` objects for the renderer.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+import re
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, ValidationInfo, model_validator
 
 # Message-level keys we recognize; everything else is dropped during cleanup.
 _MESSAGE_KEYS = ("role", "content", "trainable", "tool_calls", "tool_call_id", "name")
 # Optional keys that arrive as ``None`` from a parquet struct-unification round
 # trip; a ``None`` here means "absent", so we drop the key entirely.
 _OPTIONAL_NONE_KEYS = ("tool_calls", "tool_call_id", "name")
+_STRUCTURAL_THINK_RE = re.compile(r"\s*<think>.*?</think>", re.DOTALL)
 
 
 class SFTSchemaError(ValueError):
@@ -58,6 +60,23 @@ class ThinkingPart(BaseModel):
 
 # Discriminated on ``type`` so an unknown part type is a clean validation error.
 ContentPart = Annotated[TextPart | ThinkingPart, Field(discriminator="type")]
+
+
+def _has_structural_inline_thinking(content: Any) -> bool:
+    """Whether an assistant text stream starts with a complete think block."""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        chunks: list[str] = []
+        for part in content:
+            if isinstance(part, TextPart):
+                chunks.append(part.text)
+            elif isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str):
+                chunks.append(part["text"])
+        text = "".join(chunks)
+    else:
+        return False
+    return _STRUCTURAL_THINK_RE.match(text) is not None
 
 
 # --- tool calls --------------------------------------------------------------
@@ -98,6 +117,15 @@ class SFTMessage(BaseModel):
     tool_calls: list[SFTToolCall] | None = None
     tool_call_id: str | None = None
     name: str | None = None
+
+    @model_validator(mode="after")
+    def reject_structural_inline_thinking(self, info: ValidationInfo):
+        allow_inline = bool((info.context or {}).get("allow_structural_inline_thinking_text"))
+        if not allow_inline and self.role == "assistant" and _has_structural_inline_thinking(self.content):
+            raise ValueError(
+                "assistant text begins with a structural <think>...</think> block; import wire-format text with `rllm dataset import --format think-tags` or provide canonical thinking parts."
+            )
+        return self
 
     def text(self) -> str:
         """Concatenated visible text across the message's ``TextPart``s."""
@@ -205,7 +233,12 @@ def normalize_message_dict(msg: dict) -> dict:
     return out
 
 
-def normalize_messages(messages, default_trainable: str = "all") -> list[SFTMessage]:
+def normalize_messages(
+    messages,
+    default_trainable: str = "all",
+    *,
+    allow_structural_inline_thinking_text: bool = False,
+) -> list[SFTMessage]:
     """Clean and validate a conversation into ``SFTMessage`` objects.
 
     Trainable-flag policy: if ANY message lacks a real bool ``trainable`` (missing
@@ -248,13 +281,23 @@ def normalize_messages(messages, default_trainable: str = "all") -> list[SFTMess
     out: list[SFTMessage] = []
     for i, m in enumerate(cleaned):
         try:
-            out.append(SFTMessage.model_validate(m))
+            out.append(
+                SFTMessage.model_validate(
+                    m,
+                    context={"allow_structural_inline_thinking_text": allow_structural_inline_thinking_text},
+                )
+            )
         except ValidationError as e:
             raise SFTSchemaError(f"message {i}: {e}") from e
     return out
 
 
-def normalize_row(row: dict, default_trainable: str = "all") -> SFTRow:
+def normalize_row(
+    row: dict,
+    default_trainable: str = "all",
+    *,
+    allow_structural_inline_thinking_text: bool = False,
+) -> SFTRow:
     """Normalize a single ``{"messages": [...], **extra}`` row into an ``SFTRow``.
 
     Raises :class:`SFTSchemaError` for a non-dict row, a missing/empty
@@ -266,10 +309,17 @@ def normalize_row(row: dict, default_trainable: str = "all") -> SFTRow:
     if "messages" not in row:
         raise SFTSchemaError("row is missing a 'messages' field.")
 
-    messages = normalize_messages(row["messages"], default_trainable=default_trainable)
+    messages = normalize_messages(
+        row["messages"],
+        default_trainable=default_trainable,
+        allow_structural_inline_thinking_text=allow_structural_inline_thinking_text,
+    )
     extra = {k: v for k, v in row.items() if k != "messages"}
     try:
-        return SFTRow(messages=messages, **extra)
+        return SFTRow.model_validate(
+            {"messages": messages, **extra},
+            context={"allow_structural_inline_thinking_text": allow_structural_inline_thinking_text},
+        )
     except ValidationError as e:  # pragma: no cover - extra="allow" makes this rare
         raise SFTSchemaError(str(e)) from e
 

--- a/rllm/trainer/sft/backend.py
+++ b/rllm/trainer/sft/backend.py
@@ -24,7 +24,12 @@ class SFTConfigError(Exception):
     """Raised for invalid SFT specs/config or unsupported backends."""
 
 
-def validate_messages_dataset(dataset, label: str = "train") -> None:
+def validate_messages_dataset(
+    dataset,
+    label: str = "train",
+    *,
+    allow_structural_inline_thinking_text: bool = False,
+) -> None:
     """Validate that *dataset* has the SFT ``messages`` schema.
 
     Mirrors the check the old experimental SFT CLI did, raising
@@ -49,7 +54,10 @@ def validate_messages_dataset(dataset, label: str = "train") -> None:
     from rllm.data.sft_schema import SFTSchemaError, normalize_row
 
     try:
-        normalize_row(row)
+        normalize_row(
+            row,
+            allow_structural_inline_thinking_text=allow_structural_inline_thinking_text,
+        )
     except SFTSchemaError as e:
         raise SFTConfigError(f"{label} dataset: row 0 does not match the SFT schema: {e}") from e
 

--- a/rllm/trainer/sft/verl_backend.py
+++ b/rllm/trainer/sft/verl_backend.py
@@ -47,9 +47,17 @@ class VerlSFTBackend(SFTBackend):
     # -- contract -----------------------------------------------------------
 
     def validate_spec(self) -> None:
-        validate_messages_dataset(self.spec.train_dataset, "train")
+        validate_messages_dataset(
+            self.spec.train_dataset,
+            "train",
+            allow_structural_inline_thinking_text=True,
+        )
         if self.spec.val_dataset is not None:
-            validate_messages_dataset(self.spec.val_dataset, "val")
+            validate_messages_dataset(
+                self.spec.val_dataset,
+                "val",
+                allow_structural_inline_thinking_text=True,
+            )
         if self.spec.lr_schedule not in _LR_SCHEDULE_MAP:
             raise SFTConfigError(f"Unsupported lr_schedule {self.spec.lr_schedule!r} for verl. Use one of {sorted(_LR_SCHEDULE_MAP)}.")
         if self.spec.lr_schedule == "linear":

--- a/tests/data/test_sft_bridges.py
+++ b/tests/data/test_sft_bridges.py
@@ -298,6 +298,50 @@ def test_reasoning_does_not_hide_unsupported_visible_content(content):
         bridge_messages([{"messages": [message]}])
 
 
+def test_sibling_reasoning_conflicts_with_structural_inline_thinking():
+    message = {
+        "role": "assistant",
+        "content": "<think>inline</think>visible",
+        "reasoning_content": "sibling",
+    }
+    with pytest.raises(SFTSchemaError, match="sibling reasoning.*structural inline"):
+        bridge_messages([{"messages": [message]}])
+
+
+def test_plain_messages_reject_structural_inline_thinking():
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "<think>inline</think>visible"},
+    ]
+    with pytest.raises(SFTSchemaError, match="think-tags.*thinking parts"):
+        bridge_messages([{"messages": messages}])
+
+
+def test_think_tags_parse_structural_text_parts():
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "<think>inline</think>visible"}],
+        },
+    ]
+    assistant = bridge_think_tags([{"messages": messages}], explode=False)[0].messages[-1]
+    assert assistant.thinking() == "inline"
+    assert assistant.text() == "visible"
+
+
+def test_literal_think_tags_outside_assistant_prefix_remain_text():
+    messages = [
+        {"role": "user", "content": "<think>literal prompt</think>"},
+        {"role": "assistant", "content": "Literal <think>tag</think>."},
+    ]
+    row = bridge_messages([{"messages": messages}])[0]
+    assert [message.text() for message in row.messages] == [
+        "<think>literal prompt</think>",
+        "Literal <think>tag</think>.",
+    ]
+
+
 def test_bridges_preserve_source_whitespace_verbatim():
     messages = [
         {"role": "system", "content": "sys prompt\n\n"},

--- a/tests/data/test_sft_schema.py
+++ b/tests/data/test_sft_schema.py
@@ -138,6 +138,35 @@ def test_normalize_messages_treats_empty_reasoning_as_absent(key, role):
     assert message.thinking() == ""
 
 
+def test_normalize_row_rejects_structural_thinking_in_text_parts():
+    with pytest.raises(SFTSchemaError, match="think-tags.*thinking parts"):
+        normalize_row(
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant", "content": [{"type": "text", "text": "<think>inline</think>visible"}]},
+                ]
+            }
+        )
+
+
+def test_structural_thinking_check_uses_concatenated_text_stream():
+    with pytest.raises(SFTSchemaError, match="think-tags.*thinking parts"):
+        normalize_row(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "<think>split"},
+                            {"type": "text", "text": " block</think>visible"},
+                        ],
+                    }
+                ]
+            }
+        )
+
+
 # --- validation errors (raised as SFTSchemaError by normalize_*) -------------
 
 

--- a/tests/trainer/test_sft_dispatcher.py
+++ b/tests/trainer/test_sft_dispatcher.py
@@ -415,6 +415,29 @@ def test_verl_rejects_structured_rows():
         VerlSFTBackend(spec).validate_spec()
 
 
+@pytest.mark.parametrize("think_row_index", [0, 1])
+def test_verl_keeps_legacy_inline_think_text(think_row_index):
+    from rllm.trainer.sft.verl_backend import VerlSFTBackend
+
+    plain = {
+        "messages": [
+            {"role": "user", "content": "plain"},
+            {"role": "assistant", "content": "answer"},
+        ]
+    }
+    inline = {
+        "messages": [
+            {"role": "user", "content": "reason"},
+            {"role": "assistant", "content": "<think>work</think>answer"},
+        ]
+    }
+    rows = [plain, plain.copy()]
+    rows[think_row_index] = inline
+    dataset = Dataset(data=rows, name="legacy-think-text", split="train")
+
+    VerlSFTBackend(_spec(train_dataset=dataset)).validate_spec()
+
+
 # -- full-parameter (lora_rank=0) support ------------------------------------
 # (build_config shape/tokenizer resolution + the provision doc for rank 0 are
 # covered by the parametrized tests above; here: spec + validate_spec gating.)


### PR DESCRIPTION
Part 4 of 13 in the draft stack replacing #809.

Base: `agent/sft-think-mask-preservation`
Previous: #843
Next: #845

## Change

Reject ambiguous structural inline thinking before hosted SFT can silently reinterpret it. Verl explicitly retains its legacy inline-text compatibility.

## Verification

- focused schema, bridge, and dispatcher tests
- Full stack tip: 167 passed, 22 skipped

This PR is intentionally limited to one reviewable behavior.