### PR TITLE
fix(sft): render hosted data with production templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 license = {file = "LICENSE"}
 dependencies = [
     "rllm-model-gateway",
+    "renderers==0.1.9",
     # CLI
     "click>=8.0",
     "rich>=13.9.4",

--- a/rllm-model-gateway/pyproject.toml
+++ b/rllm-model-gateway/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "aiosqlite>=0.19.0",
     "PyYAML>=6.0",
-    "renderers>=0.1.7",
+    "renderers==0.1.9",
     "transformers>=4.50.0",
     "orjson>=3.9.0",
 ]

--- a/rllm/renderers/adapters.py
+++ b/rllm/renderers/adapters.py
@@ -18,6 +18,26 @@ from .bridging import BridgingRendererMixin
 from .types import ParsedResponse, RenderedTokens
 
 
+def _render_with_prefix_attribution(renderer, messages, *, tools, add_generation_prompt) -> RenderedTokens:
+    """Attribute fallback-renderer tokens without guessing ownership."""
+    previous: list[int] = []
+    indices: list[int] = []
+    for index in range(len(messages)):
+        current = renderer(messages[: index + 1], tools=tools, add_generation_prompt=False)
+        if current[: len(previous)] != previous:
+            raise ValueError("renderer rewrites previously rendered history, so rLLM cannot derive an exact per-message SFT loss mask; pin a native renderer")
+        indices.extend([index] * (len(current) - len(previous)))
+        previous = current
+
+    if add_generation_prompt:
+        current = renderer(messages, tools=tools, add_generation_prompt=True)
+        if current[: len(previous)] != previous:
+            raise ValueError("renderer generation prompt rewrites the closed conversation")
+        indices.extend([-1] * (len(current) - len(previous)))
+        previous = current
+    return RenderedTokens(token_ids=previous, message_indices=indices)
+
+
 def _flatten_parts(content: Any) -> tuple[str, str]:
     """Split structured renderer content into visible text and thinking."""
     if not isinstance(content, list):
@@ -85,6 +105,78 @@ def _to_parsed(content: Any, reasoning: str | None, tool_calls: Any) -> ParsedRe
     )
 
 
+def to_tinker_messages(messages: list[dict]) -> list[dict]:
+    """Translate renderer-wire messages into cookbook message objects."""
+    from tinker_cookbook.renderers.base import ToolCall
+
+    tool_call_fields = set(ToolCall.model_fields)
+    converted_messages: list[dict] = []
+    for message in messages:
+        converted = {key: value for key, value in message.items() if key not in {"reasoning_content", "trainable"}}
+        converted["content"] = message.get("content") or ""
+        reasoning = message.get("reasoning_content") if message.get("role") == "assistant" else ""
+        if reasoning:
+            thinking = {"type": "thinking", "thinking": reasoning}
+            content = converted["content"]
+            if isinstance(content, str):
+                converted["content"] = [thinking, {"type": "text", "text": content}]
+            elif not any(isinstance(part, dict) and part.get("type") == "thinking" for part in content):
+                converted["content"] = [thinking, *content]
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            converted["tool_calls"] = [
+                ToolCall.model_validate({key: value for key, value in tool_call.items() if key in tool_call_fields}) if isinstance(tool_call, dict) else tool_call for tool_call in tool_calls
+            ]
+        converted_messages.append(converted)
+    return converted_messages
+
+
+def to_tinker_tool_specs(tools: list[dict] | None) -> list:
+    """Translate OpenAI function declarations into cookbook tool specs."""
+    from tinker_cookbook.renderers.base import ToolSpec
+
+    specs: list[ToolSpec] = []
+    for index, tool in enumerate(tools or []):
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            raise ValueError(f"Tool declaration {index} must be an OpenAI function tool.")
+        function = tool.get("function")
+        if not isinstance(function, dict) or not function.get("name"):
+            raise ValueError(f"Tool declaration {index} needs a non-empty function.name.")
+        parameters = function.get("parameters") or {}
+        if not isinstance(parameters, dict):
+            raise ValueError(f"Tool declaration {index} function.parameters must be an object.")
+        specs.append(
+            ToolSpec(
+                name=function["name"],
+                description=function.get("description") or "",
+                parameters=parameters,
+            )
+        )
+    return specs
+
+
+def prepare_tinker_messages_with_tools(renderer: Any, messages: list[dict], tools: list[dict] | None) -> list[dict]:
+    """Inject tool declarations exactly as the cookbook renderer expects."""
+    if not tools:
+        return list(messages)
+
+    remaining = list(messages)
+    system_prompt = ""
+    if remaining and remaining[0].get("role") == "system":
+        content = remaining[0].get("content") or ""
+        if isinstance(content, str):
+            system_prompt = content
+        elif isinstance(content, list):
+            system_prompt = "".join(part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text")
+        remaining = remaining[1:]
+
+    prefix = renderer.create_conversation_prefix_with_tools(
+        to_tinker_tool_specs(tools),
+        system_prompt=system_prompt,
+    )
+    return list(prefix) + remaining
+
+
 class TinkerRendererAdapter(BridgingRendererMixin):
     """Wrap a tinker-style renderer (tinker_cookbook / Fireworks cookbook)."""
 
@@ -95,18 +187,10 @@ class TinkerRendererAdapter(BridgingRendererMixin):
         self.synthesize_close = synthesize_close if synthesize_close is not None else (stops[0] if stops else None)
 
     def _with_tools(self, messages: list[dict], tools) -> list[dict]:
-        if not tools:
-            return list(messages)
-        msgs = list(messages)
-        system = ""
-        if msgs and msgs[0].get("role") == "system":
-            system = msgs[0].get("content") or ""
-            msgs = msgs[1:]
-        prefix = self._inner.create_conversation_prefix_with_tools(tools, system_prompt=system)
-        return list(prefix) + msgs
+        return prepare_tinker_messages_with_tools(self._inner, messages, tools)
 
     def render_ids(self, messages, *, tools=None, add_generation_prompt: bool = False) -> list[int]:
-        msgs = self._with_tools(list(messages), tools)
+        msgs = self._with_tools(to_tinker_messages(messages), tools)
         if add_generation_prompt:
             model_input = self._inner.build_generation_prompt(msgs)
         else:
@@ -116,7 +200,12 @@ class TinkerRendererAdapter(BridgingRendererMixin):
         return list(model_input.to_ints())
 
     def render(self, messages, *, tools=None, add_generation_prompt: bool = False) -> RenderedTokens:
-        return RenderedTokens(token_ids=self.render_ids(messages, tools=tools, add_generation_prompt=add_generation_prompt))
+        return _render_with_prefix_attribution(
+            self.render_ids,
+            list(messages),
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+        )
 
     def get_stop_token_ids(self) -> list[int]:
         return [int(t) for t in self._inner.get_stop_sequences()]
@@ -143,7 +232,12 @@ class ChatTemplateAdapter(BridgingRendererMixin):
         return list(self._tok.apply_chat_template(list(messages), **kwargs))
 
     def render(self, messages, *, tools=None, add_generation_prompt: bool = False) -> RenderedTokens:
-        return RenderedTokens(token_ids=self.render_ids(messages, tools=tools, add_generation_prompt=add_generation_prompt))
+        return _render_with_prefix_attribution(
+            self.render_ids,
+            list(messages),
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+        )
 
     def get_stop_token_ids(self) -> list[int]:
         return list(self.close_token_ids)

--- a/rllm/renderers/registry.py
+++ b/rllm/renderers/registry.py
@@ -1,8 +1,8 @@
 """Resolve a (model, backend) to the best available renderer.
 
 Priority:
-1. Explicit override — ``family`` (prime-rl native) or ``renderer_name`` (tinker
-   style, e.g. ``"deepseek_v4"``).
+1. Explicit override — ``family`` (native) or ``renderer_name`` (legacy names
+   prefer the equivalent native renderer; cookbook-only names stay adapted).
 2. prime-rl native renderer if the model is in its ``MODEL_RENDERER_MAP``
    (hand-tuned, parity-tested, first-class ``bridge_to_next_turn``).
 3. Fireworks-cookbook renderer (``glm5``, ``deepseek_v4``, ...) auto-detected by
@@ -56,6 +56,23 @@ _FW_MODULES: tuple[str, ...] = (
     "fireworks_training_cookbook.renderers",
 )
 
+# Historical CLI/config spellings for renderer families now implemented by the
+# production ``renderers`` package. Prefer the native renderer so an explicit
+# override cannot accidentally select a different train/serve implementation.
+_PRIME_FAMILY_ALIASES: dict[str, str] = {
+    "qwen3": "qwen3",
+    "qwen3_5": "qwen3.5",
+    "qwen3.5": "qwen3.5",
+    "qwen3_6": "qwen3.6",
+    "qwen3.6": "qwen3.6",
+    "deepseekv3": "deepseek-v3",
+    "deepseek_v3": "deepseek-v3",
+    "deepseek-v3": "deepseek-v3",
+    "nemotron3": "nemotron-3",
+    "nemotron_3": "nemotron-3",
+    "nemotron-3": "nemotron-3",
+}
+
 
 def _cookbook_renderer_name(model_name: str) -> str | None:
     """Fireworks-cookbook renderer name for *model_name*, or None."""
@@ -80,10 +97,12 @@ def _infer_model_name(model: str | None, tokenizer: Any) -> str:
 def _try_prime(tokenizer: Any, family: str) -> Any | None:
     """prime-rl native renderer, or None if it falls back to DefaultRenderer."""
     try:
-        from renderers import create_renderer  # type: ignore
+        import renderers as prime_renderers  # type: ignore
     except ImportError:
         return None
-    renderer = create_renderer(tokenizer, renderer=family)
+
+    config = prime_renderers.config_from_name(family)
+    renderer = prime_renderers.create_renderer(tokenizer, config)
     if type(renderer).__name__ == "DefaultRenderer":
         return None
     return renderer
@@ -128,9 +147,20 @@ def resolve(
 ) -> RendererResolution:
     name = _infer_model_name(model, tokenizer)
 
-    # 1a. Explicit tinker-style override.
+    # 1a. Explicit renderer override. Legacy cookbook spellings resolve to the
+    # native production implementation when one exists; cookbook-only names
+    # continue through the adapter below.
     if renderer_name:
-        return RendererResolution(_tinker_adapter(renderer_name, tokenizer, model=name), "tinker", renderer_name)
+        prime_family = _PRIME_FAMILY_ALIASES.get(renderer_name)
+        if prime_family:
+            renderer = _try_prime(tokenizer, prime_family)
+            if renderer is not None:
+                return RendererResolution(renderer, "prime", prime_family)
+        return RendererResolution(
+            _tinker_adapter(renderer_name, tokenizer, model=name),
+            "tinker",
+            renderer_name,
+        )
 
     # 1b. Explicit prime-rl family.
     if family and family != "auto":

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -32,77 +32,27 @@ _CONFIG_FILE = Path(__file__).resolve().parent / "config" / "tinker.yaml"
 _PLAIN_RENDERERS = {"role_colon", "llama3"}
 
 
-def _resolve_renderer_name(model_source: str, explicit: str | None) -> str:
-    """Resolve the tinker_cookbook renderer name for ``model_source``.
+def _guard_renderer_capability(renderer_name: str, renderer_source: str, train_data) -> None:
+    """Reject structured rows when the resolved renderer cannot prove support.
 
-    - ``explicit`` (a non-null ``data.renderer_name``) wins; a best-effort
-      ``warn_if_renderer_not_recommended`` advises if it looks off (never fails).
-    - otherwise auto-detect via ``model_info.get_recommended_renderer_name``;
-      tinker's map doesn't cover every model/size (e.g. ``Qwen3-0.6B`` raises
-      ``KeyError``), so on *any* exception fall back to a small family heuristic
-      on the lowercased model basename.
-
-    tinker imports stay lazy (inside the function), matching the rest of this
-    module. Every returned name is a real ``renderers.get_renderer`` entry.
+    Plain renderers cannot represent reasoning or tool calls. An automatically
+    selected chat-template fallback is likewise unverified, so it may train only
+    inspectable text-only data; file-backed input must pin a capable renderer.
     """
-    from tinker_cookbook import model_info
-
-    if explicit:
-        try:
-            model_info.warn_if_renderer_not_recommended(model_source, explicit)
-        except Exception as e:  # noqa: BLE001 - advisory only, never fail resolution
-            logger.debug("warn_if_renderer_not_recommended(%r, %r) failed: %s", model_source, explicit, e)
-        logger.info("SFT renderer %r (explicit override for model %r)", explicit, model_source)
-        return explicit
-
-    # Auto-detect: tinker's recommendation map first.
-    try:
-        rec = model_info.get_recommended_renderer_name(model_source)
-        if rec:
-            logger.info("SFT renderer %r (auto-detected for model %r via tinker_cookbook)", rec, model_source)
-            return rec
-    except Exception as e:  # noqa: BLE001 - map doesn't cover every model/size
-        logger.debug("get_recommended_renderer_name(%r) failed (%s); using family heuristic", model_source, e)
-
-    # Minimal family heuristic on the lowercased model basename.
-    base = model_source.rsplit("/", 1)[-1].lower()
-    if "qwen3.5" in base or "qwen3_5" in base or "qwen3p5" in base:
-        name = "qwen3_5"
-    elif "qwen3" in base:
-        name = "qwen3"
-    elif "deepseek" in base:
-        name = "deepseekv3"
-    elif "llama-3" in base or "llama3" in base:
-        name = "llama3"
-    else:
-        logger.warning(
-            "Could not auto-detect a renderer for model %r; falling back to 'role_colon', which "
-            "CANNOT represent reasoning (<think>) or tool-calls. If your data has either, pass "
-            "--renderer (e.g. qwen3 / qwen3_5 / deepseekv3) to pin a renderer.",
-            model_source,
-        )
-        return "role_colon"
-    logger.info("SFT renderer %r (family heuristic for model %r)", name, model_source)
-    return name
-
-
-def _guard_plain_renderer(renderer_name: str, train_data) -> None:
-    """Fail fast if a plain-text renderer would silently drop structured content.
-
-    ``role_colon`` / ``llama3`` can't represent reasoning parts or tool-calls, so
-    if the in-memory dataset carries either, raise rather than render lossily.
-    Pure dict inspection (no coupling to the ``sft_schema`` module); samples up to
-    8 rows and only runs for in-memory datasets (``get_data()``).
-    """
-    if renderer_name not in _PLAIN_RENDERERS or not hasattr(train_data, "get_data"):
+    fallback = renderer_source == "chat_template"
+    if renderer_name not in _PLAIN_RENDERERS and not fallback:
         return
+    if not hasattr(train_data, "get_data"):
+        raise SFTConfigError(f"Hosted SFT cannot verify structured-message support for the {renderer_name!r} renderer on file-backed data. Pin a capable renderer.")
     try:
-        rows = train_data.get_data()[:8]
-    except Exception:  # noqa: BLE001 - guard is best-effort
-        return
+        rows = train_data.get_data()
+    except Exception as e:  # noqa: BLE001 - convert inspection failure to config error
+        raise SFTConfigError(f"Hosted SFT could not inspect data before using the {renderer_name!r} renderer. Pin a capable renderer.") from e
     for row in rows:
         if not isinstance(row, dict):
             continue
+        if row.get("tools"):
+            raise SFTConfigError(f"The {renderer_name!r} renderer cannot safely represent tool declarations in hosted SFT. Pin a capable renderer.")
         for msg in row.get("messages") or []:
             if not isinstance(msg, dict):
                 continue
@@ -120,31 +70,56 @@ def _guard_plain_renderer(renderer_name: str, train_data) -> None:
 def build_sft_data(config, train_data, val_data):
     """Build (tokenizer, train_dataset, val_dataset) from a backend config.
 
-    Shared by the tinker and fireworks SFT backends: both render rLLM
-    ``messages`` rows into tinker Datums via tinker_cookbook renderers.
+    Shared by the Tinker and Fireworks SFT backends: both use rLLM's production
+    renderer, then package the resulting tokens and loss mask as Tinker Datums.
     """
-    from tinker_cookbook.renderers import get_renderer
+    tokenize_method = config.data.get("rllm", {}).get("tokenize_and_mask_method", "cumulative")
+    if tokenize_method == "hf_template":
+        raise SFTConfigError(
+            "Hosted SFT does not support tokenize_and_mask_method='hf_template': "
+            "it bypasses the canonical renderer and its exact trainable-token attribution. "
+            "Use 'cumulative' or 'stepwise', or use the verl backend for hf_template."
+        )
+
     from tinker_cookbook.tokenizer_utils import get_tokenizer
 
+    from rllm.renderers import resolve
     from rllm.trainer.sft.tinker_dataset import create_tinker_sft_datasets
 
     # Fireworks' model.name is a FW model path (accounts/fireworks/models/...),
     # not HF-resolvable, so render/tokenize from the HF tokenizer_model when set.
     tokenizer_name = config.model.get("tokenizer_model") or config.model.name
     tokenizer = get_tokenizer(tokenizer_name)
-    # renderer_name=null (yaml default) -> auto-detect from the model; an explicit
-    # value (e.g. from --renderer) overrides. A plain renderer that would drop
-    # reasoning/tool-calls fails fast before we render.
-    renderer_name = _resolve_renderer_name(tokenizer_name, config.data.get("renderer_name", None))
-    _guard_plain_renderer(renderer_name, train_data)
-    renderer = get_renderer(renderer_name, tokenizer)
+    # Training and serving resolve through the same production renderer layer
+    # with the same template-faithful history policy.
+    explicit = config.data.get("renderer_name", None)
+    try:
+        if explicit:
+            resolution = resolve(
+                tokenizer_name,
+                tokenizer,
+                renderer_name=explicit,
+            )
+        else:
+            resolution = resolve(tokenizer_name, tokenizer)
+    except Exception as e:  # noqa: BLE001 - surface renderer setup as config
+        raise SFTConfigError(f"Could not initialize SFT renderer for {tokenizer_name!r}: {e}") from e
+    _guard_renderer_capability(resolution.name, resolution.source, train_data)
+    if val_data is not None:
+        _guard_renderer_capability(resolution.name, resolution.source, val_data)
+    renderer = resolution.renderer
     # Masking is always CUSTOMIZED, driven by each message's ``trainable`` flag:
     # rows from ``from-eval``'s automerge carry the flags directly; flag-less rows
     # (e.g. an external ``--train-file``) get a derived default in the dataset
     # loader. ``tokenize_and_mask_method=stepwise`` only selects that default
     # (train just the last assistant turn) rather than the all-assistant default.
-    last_only = config.data.get("rllm", {}).get("tokenize_and_mask_method", "cumulative") == "stepwise"
-    logger.info(f"Using renderer: {renderer_name}, masking: CUSTOMIZED (last_only={last_only})")
+    last_only = tokenize_method == "stepwise"
+    logger.info(
+        "Using canonical renderer: %s (%s), masking=trainable (last_only=%s)",
+        resolution.name,
+        resolution.source,
+        last_only,
+    )
 
     train_batch_size = config.data.get("train_batch_size", 32)
     val_batch_size = config.data.get("micro_batch_size_per_gpu", train_batch_size)
@@ -192,6 +167,12 @@ class TinkerSFTBackend(SFTBackend):
     # -- contract -----------------------------------------------------------
 
     def validate_spec(self) -> None:
+        if self.spec.tokenize_method == "hf_template":
+            raise SFTConfigError(
+                f"The {self.name!r} hosted SFT backend does not support tokenize_method='hf_template': "
+                "it bypasses the canonical renderer and exact trainable-token attribution. "
+                "Use 'cumulative' or 'stepwise', or use the verl backend."
+            )
         if self._effective_lora_rank() == 0 and not self.supports_full_finetune:
             raise SFTConfigError(
                 f"--lora-rank 0 (full-parameter fine-tuning) is not supported by the {self.name!r} SFT backend: "

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -7,15 +7,18 @@ Imported lazily by :class:`rllm.trainer.sft.tinker_backend.TinkerSFTBackend`, so
 
 from __future__ import annotations
 
+import json
 import logging
 
 import datasets
 import tinker
-from tinker_cookbook.renderers import Message, Renderer, TrainOnWhat
+import torch
+from tinker_cookbook.renderers import Message
 from tinker_cookbook.supervised.common import datum_from_model_input_weights
 from tinker_cookbook.supervised.types import SupervisedDataset
 
-from rllm.data.sft_schema import SFTSchemaError, normalize_messages
+from rllm.data.sft_schema import SFTMessage, SFTSchemaError, normalize_messages
+from rllm.renderers.types import Renderer
 from rllm.trainer.sft.backend import SFTConfigError
 
 logger = logging.getLogger(__name__)
@@ -66,20 +69,59 @@ def _warn_truncation(row_tokens: int, max_length: int) -> None:
         )
 
 
+def _validate_rendered_attribution(rendered, message_count: int) -> None:
+    """Require one valid source-message index per rendered token."""
+    if len(rendered.message_indices) != len(rendered.token_ids):
+        raise ValueError("renderer did not return one message attribution per token")
+    invalid = next((index for index in rendered.message_indices if index < -1 or index >= message_count), None)
+    if invalid is not None:
+        raise ValueError(f"renderer returned invalid message index {invalid} for {message_count} messages")
+    is_content = getattr(rendered, "is_content", None)
+    if is_content and len(is_content) != len(rendered.token_ids):
+        raise ValueError("renderer returned incomplete content-token metadata")
+
+
+def _validate_trainable_targets_represented(
+    renderer: Renderer,
+    renderer_messages: list[dict],
+    messages: list[SFTMessage],
+    rendered,
+    *,
+    tools: list[dict] | None,
+) -> None:
+    """Fail when a full render rewrites an explicitly trainable target.
+
+    Compare the full sequence through every earlier trainable target with that
+    prefix rendered alone. This protects both the target and its causal context
+    from history-dependent template rewrites.
+    """
+    for index, message in enumerate(messages):
+        if not message.trainable or index == len(messages) - 1:
+            continue
+        prefix = renderer.render(renderer_messages[: index + 1], tools=tools)
+        _validate_rendered_attribution(prefix, index + 1)
+        if rendered.token_ids[: len(prefix.token_ids)] != prefix.token_ids:
+            raise ValueError(
+                f"the rendered prefix through trainable message {index} is rewritten when later turns are present. Explode this trajectory per target, or store that target as a separate SFT example."
+            )
+
+
 def conversation_to_datum(
     conversation: list[Message],
     renderer: Renderer,
     max_length: int | None,
     last_only: bool = False,
+    *,
+    tools: list[dict] | None = None,
 ) -> tinker.Datum:
     """Convert a conversation (list of messages) to a Tinker Datum.
 
-    Normalizes the raw messages through :mod:`rllm.data.sft_schema` (str/None
-    content coercion, parquet ``None``-artifact stripping, structured
-    ``tool_calls``, trainable-flag derivation) and renders with tinker's
-    ``CUSTOMIZED`` masking — each message's ``trainable`` flag alone decides the
-    loss mask. ``last_only`` selects the flag-less default (train just the last
-    assistant turn) rather than the all-assistant default.
+    Normalizes through :mod:`rllm.data.sft_schema`, then renders with the same
+    canonical :mod:`rllm.renderers` implementation used for inference. The
+    renderer returns a source-message index for every token; ``trainable`` maps
+    those indices to the loss mask. When the renderer also identifies message
+    body tokens, template scaffolding is excluded. ``last_only`` only selects
+    the default for source rows without a complete explicit mask.
 
     Schema/validation failures are re-raised as :class:`SFTConfigError` with the
     failing row's context.
@@ -87,21 +129,102 @@ def conversation_to_datum(
     default_trainable = "last" if last_only else "all"
     try:
         messages = normalize_messages(conversation, default_trainable=default_trainable)
-        tinker_messages = [m.to_tinker_message() for m in messages]
+        renderer_messages = [_to_renderer_message(message) for message in messages]
+        renderer_tools = _validate_tools(tools)
+        rendered = renderer.render(
+            renderer_messages,
+            tools=renderer_tools,
+        )
+        _validate_rendered_attribution(rendered, len(messages))
+        _validate_trainable_targets_represented(
+            renderer,
+            renderer_messages,
+            messages,
+            rendered,
+            tools=renderer_tools,
+        )
     except SFTSchemaError as e:
         raise SFTConfigError(f"SFT row failed schema normalization: {e}\n  row={_row_context(conversation)}") from e
-    model_input, weights = renderer.build_supervised_example(tinker_messages, train_on_what=TrainOnWhat.CUSTOMIZED)
+    except (TypeError, ValueError) as e:
+        raise SFTConfigError(f"SFT row failed canonical rendering: {e}\n  row={_row_context(conversation)}") from e
+
+    is_content = getattr(rendered, "is_content", None)
+    content_mask = is_content or [True] * len(rendered.token_ids)
+    weights = torch.tensor(
+        [float(index >= 0 and bool(messages[index].trainable) and content) for index, content in zip(rendered.message_indices, content_mask, strict=True)],
+        dtype=torch.float32,
+    )
+    model_input = tinker.ModelInput.from_ints(rendered.token_ids)
     if max_length is not None and model_input.length > max_length:
         _warn_truncation(model_input.length, max_length)
     return datum_from_model_input_weights(model_input, weights, max_length)
+
+
+def _to_renderer_message(message: SFTMessage) -> dict:
+    """Lower one canonical SFT message to the renderer/OpenAI message shape.
+
+    Structured parts remain canonical in storage; the rendering contract has a
+    single visible-text field and a sibling ``reasoning_content`` field. Joining
+    parts by kind preserves their bytes and avoids provider-specific objects.
+    """
+    thinking_parts: list[str] = []
+    text_parts: list[str] = []
+    seen_text = False
+    for part in message.content:
+        if part.type == "text":
+            seen_text = True
+            text_parts.append(part.text)
+        elif seen_text:
+            raise ValueError("thinking parts must precede visible text; the renderer schema cannot preserve interleaved text/thinking order")
+        else:
+            thinking_parts.append(part.thinking)
+
+    output: dict = {
+        "role": message.role,
+        "content": "".join(text_parts),
+        "trainable": bool(message.trainable),
+    }
+    thinking = "".join(thinking_parts)
+    if thinking:
+        output["reasoning_content"] = thinking
+    if message.tool_calls:
+        output["tool_calls"] = []
+        for index, tool_call in enumerate(message.tool_calls):
+            try:
+                arguments = json.loads(tool_call.function.arguments)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"tool call {index} has invalid JSON arguments") from e
+            if not isinstance(arguments, dict):
+                raise ValueError(f"tool call {index} arguments must decode to an object")
+            output["tool_calls"].append(tool_call.model_dump(exclude_none=True))
+    if message.tool_call_id is not None:
+        output["tool_call_id"] = message.tool_call_id
+    if message.name is not None:
+        output["name"] = message.name
+    return output
+
+
+def _validate_tools(tools: list[dict] | None) -> list[dict] | None:
+    """Validate declarations before a renderer can ignore malformed entries."""
+    if not tools:
+        return None
+    for index, tool in enumerate(tools):
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            raise ValueError(f"tool declaration {index} must be an OpenAI function tool")
+        function = tool.get("function")
+        if not isinstance(function, dict) or not function.get("name"):
+            raise ValueError(f"tool declaration {index} needs a non-empty function.name")
+        if not isinstance(function.get("parameters", {}), dict):
+            raise ValueError(f"tool declaration {index} function.parameters must be an object")
+    return tools
 
 
 class TinkerSFTDataset(SupervisedDataset):
     """Dataset for Tinker SFT that loads from rLLM sources.
 
     Accepts a HuggingFace/rLLM Dataset object (from DatasetRegistry) or parquet
-    file path(s) with a ``messages`` column, renders via Tinker's renderer, and
-    yields Tinker Datums in batches.
+    file path(s) with a ``messages`` column, renders through rLLM's production
+    renderer, and yields Tinker-compatible Datums in batches.
     """
 
     def __init__(
@@ -143,7 +266,15 @@ class TinkerSFTDataset(SupervisedDataset):
         for i in range(start_idx, end_idx):
             row = self.dataset[i]
             try:
-                datums.append(conversation_to_datum(row["messages"], self.renderer, self.max_length, self.last_only))
+                datums.append(
+                    conversation_to_datum(
+                        row["messages"],
+                        self.renderer,
+                        self.max_length,
+                        self.last_only,
+                        tools=row.get("tools"),
+                    )
+                )
             except SFTConfigError as e:
                 raise SFTConfigError(f"dataset row {i}: {e}") from e
         return datums

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -8,6 +8,7 @@ are skipped if it (or tinker_cookbook) is unavailable. Run offline.
 from __future__ import annotations
 
 import os
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -16,7 +17,12 @@ os.environ.setdefault("HF_HUB_OFFLINE", "1")
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 from rllm.renderers import BridgingRendererMixin, get_renderer, resolve  # noqa: E402
-from rllm.renderers.adapters import ChatTemplateAdapter, TinkerRendererAdapter  # noqa: E402
+from rllm.renderers.adapters import (  # noqa: E402
+    ChatTemplateAdapter,
+    TinkerRendererAdapter,
+    to_tinker_messages,
+    to_tinker_tool_specs,
+)
 
 QWEN = "Qwen/Qwen3-0.6B"
 
@@ -115,9 +121,9 @@ def _tinker_qwen3(tokenizer):
 
 
 def _prime_qwen3(tokenizer):
-    from renderers import create_renderer
+    import renderers
 
-    return create_renderer(tokenizer, renderer="qwen3")
+    return renderers.create_renderer(tokenizer, renderers.config_from_name("qwen3"))
 
 
 def test_tinker_adapter_renders(qwen_tokenizer):
@@ -175,8 +181,95 @@ def test_tinker_parse_normalizes_structured_content_and_tool_calls():
         assert parsed.tool_calls[0].status.value == "ok"
 
 
-def test_tinker_adapter_bridge_matches_prime(qwen_tokenizer):
-    """The synthesized bridge must equal prime-rl's hand-tuned qwen3 bridge."""
+def test_cookbook_input_normalizes_reasoning_tools_and_trainable():
+    converted = to_tinker_messages(
+        [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "plan",
+                "trainable": True,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert "reasoning_content" not in converted[0]
+    assert "trainable" not in converted[0]
+    assert converted[0]["content"] == [
+        {"type": "thinking", "thinking": "plan"},
+        {"type": "text", "text": "answer"},
+    ]
+    assert converted[0]["tool_calls"][0].function.name == "bash"
+
+
+def test_cookbook_adapter_attributes_tokens_by_message():
+    class ModelInput:
+        def __init__(self, token_ids):
+            self._token_ids = token_ids
+
+        def to_ints(self):
+            return self._token_ids
+
+    class CookbookRenderer:
+        @staticmethod
+        def get_stop_sequences():
+            return [99]
+
+        @staticmethod
+        def build_supervised_example(messages):
+            return ModelInput(list(range(1, len(messages) + 1))), None
+
+    rendered = TinkerRendererAdapter(CookbookRenderer()).render(
+        [
+            {"role": "user", "content": "question", "trainable": False},
+            {"role": "assistant", "content": "answer", "trainable": True},
+        ]
+    )
+
+    assert rendered.token_ids == [1, 2]
+    assert rendered.message_indices == [0, 1]
+
+    class RewritingCookbookRenderer(CookbookRenderer):
+        @staticmethod
+        def build_supervised_example(messages):
+            token_ids = [1] if len(messages) == 1 else [9, 2]
+            return ModelInput(token_ids), None
+
+    with pytest.raises(ValueError, match="rewrites previously rendered history"):
+        TinkerRendererAdapter(RewritingCookbookRenderer()).render(
+            [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ]
+        )
+
+
+def test_openai_tool_declarations_become_cookbook_specs():
+    specs = to_tinker_tool_specs(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "description": "Run a command",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+    )
+
+    assert specs[0]["name"] == "bash"
+    assert specs[0]["parameters"] == {"type": "object"}
+
+
+def test_tinker_adapter_bridge_preserves_prefix_and_matches_prime_when_available(qwen_tokenizer):
     adapter = _tinker_qwen3(qwen_tokenizer)
     prime = _prime_qwen3(qwen_tokenizer)
 
@@ -189,17 +282,53 @@ def test_tinker_adapter_bridge_matches_prime(qwen_tokenizer):
         )[len(prompt) :]
     ]
 
-    for new in (
-        [{"role": "user", "content": "and then?"}],
-        [{"role": "user", "content": "a"}, {"role": "user", "content": "b"}],
-    ):
-        a_out = adapter.bridge_to_next_turn(prompt, completion, new)
-        p_out = prime.bridge_to_next_turn(prompt, completion, new)
-        assert a_out is not None and p_out is not None
-        assert a_out.token_ids == p_out.token_ids, f"bridge mismatch for new={new}"
+    new = [{"role": "user", "content": "and then?"}]
+    a_out = adapter.bridge_to_next_turn(prompt, completion, new)
+    p_out = prime.bridge_to_next_turn(prompt, completion, new)
+    assert a_out is not None
+    assert a_out.token_ids[: len(prompt + completion)] == prompt + completion
+    if p_out is not None:  # Newer native renderers may request a full rerender.
+        assert a_out.token_ids == p_out.token_ids
 
 
 # ── registry resolution ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("renderer_name", "prime_name"),
+    [
+        ("qwen3_5", "qwen3.5"),
+        ("nemotron3", "nemotron-3"),
+        ("nemotron_3", "nemotron-3"),
+        ("nemotron-3", "nemotron-3"),
+    ],
+)
+def test_resolve_legacy_name_through_pinned_typed_factory(monkeypatch, renderer_name, prime_name):
+    calls = []
+    lookups = []
+    config = object()
+
+    class NativeRenderer: ...
+
+    def config_from_name(name):
+        lookups.append(name)
+        return config
+
+    monkeypatch.setitem(
+        sys.modules,
+        "renderers",
+        SimpleNamespace(
+            config_from_name=config_from_name,
+            create_renderer=lambda tokenizer, renderer_config: calls.append((tokenizer, renderer_config)) or NativeRenderer(),
+        ),
+    )
+    tokenizer = object()
+
+    result = resolve("model", tokenizer, renderer_name=renderer_name)
+
+    assert result.source == "prime"
+    assert lookups == [prime_name]
+    assert calls == [(tokenizer, config)]
 
 
 def test_resolve_prime_native_for_qwen(qwen_tokenizer):
@@ -214,11 +343,6 @@ def test_resolve_chat_template_fallback(qwen_tokenizer, monkeypatch):
     res = resolve("some/Unknown-Finetune-XYZ", qwen_tokenizer, family="auto")
     assert res.source == "chat_template"
     assert isinstance(res.renderer, ChatTemplateAdapter)
-
-
-def test_resolve_renderer_name_override_uses_tinker(qwen_tokenizer):
-    res = resolve(QWEN, qwen_tokenizer, renderer_name="qwen3")
-    assert res.source == "tinker"
 
 
 def test_unified_renderer_matches_chat_template_for_qwen(qwen_tokenizer):

--- a/tests/trainer/test_sft_dispatcher.py
+++ b/tests/trainer/test_sft_dispatcher.py
@@ -3,6 +3,8 @@
 These avoid the tinker stack: only ``fit()`` needs it, and it is patched.
 """
 
+from types import SimpleNamespace
+
 import pytest
 from omegaconf import OmegaConf
 
@@ -10,7 +12,7 @@ from rllm.data import Dataset
 from rllm.trainer.agent_sft_trainer import AgentSFTTrainer
 from rllm.trainer.sft import SFTSpec
 from rllm.trainer.sft.backend import SFTConfigError
-from rllm.trainer.sft.tinker_backend import TinkerSFTBackend
+from rllm.trainer.sft.tinker_backend import TinkerSFTBackend, build_sft_data
 
 
 def _ds(n: int = 4):
@@ -93,6 +95,73 @@ def test_validate_spec_rejects_empty():
     empty = Dataset(data=[], name="e", split="train")
     with pytest.raises(SFTConfigError):
         TinkerSFTBackend(_spec(train_dataset=empty)).validate_spec()
+
+
+@pytest.mark.parametrize("backend_name", ["tinker", "fireworks"])
+def test_hosted_validate_spec_rejects_hf_template(backend_name):
+    backend_type = TinkerSFTBackend
+    if backend_name == "fireworks":
+        from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend
+
+        backend_type = FireworksSFTBackend
+
+    with pytest.raises(SFTConfigError, match="bypasses the canonical renderer"):
+        backend_type(_spec(tokenize_method="hf_template")).validate_spec()
+
+
+def test_build_sft_data_rejects_hf_template_before_renderer_setup():
+    config = OmegaConf.create(
+        {
+            "model": {"name": "Qwen/Qwen3.5-4B"},
+            "data": {"rllm": {"tokenize_and_mask_method": "hf_template"}},
+        }
+    )
+
+    with pytest.raises(SFTConfigError, match="bypasses the canonical renderer"):
+        build_sft_data(config, _ds(), None)
+
+
+def test_build_sft_data_rejects_structured_chat_template_fallback(monkeypatch):
+    config = OmegaConf.create(
+        {
+            "model": {"name": "unknown/model", "tokenizer_model": None},
+            "data": {
+                "renderer_name": None,
+                "rllm": {"tokenize_and_mask_method": "cumulative"},
+            },
+        }
+    )
+    structured = Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "question"}]},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": "reason"},
+                            {"type": "text", "text": "answer"},
+                        ],
+                    },
+                ]
+            }
+        ],
+        name="structured",
+        split="train",
+    )
+    monkeypatch.setattr("tinker_cookbook.tokenizer_utils.get_tokenizer", lambda _: object())
+    monkeypatch.setattr(
+        "rllm.renderers.resolve",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            renderer=object(),
+            name="chat_template",
+            source="chat_template",
+        ),
+    )
+
+    for train_data, val_data in ((structured, None), (_ds(), structured)):
+        with pytest.raises(SFTConfigError, match="cannot represent reasoning"):
+            build_sft_data(config, train_data, val_data)
 
 
 def test_dispatch_tinker_runs_lifecycle(monkeypatch):

--- a/tests/trainer/test_sft_render_path.py
+++ b/tests/trainer/test_sft_render_path.py
@@ -1,27 +1,24 @@
 """Red tests for the tinker SFT render path (PR #739 follow-up).
 
-Three empirically-confirmed defects in ``rllm.trainer.sft`` render conversations
-into tinker Datums incorrectly. Each test below asserts the *fixed* (green)
-behavior and therefore FAILS on current code with the documented exception:
+Regression tests for the canonical SFT rendering path. They exercise the real
+production renderer and the conversion from canonical messages to provider
+Datums:
 
-  F1  the default ``role_colon`` renderer crashes on reasoning rows (multimodal
-      ``thinking`` content) -> ``tinker_cookbook`` ``RendererError``.
-  F2  dict-shaped ``tool_calls`` crash the qwen3 renderer, which expects
-      structured ``ToolCall`` objects -> ``AttributeError`` ('dict' has no
-      attribute 'function').
+  F1  structured reasoning must reach the native model renderer.
+  F2  canonical dict-shaped tool calls must render without provider objects.
   F3  a pandas->polars parquet round-trip unifies the per-row struct schema and
       stamps ``None`` into keys only *some* messages carry: ``tool_calls`` (a)
       and ``trainable`` (b) -> ``TypeError`` when the renderer iterates / ints
       the ``None``.
 
-These use the REAL ``tinker_cookbook`` renderers and a REAL locally-cached
-Qwen3-0.6B tokenizer (skipped if unavailable / offline), mirroring the guard
-pattern of ``tests/test_renderers.py``.
+These use the real ``rllm.renderers.resolve`` path and locally cached Qwen
+tokenizers (skipped if unavailable / offline).
 """
 
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 
 os.environ.setdefault("HF_HUB_OFFLINE", "1")
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
@@ -33,23 +30,42 @@ pytest.importorskip("tinker")
 
 import pandas as pd  # noqa: E402
 import polars as pl  # noqa: E402
-from tinker_cookbook.renderers import get_renderer  # noqa: E402
 
 from rllm.data import Dataset  # noqa: E402
+from rllm.renderers import resolve  # noqa: E402
 from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
 from rllm.trainer.sft.tinker_backend import TinkerSFTBackend, build_sft_data  # noqa: E402
 from rllm.trainer.sft.tinker_dataset import conversation_to_datum  # noqa: E402
 
 QWEN = "Qwen/Qwen3-0.6B"
+QWEN35 = "Qwen/Qwen3.5-35B-A3B"
+
+
+def _load_cached_tokenizer(model: str):
+    transformers = pytest.importorskip("transformers")
+    from huggingface_hub import snapshot_download
+
+    snapshot = snapshot_download(model, local_files_only=True)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(snapshot, local_files_only=True)
+    tokenizer.name_or_path = model
+    return tokenizer
 
 
 @pytest.fixture(scope="module")
 def qwen_tokenizer():
-    transformers = pytest.importorskip("transformers")
     try:
-        return transformers.AutoTokenizer.from_pretrained(QWEN)
-    except OSError as e:  # not cached / offline
-        pytest.skip(f"Qwen3-0.6B tokenizer unavailable: {e}")
+        return _load_cached_tokenizer(QWEN)
+    except Exception as e:  # not cached / incompatible local tokenizer
+        pytest.skip(f"Qwen3 tokenizer unavailable: {e}")
+
+
+@pytest.fixture(scope="module")
+def qwen35_tokenizer():
+    try:
+        return _load_cached_tokenizer(QWEN35)
+    except Exception as e:  # not cached / incompatible local tokenizer
+        pytest.skip(f"Qwen3.5 tokenizer unavailable: {e}")
 
 
 # -- Datum introspection helpers ---------------------------------------------
@@ -75,21 +91,168 @@ def _trained_text(datum, tokenizer) -> str:
     return tokenizer.decode(trained)
 
 
+def _full_tokens(datum) -> list[int]:
+    """Reconstruct the pre-shift token stream from a Datum."""
+    return _input_ids(datum) + _targets(datum)[-1:]
+
+
+def test_row_tools_reach_renderer_without_tokenizer():
+    class RecordingRenderer:
+        def render(self, messages, *, tools=None, add_generation_prompt=False):
+            self.messages = messages
+            self.tools = tools
+            return SimpleNamespace(token_ids=[1, 2, 3], message_indices=[-1, 0, 1], is_content=[])
+
+    renderer = RecordingRenderer()
+    datum = conversation_to_datum(
+        [
+            {"role": "user", "content": "inspect", "trainable": False},
+            {"role": "assistant", "content": "done", "trainable": True},
+        ],
+        renderer,
+        max_length=None,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "bash", "parameters": {"type": "object"}},
+            }
+        ],
+    )
+
+    assert datum.model_input.length == 2
+    assert renderer.messages[0] == {"role": "user", "content": "inspect", "trainable": False}
+    assert renderer.tools[0]["function"]["name"] == "bash"
+
+    with pytest.raises(SFTConfigError, match="canonical rendering"):
+        conversation_to_datum(
+            [
+                {"role": "user", "content": "inspect", "trainable": False},
+                {"role": "assistant", "content": "done", "trainable": True},
+            ],
+            renderer,
+            max_length=None,
+            tools=[{"type": "custom", "name": "not-supported"}],
+        )
+
+
+def test_content_metadata_excludes_assistant_scaffolding_from_loss():
+    class ContentAwareRenderer:
+        @staticmethod
+        def render(messages, *, tools=None, add_generation_prompt=False):
+            # user body, assistant opener, two answer tokens, assistant closer
+            return SimpleNamespace(
+                token_ids=[10, 11, 12, 13, 14],
+                message_indices=[0, 1, 1, 1, 1],
+                is_content=[True, False, True, True, False],
+            )
+
+    datum = conversation_to_datum(
+        [
+            {"role": "user", "content": "question", "trainable": False},
+            {"role": "assistant", "content": "answer", "trainable": True},
+        ],
+        ContentAwareRenderer(),
+        max_length=None,
+    )
+
+    # Datum construction right-shifts the raw token weights by one position.
+    assert _weights(datum) == [0.0, 1.0, 1.0, 0.0]
+
+
+@pytest.mark.parametrize("with_content_metadata", [False, True])
+def test_renderer_rejects_rewritten_trainable_target(with_content_metadata):
+    class HistoryRewritingRenderer:
+        @staticmethod
+        def render(messages, *, tools=None, add_generation_prompt=False):
+            if len(messages) == 4:
+                # The target remains [11, 12], but later history rewrites its
+                # causal user context from token 10 to token 99.
+                rendered = SimpleNamespace(
+                    token_ids=[99, 11, 12, 13, 14],
+                    message_indices=[0, 1, 1, 2, 3],
+                )
+            else:
+                rendered = SimpleNamespace(
+                    token_ids=list(range(10, 10 + len(messages) + 1)),
+                    message_indices=list(range(len(messages))) + [len(messages) - 1],
+                )
+            if with_content_metadata:
+                rendered.is_content = [True] * len(rendered.token_ids)
+            return rendered
+
+    with pytest.raises(SFTConfigError, match="Explode this trajectory per target"):
+        conversation_to_datum(
+            [
+                {"role": "user", "content": "first", "trainable": False},
+                {"role": "assistant", "content": "old target", "trainable": True},
+                {"role": "user", "content": "second", "trainable": False},
+                {"role": "assistant", "content": "current target", "trainable": True},
+            ],
+            HistoryRewritingRenderer(),
+            max_length=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("message_indices", "is_content", "error"),
+    [
+        ([0, 0], [True], "incomplete content-token metadata"),
+        ([-2, 0], [True, True], "invalid message index"),
+        ([1, 0], [True, True], "invalid message index"),
+    ],
+)
+def test_malformed_attribution_fails_as_dataset_error(message_indices, is_content, error):
+    class MalformedRenderer:
+        @staticmethod
+        def render(messages, *, tools=None, add_generation_prompt=False):
+            return SimpleNamespace(
+                token_ids=[10, 11],
+                message_indices=message_indices,
+                is_content=is_content,
+            )
+
+    with pytest.raises(SFTConfigError, match=error):
+        conversation_to_datum(
+            [{"role": "assistant", "content": "answer", "trainable": True}],
+            MalformedRenderer(),
+            max_length=None,
+        )
+
+
+def test_interleaved_content_parts_fail_instead_of_being_reordered():
+    from rllm.renderers.types import RenderedTokens
+
+    class RecordingRenderer:
+        @staticmethod
+        def render(messages, *, tools=None, add_generation_prompt=False):
+            return RenderedTokens(token_ids=[1], message_indices=[0])
+
+    with pytest.raises(SFTConfigError, match="interleaved"):
+        conversation_to_datum(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "visible first"},
+                        {"type": "thinking", "thinking": "hidden later"},
+                    ],
+                    "trainable": True,
+                }
+            ],
+            RecordingRenderer(),
+            max_length=None,
+        )
+
+
 # -- F1: default renderer must not crash on reasoning rows -------------------
 
 
-def test_f1_reasoning_row_renders_through_build_sft_data(qwen_tokenizer):
+def test_f1_reasoning_row_renders_through_build_sft_data(qwen_tokenizer, monkeypatch):
     """A reasoning row (assistant ``thinking`` + ``text`` parts) must survive the
     full ``build_config`` -> ``build_sft_data`` -> ``get_batch`` path.
 
-    RED today: ``build_sft_data`` resolves the ``role_colon`` default renderer
-    (tinker.yaml), and ``get_batch(0)`` raises tinker's ``RendererError``
-    ("Expected text content, got multimodal content ...").
-
-    GREEN: the model's renderer resolves to a qwen thinking renderer, which
-    preserves the reasoning as a ``<think>...</think>`` block. (Qwen3-0.6B is
-    absent from ``model_info``'s recommended-renderer map, but every qwen3-family
-    thinking renderer emits the ``<think>`` tag, so we assert the literals.)
+    The model resolves to the production Qwen renderer, which preserves the
+    reasoning as a ``<think>...</think>`` block.
     """
     rows = [
         {
@@ -106,6 +269,7 @@ def test_f1_reasoning_row_renders_through_build_sft_data(qwen_tokenizer):
     ds = Dataset(data=rows, name="t1_reasoning", split="train")
     spec = SFTSpec(model=QWEN, train_dataset=ds)
 
+    monkeypatch.setattr("tinker_cookbook.tokenizer_utils.get_tokenizer", lambda _: qwen_tokenizer)
     cfg = TinkerSFTBackend(spec).build_config()
     tokenizer, train_ds, val_ds = build_sft_data(cfg, spec.train_dataset, None)
 
@@ -119,19 +283,16 @@ def test_f1_reasoning_row_renders_through_build_sft_data(qwen_tokenizer):
     assert "<think>" in text  # rendered as a qwen thinking block
 
 
-# -- F2: dict tool_calls must render on the qwen3 renderer -------------------
+# -- F2: dict tool_calls must render on the production renderer --------------
 
 
 def test_f2_dict_tool_calls_render(qwen_tokenizer):
     """OpenAI dict-shaped ``tool_calls`` must render.
 
-    RED today: the qwen3 renderer does ``tool_call.function`` on a plain dict ->
-    ``AttributeError: 'dict' object has no attribute 'function'``.
-
-    GREEN: the dict is normalized to a structured ``ToolCall`` and the tool name
-    lands in the rendered assistant turn.
+    The canonical OpenAI-shaped dictionary reaches the native renderer and the
+    tool name lands in the rendered assistant turn.
     """
-    renderer = get_renderer("qwen3", qwen_tokenizer)
+    renderer = resolve(QWEN, qwen_tokenizer).renderer
     conversation = [
         {"role": "user", "content": [{"type": "text", "text": "list files"}], "trainable": False},
         {
@@ -155,12 +316,9 @@ def test_f3_roundtrip_stamps_tool_calls_none(qwen_tokenizer, tmp_path):
     unifies the messages struct schema, so a message WITHOUT ``tool_calls`` gets
     the key stamped to ``None`` (here the user turn).
 
-    RED today: the qwen3 renderer iterates ``message["tool_calls"]`` on the user
-    turn -> ``TypeError: 'NoneType' object is not iterable``.
-
-    GREEN: a ``None`` ``tool_calls`` is treated as absent and every row renders.
+    A ``None`` ``tool_calls`` is treated as absent and every row renders.
     """
-    renderer = get_renderer("qwen3", qwen_tokenizer)
+    renderer = resolve(QWEN, qwen_tokenizer).renderer
     rows = [
         {
             "messages": [
@@ -207,7 +365,7 @@ def test_f3_roundtrip_stamps_trainable_none(qwen_tokenizer, tmp_path):
     that mixes list-content and str-content messages, which would fail the write
     before this round-trip bug could surface.
     """
-    renderer = get_renderer("qwen3", qwen_tokenizer)
+    renderer = resolve(QWEN, qwen_tokenizer).renderer
     rows = [
         # Flagged reasoning row (T1-style): every message carries ``trainable``.
         {
@@ -240,7 +398,7 @@ def test_f3_roundtrip_stamps_trainable_none(qwen_tokenizer, tmp_path):
     # Flag-less row falls back to the assistant-only default.
     trained = _trained_text(datums[1], qwen_tokenizer)
     assert "hello" in trained
-    assert "hi" not in trained
+    assert "user\nhi" not in trained
 
 
 # -- max_length truncation must be loud (vetting handoff item b) --------------
@@ -259,7 +417,7 @@ def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
 
     import rllm.trainer.sft.tinker_dataset as td
 
-    renderer = get_renderer("qwen3", qwen_tokenizer)
+    renderer = resolve(QWEN, qwen_tokenizer).renderer
     convo = [
         {"role": "user", "content": "count: " + " ".join(str(i) for i in range(300)), "trainable": False},
         {"role": "assistant", "content": "done", "trainable": True},
@@ -279,3 +437,71 @@ def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
     with caplog.at_level(logging.WARNING, logger="rllm.trainer.sft.tinker_dataset"):
         conversation_to_datum(convo, renderer, max_length=100_000)
     assert not [r for r in caplog.records if "max_length" in r.getMessage()]
+
+
+def test_tools_reasoning_and_whitespace_match_production_qwen35_renderer(qwen35_tokenizer, monkeypatch):
+    from renderers.qwen35 import Qwen35Renderer
+
+    from rllm.data.sft_bridges import bridge_messages
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Run a shell command.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        }
+    ]
+    wire_messages = [
+        {"role": "system", "content": "Solve the task.\nKeep whitespace."},
+        {"role": "user", "content": "Inspect the repository."},
+        {
+            "role": "assistant",
+            "content": "  ",
+            "reasoning_content": "I should list the files first.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "a.py"},
+        {
+            "role": "assistant",
+            "content": "Done.",
+            "reasoning_content": "The repository has one file.",
+        },
+    ]
+    canonical = bridge_messages([{"messages": wire_messages, "tools": tools}])[0].to_record()
+    dataset = Dataset(data=[canonical], name="tool-parity", split="train")
+    spec = SFTSpec(
+        model=QWEN35,
+        train_dataset=dataset,
+        max_length=100_000,
+        overrides={"data": {"renderer_name": "qwen3_5"}},
+    )
+    monkeypatch.setattr("tinker_cookbook.tokenizer_utils.get_tokenizer", lambda _: qwen35_tokenizer)
+    config = TinkerSFTBackend(spec).build_config()
+    _, training_dataset, _ = build_sft_data(config, dataset, None)
+    datum = training_dataset.get_batch(0)[0]
+
+    serving_renderer = resolve(QWEN35, qwen35_tokenizer).renderer
+    assert isinstance(serving_renderer, Qwen35Renderer)
+    serving_ids = serving_renderer.render_ids(
+        wire_messages,
+        tools=tools,
+        add_generation_prompt=False,
+    )
+    assert _full_tokens(datum) == serving_ids
+    trained = _trained_text(datum, qwen35_tokenizer)
+    assert "list the files" in trained
+    assert "repository has one file" in trained
+    assert "Inspect the repository" not in trained


### PR DESCRIPTION
## Why

rLLM stores SFT examples as canonical `SFTRow` messages, while Tinker and Fireworks train on tokenized `Datum` objects. That conversion must use the same model template as serving and must turn each message's `trainable` flag into a token-level loss mask.

## Flow

```text
canonical SFTRow
  -> renderer-compatible messages + tools
  -> rllm.renderers.resolve(...)
  -> RenderedTokens(token_ids, message_indices, is_content)
  -> trainable/content loss mask
  -> Tinker Datum consumed by Tinker or Fireworks
```

## Change

- Pins the shared Prime renderer dependency to `renderers==0.1.9` and uses its typed renderer API.
- Maps `nemotron3`, `nemotron_3`, and `nemotron-3` to Prime's native `nemotron-3` renderer.
- Resolves hosted SFT through the production renderer registry used by serving.
- Lowers canonical thinking/text parts, tool calls, and tool declarations only at the renderer boundary.
- Derives loss weights from source-message attribution and native body-token metadata, excluding template scaffolding when the renderer supplies that metadata.
- Fails closed on malformed attribution, rewritten trainable prefixes, unsupported structured fallbacks, and hosted `hf_template` mode.
- Keeps the provider payload unchanged: both hosted backends still consume Tinker-compatible `Datum` batches.

## Nemotron compatibility audit

The 9,271-row reproduction corpus (9,104 train and 167 validation) was rendered completely with the pinned Nemotron tokenizer using both the prior Cookbook `nemotron3` renderer and Prime `renderers==0.1.9`.

- Every Prime sequence is the prior sequence plus one final masked newline token.
- Supervised tokens are unchanged: `102,952,819` total.
- Rendered tokens change from `307,272,571` to `307,281,842` (`+1` per row).
- Maximum length changes from `65,534` to `65,535`, below `max_length=65,536`.
- No row changes its gradient-bearing token sequence or crosses the length limit.

Before the Nemotron alias fix, the explicit `renderer_name: nemotron3` selected the Cookbook adapter rather than Prime. Its attribution-only fallback would have supervised assistant header tokens, adding `2,356,180` unintended weighted positions on this corpus. Native Prime resolution supplies `is_content` and avoids that discrepancy.

## Compatibility

The stored SFT schema and provider `Datum` shape do not change. Token IDs can intentionally change when an old explicit renderer alias now selects the production-native implementation. Cookbook-only model families remain supported through the adapter, but only native renderers provide the stronger body-token metadata used to exclude scaffolding exactly.

Hosted `hf_template` now raises explicitly because the old path silently behaved like cumulative rendering and could not honor the canonical mask contract.

## Not included

- Validation semantics: #848.
- Batch, loss, optimizer, and preflight controls: #850.
- Checkpoint/resume semantics: #851.

## Testing

- `69 passed, 7 deselected` in the focused renderer/SFT/dispatcher suite against `renderers==0.1.9`.
- Deterministic tests cover aliases, tools, content-only masks, malformed attribution, rewritten prefixes, fallback safety, and typed renderer resolution.
- A real Qwen 3.5 test compares hosted-training tokens with the production serving renderer.
- The full Nemotron corpus audit verifies the token and loss-mask totals above.
- Ruff check, Ruff format check, TOML parsing, and `git diff --check` pass.

## Stack

Base hosted-SFT rendering PR. Follow with #848, #850, then #851.
