### PR TITLE
feat(sft): define hosted training execution contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ tinker = [
 
 fireworks = [
     "fireworks-ai[training]==1.2.1 ; python_version >= '3.11'",
-    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git#subdirectory=training ; python_version >= '3.11'",
+    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@6b1232504fdacd1149895acf63b388ae792cb062#subdirectory=training ; python_version >= '3.11'",
 ]
 
 opentelemetry = [

--- a/rllm/trainer/sft/config/fireworks.yaml
+++ b/rllm/trainer/sft/config/fireworks.yaml
@@ -40,6 +40,8 @@ data:
   renderer_name: null   # null = auto-detect from the model; set explicitly to override, e.g. qwen3 / qwen3_5 / deepseekv3 / role_colon
   rllm:
     tokenize_and_mask_method: cumulative
+    overlength_policy: truncate  # compatibility default; error rejects a whole over-length trajectory
+    loss_reduction: token_mean   # token_mean (default) | sequence_mean | none (raw weights)
 
 optim:
   lr: 1e-5
@@ -47,9 +49,14 @@ optim:
   eps: 1e-8
   lr_scheduler: constant
   warmup_steps_ratio: 0.1
+  warmup_steps: -1      # -1 = derive from ratio; 0 = disable; non-negative value overrides ratio
+  min_lr: 0.0
+  weight_decay: 0.0
+  grad_clip_norm: 0.0
 
 trainer:
   total_epochs: 1
+  max_steps: null
   logger: ['console']
   project_name: 'rllm-fireworks-sft'
   experiment_name: 'default'

--- a/rllm/trainer/sft/config/tinker.yaml
+++ b/rllm/trainer/sft/config/tinker.yaml
@@ -22,6 +22,8 @@ data:
   renderer_name: null   # null = auto-detect from the model; set explicitly to override, e.g. qwen3 / qwen3_5 / deepseekv3 / role_colon
   rllm:
     tokenize_and_mask_method: cumulative  # cumulative -> ALL_ASSISTANT_MESSAGES; stepwise -> LAST_ASSISTANT_MESSAGE
+    overlength_policy: truncate  # compatibility default; use error to preserve whole trajectories
+    loss_reduction: token_mean   # token_mean (default) | sequence_mean | none (raw weights)
 
 optim:
   lr: 1e-5
@@ -29,9 +31,14 @@ optim:
   eps: 1e-8
   lr_scheduler: constant  # constant | linear | cosine
   warmup_steps_ratio: 0.1
+  warmup_steps: -1      # -1 = derive from ratio; 0 = disable; non-negative value overrides ratio
+  min_lr: 0.0
+  weight_decay: 0.0
+  grad_clip_norm: 0.0
 
 trainer:
   total_epochs: 1
+  max_steps: null             # optional exact optimizer-step cap
   logger: ['console']
   project_name: 'rllm-tinker-sft'
   experiment_name: 'default'

--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -33,7 +33,12 @@ from omegaconf import DictConfig, OmegaConf
 from rllm.trainer.sft.backend import SFTConfigError
 from rllm.trainer.sft.tinker_backend import (
     TinkerSFTBackend,
+    build_adam_params,
     build_sft_data,
+    iter_training_batches,
+    resolve_sft_optimizer_settings,
+    resolve_training_steps,
+    sft_lr_multiplier,
     should_validate_step,
 )
 
@@ -194,13 +199,12 @@ class FireworksSFTBackend(TinkerSFTBackend):
         config = self._config
 
         try:
-            import tinker
-            from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier
             from training.utils.checkpoints import TrainingCheckpoints
             from training.utils.client import DEFAULT_TIMEOUT_S
         except ImportError as e:
             raise SFTConfigError(f"Fireworks SFT backend requires the Fireworks training SDK: {e}") from None
 
+        from rllm.trainer.sft.tinker_dataset import count_loss_tokens, sum_loss_weights
         from rllm.utils.tracking import Tracking
 
         api_key = os.environ.get("FIREWORKS_API_KEY", "")
@@ -236,6 +240,29 @@ class FireworksSFTBackend(TinkerSFTBackend):
         try:
             _tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
 
+            n_batches = len(train_dataset)
+            total_epochs = config.trainer.get("total_epochs", 1)
+            max_steps = config.trainer.get("max_steps")
+            total_steps = resolve_training_steps(n_batches, total_epochs, max_steps)
+            progress_denominator = total_steps
+            optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=total_steps)
+            save_every = config.trainer.get("save_freq", 20)
+            eval_every = config.trainer.get("test_freq", 10)
+
+            train_dataset.preflight(
+                label="train",
+                planned_batches=(
+                    (epoch_idx, batch_idx)
+                    for _step, epoch_idx, batch_idx in iter_training_batches(
+                        n_batches=n_batches,
+                        total_epochs=total_epochs,
+                        max_steps=max_steps,
+                    )
+                ),
+            )
+            if val_dataset is not None:
+                val_dataset.preflight(label="validation")
+
             infra = self._provision(config, api_key, base_url)
             try:
                 client = infra.policy
@@ -251,20 +278,7 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 resume = ckpt.resume()
                 start_step = resume.step if resume else 0
 
-                # len(dataset) floors examples//batch_size; keep the final partial
-                # batch when the dataset is smaller than one batch (else 0 steps).
-                n_batches = max(1, len(train_dataset))
-                total_epochs = config.trainer.get("total_epochs", 1)
-                total_steps = n_batches * total_epochs
-                progress_denominator = total_steps if total_steps > 0 else 1
                 logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
-
-                base_lr = config.optim.lr
-                lr_schedule = config.optim.get("lr_scheduler", "constant")
-                betas = config.optim.get("betas", [0.9, 0.95])
-                eps = config.optim.get("eps", 1e-8)
-                save_every = config.trainer.get("save_freq", 20)
-                eval_every = config.trainer.get("test_freq", 10)
 
                 if should_validate_step(
                     0,
@@ -281,10 +295,24 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 in_flight: deque = deque()
 
                 def submit(step: int):
-                    lr = base_lr * compute_schedule_lr_multiplier(lr_schedule=lr_schedule, step=step, total_steps=total_steps)
-                    adam = tinker.AdamParams(learning_rate=lr, beta1=betas[0], beta2=betas[1], eps=eps)
+                    lr = optimizer.learning_rate * sft_lr_multiplier(
+                        optimizer.lr_schedule,
+                        step,
+                        total_steps,
+                        optimizer.warmup_steps_ratio,
+                        optimizer.warmup_steps,
+                        optimizer.min_lr_ratio,
+                    )
+                    adam = build_adam_params(
+                        learning_rate=lr,
+                        betas=optimizer.betas,
+                        eps=optimizer.eps,
+                        weight_decay=optimizer.weight_decay,
+                        grad_clip_norm=optimizer.grad_clip_norm,
+                    )
                     data = train_dataset.get_batch(step % n_batches)
                     fb_fut = client.submit_forward_backward(data, loss_fn="cross_entropy")
+                    # Datum weights encode reduction; provider normalization would double-divide token_mean.
                     opt_fut = client.submit_optim_step(adam)
                     in_flight.append((step, lr, data, fb_fut, opt_fut, time.time()))
 
@@ -292,11 +320,13 @@ class FireworksSFTBackend(TinkerSFTBackend):
                     step, lr, data, fb_fut, opt_fut, t0 = in_flight.popleft()
                     fb_result = fb_fut.result(timeout=DEFAULT_TIMEOUT_S)
                     opt_fut.result(timeout=DEFAULT_TIMEOUT_S)
-                    # Fireworks' cross_entropy forward_backward returns aggregate
-                    # metrics (loss:sum / response_tokens), not per-token logprobs.
+                    # Fireworks exposes only aggregate loss. Divide by the
+                    # submitted weight mass, while logging the independent count
+                    # of positive-weight tokens (normalization can rescale mass).
                     fb_metrics = getattr(fb_result, "metrics", {}) or {}
-                    n_loss_tokens = fb_metrics.get("response_tokens") or 0
-                    train_loss = (fb_metrics.get("loss:sum", 0.0) / n_loss_tokens) if n_loss_tokens else 0.0
+                    n_loss_tokens = count_loss_tokens(data)
+                    loss_weight = sum_loss_weights(data)
+                    train_loss = (fb_metrics.get("loss:sum", 0.0) / loss_weight) if loss_weight else 0.0
                     metrics = {
                         "learning_rate": lr,
                         "progress": min((step + 1) / progress_denominator, 1.0),
@@ -374,13 +404,15 @@ class FireworksSFTBackend(TinkerSFTBackend):
         """Compute held-out NLL without adding validation gradients."""
         from tinker_cookbook.supervised.common import compute_mean_nll
 
+        from rllm.trainer.sft.tinker_dataset import count_loss_tokens
+
         logger.info("Running validation...")
         total_nll = 0.0
         total_tokens = 0
         for batch_idx in range(len(val_dataset)):
             data = val_dataset.get_batch(batch_idx)
             weights = [datum.loss_fn_inputs["weights"] for datum in data]
-            batch_tokens = sum(sum(weight.data) for weight in weights)
+            batch_tokens = count_loss_tokens(data)
             if not batch_tokens:
                 continue
             forward_result = client.forward(data, "cross_entropy")

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -123,6 +124,7 @@ def build_sft_data(config, train_data, val_data):
 
     train_batch_size = config.data.get("train_batch_size", 32)
     val_batch_size = config.data.get("micro_batch_size_per_gpu", train_batch_size)
+    rllm_data = config.data.get("rllm", {})
     train_dataset, val_dataset = create_tinker_sft_datasets(
         train_data=train_data,
         val_data=val_data,
@@ -133,6 +135,8 @@ def build_sft_data(config, train_data, val_data):
         last_only=last_only,
         max_train_samples=config.data.get("train_max_samples", -1),
         max_val_samples=config.data.get("val_max_samples", -1),
+        overlength_policy=str(rllm_data.get("overlength_policy", "truncate")),
+        loss_reduction=str(rllm_data.get("loss_reduction", "token_mean")),
     )
     return tokenizer, train_dataset, val_dataset
 
@@ -150,6 +154,173 @@ def should_validate_step(
     if completed_steps == 0:
         return include_initial
     return completed_steps % eval_every == 0
+
+
+def resolve_training_steps(
+    n_batches: int,
+    total_epochs: int,
+    max_steps: int | None,
+) -> int:
+    """Resolve an optional positive step cap against the available batches."""
+    if n_batches <= 0:
+        raise SFTConfigError("The SFT training dataset contains no batches.")
+    if isinstance(total_epochs, bool) or not isinstance(total_epochs, int) or total_epochs <= 0:
+        raise SFTConfigError(f"trainer.total_epochs must be a positive integer, got {total_epochs!r}.")
+    available_steps = n_batches * total_epochs
+    if max_steps is None:
+        return available_steps
+    if isinstance(max_steps, bool) or not isinstance(max_steps, int) or max_steps <= 0:
+        raise SFTConfigError(f"trainer.max_steps must be a positive integer when set, got {max_steps!r}.")
+    return min(available_steps, max_steps)
+
+
+def iter_training_batches(
+    *,
+    n_batches: int,
+    total_epochs: int,
+    start_epoch: int = 0,
+    start_batch: int = 0,
+    max_steps: int | None = None,
+):
+    """Yield ``(step, epoch, batch)`` up to the exact effective horizon.
+
+    ``start_epoch`` and ``start_batch`` are an input cursor supplied by the
+    existing checkpoint layer. Defining how that cursor is persisted or
+    restored is intentionally outside this scheduling helper.
+    """
+    total_steps = resolve_training_steps(n_batches, total_epochs, max_steps)
+    start_step = start_epoch * n_batches + start_batch
+    for step in range(start_step, total_steps):
+        epoch, batch = divmod(step, n_batches)
+        yield step, epoch, batch
+
+
+def sft_lr_multiplier(
+    lr_schedule: str,
+    step: int,
+    total_steps: int,
+    warmup_steps_ratio: float = 0.0,
+    warmup_steps: int | None = -1,
+    min_lr_ratio: float = 0.0,
+) -> float:
+    """Apply linear warmup followed by the selected decay schedule."""
+    from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier
+
+    if total_steps <= 0:
+        raise SFTConfigError(f"total_steps must be positive, got {total_steps}.")
+    if step < 0:
+        raise SFTConfigError(f"optimizer step must be non-negative, got {step}.")
+    if not 0 <= warmup_steps_ratio <= 1:
+        raise SFTConfigError(f"optim.warmup_steps_ratio must be in [0, 1], got {warmup_steps_ratio}.")
+    if not 0 <= min_lr_ratio <= 1:
+        raise SFTConfigError(f"optim.min_lr / optim.lr must be in [0, 1], got {min_lr_ratio}.")
+    resolved_warmup = -1 if warmup_steps is None else int(warmup_steps)
+    if resolved_warmup < 0:
+        resolved_warmup = int(total_steps * (warmup_steps_ratio or 0.0))
+    if resolved_warmup > 0 and step < resolved_warmup:
+        return step / resolved_warmup
+    decay = compute_schedule_lr_multiplier(
+        lr_schedule=lr_schedule,
+        step=step - resolved_warmup,
+        total_steps=max(total_steps - resolved_warmup, 1),
+    )
+    return min_lr_ratio + (1 - min_lr_ratio) * decay
+
+
+def build_adam_params(
+    *,
+    learning_rate: float,
+    betas: tuple[float, float],
+    eps: float,
+    weight_decay: float,
+    grad_clip_norm: float,
+):
+    import tinker
+
+    return tinker.AdamParams(
+        learning_rate=learning_rate,
+        beta1=betas[0],
+        beta2=betas[1],
+        eps=eps,
+        weight_decay=weight_decay,
+        grad_clip_norm=grad_clip_norm,
+    )
+
+
+@dataclass(frozen=True)
+class SFTOptimizerSettings:
+    learning_rate: float
+    lr_schedule: str
+    warmup_steps_ratio: float
+    warmup_steps: int
+    min_lr_ratio: float
+    betas: tuple[float, float]
+    eps: float
+    weight_decay: float
+    grad_clip_norm: float
+
+
+def resolve_sft_optimizer_settings(optim_cfg, *, total_steps: int) -> SFTOptimizerSettings:
+    """Validate optimizer controls and normalize them for both hosted loops."""
+    if total_steps <= 0:
+        raise SFTConfigError(f"total_steps must be positive, got {total_steps}.")
+    try:
+        learning_rate = float(optim_cfg.get("lr", 1e-5))
+        min_learning_rate = float(optim_cfg.get("min_lr", 0.0))
+    except (TypeError, ValueError) as e:
+        raise SFTConfigError("optim.lr and optim.min_lr must be numeric.") from e
+    if not math.isfinite(learning_rate) or learning_rate <= 0:
+        raise SFTConfigError(f"optim.lr must be positive, got {learning_rate}.")
+    if not math.isfinite(min_learning_rate) or not 0 <= min_learning_rate <= learning_rate:
+        raise SFTConfigError(f"optim.min_lr must be between zero and optim.lr, got {min_learning_rate} with lr={learning_rate}.")
+
+    lr_schedule = str(optim_cfg.get("lr_scheduler", "constant"))
+    if lr_schedule not in {"constant", "linear", "cosine"}:
+        raise SFTConfigError(f"optim.lr_scheduler must be constant, linear, or cosine, got {lr_schedule!r}.")
+    try:
+        warmup_steps_ratio = float(optim_cfg.get("warmup_steps_ratio", 0.0) or 0.0)
+    except (TypeError, ValueError) as e:
+        raise SFTConfigError("optim.warmup_steps_ratio must be numeric.") from e
+    if not math.isfinite(warmup_steps_ratio) or not 0 <= warmup_steps_ratio <= 1:
+        raise SFTConfigError(f"optim.warmup_steps_ratio must be in [0, 1], got {warmup_steps_ratio}.")
+    raw_warmup_steps = optim_cfg.get("warmup_steps", -1)
+    if isinstance(raw_warmup_steps, bool) or not isinstance(raw_warmup_steps, int) or raw_warmup_steps < -1:
+        raise SFTConfigError(f"optim.warmup_steps must be -1 or a non-negative integer, got {raw_warmup_steps!r}.")
+    warmup_steps = raw_warmup_steps
+    if warmup_steps > total_steps:
+        raise SFTConfigError(f"optim.warmup_steps cannot exceed total training steps ({total_steps}), got {warmup_steps}.")
+
+    raw_betas = optim_cfg.get("betas", [0.9, 0.95])
+    if isinstance(raw_betas, str | bytes) or not hasattr(raw_betas, "__len__") or len(raw_betas) != 2:
+        raise SFTConfigError(f"optim.betas must contain beta1 and beta2, got {raw_betas}.")
+    try:
+        betas = (float(raw_betas[0]), float(raw_betas[1]))
+    except (TypeError, ValueError) as e:
+        raise SFTConfigError(f"optim.betas must be numeric, got {raw_betas}.") from e
+    if any(not math.isfinite(beta) or not 0 <= beta < 1 for beta in betas):
+        raise SFTConfigError(f"optim.betas must each be in [0, 1), got {betas}.")
+    try:
+        eps = float(optim_cfg.get("eps", 1e-8))
+        weight_decay = float(optim_cfg.get("weight_decay", 0.0))
+        grad_clip_norm = float(optim_cfg.get("grad_clip_norm", 0.0))
+    except (TypeError, ValueError) as e:
+        raise SFTConfigError("optim.eps, optim.weight_decay, and optim.grad_clip_norm must be numeric.") from e
+    if not math.isfinite(eps) or eps <= 0:
+        raise SFTConfigError(f"optim.eps must be positive, got {eps}.")
+    if any(not math.isfinite(value) or value < 0 for value in (weight_decay, grad_clip_norm)):
+        raise SFTConfigError("optim.weight_decay and optim.grad_clip_norm must be non-negative.")
+
+    return SFTOptimizerSettings(
+        learning_rate=learning_rate,
+        lr_schedule=lr_schedule,
+        warmup_steps_ratio=warmup_steps_ratio,
+        warmup_steps=warmup_steps,
+        min_lr_ratio=min_learning_rate / learning_rate,
+        betas=betas,
+        eps=eps,
+        weight_decay=weight_decay,
+        grad_clip_norm=grad_clip_norm,
+    )
 
 
 @dataclass
@@ -270,13 +441,43 @@ class TinkerSFTBackend(SFTBackend):
         from tinker_cookbook import checkpoint_utils
         from tinker_cookbook.display import colorize_example
         from tinker_cookbook.supervised.common import compute_mean_nll
-        from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier
         from tinker_cookbook.utils.misc_utils import timed
 
+        from rllm.trainer.sft.tinker_dataset import count_loss_tokens
         from rllm.utils.tracking import Tracking
 
         config = self._config
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
+        tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
+
+        resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
+        start_epoch = resume_info.get("epoch", 0) if resume_info else 0
+        start_batch = resume_info.get("batch", 0) if resume_info else 0
+        n_batches = len(train_dataset)
+        total_epochs = config.trainer.get("total_epochs", 1)
+        max_steps = config.trainer.get("max_steps")
+        total_steps = resolve_training_steps(n_batches, total_epochs, max_steps)
+        progress_denominator = total_steps
+        optimizer = resolve_sft_optimizer_settings(config.get("optim", {}), total_steps=total_steps)
+        save_every = config.trainer.get("save_freq", 20)
+        eval_every = config.trainer.get("test_freq", 10)
+
+        train_dataset.preflight(
+            label="train",
+            planned_batches=(
+                (epoch_idx, batch_idx)
+                for _step, epoch_idx, batch_idx in iter_training_batches(
+                    n_batches=n_batches,
+                    total_epochs=total_epochs,
+                    start_epoch=start_epoch,
+                    start_batch=start_batch,
+                    max_steps=max_steps,
+                )
+            ),
+        )
+        if val_dataset is not None:
+            val_dataset.preflight(label="validation")
+
         service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
 
         logger_backend = config.trainer.logger
@@ -292,14 +493,9 @@ class TinkerSFTBackend(SFTBackend):
         # Wrap the loop so tracking_logger.finish() runs even on failure: the 'ui'
         # backend tees stdout/stderr and holds an open session until finish().
         try:
-            tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
-
-            resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
             if resume_info:
                 logger.info(f"Resuming from checkpoint: {resume_info}")
                 training_client = await service_client.create_training_client_from_state_async(resume_info["state_path"])
-                start_epoch = resume_info.get("epoch", 0)
-                start_batch = resume_info.get("batch", 0)
             else:
                 logger.info("Starting training from scratch")
                 training_client = await service_client.create_lora_training_client_async(
@@ -309,23 +505,7 @@ class TinkerSFTBackend(SFTBackend):
                     train_attn=OmegaConf.select(config, "model.train_attn", default=True),
                     train_mlp=OmegaConf.select(config, "model.train_mlp", default=True),
                 )
-                start_epoch = 0
-                start_batch = 0
-
-            # len(dataset) floors examples//batch_size; keep the final partial batch
-            # when the dataset is smaller than one batch (else 0 steps).
-            n_batches = max(1, len(train_dataset))
-            total_epochs = config.trainer.get("total_epochs", 1)
-            total_steps = n_batches * total_epochs
-            progress_denominator = total_steps if total_steps > 0 else 1
             logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
-
-            base_learning_rate = config.get("optim", {}).get("lr", 1e-5)
-            lr_schedule = config.get("optim", {}).get("lr_scheduler", "constant")
-            adam_betas = config.get("optim", {}).get("betas", [0.9, 0.95])
-            adam_eps = config.get("optim", {}).get("eps", 1e-8)
-            save_every = config.trainer.get("save_freq", 20)
-            eval_every = config.trainer.get("test_freq", 10)
 
             if should_validate_step(
                 0,
@@ -342,9 +522,22 @@ class TinkerSFTBackend(SFTBackend):
                 step = epoch_idx * n_batches + batch_idx
                 batch_start_time = time.time()
                 metrics: dict[str, Any] = {"epoch": epoch_idx, "progress": step / progress_denominator}
-                learning_rate = base_learning_rate * compute_schedule_lr_multiplier(lr_schedule=lr_schedule, step=step, total_steps=total_steps)
+                learning_rate = optimizer.learning_rate * sft_lr_multiplier(
+                    optimizer.lr_schedule,
+                    step,
+                    total_steps,
+                    optimizer.warmup_steps_ratio,
+                    optimizer.warmup_steps,
+                    optimizer.min_lr_ratio,
+                )
                 metrics["learning_rate"] = learning_rate
-                adam_params = tinker.AdamParams(learning_rate=learning_rate, beta1=adam_betas[0], beta2=adam_betas[1], eps=adam_eps)
+                adam_params = build_adam_params(
+                    learning_rate=learning_rate,
+                    betas=optimizer.betas,
+                    eps=optimizer.eps,
+                    weight_decay=optimizer.weight_decay,
+                    grad_clip_norm=optimizer.grad_clip_norm,
+                )
 
                 with timed("get_batch", metrics):
                     data = train_dataset.get_batch(batch_idx)
@@ -377,7 +570,7 @@ class TinkerSFTBackend(SFTBackend):
                 metrics.update(
                     num_sequences=len(submitted.data),
                     num_tokens=sum(datum.model_input.length for datum in submitted.data),
-                    num_loss_tokens=sum(sum(datum.loss_fn_inputs["weights"].data) for datum in submitted.data),
+                    num_loss_tokens=count_loss_tokens(submitted.data),
                     train_mean_nll=train_nll,
                 )
                 metrics["time/total"] = time.time() - submitted.batch_start_time
@@ -396,32 +589,41 @@ class TinkerSFTBackend(SFTBackend):
                 logger.info(f"Step {completed_steps}: train_nll={train_nll:.4f}, lr={metrics['learning_rate']:.2e}")
 
             pending: _SubmittedBatch | None = None
-            for epoch_idx in range(start_epoch, total_epochs):
-                logger.info(f"Starting epoch {epoch_idx}")
-                train_dataset.set_epoch(seed=epoch_idx)
-                start_batch_idx = start_batch if epoch_idx == start_epoch else 0
-                for batch_idx in range(start_batch_idx, n_batches):
-                    if pending is not None and should_validate_step(
-                        pending.step + 1,
-                        eval_every=eval_every,
-                        has_validation=val_dataset is not None,
-                    ):
-                        await finish_batch(pending)
-                        pending = None
-                    submitted = await submit_batch(epoch_idx, batch_idx)
-                    if pending is not None:
-                        await finish_batch(pending)
-                    pending = submitted
+            current_epoch: int | None = None
+            for _step, epoch_idx, batch_idx in iter_training_batches(
+                n_batches=n_batches,
+                total_epochs=total_epochs,
+                start_epoch=start_epoch,
+                start_batch=start_batch,
+                max_steps=max_steps,
+            ):
+                if epoch_idx != current_epoch:
+                    logger.info(f"Starting epoch {epoch_idx}")
+                    train_dataset.set_epoch(seed=epoch_idx)
+                    current_epoch = epoch_idx
+                if pending is not None and should_validate_step(
+                    pending.step + 1,
+                    eval_every=eval_every,
+                    has_validation=val_dataset is not None,
+                ):
+                    await finish_batch(pending)
+                    pending = None
+                submitted = await submit_batch(epoch_idx, batch_idx)
+                if pending is not None:
+                    await finish_batch(pending)
+                pending = submitted
             if pending is not None:
                 await finish_batch(pending)
 
-            if start_epoch < total_epochs:
+            start_step = start_epoch * n_batches + start_batch
+            if start_step < total_steps:
+                final_epoch, final_batch = divmod(total_steps, n_batches)
                 await checkpoint_utils.save_checkpoint_async(
                     training_client=training_client,
                     name="final",
                     log_path=config.trainer.default_local_dir,
                     kind="both",
-                    loop_state={"epoch": total_epochs, "batch": n_batches},
+                    loop_state={"epoch": final_epoch, "batch": final_batch},
                 )
             else:
                 logger.info("Training was already complete; nothing to do")
@@ -437,13 +639,15 @@ class TinkerSFTBackend(SFTBackend):
     @staticmethod
     async def _validate(training_client, val_dataset, compute_mean_nll) -> dict[str, float]:
         """Compute held-out NLL without adding validation gradients."""
+        from rllm.trainer.sft.tinker_dataset import count_loss_tokens
+
         logger.info("Running validation...")
         total_nll = 0.0
         total_tokens = 0
         for batch_idx in range(len(val_dataset)):
             data = val_dataset.get_batch(batch_idx)
             weights = [datum.loss_fn_inputs["weights"] for datum in data]
-            batch_tokens = sum(sum(weight.data) for weight in weights)
+            batch_tokens = count_loss_tokens(data)
             if not batch_tokens:
                 continue
             forward_future = await training_client.forward_async(data, loss_fn="cross_entropy")

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import json
 import logging
+import math
+from collections.abc import Iterable
+from typing import Literal
 
 import datasets
 import tinker
@@ -113,6 +116,8 @@ def conversation_to_datum(
     last_only: bool = False,
     *,
     tools: list[dict] | None = None,
+    overlength_policy: Literal["error", "truncate"] = "truncate",
+    loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
 ) -> tinker.Datum:
     """Convert a conversation (list of messages) to a Tinker Datum.
 
@@ -155,9 +160,61 @@ def conversation_to_datum(
         dtype=torch.float32,
     )
     model_input = tinker.ModelInput.from_ints(rendered.token_ids)
+    if overlength_policy not in ("error", "truncate"):
+        raise SFTConfigError(f"Unknown overlength policy {overlength_policy!r}; use 'error' or 'truncate'.")
+    if loss_reduction not in ("none", "sequence_mean", "token_mean"):
+        raise SFTConfigError(f"Unknown SFT loss reduction {loss_reduction!r}; use 'none', 'sequence_mean', or 'token_mean'.")
     if max_length is not None and model_input.length > max_length:
+        if overlength_policy == "error":
+            raise SFTConfigError(
+                f"SFT row renders to {model_input.length} tokens > data.max_length={max_length}. "
+                "The trajectory was not truncated. Drop it whole during preprocessing, raise max_length, "
+                "or explicitly select overlength_policy='truncate'."
+            )
         _warn_truncation(model_input.length, max_length)
-    return datum_from_model_input_weights(model_input, weights, max_length)
+    datum_max_length = max_length if overlength_policy == "truncate" else None
+    reduction = "mean" if loss_reduction == "sequence_mean" else "none"
+    datum = datum_from_model_input_weights(
+        model_input,
+        weights,
+        datum_max_length,
+        reduction=reduction,
+    )
+    _validate_datum_loss(datum, conversation)
+    return datum
+
+
+def count_loss_tokens(datums: list[tinker.Datum]) -> int:
+    """Count supervised positions independently of loss-weight scaling."""
+    return sum(1 for datum in datums for weight in datum.loss_fn_inputs["weights"].data if weight > 0)
+
+
+def sum_loss_weights(datums: list[tinker.Datum]) -> float:
+    """Return the loss denominator represented by a rendered batch."""
+    return sum(float(weight) for datum in datums for weight in datum.loss_fn_inputs["weights"].data)
+
+
+def _validate_datum_loss(datum: tinker.Datum, conversation: list[Message]) -> None:
+    """Reject a malformed or zero-loss row before it can hide in a batch."""
+    weights = [float(weight) for weight in datum.loss_fn_inputs["weights"].data]
+    if any(not math.isfinite(weight) or weight < 0 for weight in weights):
+        raise SFTConfigError(f"SFT row produced invalid loss weights after rendering and masking. Weights must be finite and non-negative.\n  row={_row_context(conversation)}")
+    if not any(weight > 0 for weight in weights):
+        raise SFTConfigError(f"SFT row has no trainable tokens after rendering, masking, and truncation. Check its trainable flags and overlength policy.\n  row={_row_context(conversation)}")
+
+
+def _normalize_token_mean(datums: list[tinker.Datum]) -> None:
+    """Make one batch loss the mean over all supervised tokens."""
+    total_weight = sum_loss_weights(datums)
+    if total_weight <= 0:
+        raise SFTConfigError("SFT batch has no trainable tokens after rendering and masking.")
+    for datum in datums:
+        weights = datum.loss_fn_inputs["weights"]
+        datum.loss_fn_inputs["weights"] = tinker.TensorData(
+            data=[float(weight) / total_weight for weight in weights.data],
+            dtype=weights.dtype,
+            shape=list(weights.shape),
+        )
 
 
 def _to_renderer_message(message: SFTMessage) -> dict:
@@ -235,11 +292,23 @@ class TinkerSFTDataset(SupervisedDataset):
         max_length: int | None = None,
         last_only: bool = False,
         max_samples: int = -1,
+        overlength_policy: Literal["error", "truncate"] = "truncate",
+        loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
     ):
         self.renderer = renderer
+        if batch_size <= 0:
+            raise SFTConfigError(f"SFT batch_size must be positive, got {batch_size}.")
+        if max_length is not None and max_length <= 1:
+            raise SFTConfigError(f"SFT max_length must be greater than 1, got {max_length}.")
+        if overlength_policy not in ("error", "truncate"):
+            raise SFTConfigError(f"Unknown overlength policy {overlength_policy!r}; use 'error' or 'truncate'.")
+        if loss_reduction not in ("none", "sequence_mean", "token_mean"):
+            raise SFTConfigError(f"Unknown SFT loss reduction {loss_reduction!r}; use 'none', 'sequence_mean', or 'token_mean'.")
         self.batch_size = batch_size
         self.max_length = max_length
         self.last_only = last_only
+        self.overlength_policy = overlength_policy
+        self.loss_reduction = loss_reduction
 
         if isinstance(dataset_or_files, str | list):
             if isinstance(dataset_or_files, str):
@@ -256,8 +325,19 @@ class TinkerSFTDataset(SupervisedDataset):
             self.dataset = self.dataset.select(range(max_samples))
             logger.info(f"Limited dataset to {max_samples} samples")
 
+        # Every epoch is derived from this stable source order. This makes the
+        # sequence rendered during preflight identical to the sequence consumed
+        # during training, without letting preflight mutate training state.
+        self._source_dataset = self.dataset
+
         logger.info(f"Loaded {len(self.dataset)} examples from {source}")
         logger.info(f"Masking: CUSTOMIZED (derive last_only={last_only} for flag-less rows)")
+        logger.info(
+            "Batching: batch_size=%d, final partial batch included; overlength=%s; loss_reduction=%s",
+            batch_size,
+            overlength_policy,
+            loss_reduction,
+        )
 
     def get_batch(self, index: int) -> list[tinker.Datum]:
         start_idx = index * self.batch_size
@@ -273,18 +353,55 @@ class TinkerSFTDataset(SupervisedDataset):
                         self.max_length,
                         self.last_only,
                         tools=row.get("tools"),
+                        overlength_policy=self.overlength_policy,
+                        loss_reduction=self.loss_reduction,
                     )
                 )
             except SFTConfigError as e:
                 raise SFTConfigError(f"dataset row {i}: {e}") from e
+        if self.loss_reduction == "token_mean":
+            _normalize_token_mean(datums)
         return datums
 
+    def preflight(
+        self,
+        *,
+        label: str,
+        planned_batches: Iterable[tuple[int, int]] | None = None,
+    ) -> None:
+        """Render planned batches without changing the order used for training."""
+        if len(self) == 0:
+            raise SFTConfigError(f"{label} preflight failed: dataset contains no batches.")
+        original_dataset = self.dataset
+        try:
+            if planned_batches is None:
+                for batch_idx in range(len(self)):
+                    try:
+                        if not self.get_batch(batch_idx):
+                            raise SFTConfigError("rendered batch is empty")
+                    except SFTConfigError as e:
+                        raise SFTConfigError(f"{label} preflight failed at batch {batch_idx}: {e}") from e
+                return
+
+            current_epoch: int | None = None
+            for epoch_idx, batch_idx in planned_batches:
+                if epoch_idx != current_epoch:
+                    self.set_epoch(seed=epoch_idx)
+                    current_epoch = epoch_idx
+                try:
+                    if not self.get_batch(batch_idx):
+                        raise SFTConfigError("rendered batch is empty")
+                except SFTConfigError as e:
+                    raise SFTConfigError(f"{label} preflight failed at epoch {epoch_idx}, batch {batch_idx}: {e}") from e
+        finally:
+            self.dataset = original_dataset
+
     def set_epoch(self, seed: int = 0):
-        self.dataset = self.dataset.shuffle(seed=seed)
+        self.dataset = self._source_dataset.shuffle(seed=seed)
         logger.info(f"Shuffled dataset with seed {seed} ({len(self.dataset)} samples)")
 
     def __len__(self) -> int:
-        return len(self.dataset) // self.batch_size
+        return math.ceil(len(self.dataset) / self.batch_size)
 
 
 def create_tinker_sft_datasets(
@@ -297,6 +414,8 @@ def create_tinker_sft_datasets(
     last_only: bool = False,
     max_train_samples: int = -1,
     max_val_samples: int = -1,
+    overlength_policy: Literal["error", "truncate"] = "truncate",
+    loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
 ) -> tuple[TinkerSFTDataset, TinkerSFTDataset | None]:
     """Create train and optional validation datasets for Tinker SFT."""
     if val_batch_size is None:
@@ -309,6 +428,8 @@ def create_tinker_sft_datasets(
         max_length=max_length,
         last_only=last_only,
         max_samples=max_train_samples,
+        overlength_policy=overlength_policy,
+        loss_reduction=loss_reduction,
     )
 
     val_dataset = None
@@ -320,6 +441,8 @@ def create_tinker_sft_datasets(
             max_length=max_length,
             last_only=last_only,
             max_samples=max_val_samples,
+            overlength_policy=overlength_policy,
+            loss_reduction="none",
         )
 
     return train_dataset, val_dataset

--- a/tests/trainer/test_sft_data_semantics.py
+++ b/tests/trainer/test_sft_data_semantics.py
@@ -1,0 +1,136 @@
+"""Focused contracts for hosted-SFT batching and loss semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+tinker = pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+from rllm.data import Dataset  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.tinker_dataset import (  # noqa: E402
+    TinkerSFTDataset,
+    count_loss_tokens,
+)
+
+
+class _TokenRenderer:
+    def render(self, messages, *, tools=None, add_generation_prompt=False):
+        from rllm.renderers.types import RenderedTokens
+
+        del tools, add_generation_prompt
+        count = int(messages[-1]["content"])
+        return RenderedTokens(
+            token_ids=list(range(count + 2)),
+            message_indices=[-1, *([1] * count), -1],
+        )
+
+
+def _dataset(lengths):
+    return Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": str(length), "trainable": True},
+                ]
+            }
+            for length in lengths
+        ],
+        name="lengths",
+        split="train",
+    )
+
+
+def test_token_mean_weights_every_supervised_token_equally():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 6]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        max_length=100,
+        loss_reduction="token_mean",
+    )
+    weights = [datum.loss_fn_inputs["weights"].data for datum in dataset.get_batch(0)]
+    positive = [weight for row in weights for weight in row if weight > 0]
+    assert positive == pytest.approx([1 / 8] * 8)
+    assert count_loss_tokens(dataset.get_batch(0)) == 8
+
+
+def test_sequence_mean_gives_each_trajectory_equal_weight():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 6]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        max_length=100,
+        loss_reduction="sequence_mean",
+    )
+    weights = [datum.loss_fn_inputs["weights"].data for datum in dataset.get_batch(0)]
+    assert [sum(row) for row in weights] == pytest.approx([1.0, 1.0])
+
+
+def test_default_loss_reduction_preserves_raw_weights():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 6]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        max_length=100,
+    )
+    weights = [datum.loss_fn_inputs["weights"].data for datum in dataset.get_batch(0)]
+    assert [sum(row) for row in weights] == pytest.approx([2.0, 6.0])
+
+
+@pytest.mark.parametrize("backend", ["tinker", "fireworks"])
+def test_hosted_configs_default_to_token_mean(backend):
+    config_path = Path(__file__).parents[2] / "rllm" / "trainer" / "sft" / "config" / f"{backend}.yaml"
+    config = OmegaConf.load(config_path)
+    assert config.data.rllm.loss_reduction == "token_mean"
+
+
+def test_final_partial_batch_is_not_dropped():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 2, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+    )
+    assert len(dataset) == 2
+    assert len(dataset.get_batch(1)) == 1
+
+
+def test_overlength_error_is_explicit_opt_in():
+    dataset = TinkerSFTDataset(
+        _dataset([20]),
+        renderer=_TokenRenderer(),
+        batch_size=1,
+        max_length=10,
+        overlength_policy="error",
+    )
+    with pytest.raises(SFTConfigError, match="trajectory was not truncated"):
+        dataset.get_batch(0)
+
+
+def test_zero_loss_row_is_rejected_with_its_dataset_index():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 0]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+    )
+    with pytest.raises(SFTConfigError, match=r"dataset row 1:[\s\S]*no trainable tokens"):
+        dataset.get_batch(0)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"batch_size": 0}, "batch_size"),
+        ({"batch_size": 1, "max_length": 1}, "max_length"),
+        ({"batch_size": 1, "overlength_policy": "drop"}, "overlength policy"),
+        ({"batch_size": 1, "loss_reduction": "batch_mean"}, "loss reduction"),
+    ],
+)
+def test_invalid_render_settings_fail_before_iteration(kwargs, message):
+    with pytest.raises(SFTConfigError, match=message):
+        TinkerSFTDataset(_dataset([2]), renderer=_TokenRenderer(), **kwargs)

--- a/tests/trainer/test_sft_lr_warmup.py
+++ b/tests/trainer/test_sft_lr_warmup.py
@@ -1,0 +1,134 @@
+"""SFT learning-rate schedule and optimizer configuration.
+
+The SFT fits multiply the base LR by ``sft_lr_multiplier`` each step. Paper-
+aligned agentic SFT uses a linear warmup (ratio 0.1) then a cosine decay; the
+tinker_cookbook multiplier the fits used before had no warmup term, so the
+``warmup_steps_ratio`` config knob was dead. These pin the warmup math and that
+``warmup_steps_ratio=0`` remains an exact opt-out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+pytest.importorskip("tinker_cookbook")  # sft_lr_multiplier delegates decay to it
+
+from tinker_cookbook.utils.lr_scheduling import compute_schedule_lr_multiplier as _cookbook  # noqa: E402
+
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.tinker_backend import (  # noqa: E402
+    build_adam_params,
+    resolve_sft_optimizer_settings,
+    sft_lr_multiplier,
+)
+
+
+@pytest.mark.parametrize("backend", ["tinker", "fireworks"])
+def test_hosted_configs_preserve_ten_percent_warmup_default(backend):
+    config_path = Path(__file__).resolve().parents[2] / "rllm" / "trainer" / "sft" / "config" / f"{backend}.yaml"
+    config = OmegaConf.load(config_path)
+    assert config.optim.warmup_steps_ratio == pytest.approx(0.1)
+
+
+def test_warmup_ramps_linearly_then_cosine_decays():
+    # 10% of 100 steps => 10 warmup steps: linear 0->1, then cosine over the rest.
+    assert sft_lr_multiplier("cosine", 0, 100, warmup_steps_ratio=0.1) == pytest.approx(0.0)
+    assert sft_lr_multiplier("cosine", 5, 100, warmup_steps_ratio=0.1) == pytest.approx(0.5)
+    assert sft_lr_multiplier("cosine", 10, 100, warmup_steps_ratio=0.1) == pytest.approx(1.0)  # cosine(0)
+    assert sft_lr_multiplier("cosine", 100, 100, warmup_steps_ratio=0.1) == pytest.approx(0.0)  # cosine(pi)
+
+
+def test_cosine_decay_respects_minimum_lr_ratio():
+    """A configured 10% floor decays to that floor, not to zero."""
+    assert sft_lr_multiplier(
+        "cosine",
+        100,
+        100,
+        min_lr_ratio=0.1,
+    ) == pytest.approx(0.1)
+    assert sft_lr_multiplier(
+        "cosine",
+        50,
+        100,
+        min_lr_ratio=0.1,
+    ) == pytest.approx(0.55)
+
+
+def test_invalid_minimum_lr_ratio_fails_during_warmup():
+    with pytest.raises(SFTConfigError, match="must be in"):
+        sft_lr_multiplier(
+            "cosine",
+            step=0,
+            total_steps=100,
+            warmup_steps=10,
+            min_lr_ratio=1.1,
+        )
+
+
+def test_absolute_warmup_steps_override_ratio():
+    # warmup_steps=4 wins over the ratio: LR is half-ramped at step 2.
+    assert sft_lr_multiplier("constant", 2, 100, warmup_steps_ratio=0.5, warmup_steps=4) == pytest.approx(0.5)
+    assert sft_lr_multiplier("constant", 4, 100, warmup_steps_ratio=0.5, warmup_steps=4) == pytest.approx(1.0)
+
+
+def test_explicit_zero_warmup_overrides_nonzero_ratio():
+    assert sft_lr_multiplier("constant", 0, 100, warmup_steps_ratio=0.5, warmup_steps=0) == pytest.approx(1.0)
+
+
+def test_adam_controls_reach_the_provider_request():
+    params = build_adam_params(
+        learning_rate=2e-5,
+        betas=(0.8, 0.9),
+        eps=1e-7,
+        weight_decay=0.01,
+        grad_clip_norm=1.0,
+    )
+
+    assert params.learning_rate == pytest.approx(2e-5)
+    assert params.beta1 == pytest.approx(0.8)
+    assert params.beta2 == pytest.approx(0.9)
+    assert params.eps == pytest.approx(1e-7)
+    assert params.weight_decay == pytest.approx(0.01)
+    assert params.grad_clip_norm == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("schedule", ["cosine", "linear", "constant"])
+def test_zero_warmup_reduces_to_cookbook(schedule):
+    for step in (0, 25, 50, 99):
+        assert sft_lr_multiplier(schedule, step, 100, warmup_steps_ratio=0.0) == pytest.approx(_cookbook(lr_schedule=schedule, step=step, total_steps=100))
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"lr": 0}, "optim.lr must be positive"),
+        ({"lr": 1e-4, "min_lr": 2e-4}, "optim.min_lr"),
+        ({"lr_scheduler": "polynomial"}, "optim.lr_scheduler"),
+        ({"warmup_steps_ratio": 1.5}, "warmup_steps_ratio"),
+        ({"warmup_steps": 101}, "cannot exceed"),
+        ({"warmup_steps": -2}, "warmup_steps"),
+        ({"warmup_steps": 1.5}, "warmup_steps"),
+        ({"betas": [0.9, 1.0]}, "optim.betas"),
+        ({"eps": 0}, "optim.eps"),
+        ({"weight_decay": -0.1}, "weight_decay"),
+        ({"grad_clip_norm": -1}, "grad_clip_norm"),
+    ],
+)
+def test_optimizer_settings_reject_invalid_runs_before_provision(overrides, match):
+    config = {
+        "lr": 1e-4,
+        "min_lr": 1e-5,
+        "lr_scheduler": "cosine",
+        "warmup_steps_ratio": 0.0,
+        "warmup_steps": 10,
+        "betas": [0.9, 0.999],
+        "eps": 1e-8,
+        "weight_decay": 1e-2,
+        "grad_clip_norm": 1.0,
+        **overrides,
+    }
+    with pytest.raises(SFTConfigError, match=match):
+        resolve_sft_optimizer_settings(config, total_steps=100)

--- a/tests/trainer/test_sft_preflight.py
+++ b/tests/trainer/test_sft_preflight.py
@@ -1,0 +1,168 @@
+"""Hosted SFT data is rendered before a provider is started."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+from rllm.data import Dataset  # noqa: E402
+from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend  # noqa: E402
+from rllm.trainer.sft.tinker_backend import TinkerSFTBackend  # noqa: E402
+from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset  # noqa: E402
+
+
+class _TokenRenderer:
+    def __init__(self):
+        self.seen: list[int] = []
+
+    def render(self, messages, *, tools=None, add_generation_prompt=False):
+        from rllm.renderers.types import RenderedTokens
+
+        del tools, add_generation_prompt
+        count = int(messages[-1]["content"])
+        self.seen.append(count)
+        return RenderedTokens(
+            token_ids=list(range(count + 2)),
+            message_indices=[-1, *([1] * count), -1],
+        )
+
+
+def _dataset(lengths):
+    return Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": str(length), "trainable": True},
+                ]
+            }
+            for length in lengths
+        ],
+        name="lengths",
+        split="train",
+    )
+
+
+def test_preflight_checks_planned_shuffle_and_restores_source_order():
+    source = _dataset([0, 2, 0, 2])
+    dataset = TinkerSFTDataset(source, renderer=_TokenRenderer(), batch_size=2)
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        dataset.preflight(label="train", planned_batches=[(0, 0), (0, 1)])
+
+    assert dataset.dataset is source
+
+
+def test_preflight_renders_the_exact_planned_training_order():
+    source = _dataset([2, 3, 4, 5])
+    renderer = _TokenRenderer()
+    dataset = TinkerSFTDataset(source, renderer=renderer, batch_size=2)
+    plan = [(0, 0), (0, 1), (1, 0)]
+
+    dataset.preflight(label="train", planned_batches=plan)
+    preflight_order = renderer.seen.copy()
+    assert dataset.dataset is source
+
+    renderer.seen.clear()
+    current_epoch = None
+    for epoch_idx, batch_idx in plan:
+        if epoch_idx != current_epoch:
+            dataset.set_epoch(seed=epoch_idx)
+            current_epoch = epoch_idx
+        dataset.get_batch(batch_idx)
+
+    assert renderer.seen == preflight_order
+
+
+def test_validation_preflight_checks_every_batch():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 20]),
+        renderer=_TokenRenderer(),
+        batch_size=1,
+        max_length=10,
+        overlength_policy="error",
+    )
+
+    with pytest.raises(SFTConfigError, match="validation preflight.*batch 1.*max_length=10"):
+        dataset.preflight(label="validation")
+
+
+def test_tinker_preflight_failure_precedes_service_client(monkeypatch, tmp_path):
+    from tinker_cookbook import checkpoint_utils
+
+    import rllm.trainer.sft.tinker_backend as backend_module
+
+    train = TinkerSFTDataset(
+        _dataset([0, 2, 0, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+    )
+    monkeypatch.setattr(backend_module, "build_sft_data", lambda *_: (object(), train, None))
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: None)
+    monkeypatch.setattr(tinker, "ServiceClient", lambda **_: pytest.fail("provider client must not be created"))
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_dataset([2]),
+            output_dir=str(tmp_path),
+            batch_size=2,
+            overrides={"trainer": {"max_steps": 2}},
+        )
+    )
+    backend.build_config()
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        asyncio.run(backend._fit_async())
+
+
+def test_fireworks_preflight_failure_precedes_provision(monkeypatch, tmp_path):
+    import rllm.trainer.sft.fireworks_backend as backend_module
+    import rllm.utils.tracking as tracking_module
+
+    train = TinkerSFTDataset(
+        _dataset([0, 2, 0, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+    )
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_dataset([2]),
+            output_dir=str(tmp_path),
+            batch_size=2,
+            overrides={"trainer": {"max_steps": 2}},
+        )
+    )
+    backend.build_config()
+
+    class _Tracking:
+        def __init__(self, **_kwargs):
+            pass
+
+        def finish(self):
+            pass
+
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
+    training = types.ModuleType("training")
+    training_utils = types.ModuleType("training.utils")
+    checkpoints = types.ModuleType("training.utils.checkpoints")
+    checkpoints.TrainingCheckpoints = object
+    client = types.ModuleType("training.utils.client")
+    client.DEFAULT_TIMEOUT_S = 1
+    monkeypatch.setitem(sys.modules, "training", training)
+    monkeypatch.setitem(sys.modules, "training.utils", training_utils)
+    monkeypatch.setitem(sys.modules, "training.utils.checkpoints", checkpoints)
+    monkeypatch.setitem(sys.modules, "training.utils.client", client)
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+    monkeypatch.setattr(backend_module, "build_sft_data", lambda *_: (None, train, None))
+    monkeypatch.setattr(backend, "_provision", lambda *_: pytest.fail("provider trainer must not be provisioned"))
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        backend.fit()

--- a/tests/trainer/test_sft_render_path.py
+++ b/tests/trainer/test_sft_render_path.py
@@ -405,13 +405,11 @@ def test_f3_roundtrip_stamps_trainable_none(qwen_tokenizer, tmp_path):
 
 
 def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
-    """A row that renders past ``data.max_length`` must emit a loud warning.
+    """Overlength rows warn and fail when truncation removes every target.
 
     ``SFTSpec.max_length`` defaults to 2048, which silently truncated every
-    long trajectory row at datum build (the tail — including the final trainable
-    turn — dropped from training with zero signal to the user).
-
-    RED today: ``datum_from_model_input_weights`` truncates silently.
+    long trajectory row at datum build. The tail — including the final trainable
+    turn — must not disappear silently or enter training with zero loss.
     """
     import logging
 
@@ -425,8 +423,8 @@ def test_truncation_past_max_length_warns_loudly(qwen_tokenizer, caplog):
 
     td._truncation_warn_count = 0
     with caplog.at_level(logging.WARNING, logger="rllm.trainer.sft.tinker_dataset"):
-        datum = conversation_to_datum(convo, renderer, max_length=64)
-    assert datum.model_input.length <= 64
+        with pytest.raises(SFTConfigError, match="no trainable tokens"):
+            conversation_to_datum(convo, renderer, max_length=64)
     warned = [r for r in caplog.records if "max_length" in r.getMessage()]
     assert warned, "expected a loud truncation warning"
     assert "64" in warned[0].getMessage()

--- a/tests/trainer/test_sft_training_horizon.py
+++ b/tests/trainer/test_sft_training_horizon.py
@@ -1,0 +1,53 @@
+"""Exact hosted-SFT training horizon contracts."""
+
+import pytest
+
+from rllm.trainer.sft.backend import SFTConfigError
+from rllm.trainer.sft.tinker_backend import iter_training_batches, resolve_training_steps
+
+
+def test_training_iterator_caps_mid_epoch_at_exact_max_steps():
+    batches = list(
+        iter_training_batches(
+            n_batches=3262,
+            total_epochs=1,
+            max_steps=1000,
+        )
+    )
+    assert len(batches) == 1000
+    assert batches[0] == (0, 0, 0)
+    assert batches[-1] == (999, 0, 999)
+
+
+def test_training_iterator_honors_a_caller_supplied_start_cursor():
+    batches = list(
+        iter_training_batches(
+            n_batches=20,
+            total_epochs=2,
+            start_epoch=1,
+            start_batch=3,
+            max_steps=30,
+        )
+    )
+    assert batches[0] == (23, 1, 3)
+    assert batches[-1] == (29, 1, 9)
+
+
+def test_max_steps_cannot_extend_available_training():
+    assert resolve_training_steps(3, 2, None) == 6
+    assert resolve_training_steps(3, 2, 100) == 6
+
+
+@pytest.mark.parametrize(
+    ("n_batches", "epochs", "max_steps", "message"),
+    [
+        (0, 1, None, "no batches"),
+        (1, 0, None, "total_epochs"),
+        (1, True, None, "total_epochs"),
+        (1, 1, 0, "max_steps"),
+        (1, 1, True, "max_steps"),
+    ],
+)
+def test_invalid_training_horizons_fail_before_launch(n_batches, epochs, max_steps, message):
+    with pytest.raises(SFTConfigError, match=message):
+        resolve_training_steps(n_batches, epochs, max_steps)

--- a/tests/trainer/test_sft_validation.py
+++ b/tests/trainer/test_sft_validation.py
@@ -90,6 +90,9 @@ class _ValDataset:
     def get_batch(self, idx):
         return self._batches[idx]
 
+    def preflight(self, **_kwargs):
+        pass
+
 
 class _AsyncFuture:
     def __init__(self, output):
@@ -256,6 +259,9 @@ class _LoopDataset:
     def get_batch(self, index):
         self.events.append(f"batch-{index}")
         return self.batches[index]
+
+    def preflight(self, **_kwargs):
+        pass
 
 
 class _LoopTinkerClient:


### PR DESCRIPTION
## Summary

Defines one hosted SFT execution contract shared by Tinker and Fireworks.

- Includes the final partial batch instead of dropping it.
- Adds an exact validated `max_steps` cap.
- Rejects rendered rows with missing, negative, non-finite, or zero loss weight.
- Makes truncation and loss reduction explicit while retaining compatible defaults.
- Validates and applies warmup, minimum LR, Adam betas/epsilon, weight decay, and gradient clipping consistently.
- Pre-renders the exact planned train order and validation set before opening paid provider resources.
- Separates positive supervised-token counts from the loss-weight denominator.
- Pins the tested Fireworks SDK/cookbook pair.

## Contract

Every submitted Datum contains at least one valid supervised token. The batch plan, horizon, scheduler, and optimizer settings are validated before provider work begins. Preflight follows the planned epoch order and restores dataset state afterward.

Compatibility defaults remain `overlength_policy: truncate` and `loss_reduction: none`. Intentional execution changes are that the final partial batch now trains, each epoch is shuffled from a stable source order, the configured warmup is actually applied, and zero-loss rows fail before provider launch.

## Datum parity

The complete 9,271-row Nemotron corpus was rendered independently at merged #848 and this PR with compatibility defaults.

- 0 row or Datum-hash mismatches.
- Identical ordered corpus SHA: `1e677f50b6ad98c013fc3ce81cb45c87a1e68d78d62718807d9180e61258d379`.
- Identical totals: `307,272,571` inputs/targets and `102,952,819` supervised positions.
- No truncation.

The reproduction recipe intentionally selects `overlength_policy: error` and `loss_reduction: token_mean`. Every row fits under 65,536. Actual planned batches 0, 500, and 999 preserve token IDs, targets, and mask support; positive weights are normalized to `1 / batch supervised-token count`, with only expected float32 rounding.

## Scope

The 12-file diff contains six production/config files and six focused test files. Each maps directly to dataset execution semantics, shared planning/optimizer validation, provider integration, or its regression coverage. Checkpoint/resume semantics remain in #851.

The Fireworks cookbook pin also constrains the optional dependency used by RL installations; this PR does not change RL code.

## Testing

- Focused hosted-SFT suite: 132 passed, 9 deselected.
- Full default-Datum parity: 9,271/9,271 rows matched.
- Ruff check, Ruff format check, and `git diff --check` pass.

## Stack

Follows merged #848. Merge this PR before #851.
