### PR TITLE
fix(sft): validate on completed-step boundaries

### DIFF
--- a/docs/guides/sft-distillation.mdx
+++ b/docs/guides/sft-distillation.mdx
@@ -47,13 +47,54 @@ The two recognized part types are `text` (visible output) and `thinking` (the mo
 
 The schema and its normalization live in `rllm/data/sft_schema.py` (`SFTMessage`, `TextPart`, `ThinkingPart`, `SFTToolCall`).
 
+The import bridges also accept common provider wire variants. Assistant
+`reasoning_content` or `reasoning` becomes one leading `thinking` part;
+`tool_calls` may be a list or a JSON-stringified list; and
+`function.arguments` may be a JSON string or a parsed object/array. Stored
+canonical rows always use structured `thinking`, a tool-call list, and
+JSON-string arguments. Ambiguous dual reasoning representations are rejected.
+
+### Multi-message rows and loss targets
+
+A **row** is one training example containing an ordered `messages` sequence. A
+message with `trainable: true` is a **target message**; `trainable: false` makes
+it **context-only**. Context-only messages stay in the rendered sequence—the
+flag controls loss eligibility, not visibility.
+
+The flag applies to the whole rendered message. Its thinking, visible text, and
+tool-call output cannot be masked independently. The canonical schema does not
+restrict explicit targets by role, although derived masks and think-tag
+explosion select assistant messages.
+
+For rows that remain intact (`messages`, direct normalization, or compact
+`think-tags`), mask resolution is all-or-nothing:
+
+- If every source message has a boolean `trainable`, rLLM preserves the mask
+  exactly and ignores the derivation policy.
+- If any value is missing, null, or non-boolean, the mask is partial. rLLM
+  derives the entire mask again, overwriting any explicit values in that row.
+  `messages` uses its `all` or `last` policy; compact `think-tags` selects every
+  assistant message.
+
+For `think-tags`, exploded mode emits one prefix row per selected assistant
+target. The selected target is the final and only trainable message in that
+row; future messages are omitted, and thinking is removed from historical
+assistant messages. A complete source mask uses `trainable: true` assistant
+messages as selectors, then rewrites each emitted row to one target and
+all-false history. A non-assistant selector is rejected. A partial mask ignores
+its explicit values and selects every assistant message.
+
+A renderer may still omit content according to its history policy. If a
+renderer is configured to omit historical reasoning, explosion keeps each
+selected reasoning target final so that history stripping cannot remove it.
+
 ### Why structured `thinking` parts, not baked `<think>` strings
 
 Different model families wrap reasoning in different wire formats — DeepSeek uses `<think>...</think>`, Qwen and Harmony use their own. If the dataset hard-coded one format, it would only train that family. Instead, reasoning is stored **model-agnostically** as a `thinking` part, and the student's *renderer* decides the on-the-wire format at training time. One curated dataset trains any student.
 
-### Flag-less plain rows still work
+### Flag-less and partially flagged rows still work
 
-You can hand `rllm sft` a plain `{"role", "content": "..."}` dataset with no `trainable` flags at all (e.g. an external `--train-file`). The loader derives the mask: assistant turns are trainable, everything else is not. With `--tokenize-method stepwise`, only the **last** assistant turn is trained instead of all of them. Rows that already carry per-message `trainable` flags (everything from `from-eval` and `import`) are used verbatim — `--tokenize-method` does not override them.
+You can hand `rllm sft` a plain `{"role", "content": "..."}` dataset with no `trainable` flags at all (e.g. an external `--train-file`). The loader derives the mask: assistant messages are trainable, everything else is not. With `--tokenize-method stepwise`, only the **last** assistant message is trained instead of all of them. A complete boolean mask is used verbatim; a partial mask is fully re-derived as described above.
 
 ## Getting data in
 
@@ -102,17 +143,19 @@ rllm dataset import data.jsonl --name my-sft --train-on last             # only 
 rllm dataset import traces.jsonl --name distill-traces --format think-tags  # split <think>...</think> into a thinking part
 ```
 
-- **`messages`** — plain OpenAI rows. The loss mask is derived from `--train-on` (`all` assistant turns, default, or only the `last`).
-- **`think-tags`** — rows whose assistant turns start with a `<think>...</think>` block (a common convention for distilled reasoning traces). The bridge splits that block into a `thinking` part and carries every non-`messages` top-level key through verbatim as row metadata.
+- **`messages`** — plain OpenAI rows, including provider reasoning fields and OpenAI-shaped tool calls. Complete boolean masks are preserved; otherwise the loss mask is derived from `--train-on` (`all` assistant messages, default, or only the `last`).
+- **`think-tags`** — rows whose assistant messages start with a `<think>...</think>` block (a common convention for distilled reasoning traces). The bridge splits that block into a `thinking` part and carries every non-`messages` top-level key through verbatim as row metadata. In compact mode, complete boolean masks are preserved. In exploded mode, true assistant flags select targets, non-assistant selectors are rejected, and a partial mask selects every assistant message.
 
 #### `--explode` (think-tags only, default ON)
 
 This is the most important knob for `think-tags`, so spell out the tradeoff before choosing:
 
-- **Exploded (default)** — the conversation is split into one row per assistant turn. History turns keep only their visible text (CoT stripped), and the row's single final assistant turn is the trained target with its CoT kept. This is exactly what a next-token SFT loss wants, and it's **inference-faithful**: thinking-family renderers strip prior-turn reasoning at render time, so training every CoT block requires giving each its own row. The cost is duplicated history tokens.
-- **`--no-explode`** — one compact row per full conversation, every assistant turn trainable. But because thinking-family renderers strip history CoT at render time, only the **final** turn's CoT is actually trained; earlier turns contribute their visible text only. You save history-token duplication but train fewer CoT blocks.
+- **Exploded (default)** — the conversation is split into one row per selected assistant target. A complete source mask selects the targets; with a partial mask, every assistant message is selected. History messages keep only visible text (thinking stripped), and the row's single final assistant message is the trained target with its thinking kept. This matches inference when the renderer omits historical reasoning. The cost is duplicated history tokens.
+- **`--no-explode`** — one compact row per full conversation. A complete source mask is preserved; a partial mask makes every assistant message trainable. If the renderer omits historical thinking, only the final message's thinking is emitted and trained. You save history-token duplication but may train fewer reasoning blocks.
 
-Rule of thumb: keep the default `--explode` when you want every reasoning block trained; use `--no-explode` for compact conversations where only the last turn's reasoning matters.
+Rule of thumb: keep the default `--explode` when every selected reasoning block
+must be a final target. Use `--no-explode` for compact conversations when your
+renderer retains the reasoning you intend to train.
 
 ## Training with `rllm sft`
 

--- a/rllm/cli/dataset.py
+++ b/rllm/cli/dataset.py
@@ -290,17 +290,24 @@ def register(name: str, file_path: str, split: str, category: str | None, descri
     help="Source row format: 'messages' (plain OpenAI, default) or 'think-tags' (assistant `<think>...</think>` blocks).",
 )
 @click.option("--split", default="train", help="Split name to register the rows under (default: train).")
-@click.option("--train-on", type=click.Choice(["all", "last"]), default="all", help="[messages] Derive the loss mask over 'all' assistant turns (default) or only the 'last'.")
-@click.option("--no-explode", is_flag=True, help="[think-tags] Emit one row per conversation instead of one row per assistant turn.")
+@click.option(
+    "--train-on",
+    type=click.Choice(["all", "last"]),
+    default="all",
+    help="[messages] Fallback target policy without a complete boolean mask: 'all' assistant messages (default) or only the 'last'.",
+)
+@click.option("--no-explode", is_flag=True, help="[think-tags] Emit one row per conversation instead of one row per selected assistant target.")
 @click.option("--description", default=None, help="Short description of the dataset.")
 @click.pass_context
 def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: str, train_on: str, no_explode: bool, description: str | None):
     """Import a local SFT data file, bridging it to the canonical row schema.
 
     FILE is a JSON/JSONL/CSV/Parquet file of ``{"messages": [...]}`` rows. The
-    chosen --format bridge normalizes each row (deriving ``trainable`` masks and,
-    for think-tags, splitting the ``<think>`` chain-of-thought) before the rows
-    are registered ready for ``rllm sft``.
+    chosen --format bridge normalizes each row (preserving complete boolean
+    ``trainable`` masks or deriving a complete mask, lifting provider reasoning
+    into thinking parts, decoding JSON-string ``tool_calls`` and, for
+    think-tags, splitting the ``<think>`` chain-of-thought) before the rows are
+    registered ready for ``rllm sft``.
 
     \b
     Examples:
@@ -315,7 +322,7 @@ def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: 
     # Friendly guardrails on format-specific options.
     train_on_set = ctx.get_parameter_source("train_on") != click.core.ParameterSource.DEFAULT
     if fmt == "think-tags" and train_on_set:
-        console.print("  [yellow]--train-on is ignored for --format think-tags[/] [dim](trainable masks are derived from explode).[/]")
+        console.print("  [yellow]--train-on is ignored for --format think-tags[/] [dim](complete boolean masks select targets; partial masks select every assistant target).[/]")
     if fmt == "messages" and no_explode:
         console.print("  [yellow]--no-explode is ignored for --format messages[/] [dim](explosion only applies to think-tags).[/]")
 
@@ -336,7 +343,7 @@ def import_data(ctx: click.Context, file_path: str, name: str, fmt: str, split: 
         description=description or "",
     )
 
-    detail = " [dim](exploded, one row per assistant turn)[/]" if fmt == "think-tags" and not no_explode else ""
+    detail = " [dim](exploded, one row per selected assistant target)[/]" if fmt == "think-tags" and not no_explode else ""
     console.print()
     console.print(f"  [success]Imported[/] [val]{name}[/]/[val]{split}[/]  [dim]—[/] [val]{len(ds.data)}[/] [dim]source rows →[/] [val]{len(records)}[/] [dim]SFT rows[/]{detail}")
     console.print(f"  [dim]Inspect: [bold]rllm dataset inspect {name} --split {split}[/][/]")

--- a/rllm/data/sft_bridges.py
+++ b/rllm/data/sft_bridges.py
@@ -5,16 +5,27 @@ A *bridge* is the ingestion boundary in front of the SFT schema
 each bridge knows how to turn one of them into schema ``SFTRow`` objects that the
 tinker loader can render with ``CUSTOMIZED`` masking:
 
-- ``messages`` — plain OpenAI ``{"messages": [...]}`` rows. Delegates straight to
-  :func:`rllm.data.sft_schema.normalize_rows`, deriving the ``trainable`` mask
-  from ``train_on`` (``"all"`` assistant turns, or only the ``"last"`` one).
+- ``messages`` — plain OpenAI ``{"messages": [...]}`` rows, including the
+  reasoning-model flavour where chain-of-thought rides in a sibling
+  ``reasoning_content`` field. Derives the ``trainable`` mask from ``train_on``
+  (``"all"`` assistant turns, or only the ``"last"`` one).
 - ``think-tags`` — rows whose assistant turns carry a leading
   ``<think>...</think>`` block, a common convention for distilled reasoning
   traces (R1-style exports, many HF distill datasets). The chain-of-thought is
   split into a :class:`ThinkingPart`; every non-``messages`` top-level key is
   carried through verbatim as row-level metadata. By default the conversation is
-  *exploded* into one row per assistant turn (history CoT stripped, single
-  trainable target), which is the shape a next-token SFT loss wants.
+  *exploded* into one row per selected assistant target (history CoT stripped,
+  single trainable target), which is the shape a next-token SFT loss wants.
+
+Source shape varies far more than the schema does, so the *bridge* is where that
+variance is absorbed — once, at dataset-build time — rather than in renderers and
+trainers that would otherwise each have to cope with every export's quirks. Both
+bridges therefore apply the same source-shape normalization before validation
+(``reasoning_content`` lifted to a thinking part, JSON-string ``tool_calls``
+decoded, already-parsed ``arguments`` re-encoded). The ``messages`` bridge
+preserves source text verbatim. The ``think-tags`` bridge intentionally strips
+whitespace inside the reasoning delimiters and left-strips the visible
+remainder; model-aware formatting belongs with the resolved renderer.
 
 Both bridges return ``list[SFTRow]``; callers persist ``[r.to_record() for r in
 rows]``. Malformed rows raise :class:`SFTSchemaError` naming the failing row
@@ -25,6 +36,7 @@ the file first.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -45,8 +57,126 @@ from rllm.data.sft_schema import (
 # plain text.
 _THINK_RE = re.compile(r"\s*<think>(.*?)</think>(.*)", re.DOTALL)
 
+# Sibling fields carrying chain-of-thought next to ``content`` in the
+# OpenAI-compatible reasoning-model wire shape, in precedence order.
+_REASONING_KEYS = ("reasoning_content", "reasoning")
+
+
+# --- source-shape normalization ----------------------------------------------
+
+
+def _text_payload(part: Any) -> str | None:
+    if not isinstance(part, dict) or part.get("type") != "text":
+        return None
+    value = part.get("text")
+    return value if isinstance(value, str) else None
+
+
+def _text_stream(content: Any) -> str | None:
+    """Return concatenated text without flattening non-text content parts."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    return "".join(text for part in content if (text := _text_payload(part)) is not None)
+
+
+def _has_leading_think_tag(content: Any) -> bool:
+    text = _text_stream(content)
+    return text is not None and _THINK_RE.match(text) is not None
+
+
+def _has_thinking_part(content: Any) -> bool:
+    return isinstance(content, list) and any(isinstance(part, dict) and part.get("type") == "thinking" for part in content)
+
+
+def _normalize_tool_call(call: Any) -> Any:
+    """Canonicalize one ``tool_calls`` element to the OpenAI wire shape.
+
+    ``arguments`` is a JSON *string* in the canonical schema, but exports that
+    round-trip through a JSON/parquet writer often store it already parsed. Both
+    shapes describe the same call, so re-encode the parsed one rather than
+    rejecting the row.
+    """
+    if not isinstance(call, dict):
+        return call
+    fn = call.get("function")
+    if not isinstance(fn, dict) or not isinstance(fn.get("arguments"), dict | list):
+        return call
+    try:
+        arguments = json.dumps(fn["arguments"], ensure_ascii=False)
+    except TypeError as e:
+        raise SFTSchemaError(f"tool call arguments are not JSON-serializable: {e}") from e
+    return {**call, "function": {**fn, "arguments": arguments}}
+
+
+def _normalize_source_message(msg: Any) -> Any:
+    """Coerce provider reasoning and tool-call fields into schema shapes."""
+    if not isinstance(msg, dict):
+        return msg
+    out = dict(msg)
+
+    tool_calls = out.get("tool_calls")
+    if isinstance(tool_calls, str):
+        if not tool_calls.strip():
+            out.pop("tool_calls")
+        else:
+            try:
+                tool_calls = json.loads(tool_calls)
+            except ValueError as e:
+                raise SFTSchemaError(f"tool_calls is a string but not valid JSON: {e}") from e
+            if not isinstance(tool_calls, list):
+                raise SFTSchemaError(f"tool_calls JSON must decode to a list, got {type(tool_calls).__name__}.")
+            out["tool_calls"] = tool_calls
+    if isinstance(out.get("tool_calls"), list):
+        out["tool_calls"] = [_normalize_tool_call(call) for call in out["tool_calls"]]
+
+    reasoning_values: list[tuple[str, str]] = []
+    for key in _REASONING_KEYS:
+        value = out.pop(key, None)
+        if value is None or (isinstance(value, str) and value == ""):
+            continue
+        if not isinstance(value, str):
+            raise SFTSchemaError(f"{key} must be a string, got {type(value).__name__}.")
+        if out.get("role") != "assistant":
+            raise SFTSchemaError(f"{key} is supported only on assistant messages, got role {out.get('role')!r}.")
+        reasoning_values.append((key, value))
+    if len({value for _, value in reasoning_values}) > 1:
+        fields = ", ".join(key for key, _ in reasoning_values)
+        raise SFTSchemaError(f"conflicting reasoning aliases ({fields}) carry different values.")
+
+    reasoning = reasoning_values[0][1] if reasoning_values else ""
+    if reasoning:
+        content = out.get("content")
+        if _has_leading_think_tag(content):
+            fields = ", ".join(key for key, _ in reasoning_values)
+            raise SFTSchemaError(f"sibling reasoning field ({fields}) conflicts with structural inline <think>...</think> content; choose one reasoning representation.")
+        if _has_thinking_part(content):
+            fields = ", ".join(key for key, _ in reasoning_values)
+            raise SFTSchemaError(f"sibling reasoning field ({fields}) conflicts with an existing thinking part; choose one reasoning representation.")
+        parts: list = [{"type": "thinking", "thinking": reasoning}]
+        if isinstance(content, str):
+            if content:
+                parts.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            parts.extend(normalize_message_dict({"role": out.get("role"), "content": content}).get("content", []))
+        elif content is not None:
+            raise SFTSchemaError(f"assistant content must be a string, list, or null when reasoning is present, got {type(content).__name__}.")
+        out["content"] = parts
+    return out
+
 
 # --- shared helpers ----------------------------------------------------------
+
+
+def _split_think_tag(text: str) -> list[dict]:
+    match = _THINK_RE.match(text)
+    if not match:
+        return [{"type": "text", "text": text}]
+    return [
+        {"type": "thinking", "thinking": match.group(1).strip()},
+        {"type": "text", "text": match.group(2).lstrip()},
+    ]
 
 
 def _content_to_parts(role: str, content: Any) -> list[dict]:
@@ -59,19 +189,21 @@ def _content_to_parts(role: str, content: Any) -> list[dict]:
     does, so this bridge tolerates partially-structured inputs too.
     """
     if isinstance(content, str):
-        if role == "assistant":
-            m = _THINK_RE.match(content)
-            if m:
-                return [
-                    {"type": "thinking", "thinking": m.group(1).strip()},
-                    {"type": "text", "text": m.group(2).lstrip()},
-                ]
-        return [{"type": "text", "text": content}]
+        return _split_think_tag(content) if role == "assistant" else [{"type": "text", "text": content}]
     if content is None:
         return [{"type": "text", "text": ""}]
     if isinstance(content, list):
-        # Reuse the schema's part cleanup (drops ``None`` cross-keys).
-        return list(normalize_message_dict({"role": role, "content": content}).get("content", []))
+        parts = list(normalize_message_dict({"role": role, "content": content}).get("content", []))
+        if role != "assistant":
+            return parts
+        text = _text_stream(parts)
+        if text is not None and _THINK_RE.match(text):
+            if _has_thinking_part(parts):
+                raise SFTSchemaError("structural inline <think>...</think> content conflicts with an existing thinking part; choose one reasoning representation.")
+            if not all(_text_payload(part) is not None for part in parts):
+                raise SFTSchemaError("structural inline <think>...</think> content must be represented entirely by text parts.")
+            return _split_think_tag(text)
+        return parts
     raise SFTSchemaError(f"unsupported content type {type(content).__name__} for role {role!r}.")
 
 
@@ -120,17 +252,37 @@ def _bridge_think_row(row: dict, explode: bool) -> list[SFTRow]:
         if not isinstance(m, dict):
             raise SFTSchemaError(f"message {j}: expected a dict, got {type(m).__name__}.")
 
+    messages = [_normalize_source_message(m) for m in messages]
     roles = [m.get("role") for m in messages]
     full_parts = [_content_to_parts(role, m.get("content")) for role, m in zip(roles, messages, strict=True)]
     hist_parts = [_strip_thinking(p) for p in full_parts]
     fields = _row_fields(row)
+    all_flagged = all(isinstance(m.get("trainable"), bool) for m in messages)
+
+    if explode and all_flagged:
+        invalid_target = next((j for j, message in enumerate(messages) if roles[j] != "assistant" and message["trainable"]), None)
+        if invalid_target is not None:
+            raise SFTSchemaError(f"message {invalid_target}: think-tags explosion supports only assistant target messages.")
 
     if not explode:
-        msgs = [_make_message(messages[j], full_parts[j], roles[j] == "assistant", j) for j in range(len(messages))]
+        msgs = [
+            _make_message(
+                messages[j],
+                full_parts[j],
+                bool(messages[j]["trainable"]) if all_flagged else roles[j] == "assistant",
+                j,
+            )
+            for j in range(len(messages))
+        ]
         return [SFTRow(messages=msgs, **fields)]
 
+    def _is_target(index: int) -> bool:
+        if roles[index] != "assistant":
+            return False
+        return bool(messages[index].get("trainable")) if all_flagged else True
+
     rows: list[SFTRow] = []
-    for target in (j for j, role in enumerate(roles) if role == "assistant"):
+    for target in (j for j in range(len(messages)) if _is_target(j)):
         history = [_make_message(messages[j], hist_parts[j], False, j) for j in range(target)]
         history.append(_make_message(messages[target], full_parts[target], True, target))
         rows.append(SFTRow(messages=history, **fields))
@@ -144,19 +296,36 @@ def bridge_messages(rows: Sequence[dict], *, train_on: str = "all") -> list[SFTR
     """Bridge plain OpenAI ``{"messages": [...]}`` rows via the schema.
 
     ``train_on`` picks the derived loss mask: ``"all"`` trains every assistant
-    turn, ``"last"`` only the final one. Explicit per-message ``trainable`` flags
-    (when *every* message carries one) are preserved by the schema.
+    message, ``"last"`` only the final one. Explicit per-message ``trainable``
+    flags (when *every* message carries one) are preserved by the schema.
+    Source-shape normalization (reasoning lifting and tool-call decoding) always
+    applies.
     """
-    return normalize_rows(rows, default_trainable=train_on)
+    prepared: list = []
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict) or not isinstance(row.get("messages"), list):
+            prepared.append(row)
+            continue
+        try:
+            messages = [_normalize_source_message(m) for m in row["messages"]]
+            for j, message in enumerate(messages):
+                content = message.get("content") if isinstance(message, dict) else None
+                if isinstance(message, dict) and message.get("role") == "assistant" and isinstance(content, str) and _has_leading_think_tag(content):
+                    raise SFTSchemaError(f"message {j}: assistant text begins with a structural <think>...</think> block; use `--format think-tags` or provide canonical thinking parts.")
+            prepared.append({**row, "messages": messages})
+        except SFTSchemaError as e:
+            raise SFTSchemaError(f"row {i}: {e}") from e
+    return normalize_rows(prepared, default_trainable=train_on)
 
 
 def bridge_think_tags(rows: Sequence[dict], *, explode: bool = True) -> list[SFTRow]:
     """Bridge ``<think>``-tagged rows into schema rows.
 
-    ``explode=True`` (default) emits one row per assistant turn: history turns
-    are non-trainable with their CoT stripped, and the single final assistant
-    turn is the trainable target (CoT kept). ``explode=False`` emits one row per
-    conversation with every assistant turn trainable and CoT kept.
+    ``explode=True`` (default) emits one row per assistant target: history turns
+    are non-trainable with their CoT stripped, and the final assistant turn is
+    the trainable target. A complete source ``trainable`` mask selects targets;
+    otherwise every assistant turn is selected. ``explode=False`` preserves a
+    complete source mask and derives assistant targets when the mask is partial.
     """
     out: list[SFTRow] = []
     for i, row in enumerate(rows):

--- a/rllm/data/sft_schema.py
+++ b/rllm/data/sft_schema.py
@@ -217,6 +217,21 @@ def normalize_messages(messages, default_trainable: str = "all") -> list[SFTMess
     if not isinstance(messages, list) or len(messages) == 0:
         raise SFTSchemaError("'messages' must be a non-empty list of conversation turns.")
 
+    # Empty provider fields are serialization artifacts. Non-empty siblings are
+    # source data that must be lifted by the messages bridge rather than dropped.
+    for i, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        for reasoning_key in ("reasoning_content", "reasoning"):
+            if reasoning_key not in message:
+                continue
+            value = message[reasoning_key]
+            if value is None or (isinstance(value, str) and value == ""):
+                continue
+            if not isinstance(value, str):
+                raise SFTSchemaError(f"message {i} field {reasoning_key!r} must be a string, got {type(value).__name__}.")
+            raise SFTSchemaError(f"message {i} contains source field {reasoning_key!r}; import it through `rllm dataset import --format messages` so reasoning is preserved as a thinking part.")
+
     cleaned = [normalize_message_dict(m) for m in messages]
 
     all_flagged = all(isinstance(m, dict) and isinstance(m.get("trainable"), bool) for m in cleaned)

--- a/rllm/gateway/tinker_adapter.py
+++ b/rllm/gateway/tinker_adapter.py
@@ -25,24 +25,29 @@ logger = logging.getLogger(__name__)
 def _to_openai_tool_calls(tool_calls: list) -> list[dict[str, Any]]:
     """Convert tool calls from any producer shape to the OpenAI wire format.
 
-    ``ModelOutput.tool_calls`` arrives in one of three shapes depending on which parser
+    ``ModelOutput.tool_calls`` arrives in one of four shapes depending on which parser
     ``assemble_model_output`` used:
 
     * prime-rl ``renderers`` (the unified renderer, e.g. ``parse_qwen35``): a **nested**
       dict ``{"function": {"name", "arguments"}}`` — the OpenAI-ish shape.
+    * tinker/Fireworks-cookbook ``ToolCall``: the same nesting as a pydantic
+      **object**, ``.function.name`` / ``.function.arguments``.
     * rLLM ``ToolCall`` object: ``.name`` / ``.arguments`` attributes.
     * flat dict: ``{"name", "arguments"}``.
 
-    The nested form is easy to mis-read: pulling top-level ``name``/``arguments`` off it
-    yields empty tool calls (name=""), which is exactly what broke OpenAI function-calling
-    clients like opencode — they received a structurally-present but empty tool call and
-    took no action. Extract ``function`` first, then object attrs, then flat keys.
+    Every nested form is easy to mis-read: pulling top-level ``name``/``arguments`` off
+    one yields empty tool calls (name=""), which is exactly what broke OpenAI
+    function-calling clients like opencode — they received a structurally-present but
+    empty tool call and took no action. Unwrap ``function`` first, in both dict and
+    attribute form, then fall back to the flat shapes.
     """
     result = []
     for i, tc in enumerate(tool_calls):
-        fn = tc.get("function") if isinstance(tc, dict) else None
+        fn = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
         if isinstance(fn, dict):  # prime-rl nested shape
             name, args = fn.get("name", ""), fn.get("arguments", {})
+        elif fn is not None:  # cookbook ToolCall: nested pydantic model
+            name, args = getattr(fn, "name", ""), getattr(fn, "arguments", {})
         elif isinstance(tc, dict):  # flat dict
             name, args = tc.get("name", ""), tc.get("arguments", {})
         else:  # rLLM ToolCall object

--- a/rllm/renderers/adapters.py
+++ b/rllm/renderers/adapters.py
@@ -17,7 +17,33 @@ from .bridging import BridgingRendererMixin
 from .types import ParsedResponse, RenderedTokens
 
 
-def _to_parsed(content: str, reasoning: str | None, tool_calls: Any) -> ParsedResponse:
+def _flatten_parts(content: Any) -> tuple[str, str]:
+    """Split a renderer's content into ``(text, thinking)``.
+
+    Parts concatenate without a separator — each carries its own whitespace.
+    Ordering between text and thinking is lost, which the flat
+    ``ParsedResponse`` shape cannot express; for the one-thinking-block-then-text
+    turn every renderer here produces, the join is exact.
+    """
+    if not isinstance(content, list):
+        return content or "", ""
+    text = "".join(p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text")
+    thinking = "".join(p.get("thinking", "") for p in content if isinstance(p, dict) and p.get("type") == "thinking")
+    return text, thinking
+
+
+def _to_parsed(content: Any, reasoning: str | None, tool_calls: Any) -> ParsedResponse:
+    """Build a ``ParsedResponse``, flattening structured content.
+
+    Tinker-style renderers return a turn's content as a parts list whenever the
+    model emitted thinking, with the reasoning inside it rather than on
+    ``reasoning_content``. ``ParsedResponse.content`` is a ``str`` and its
+    consumers (``ModelOutput`` -> ``Step.model_response``) enforce that, so the
+    parts are split here rather than left for every consumer to handle.
+    """
+    if isinstance(content, list):
+        content, thinking = _flatten_parts(content)
+        reasoning = reasoning or thinking
     return ParsedResponse(
         content=content or "",
         reasoning_content=reasoning or None,
@@ -25,28 +51,195 @@ def _to_parsed(content: str, reasoning: str | None, tool_calls: Any) -> ParsedRe
     )
 
 
+def _sibling_reasoning(message: dict) -> str:
+    """A turn's reasoning as harnesses echo it back, in wire-preference order."""
+    for key in ("reasoning_content", "reasoning"):
+        value = message.get(key)
+        if isinstance(value, str) and value:
+            return value
+    provider = message.get("provider_specific_fields")
+    value = provider.get("reasoning") if isinstance(provider, dict) else None
+    return value if isinstance(value, str) else ""
+
+
+def _is_qwen_history_renderer(renderer: Any) -> bool:
+    """Whether ``renderer`` uses Qwen's last-real-user reasoning boundary."""
+    return any(cls.__module__.startswith("tinker_cookbook.renderers.qwen3") for cls in type(renderer).__mro__)
+
+
+def _text_content(content: Any) -> str | None:
+    """Read wire text without mistaking multimodal content for a tool result."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    text: list[str] = []
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") != "text" or not isinstance(part.get("text"), str):
+            return None
+        text.append(part["text"])
+    return "".join(text)
+
+
+def _is_tool_response_user(message: dict) -> bool:
+    """Recognize the legacy Qwen wire shape where a tool result has user role."""
+    content = _text_content(message.get("content"))
+    return message.get("role") == "user" and content is not None and content.startswith("<tool_response>") and content.endswith("</tool_response>")
+
+
+def _last_real_user_index(messages: list[dict]) -> int:
+    """The boundary used by Qwen chat templates to retain recent thinking."""
+    return max(
+        (index for index, message in enumerate(messages) if message.get("role") == "user" and not _is_tool_response_user(message)),
+        default=-1,
+    )
+
+
+def to_tinker_messages(
+    messages: list[dict],
+    *,
+    lift_reasoning: bool = False,
+    keep_reasoning_after: int | None = None,
+) -> list[dict]:
+    """Translate OpenAI wire messages into tinker-cookbook ``Message``s.
+
+    Tinker-style renderers read a turn's tool calls only as pydantic
+    ``ToolCall`` objects; harnesses send plain dicts, which raise on the first
+    tool call in history.
+
+    ``lift_reasoning`` additionally moves a turn's sibling ``reasoning_content``
+    / ``reasoning`` into a structured ``thinking`` part, the only form a
+    renderer reads it in. ``keep_reasoning_after`` applies Qwen's history rule:
+    assistant thinking at or before that message index is removed, while later
+    thinking is retained. It is off by default because lifting is only sound
+    when the wrapped renderer keeps the supplied thinking parts.
+
+    Messages already in cookbook form (parts-list content, ``ToolCall``
+    objects) keep it; every other key rides along untouched, so cookbook-only
+    fields (``trainable``, ``tools``, ``response_format``) survive the trip.
+    """
+    from tinker_cookbook.renderers.base import ToolCall
+
+    modelled_tool_call_fields = set(ToolCall.model_fields)
+    out: list[dict] = []
+    for index, message in enumerate(messages):
+        converted = {**message, "content": message.get("content") or ""}
+        keep_reasoning = keep_reasoning_after is None or index > keep_reasoning_after
+        content = converted["content"]
+        if not keep_reasoning and message.get("role") == "assistant" and isinstance(content, list):
+            converted["content"] = [part for part in content if not (isinstance(part, dict) and part.get("type") == "thinking")]
+        reasoning = _sibling_reasoning(message) if lift_reasoning and keep_reasoning and message.get("role") == "assistant" else ""
+        if reasoning:
+            thinking = {"type": "thinking", "thinking": reasoning}
+            content = converted["content"]
+            if isinstance(content, str):
+                converted["content"] = [thinking, {"type": "text", "text": content}]
+            elif not any(isinstance(p, dict) and p.get("type") == "thinking" for p in content):
+                converted["content"] = [thinking, *content]
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            # Wire tool calls carry fields the cookbook model forbids (e.g. the
+            # streaming ``index``), so keep only what it declares.
+            converted["tool_calls"] = [ToolCall.model_validate({k: v for k, v in tc.items() if k in modelled_tool_call_fields}) if isinstance(tc, dict) else tc for tc in tool_calls]
+        out.append(converted)
+    return out
+
+
+def prepare_tinker_messages_for_history(
+    renderer: Any,
+    messages: list[dict],
+    *,
+    lift_reasoning: bool,
+) -> list[dict]:
+    """Apply the wrapped renderer's history policy while translating messages."""
+    boundary = _last_real_user_index(messages) if _is_qwen_history_renderer(renderer) and not getattr(renderer, "strip_thinking_from_history", False) else None
+    return to_tinker_messages(
+        messages,
+        lift_reasoning=lift_reasoning,
+        keep_reasoning_after=boundary,
+    )
+
+
+def to_tinker_tool_specs(tools: list[dict] | None) -> list:
+    """Translate OpenAI function declarations into cookbook ``ToolSpec``s."""
+    from tinker_cookbook.renderers.base import ToolSpec
+
+    specs: list[ToolSpec] = []
+    for index, tool in enumerate(tools or []):
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            raise ValueError(f"Tool declaration {index} must be an OpenAI function tool.")
+        function = tool.get("function")
+        if not isinstance(function, dict) or not function.get("name"):
+            raise ValueError(f"Tool declaration {index} needs a non-empty function.name.")
+        parameters = function.get("parameters") or {}
+        if not isinstance(parameters, dict):
+            raise ValueError(f"Tool declaration {index} function.parameters must be an object.")
+        specs.append(
+            ToolSpec(
+                name=function["name"],
+                description=function.get("description") or "",
+                parameters=parameters,
+            )
+        )
+    return specs
+
+
+def prepare_tinker_messages_with_tools(
+    renderer: Any,
+    messages: list[dict],
+    tools: list[dict] | None,
+) -> list[dict]:
+    """Inject declarations exactly as the cookbook serving renderer does."""
+    if not tools:
+        return list(messages)
+
+    remaining = list(messages)
+    system_prompt = ""
+    if remaining and remaining[0].get("role") == "system":
+        content = remaining[0].get("content") or ""
+        if isinstance(content, str):
+            system_prompt = content
+        elif isinstance(content, list):
+            system_prompt = "".join(part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text")
+        remaining = remaining[1:]
+
+    prefix = renderer.create_conversation_prefix_with_tools(
+        to_tinker_tool_specs(tools),
+        system_prompt=system_prompt,
+    )
+    return list(prefix) + remaining
+
+
 class TinkerRendererAdapter(BridgingRendererMixin):
     """Wrap a tinker-style renderer (tinker_cookbook / Fireworks cookbook)."""
 
     def __init__(self, inner: Any, *, close_token_ids: set[int] | None = None, synthesize_close: int | None = None):
         self._inner = inner
+        # Cookbook Qwen strips thinking from every historical assistant turn,
+        # while the HF template strips only at/before the last genuine user
+        # query. Disable the coarse renderer behavior and apply the precise
+        # boundary while translating messages. Tool-role observations therefore
+        # preserve the current agent trace; a new user query clears earlier CoT.
+        is_qwen_history_renderer = _is_qwen_history_renderer(inner)
+        if is_qwen_history_renderer and getattr(inner, "strip_thinking_from_history", False):
+            inner.strip_thinking_from_history = False
+        self._lift_reasoning = not getattr(inner, "strip_thinking_from_history", False)
         stops = [int(t) for t in inner.get_stop_sequences()]
         self.close_token_ids = set(close_token_ids) if close_token_ids is not None else set(stops)
         self.synthesize_close = synthesize_close if synthesize_close is not None else (stops[0] if stops else None)
 
     def _with_tools(self, messages: list[dict], tools) -> list[dict]:
-        if not tools:
-            return list(messages)
-        msgs = list(messages)
-        system = ""
-        if msgs and msgs[0].get("role") == "system":
-            system = msgs[0].get("content") or ""
-            msgs = msgs[1:]
-        prefix = self._inner.create_conversation_prefix_with_tools(tools, system_prompt=system)
-        return list(prefix) + msgs
+        return prepare_tinker_messages_with_tools(self._inner, messages, tools)
 
     def render_ids(self, messages, *, tools=None, add_generation_prompt: bool = False) -> list[int]:
-        msgs = self._with_tools(list(messages), tools)
+        msgs = self._with_tools(
+            prepare_tinker_messages_for_history(
+                self._inner,
+                messages,
+                lift_reasoning=self._lift_reasoning,
+            ),
+            tools,
+        )
         if add_generation_prompt:
             model_input = self._inner.build_generation_prompt(msgs)
         else:
@@ -64,7 +257,11 @@ class TinkerRendererAdapter(BridgingRendererMixin):
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
         msg, _term = self._inner.parse_response(list(token_ids))
         get = msg.get if isinstance(msg, dict) else (lambda k, d=None: getattr(msg, k, d))
-        return _to_parsed(get("content", ""), get("reasoning_content"), get("tool_calls"))
+        return _to_parsed(
+            get("content", ""),
+            get("reasoning_content"),
+            get("tool_calls"),
+        )
 
 
 class ChatTemplateAdapter(BridgingRendererMixin):

--- a/rllm/trainer/sft/config/fireworks.yaml
+++ b/rllm/trainer/sft/config/fireworks.yaml
@@ -40,6 +40,7 @@ data:
   renderer_name: null   # null = auto-detect from the model; set explicitly to override, e.g. qwen3 / qwen3_5 / deepseekv3 / role_colon
   rllm:
     tokenize_and_mask_method: cumulative
+    strip_thinking_from_history: false
 
 optim:
   lr: 1e-5

--- a/rllm/trainer/sft/config/tinker.yaml
+++ b/rllm/trainer/sft/config/tinker.yaml
@@ -22,6 +22,7 @@ data:
   renderer_name: null   # null = auto-detect from the model; set explicitly to override, e.g. qwen3 / qwen3_5 / deepseekv3 / role_colon
   rllm:
     tokenize_and_mask_method: cumulative  # cumulative -> ALL_ASSISTANT_MESSAGES; stepwise -> LAST_ASSISTANT_MESSAGE
+    strip_thinking_from_history: false    # preserve the active reasoning trace, matching serving
 
 optim:
   lr: 1e-5

--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -31,7 +31,11 @@ from pathlib import Path
 from omegaconf import DictConfig, OmegaConf
 
 from rllm.trainer.sft.backend import SFTConfigError
-from rllm.trainer.sft.tinker_backend import TinkerSFTBackend, build_sft_data
+from rllm.trainer.sft.tinker_backend import (
+    TinkerSFTBackend,
+    build_sft_data,
+    should_validate_step,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +266,17 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 save_every = config.trainer.get("save_freq", 20)
                 eval_every = config.trainer.get("test_freq", 10)
 
+                if should_validate_step(
+                    0,
+                    eval_every=eval_every,
+                    has_validation=val_dataset is not None,
+                    include_initial=start_step == 0,
+                ):
+                    tracking_logger.log(
+                        data=self._validate(client, val_dataset, DEFAULT_TIMEOUT_S),
+                        step=0,
+                    )
+
                 # Pipelined sync loop: keep one (fwd_bwd, optim) pair in flight.
                 in_flight: deque = deque()
 
@@ -290,10 +305,15 @@ class FireworksSFTBackend(TinkerSFTBackend):
                         "train_loss": train_loss,
                         "time/total": time.time() - t0,
                     }
-                    if val_dataset and eval_every > 0 and step % eval_every == 0 and step > 0:
+                    completed_steps = step + 1
+                    if should_validate_step(
+                        completed_steps,
+                        eval_every=eval_every,
+                        has_validation=val_dataset is not None,
+                    ):
                         metrics.update(self._validate(client, val_dataset, DEFAULT_TIMEOUT_S))
-                    tracking_logger.log(data=metrics, step=step)
-                    logger.info(f"Step {step}: train_loss={train_loss:.4f}, lr={lr:.2e}")
+                    tracking_logger.log(data=metrics, step=completed_steps)
+                    logger.info(f"Step {completed_steps}: train_loss={train_loss:.4f}, lr={lr:.2e}")
                     if save_every > 0 and step % save_every == 0 and step > 0:
                         logger.info(f"Saving checkpoint at step {step}")
                         ckpt.save(f"step-{step}", resumable=True, promotable=False)
@@ -301,6 +321,12 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 for step in range(start_step, total_steps):
                     if step % n_batches == 0:
                         train_dataset.set_epoch(seed=step // n_batches)
+                    if in_flight and should_validate_step(
+                        in_flight[0][0] + 1,
+                        eval_every=eval_every,
+                        has_validation=val_dataset is not None,
+                    ):
+                        collect()
                     submit(step)
                     if len(in_flight) > 1:
                         collect()

--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -344,16 +344,25 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 pass
 
     @staticmethod
-    def _validate(client, val_dataset, timeout) -> dict[str, float]:
+    def _validate(client, val_dataset, _timeout=None) -> dict[str, float]:
+        """Compute held-out NLL without adding validation gradients."""
+        from tinker_cookbook.supervised.common import compute_mean_nll
+
         logger.info("Running validation...")
-        total_loss = 0.0
+        total_nll = 0.0
         total_tokens = 0
         for batch_idx in range(len(val_dataset)):
             data = val_dataset.get_batch(batch_idx)
-            fb_result = client.submit_forward_backward(data, loss_fn="cross_entropy").result(timeout=timeout)
-            m = getattr(fb_result, "metrics", {}) or {}
-            total_loss += m.get("loss:sum", 0.0)
-            total_tokens += m.get("response_tokens") or 0
-        val_loss = total_loss / total_tokens if total_tokens > 0 else 0.0
+            forward_result = client.forward(data, "cross_entropy")
+            weights = [datum.loss_fn_inputs["weights"] for datum in data]
+            batch_tokens = sum(sum(weight.data) for weight in weights)
+            if not batch_tokens:
+                continue
+            logprobs = [output["logprobs"] for output in forward_result.loss_fn_outputs]
+            total_nll += compute_mean_nll(logprobs, weights) * batch_tokens
+            total_tokens += batch_tokens
+        if total_tokens <= 0:
+            raise SFTConfigError("The validation dataset has no trainable tokens after rendering and masking.")
+        val_loss = total_nll / total_tokens
         logger.info(f"Validation loss: {val_loss:.4f}")
         return {"test/loss": val_loss}

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -164,6 +164,21 @@ def build_sft_data(config, train_data, val_data):
     return tokenizer, train_dataset, val_dataset
 
 
+def should_validate_step(
+    completed_steps: int,
+    *,
+    eval_every: int,
+    has_validation: bool,
+    include_initial: bool = False,
+) -> bool:
+    """Whether validation belongs at this completed-update boundary."""
+    if not has_validation:
+        return False
+    if completed_steps == 0:
+        return include_initial
+    return eval_every > 0 and completed_steps % eval_every == 0
+
+
 @dataclass
 class _SubmittedBatch:
     """A batch submitted to Tinker (forward-backward + optim step in flight)."""
@@ -333,6 +348,17 @@ class TinkerSFTBackend(SFTBackend):
             save_every = config.trainer.get("save_freq", 20)
             eval_every = config.trainer.get("test_freq", 10)
 
+            if should_validate_step(
+                0,
+                eval_every=eval_every,
+                has_validation=val_dataset is not None,
+                include_initial=start_epoch == 0 and start_batch == 0,
+            ):
+                initial_metrics: dict[str, Any] = {}
+                with timed("validation", initial_metrics):
+                    initial_metrics.update(await self._validate(training_client, val_dataset, compute_mean_nll))
+                tracking_logger.log(data=initial_metrics, step=0)
+
             async def submit_batch(epoch_idx: int, batch_idx: int) -> _SubmittedBatch:
                 step = epoch_idx * n_batches + batch_idx
                 batch_start_time = time.time()
@@ -377,13 +403,18 @@ class TinkerSFTBackend(SFTBackend):
                 )
                 metrics["time/total"] = time.time() - submitted.batch_start_time
 
-                if val_dataset and eval_every > 0 and submitted.step % eval_every == 0 and submitted.step > 0:
+                completed_steps = submitted.step + 1
+                if should_validate_step(
+                    completed_steps,
+                    eval_every=eval_every,
+                    has_validation=val_dataset is not None,
+                ):
                     with timed("validation", metrics):
                         val_metrics = await self._validate(training_client, val_dataset, compute_mean_nll)
                     metrics.update(val_metrics)
 
-                tracking_logger.log(data=metrics, step=submitted.step)
-                logger.info(f"Step {submitted.step}: train_nll={train_nll:.4f}, lr={metrics['learning_rate']:.2e}")
+                tracking_logger.log(data=metrics, step=completed_steps)
+                logger.info(f"Step {completed_steps}: train_nll={train_nll:.4f}, lr={metrics['learning_rate']:.2e}")
 
             pending: _SubmittedBatch | None = None
             for epoch_idx in range(start_epoch, total_epochs):
@@ -391,6 +422,13 @@ class TinkerSFTBackend(SFTBackend):
                 train_dataset.set_epoch(seed=epoch_idx)
                 start_batch_idx = start_batch if epoch_idx == start_epoch else 0
                 for batch_idx in range(start_batch_idx, n_batches):
+                    if pending is not None and should_validate_step(
+                        pending.step + 1,
+                        eval_every=eval_every,
+                        has_validation=val_dataset is not None,
+                    ):
+                        await finish_batch(pending)
+                        pending = None
                     submitted = await submit_batch(epoch_idx, batch_idx)
                     if pending is not None:
                         await finish_batch(pending)

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -419,19 +419,24 @@ class TinkerSFTBackend(SFTBackend):
 
     @staticmethod
     async def _validate(training_client, val_dataset, compute_mean_nll) -> dict[str, float]:
+        """Compute held-out NLL without adding validation gradients."""
         logger.info("Running validation...")
         total_nll = 0.0
         total_tokens = 0
         for batch_idx in range(len(val_dataset)):
             data = val_dataset.get_batch(batch_idx)
-            fwd_bwd_future = await training_client.forward_backward_async(data, loss_fn="cross_entropy")
-            fwd_bwd_result = await fwd_bwd_future.result_async()
-            logprobs = [x["logprobs"] for x in fwd_bwd_result.loss_fn_outputs]
+            forward_future = await training_client.forward_async(data, loss_fn="cross_entropy")
+            forward_result = await forward_future.result_async()
             weights = [datum.loss_fn_inputs["weights"] for datum in data]
+            batch_tokens = sum(sum(weight.data) for weight in weights)
+            if not batch_tokens:
+                continue
+            logprobs = [output["logprobs"] for output in forward_result.loss_fn_outputs]
             batch_nll = compute_mean_nll(logprobs, weights)
-            batch_tokens = sum(sum(datum.loss_fn_inputs["weights"].data) for datum in data)
             total_nll += batch_nll * batch_tokens
             total_tokens += batch_tokens
-        val_nll = total_nll / total_tokens if total_tokens > 0 else 0.0
+        if total_tokens <= 0:
+            raise SFTConfigError("The validation dataset has no trainable tokens after rendering and masking.")
+        val_nll = total_nll / total_tokens
         logger.info(f"Validation NLL: {val_nll:.4f}")
         return {"test/mean_nll": val_nll}

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -137,7 +137,9 @@ def build_sft_data(config, train_data, val_data):
     # reasoning/tool-calls fails fast before we render.
     renderer_name = _resolve_renderer_name(tokenizer_name, config.data.get("renderer_name", None))
     _guard_plain_renderer(renderer_name, train_data)
-    renderer = get_renderer(renderer_name, tokenizer)
+    renderer = get_renderer(renderer_name, tokenizer, model_name=tokenizer_name)
+    if hasattr(renderer, "strip_thinking_from_history"):
+        renderer.strip_thinking_from_history = bool(config.data.get("rllm", {}).get("strip_thinking_from_history", False))
     # Masking is always CUSTOMIZED, driven by each message's ``trainable`` flag:
     # rows from ``from-eval``'s automerge carry the flags directly; flag-less rows
     # (e.g. an external ``--train-file``) get a derived default in the dataset

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -71,6 +71,8 @@ def conversation_to_datum(
     renderer: Renderer,
     max_length: int | None,
     last_only: bool = False,
+    *,
+    tools: list[dict] | None = None,
 ) -> tinker.Datum:
     """Convert a conversation (list of messages) to a Tinker Datum.
 
@@ -90,7 +92,39 @@ def conversation_to_datum(
         tinker_messages = [m.to_tinker_message() for m in messages]
     except SFTSchemaError as e:
         raise SFTConfigError(f"SFT row failed schema normalization: {e}\n  row={_row_context(conversation)}") from e
-    model_input, weights = renderer.build_supervised_example(tinker_messages, train_on_what=TrainOnWhat.CUSTOMIZED)
+    if not getattr(renderer, "strip_thinking_from_history", False):
+        from rllm.renderers.adapters import prepare_tinker_messages_for_history
+
+        tinker_messages = prepare_tinker_messages_for_history(
+            renderer,
+            tinker_messages,
+            lift_reasoning=False,
+        )
+
+    if tools and hasattr(renderer, "build_supervised_example_with_tools"):
+        model_input, weights = renderer.build_supervised_example_with_tools(
+            tinker_messages,
+            tools,
+            train_on_what=TrainOnWhat.CUSTOMIZED,
+        )
+    else:
+        if tools:
+            from rllm.renderers.adapters import prepare_tinker_messages_with_tools
+
+            try:
+                tinker_messages = prepare_tinker_messages_with_tools(
+                    renderer,
+                    tinker_messages,
+                    tools,
+                )
+            except (TypeError, ValueError) as e:
+                raise SFTConfigError(f"SFT row has invalid tool declarations: {e}") from e
+            for message in tinker_messages:
+                message.setdefault("trainable", False)
+        model_input, weights = renderer.build_supervised_example(
+            tinker_messages,
+            train_on_what=TrainOnWhat.CUSTOMIZED,
+        )
     if max_length is not None and model_input.length > max_length:
         _warn_truncation(model_input.length, max_length)
     return datum_from_model_input_weights(model_input, weights, max_length)
@@ -143,7 +177,15 @@ class TinkerSFTDataset(SupervisedDataset):
         for i in range(start_idx, end_idx):
             row = self.dataset[i]
             try:
-                datums.append(conversation_to_datum(row["messages"], self.renderer, self.max_length, self.last_only))
+                datums.append(
+                    conversation_to_datum(
+                        row["messages"],
+                        self.renderer,
+                        self.max_length,
+                        self.last_only,
+                        tools=row.get("tools"),
+                    )
+                )
             except SFTConfigError as e:
                 raise SFTConfigError(f"dataset row {i}: {e}") from e
         return datums

--- a/tests/cli/test_dataset_commands.py
+++ b/tests/cli/test_dataset_commands.py
@@ -188,3 +188,39 @@ class TestDatasetRegister:
         result = runner.invoke(cli, ["dataset", "inspect", "rt_ds", "--split", "test", "-n", "1"])
         assert result.exit_code == 0
         assert "Best pizza?" in result.output
+
+
+class TestDatasetImport:
+    def test_import_preserves_reasoning_tools_and_whitespace(self, runner, tmp_rllm_home, tmp_path):
+        source = {
+            "messages": [
+                {"role": "system", "content": "sys\n\n"},
+                {"role": "user", "content": "  fix it\n"},
+                {
+                    "role": "assistant",
+                    "content": "\n\nTHOUGHT: look\n",
+                    "reasoning_content": "Let me explore.\n\n",
+                    "tool_calls": '[{"id": "c1", "type": "function", "function": {"name": "bash", "arguments": "{\\"cmd\\": \\"ls\\"}"}}]',
+                },
+            ],
+            "task_id": "t1",
+        }
+        path = tmp_path / "traces.jsonl"
+        path.write_text(json.dumps(source))
+
+        result = runner.invoke(cli, ["dataset", "import", str(path), "--name", "imported-sft"])
+        assert result.exit_code == 0, result.output
+
+        from rllm.data import DatasetRegistry
+        from rllm.data.sft_schema import normalize_row
+
+        stored = DatasetRegistry.load_dataset("imported-sft", "train").get_data()[0]
+        row = normalize_row(stored)
+        assistant = row.messages[-1]
+        assert row.messages[0].text() == "sys\n\n"
+        assert row.messages[1].text() == "  fix it\n"
+        assert assistant.thinking() == "Let me explore.\n\n"
+        assert assistant.text() == "\n\nTHOUGHT: look\n"
+        assert assistant.tool_calls[0].function.name == "bash"
+        assert assistant.tool_calls[0].function.arguments == '{"cmd": "ls"}'
+        assert row.to_record()["task_id"] == "t1"

--- a/tests/data/test_sft_bridges.py
+++ b/tests/data/test_sft_bridges.py
@@ -7,10 +7,12 @@ today: the module does not exist yet, so the import below fails at collection.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from rllm.data.sft_bridges import BRIDGES, bridge_messages, bridge_think_tags, get_bridge
-from rllm.data.sft_schema import SFTRow, TextPart, ThinkingPart
+from rllm.data.sft_schema import SFTRow, SFTSchemaError, TextPart, ThinkingPart
 
 # Two think-tagged rows: one multi-turn think-tagged conversation, plus a row whose
 # assistant turn carries NO think tag.
@@ -37,6 +39,17 @@ ROW_NO_THINK = {
     "_group": "g2",
     "_model": "opus",
     "_reward": 0,
+}
+
+ROW_FLAGGED = {
+    "messages": [
+        {"role": "user", "content": "u1", "trainable": False},
+        {"role": "assistant", "content": "<think>plan A</think>first", "trainable": True},
+        {"role": "user", "content": "retry", "trainable": False},
+        {"role": "assistant", "content": "<think>oops</think>bad", "trainable": False},
+        {"role": "user", "content": "again", "trainable": False},
+        {"role": "assistant", "content": "<think>plan C</think>done", "trainable": True},
+    ]
 }
 
 
@@ -98,6 +111,43 @@ def test_explode_history_stripped_single_trainable_target():
     assert hist_asst[0].text() == '{"cmd": "ls"}'
 
 
+def test_explode_honours_preexisting_trainable_flags():
+    rows = bridge_think_tags([ROW_FLAGGED])
+    assert len(rows) == 2
+    targets = [next(message for message in row.messages if message.trainable) for row in rows]
+    assert [target.thinking() for target in targets] == ["plan A", "plan C"]
+
+    masked = [message for message in rows[-1].messages if message.text() == "bad"]
+    assert len(masked) == 1
+    assert masked[0].trainable is False
+    assert masked[0].thinking() == ""
+
+
+def test_explode_partial_flags_trigger_full_target_derivation():
+    source = {
+        "messages": [
+            {"role": "user", "content": "q", "trainable": False},
+            {"role": "assistant", "content": "<think>one</think>a1", "trainable": False},
+            {"role": "user", "content": "retry"},
+            {"role": "assistant", "content": "<think>two</think>a2", "trainable": False},
+        ]
+    }
+    rows = bridge_think_tags([source])
+    assert [row.messages[-1].thinking() for row in rows] == ["one", "two"]
+    assert all([message.trainable for message in row.messages].count(True) == 1 for row in rows)
+
+
+def test_explode_rejects_complete_mask_targeting_non_assistant():
+    source = {
+        "messages": [
+            {"role": "user", "content": "q", "trainable": True},
+            {"role": "assistant", "content": "<think>plan</think>a", "trainable": False},
+        ]
+    }
+    with pytest.raises(SFTSchemaError, match="message 0.*only assistant target"):
+        bridge_think_tags([source])
+
+
 # --- no-explode: one row per conversation ------------------------------------
 
 
@@ -111,6 +161,27 @@ def test_no_explode_single_row_all_assistant_trainable():
             assert any(isinstance(p, ThinkingPart) for p in m.content)  # ThinkingParts KEPT
         else:
             assert m.trainable is False
+
+
+def test_no_explode_honours_preexisting_trainable_flags():
+    row = bridge_think_tags([ROW_FLAGGED], explode=False)[0]
+    assert [message.trainable for message in row.messages] == [False, True, False, False, False, True]
+
+
+def test_no_explode_partial_flags_trigger_full_mask_derivation():
+    row = bridge_think_tags(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": "<think>plan</think>answer", "trainable": False},
+                    {"role": "user", "content": "follow-up"},
+                ]
+            }
+        ],
+        explode=False,
+    )[0]
+    assert [message.trainable for message in row.messages] == [False, True, False]
 
 
 # --- row-level extras passthrough --------------------------------------------
@@ -157,6 +228,220 @@ def test_bridge_messages_train_on_all():
 def test_bridge_messages_train_on_last():
     row = bridge_messages(PLAIN, train_on="last")[0]
     assert [m.trainable for m in row.messages] == [False, False, False, True]
+
+
+def test_bridge_messages_is_idempotent_for_canonical_rows():
+    record = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "q"}], "trainable": False},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "plan"},
+                    {"type": "text", "text": "answer"},
+                ],
+                "trainable": True,
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "c1",
+                        "function": {"name": "submit", "arguments": '{"answer": 42}'},
+                    }
+                ],
+            },
+        ],
+        "task_id": "t1",
+    }
+    assert bridge_messages([record], train_on="last")[0].to_record() == record
+
+
+# --- source-shape normalization ----------------------------------------------
+
+
+REASONING_ROW = {
+    "messages": [
+        {"role": "user", "content": "fix it"},
+        {
+            "role": "assistant",
+            "content": "THOUGHT: look around",
+            "reasoning_content": "Let me explore.",
+            "tool_calls": json.dumps([{"id": "c1", "type": "function", "function": {"name": "bash", "arguments": '{"cmd": "ls"}'}}]),
+        },
+        {"role": "tool", "content": "a.py"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "done",
+            "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "submit", "arguments": {"ok": True}}}],
+        },
+    ],
+    "task_id": "t1",
+}
+
+
+@pytest.mark.parametrize("key", ["reasoning_content", "reasoning"])
+def test_reasoning_sibling_field_becomes_thinking_part(key):
+    message = {"role": "assistant", "content": "answer", key: "the chain of thought"}
+    row = bridge_messages([{"messages": [{"role": "user", "content": "q"}, message]}])[0]
+    assistant = row.messages[-1]
+    assert [type(part) for part in assistant.content] == [ThinkingPart, TextPart]
+    assert assistant.thinking() == "the chain of thought"
+    assert assistant.text() == "answer"
+
+
+def test_reasoning_only_turn_has_no_empty_text_part():
+    assistant = bridge_messages([REASONING_ROW])[0].messages[-1]
+    assert [type(part) for part in assistant.content] == [ThinkingPart]
+    assert assistant.thinking() == "done"
+
+
+@pytest.mark.parametrize(
+    ("message_index", "call_id", "name", "arguments"),
+    [(1, "c1", "bash", '{"cmd": "ls"}'), (-1, "c2", "submit", '{"ok": true}')],
+)
+def test_tool_calls_decoded_to_canonical_wire_shape(message_index, call_id, name, arguments):
+    calls = bridge_messages([REASONING_ROW])[0].messages[message_index].tool_calls
+    assert calls is not None and len(calls) == 1
+    assert (calls[0].id, calls[0].function.name) == (call_id, name)
+    assert calls[0].function.arguments == arguments
+
+
+def test_unparseable_tool_calls_string_raises_naming_the_row():
+    with pytest.raises(SFTSchemaError) as exc:
+        bridge_messages([{"messages": [{"role": "assistant", "content": "x", "tool_calls": "not json"}]}])
+    assert "row 0" in str(exc.value)
+    assert "tool_calls is a string but not valid JSON" in str(exc.value)
+
+
+def test_reasoning_on_prompt_turn_raises_instead_of_being_dropped():
+    messages = [
+        {"role": "user", "content": "q", "reasoning_content": "not mine"},
+        {"role": "assistant", "content": "a"},
+    ]
+    with pytest.raises(SFTSchemaError, match="only on assistant"):
+        bridge_messages([{"messages": messages}])
+
+
+@pytest.mark.parametrize("key", ["reasoning_content", "reasoning"])
+@pytest.mark.parametrize("role", ["user", "assistant"])
+def test_empty_reasoning_field_is_absent_on_any_role(key, role):
+    message = bridge_messages([{"messages": [{"role": role, "content": "payload", key: ""}]}])[0].messages[0]
+    assert message.text() == "payload"
+    assert message.thinking() == ""
+
+
+def test_conflicting_reasoning_aliases_raise_instead_of_dropping_one():
+    message = {
+        "role": "assistant",
+        "content": "a",
+        "reasoning_content": "first",
+        "reasoning": "second",
+    }
+    with pytest.raises(SFTSchemaError, match="conflicting reasoning aliases"):
+        bridge_messages([{"messages": [message]}])
+
+
+@pytest.mark.parametrize("content", [7, {"text": "visible answer"}])
+def test_reasoning_does_not_hide_unsupported_visible_content(content):
+    message = {"role": "assistant", "content": content, "reasoning_content": "cot"}
+    with pytest.raises(SFTSchemaError, match="assistant content must be"):
+        bridge_messages([{"messages": [message]}])
+
+
+def test_sibling_reasoning_conflicts_with_structural_inline_thinking():
+    message = {
+        "role": "assistant",
+        "content": "<think>inline</think>visible",
+        "reasoning_content": "sibling",
+    }
+    with pytest.raises(SFTSchemaError, match="sibling reasoning.*structural inline"):
+        bridge_messages([{"messages": [message]}])
+
+
+def test_sibling_reasoning_conflicts_with_existing_thinking_part():
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "structured"},
+            {"type": "text", "text": "visible"},
+        ],
+        "reasoning_content": "sibling",
+    }
+    with pytest.raises(SFTSchemaError, match="sibling reasoning.*existing thinking part"):
+        bridge_messages([{"messages": [message]}])
+
+
+def test_plain_messages_reject_structural_inline_thinking_string():
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "<think>inline</think>visible"},
+    ]
+    with pytest.raises(SFTSchemaError, match="think-tags.*thinking parts"):
+        bridge_messages([{"messages": messages}])
+
+
+def test_plain_messages_preserve_literal_tags_in_canonical_text_parts():
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "q"}], "trainable": False},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "structured"},
+                {"type": "text", "text": "<think>literal</think>visible"},
+            ],
+            "trainable": True,
+        },
+    ]
+    row = bridge_messages([{"messages": messages}])[0]
+    assert row.messages[-1].thinking() == "structured"
+    assert row.messages[-1].text() == "<think>literal</think>visible"
+
+
+def test_think_tags_parse_structural_text_parts():
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "<think>inline</think>visible"}],
+        },
+    ]
+    assistant = bridge_think_tags([{"messages": messages}], explode=False)[0].messages[-1]
+    assert assistant.thinking() == "inline"
+    assert assistant.text() == "visible"
+
+
+def test_think_tags_parse_tag_split_across_text_parts():
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "<think>split"},
+                {"type": "text", "text": " reasoning</think>visible"},
+            ],
+        },
+    ]
+    assistant = bridge_think_tags([{"messages": messages}], explode=False)[0].messages[-1]
+    assert assistant.thinking() == "split reasoning"
+    assert assistant.text() == "visible"
+
+
+def test_think_tags_apply_provider_normalization_too():
+    row = bridge_think_tags([REASONING_ROW], explode=False)[0]
+    assert row.messages[1].thinking() == "Let me explore."
+    assert row.messages[1].tool_calls[0].function.arguments == '{"cmd": "ls"}'
+
+
+def test_literal_think_tags_outside_assistant_prefix_remain_text():
+    messages = [
+        {"role": "user", "content": "<think>literal prompt</think>"},
+        {"role": "assistant", "content": "Literal <think>tag</think>."},
+    ]
+    row = bridge_messages([{"messages": messages}])[0]
+    assert [message.text() for message in row.messages] == [
+        "<think>literal prompt</think>",
+        "Literal <think>tag</think>.",
+    ]
 
 
 # --- registry / get_bridge ---------------------------------------------------

--- a/tests/data/test_sft_schema.py
+++ b/tests/data/test_sft_schema.py
@@ -89,28 +89,31 @@ def test_normalize_messages_derive_last():
 
 def test_normalize_messages_already_flagged_untouched():
     # All messages carry real bools -> keep them, even a pattern derivation would
-    # never produce (trainable user, non-trainable assistant).
+    # never produce (trainable user, non-trainable assistant). The requested
+    # derivation policy is ignored for a complete mask.
     msgs = normalize_messages(
         [
             {"role": "user", "content": "u", "trainable": True},
             {"role": "assistant", "content": "a", "trainable": False},
         ],
-        default_trainable="all",
+        default_trainable="last",
     )
     assert [m.trainable for m in msgs] == [True, False]
 
 
-def test_normalize_messages_partial_flags_trigger_full_derive():
-    # ANY message lacking a bool flag -> derive the WHOLE conversation, overriding
-    # even the explicit False on the assistant.
+@pytest.mark.parametrize("partial_value", [None, 1, "true"])
+def test_normalize_messages_partial_flags_trigger_full_derive(partial_value):
+    # ANY message lacking a bool flag -> derive the WHOLE conversation,
+    # overriding even an explicit earlier target.
     msgs = normalize_messages(
         [
-            {"role": "user", "content": "u"},  # no flag
-            {"role": "assistant", "content": "a", "trainable": False},
+            {"role": "user", "content": "u", "trainable": partial_value},
+            {"role": "assistant", "content": "a1", "trainable": True},
+            {"role": "assistant", "content": "a2", "trainable": False},
         ],
-        default_trainable="all",
+        default_trainable="last",
     )
-    assert [m.trainable for m in msgs] == [False, True]
+    assert [m.trainable for m in msgs] == [False, False, True]
 
 
 def test_normalize_messages_content_is_parts_list():
@@ -118,6 +121,37 @@ def test_normalize_messages_content_is_parts_list():
     assert all(isinstance(m, SFTMessage) for m in msgs)
     assert all(isinstance(p, TextPart) for p in msgs[0].content)
     assert msgs[2].text() == "a1"
+
+
+def test_normalize_messages_rejects_unbridged_reasoning_field():
+    with pytest.raises(SFTSchemaError, match="reasoning_content.*dataset import"):
+        normalize_messages(
+            [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": "a", "reasoning_content": "important hidden reasoning"},
+            ]
+        )
+
+
+@pytest.mark.parametrize("key", ["reasoning_content", "reasoning"])
+@pytest.mark.parametrize("role", ["user", "assistant"])
+def test_normalize_messages_treats_empty_reasoning_as_absent(key, role):
+    message = normalize_messages([{"role": role, "content": "payload", key: ""}])[0]
+    assert message.text() == "payload"
+    assert message.thinking() == ""
+
+
+def test_canonical_text_part_may_contain_literal_think_tag():
+    message = normalize_messages(
+        [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "<think>literal text</think>"}],
+                "trainable": True,
+            }
+        ]
+    )[0]
+    assert message.text() == "<think>literal text</think>"
 
 
 # --- validation errors (raised as SFTSchemaError by normalize_*) -------------

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -15,7 +15,13 @@ os.environ.setdefault("HF_HUB_OFFLINE", "1")
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 from rllm.renderers import BridgingRendererMixin, get_renderer, resolve  # noqa: E402
-from rllm.renderers.adapters import ChatTemplateAdapter  # noqa: E402
+from rllm.renderers.adapters import (  # noqa: E402
+    ChatTemplateAdapter,
+    _last_real_user_index,
+    _to_parsed,
+    to_tinker_messages,
+    to_tinker_tool_specs,
+)
 
 QWEN = "Qwen/Qwen3-0.6B"
 
@@ -126,11 +132,133 @@ def test_tinker_adapter_renders(qwen_tokenizer):
     assert a.get_stop_token_ids()  # non-empty
 
 
+def test_tinker_parse_flattens_structured_response_parts():
+    parsed = _to_parsed(
+        [
+            {"type": "thinking", "thinking": "plan"},
+            {"type": "text", "text": "answer"},
+        ],
+        None,
+        [],
+    )
+    assert parsed.reasoning_content == "plan"
+    assert parsed.content == "answer"
+
+
+def test_openai_tool_declarations_become_cookbook_specs():
+    pytest.importorskip("tinker_cookbook")
+    specs = to_tinker_tool_specs(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "description": "Run a command",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+    )
+    assert len(specs) == 1
+    assert specs[0]["name"] == "bash"
+    assert specs[0]["parameters"] == {"type": "object"}
+
+
+def test_wrapped_tool_response_is_not_a_genuine_user_boundary():
+    pytest.importorskip("tinker_cookbook")
+    messages = [
+        {"role": "user", "content": "Fix it"},
+        {"role": "assistant", "content": "working", "reasoning_content": "CURRENT-TRACE"},
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "<tool_response>output</tool_response>"}],
+        },
+    ]
+    boundary = _last_real_user_index(messages)
+    assert boundary == 0
+    converted = to_tinker_messages(messages, lift_reasoning=True, keep_reasoning_after=boundary)
+    assert converted[1]["content"][0] == {"type": "thinking", "thinking": "CURRENT-TRACE"}
+
+
+@pytest.mark.parametrize(
+    "reasoning_field",
+    [
+        {"reasoning_content": "PRIOR-REASONING"},
+        {"reasoning": "PRIOR-REASONING"},
+        {"provider_specific_fields": {"refusal": None, "reasoning": "PRIOR-REASONING"}},
+    ],
+    ids=["reasoning_content", "reasoning", "provider_specific_fields"],
+)
+def test_tinker_adapter_renders_harness_wire_shape(qwen_tokenizer, reasoning_field):
+    """A reasoning harness re-sends prior turns as OpenAI dicts: reasoning in a
+    sibling field, tool calls as plain dicts, content sometimes absent. Cookbook
+    renderers read none of that, so the adapter has to translate — otherwise the
+    tool call raises and every prior turn's reasoning is missing from the prompt."""
+    adapter = _tinker_qwen3(qwen_tokenizer)
+    messages = [
+        {"role": "user", "content": "Fix the bug."},
+        {
+            "role": "assistant",
+            "content": "Exploring.",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}],
+            **reasoning_field,
+        },
+        {"role": "tool", "content": "setup.py", "tool_call_id": "c1"},
+        # A content-less assistant turn is the dominant shape in real episodes.
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "bash", "arguments": '{"command": "cat a.py"}'}}],
+            "reasoning_content": "SECOND-REASONING",
+        },
+        {"role": "tool", "content": "def f(): pass", "tool_call_id": "c2"},
+    ]
+
+    text = qwen_tokenizer.decode(adapter.render_ids(messages, add_generation_prompt=True))
+    assert "PRIOR-REASONING" in text
+    assert "SECOND-REASONING" in text
+    assert '"name": "bash"' in text
+
+
+def test_tinker_adapter_strips_reasoning_before_new_user_like_hf(qwen_tokenizer):
+    """A genuine follow-up user turn starts a new Qwen reasoning boundary."""
+    messages = [
+        {"role": "user", "content": "First question."},
+        {
+            "role": "assistant",
+            "content": "First answer.",
+            "reasoning_content": "SECRET-OLD-REASONING",
+        },
+        {"role": "user", "content": "Second question."},
+        {
+            "role": "assistant",
+            "content": "Second answer.",
+            "reasoning_content": "CURRENT-REASONING",
+        },
+    ]
+    adapter_ids = _tinker_qwen3(qwen_tokenizer).render_ids(
+        messages,
+        add_generation_prompt=False,
+    )
+    hf_ids = qwen_tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=False,
+    )
+
+    text = qwen_tokenizer.decode(adapter_ids)
+    hf_text = qwen_tokenizer.decode(hf_ids)
+    assert "SECRET-OLD-REASONING" not in text
+    assert "CURRENT-REASONING" in text
+    assert ("SECRET-OLD-REASONING" in text, "CURRENT-REASONING" in text) == (
+        "SECRET-OLD-REASONING" in hf_text,
+        "CURRENT-REASONING" in hf_text,
+    )
+
+
 def test_tinker_adapter_bridge_matches_prime(qwen_tokenizer):
     """The synthesized bridge must equal prime-rl's hand-tuned qwen3 bridge."""
     adapter = _tinker_qwen3(qwen_tokenizer)
     prime = _prime_qwen3(qwen_tokenizer)
-
     prompt = prime.render_ids([{"role": "user", "content": "hello there"}], add_generation_prompt=True)
     completion = [
         t

--- a/tests/test_tinker_adapter_cumulative.py
+++ b/tests/test_tinker_adapter_cumulative.py
@@ -106,6 +106,13 @@ def test_to_openai_tool_calls_handles_all_producer_shapes():
     assert _to_openai_tool_calls([{"function": {"name": "bash", "arguments": {"command": "ls"}}}]) == [
         {"id": "call_0", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}
     ]
+    from tinker_cookbook.renderers.base import ToolCall as CookbookToolCall
+
+    cookbook = CookbookToolCall(
+        id="c1",
+        function=CookbookToolCall.FunctionBody(name="bash", arguments='{"command": "ls"}'),
+    )
+    assert _to_openai_tool_calls([cookbook]) == [{"id": "call_0", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}]
     # flat dict and ToolCall object still work.
     assert _to_openai_tool_calls([{"name": "edit", "arguments": {"p": 1}}])[0]["function"]["name"] == "edit"
     assert _to_openai_tool_calls([SimpleNamespace(name="read", arguments={"f": "x"})])[0]["function"]["name"] == "read"

--- a/tests/trainer/test_sft_render_path.py
+++ b/tests/trainer/test_sft_render_path.py
@@ -37,6 +37,7 @@ from tinker_cookbook.renderers import get_renderer  # noqa: E402
 
 from rllm.data import Dataset  # noqa: E402
 from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
 from rllm.trainer.sft.tinker_backend import TinkerSFTBackend, build_sft_data  # noqa: E402
 from rllm.trainer.sft.tinker_dataset import conversation_to_datum  # noqa: E402
 
@@ -73,6 +74,47 @@ def _trained_text(datum, tokenizer) -> str:
     """Decode only the tokens that carry loss (weight > 0)."""
     trained = [t for t, w in zip(_targets(datum), _weights(datum), strict=True) if w > 0]
     return tokenizer.decode(trained)
+
+
+def _full_tokens(datum) -> list[int]:
+    """Reconstruct the pre-shift token stream from a Datum."""
+    return _input_ids(datum) + _targets(datum)[-1:]
+
+
+def test_row_tools_reach_renderer_without_tokenizer():
+    import tinker
+    import torch
+
+    class RecordingRenderer:
+        strip_thinking_from_history = False
+
+        def create_conversation_prefix_with_tools(self, tools, system_prompt=""):
+            assert tools[0]["name"] == "bash"
+            return [{"role": "system", "content": system_prompt or "tools"}]
+
+        def build_supervised_example(self, messages, train_on_what):
+            self.messages = messages
+            return tinker.ModelInput.from_ints([1, 2, 3]), torch.tensor([0.0, 1.0, 1.0])
+
+    renderer = RecordingRenderer()
+    datum = conversation_to_datum(
+        [
+            {"role": "user", "content": "inspect", "trainable": False},
+            {"role": "assistant", "content": "done", "trainable": True},
+        ],
+        renderer,
+        max_length=None,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "bash", "parameters": {"type": "object"}},
+            }
+        ],
+    )
+
+    assert datum.model_input.length == 2
+    assert renderer.messages[0]["role"] == "system"
+    assert renderer.messages[0]["trainable"] is False
 
 
 # -- F1: default renderer must not crash on reasoning rows -------------------
@@ -279,3 +321,116 @@ def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
     with caplog.at_level(logging.WARNING, logger="rllm.trainer.sft.tinker_dataset"):
         conversation_to_datum(convo, renderer, max_length=100_000)
     assert not [r for r in caplog.records if "max_length" in r.getMessage()]
+
+
+def test_tools_and_reasoning_match_unified_serving_renderer(qwen_tokenizer):
+    from rllm.data.sft_bridges import bridge_messages
+    from rllm.renderers.adapters import TinkerRendererAdapter
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Run a shell command.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        }
+    ]
+    wire_messages = [
+        {"role": "system", "content": "Solve the task."},
+        {"role": "user", "content": "Inspect the repository."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "I should list the files first.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "a.py"},
+        {
+            "role": "assistant",
+            "content": "Done.",
+            "reasoning_content": "The repository has one file.",
+        },
+    ]
+    canonical = bridge_messages([{"messages": wire_messages, "tools": tools}])[0].to_record()
+    dataset = Dataset(data=[canonical], name="tool-parity", split="train")
+    spec = SFTSpec(
+        model=QWEN,
+        train_dataset=dataset,
+        max_length=100_000,
+        overrides={"data": {"renderer_name": "qwen3"}},
+    )
+    config = TinkerSFTBackend(spec).build_config()
+    _, training_dataset, _ = build_sft_data(config, dataset, None)
+    datum = training_dataset.get_batch(0)[0]
+
+    serving_ids = TinkerRendererAdapter(get_renderer("qwen3", qwen_tokenizer)).render_ids(
+        wire_messages,
+        tools=tools,
+        add_generation_prompt=False,
+    )
+    assert _full_tokens(datum) == serving_ids
+    trained = _trained_text(datum, qwen_tokenizer)
+    assert "list the files" in trained
+    assert "repository has one file" in trained
+    assert "Inspect the repository" not in trained
+
+
+def test_new_user_query_strips_prior_reasoning_in_training_and_serving(qwen_tokenizer):
+    from rllm.data.sft_bridges import bridge_messages
+    from rllm.renderers.adapters import TinkerRendererAdapter
+
+    wire_messages = [
+        {"role": "user", "content": "First question."},
+        {
+            "role": "assistant",
+            "content": "First answer.",
+            "reasoning_content": "SECRET-OLD-REASONING",
+        },
+        {"role": "user", "content": "Second question."},
+        {
+            "role": "assistant",
+            "content": "Second answer.",
+            "reasoning_content": "CURRENT-REASONING",
+        },
+    ]
+    canonical = bridge_messages([{"messages": wire_messages}])[0]
+    renderer = get_renderer("qwen3", qwen_tokenizer)
+    renderer.strip_thinking_from_history = False
+    datum = conversation_to_datum(canonical.to_record()["messages"], renderer, max_length=None)
+    serving_ids = TinkerRendererAdapter(get_renderer("qwen3", qwen_tokenizer)).render_ids(
+        wire_messages,
+        add_generation_prompt=False,
+    )
+
+    assert _full_tokens(datum) == serving_ids
+    rendered = qwen_tokenizer.decode(serving_ids)
+    assert "SECRET-OLD-REASONING" not in rendered
+    assert "CURRENT-REASONING" in rendered
+
+
+def test_invalid_row_tool_declaration_fails_with_dataset_error(qwen_tokenizer):
+    renderer = get_renderer("qwen3", qwen_tokenizer)
+    messages = [
+        {"role": "user", "content": "inspect", "trainable": False},
+        {"role": "assistant", "content": "done", "trainable": True},
+    ]
+
+    with pytest.raises(SFTConfigError, match="invalid tool declarations"):
+        conversation_to_datum(
+            messages,
+            renderer,
+            max_length=None,
+            tools=[{"type": "custom", "name": "not-supported"}],
+        )

--- a/tests/trainer/test_sft_validation.py
+++ b/tests/trainer/test_sft_validation.py
@@ -1,0 +1,176 @@
+"""In-loop SFT validation on the tinker/fireworks family.
+
+Both backends accumulate gradients server-side across ``forward_backward``
+calls until the next ``optim_step``, so a validation pass that runs backward
+silently trains on the held-out set. These tests pin the val loop to the
+forward-only API, pin the metric it reports, and pin the ``fit`` call sites —
+all on fakes, so no Tinker/Fireworks spend.
+
+The two backends share the assertions but not the call protocol: tinker's
+``_validate`` is async over ``forward_async`` futures, fireworks' is sync over
+``ReconnectableClient.forward`` (which blocks internally).
+"""
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+from tinker_cookbook.supervised.common import compute_mean_nll  # noqa: E402
+
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend  # noqa: E402
+from rllm.trainer.sft.tinker_backend import TinkerSFTBackend  # noqa: E402
+
+
+def _tensor(values):
+    import torch
+
+    return tinker.TensorData.from_torch(torch.tensor(values, dtype=torch.float32))
+
+
+class _Datum:
+    """Only the fields ``_validate`` reads off a tinker Datum."""
+
+    def __init__(self, weights):
+        self.loss_fn_inputs = {"weights": _tensor(weights)}
+
+
+class _Output:
+    """A forward / forward_backward response: per-token logprobs per datum."""
+
+    def __init__(self, logprobs_per_datum):
+        self.loss_fn_outputs = [{"logprobs": _tensor(lp)} for lp in logprobs_per_datum]
+
+
+class _ValDataset:
+    def __init__(self, batches):
+        self._batches = batches
+
+    def __len__(self):
+        return len(self._batches)
+
+    def get_batch(self, idx):
+        return self._batches[idx]
+
+
+class _AsyncFuture:
+    def __init__(self, output):
+        self._output = output
+
+    async def result_async(self):
+        return self._output
+
+
+class _SyncFuture:
+    def __init__(self, output):
+        self._output = output
+
+    def result(self, timeout=None):
+        return self._output
+
+
+class _FakeTinkerClient:
+    """Tinker training client logging (pass, loss_fn) per call.
+
+    Exhausting ``outputs`` raises rather than replaying, so a val loop that
+    calls more times than there are batches fails loudly.
+    """
+
+    def __init__(self, outputs):
+        self.calls: list[tuple[str, str]] = []
+        self._outputs = iter(outputs)
+
+    async def forward_async(self, data, loss_fn):
+        self.calls.append(("forward", loss_fn))
+        return _AsyncFuture(next(self._outputs))
+
+    async def forward_backward_async(self, data, loss_fn):
+        self.calls.append(("forward_backward", loss_fn))
+        return _AsyncFuture(next(self._outputs))
+
+
+class _FakeFireworksClient:
+    """``ReconnectableClient`` surface, logging (pass, loss_fn) per call."""
+
+    def __init__(self, outputs):
+        self.calls: list[tuple[str, str]] = []
+        self._outputs = iter(outputs)
+
+    def forward(self, data, loss_fn):
+        self.calls.append(("forward", loss_fn))
+        return next(self._outputs)
+
+    def submit_forward_backward(self, data, loss_fn="cross_entropy", loss_fn_config=None):
+        self.calls.append(("forward_backward", loss_fn))
+        return _SyncFuture(next(self._outputs))
+
+
+# Two batches with different loss-token counts, so a token-weighted mean
+# (2*1.5 + 3*6.0) / 5 = 4.2 is distinguishable from a plain batch mean of 3.75.
+_BATCHES = [[_Datum([1.0, 1.0, 0.0])], [_Datum([1.0, 1.0, 1.0])]]
+_OUTPUTS = [_Output([[-1.0, -2.0, -3.0]]), _Output([[-4.0, -6.0, -8.0]])]
+_EXPECTED_NLL = 4.2
+
+# A fully loss-masked batch: every token weight 0, so it carries no signal.
+_MASKED_BATCH = [_Datum([0.0, 0.0])]
+_MASKED_OUTPUT = _Output([[-9.0, -9.0]])
+
+
+def _run_tinker(client, batches):
+    import asyncio
+
+    return asyncio.run(TinkerSFTBackend._validate(client, _ValDataset(batches), compute_mean_nll))
+
+
+def _run_fireworks(client, batches):
+    return FireworksSFTBackend._validate(client, _ValDataset(batches))
+
+
+_BACKENDS = [
+    pytest.param(_FakeTinkerClient, _run_tinker, "test/mean_nll", id="tinker"),
+    pytest.param(_FakeFireworksClient, _run_fireworks, "test/loss", id="fireworks"),
+]
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_never_runs_backward(client_cls, run_validate, metric_key):
+    """Validation scores every batch through the forward-only API.
+
+    A ``forward_backward`` here would land in the server's gradient accumulator
+    and be applied by the next ``optim_step`` — the val set would be trained on.
+    """
+    client = client_cls(_OUTPUTS)
+    metrics = run_validate(client, _BATCHES)
+    assert client.calls == [("forward", "cross_entropy")] * len(_BATCHES)
+    assert list(metrics) == [metric_key]
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_returns_token_weighted_nll(client_cls, run_validate, metric_key):
+    """The reported metric is the token-weighted mean NLL over the whole val set,
+    reduced client-side from per-token logprobs on both backends."""
+    metrics = run_validate(client_cls(_OUTPUTS), _BATCHES)
+    assert metrics[metric_key] == pytest.approx(_EXPECTED_NLL)
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_skips_fully_masked_batch(client_cls, run_validate, metric_key):
+    """A batch with no loss tokens scores nan and must not poison the run's metric.
+
+    Reachable whenever ``data.max_length`` truncates rows past their trainable
+    tail — the dataset warns about it but still yields the datum.
+    """
+    batches = [_BATCHES[0], _MASKED_BATCH, _BATCHES[1]]
+    outputs = [_OUTPUTS[0], _MASKED_OUTPUT, _OUTPUTS[1]]
+    metrics = run_validate(client_cls(outputs), batches)
+    assert metrics[metric_key] == pytest.approx(_EXPECTED_NLL)
+
+
+@pytest.mark.parametrize(("client_cls", "run_validate", "metric_key"), _BACKENDS)
+def test_validate_rejects_an_entirely_masked_dataset(
+    client_cls,
+    run_validate,
+    metric_key,
+):
+    del metric_key
+    with pytest.raises(SFTConfigError, match="no trainable tokens"):
+        run_validate(client_cls([_MASKED_OUTPUT]), [_MASKED_BATCH])

--- a/tests/trainer/test_sft_validation.py
+++ b/tests/trainer/test_sft_validation.py
@@ -18,7 +18,28 @@ from tinker_cookbook.supervised.common import compute_mean_nll  # noqa: E402
 
 from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
 from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend  # noqa: E402
-from rllm.trainer.sft.tinker_backend import TinkerSFTBackend  # noqa: E402
+from rllm.trainer.sft.tinker_backend import TinkerSFTBackend, should_validate_step  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("completed_steps", "include_initial", "expected"),
+    [(0, False, False), (0, True, True), (1, False, False), (10, False, True), (20, False, True)],
+)
+def test_validation_cadence_uses_completed_steps(completed_steps, include_initial, expected):
+    assert (
+        should_validate_step(
+            completed_steps,
+            eval_every=10,
+            has_validation=True,
+            include_initial=include_initial,
+        )
+        is expected
+    )
+
+
+def test_validation_cadence_requires_validation_data():
+    assert not should_validate_step(0, eval_every=10, has_validation=False, include_initial=True)
+    assert not should_validate_step(10, eval_every=10, has_validation=False)
 
 
 def _tensor(values):


### PR DESCRIPTION
Part 7 of 11 in the draft stack replacing #809.

Base: `agent/sft-forward-only-validation`
Previous: #848
Next: #850

## Change

Run optional initial validation at step 0, then validate and save on completed-update boundaries. Drain outstanding submitted training work before every validation boundary.

## Why it matters

Metrics and checkpoints now describe completed optimizer updates rather than submitted/off-by-one work, and validation cannot race an in-flight update.

## Verification

- focused validation-boundary tests
- full stacked tip: 152 passed, 22 skipped