### PR TITLE
fix(sft): make hosted checkpoint resume exact

### DIFF
--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -25,26 +25,127 @@ import os
 import re
 import tempfile
 import time
-from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from omegaconf import DictConfig, OmegaConf
 
 from rllm.trainer.sft.backend import SFTConfigError
 from rllm.trainer.sft.tinker_backend import (
+    PreparedResumeManifest,
+    SFTOptimizerSettings,
+    SFTResumeContract,
     TinkerSFTBackend,
+    _is_step_boundary,
     build_adam_params,
+    build_hosted_resume_contract,
     build_sft_data,
-    iter_training_batches,
+    iter_training_batches_from_step,
+    prepare_hosted_resume_manifest,
     resolve_sft_optimizer_settings,
     resolve_training_steps,
     sft_lr_multiplier,
     should_validate_step,
+    update_hosted_resume_manifest,
 )
 
 logger = logging.getLogger(__name__)
 
 _CONFIG_FILE = Path(__file__).resolve().parent / "config" / "fireworks.yaml"
+_RESUME_NOT_CHECKED = object()
+
+
+@dataclass
+class _SubmittedFireworksBatch:
+    step: int
+    data: list[Any]
+    learning_rate: float
+    started_at: float
+    fb_future: Any
+    opt_future: Any
+
+
+def _configured_policy_job_id(config) -> str | None:
+    value = OmegaConf.select(config, "fireworks_infra.trainers.policy.job_id")
+    return str(value) if value else None
+
+
+def build_fireworks_resume_contract(
+    config,
+    train_dataset,
+    optimizer: SFTOptimizerSettings,
+    *,
+    n_batches: int,
+    total_steps: int,
+) -> SFTResumeContract:
+    """Build the local identity for a Fireworks optimizer-state resume."""
+    return build_hosted_resume_contract(
+        config,
+        train_dataset,
+        optimizer,
+        backend="fireworks",
+        provider={
+            "training_shape_id": str(config.fireworks_config.policy_trainer_shape_id),
+        },
+        n_batches=n_batches,
+        total_steps=total_steps,
+    )
+
+
+def prepare_fireworks_resume_contract(
+    checkpoint_dir: str,
+    contract: SFTResumeContract,
+    *,
+    configured_job_id: str | None,
+) -> PreparedResumeManifest:
+    """Validate local identity before provisioning or reattaching a trainer."""
+    prepared = prepare_hosted_resume_manifest(
+        checkpoint_dir,
+        contract,
+        require_existing=configured_job_id is not None,
+    )
+    bound_job_id = prepared.data.get("provider_job_id")
+    if bound_job_id is not None and (not isinstance(bound_job_id, str) or not bound_job_id):
+        raise SFTConfigError("Fireworks run identity has an invalid provider_job_id. Use a new output directory.")
+    if configured_job_id is not None:
+        if bound_job_id is None:
+            raise SFTConfigError("Cannot reattach the Fireworks trainer: the local run manifest has no provider job identity. Use a new output directory.")
+        if bound_job_id != configured_job_id:
+            raise SFTConfigError(f"Cannot reattach Fireworks job {configured_job_id!r}: the local run manifest belongs to {bound_job_id!r}. Use the matching output directory.")
+    elif bound_job_id is not None:
+        raise SFTConfigError(f"The Fireworks output directory belongs to provider job {bound_job_id!r}. Set fireworks_infra.trainers.policy.job_id to reattach it, or use a new output directory.")
+    return prepared
+
+
+def validate_fireworks_resume_contract(
+    prepared: PreparedResumeManifest,
+    *,
+    configured_job_id: str | None,
+    actual_job_id: str,
+    resume_info=_RESUME_NOT_CHECKED,
+) -> PreparedResumeManifest:
+    """Bind the provider job, then optionally validate its resume state."""
+    if not isinstance(actual_job_id, str) or not actual_job_id:
+        raise SFTConfigError("Fireworks provisioning did not return a provider job identity; exact resume is unavailable.")
+    if configured_job_id is not None and actual_job_id != configured_job_id:
+        raise SFTConfigError(f"Fireworks reattached job {actual_job_id!r}, expected configured job {configured_job_id!r}.")
+
+    bound_job_id = prepared.data.get("provider_job_id")
+    if configured_job_id is not None and bound_job_id is None:
+        raise SFTConfigError("Cannot reattach the Fireworks trainer: the local run manifest has no provider job identity. Use a new output directory.")
+    if bound_job_id is not None and bound_job_id != actual_job_id:
+        raise SFTConfigError(f"Fireworks job {actual_job_id!r} does not match the local run manifest job {bound_job_id!r}.")
+    if bound_job_id is None:
+        prepared = update_hosted_resume_manifest(prepared, provider_job_id=actual_job_id)
+
+    if resume_info is _RESUME_NOT_CHECKED:
+        return prepared
+    if configured_job_id is not None and resume_info is None:
+        raise SFTConfigError(f"Fireworks reattached job {configured_job_id!r}, but it has no resumable checkpoint/cursor. Exact resume is unavailable; use a new output directory.")
+    if configured_job_id is None and resume_info is not None:
+        raise SFTConfigError("A newly provisioned Fireworks job unexpectedly contained a checkpoint. Refusing an identity-ambiguous resume; use a new output directory.")
+    return prepared
 
 
 class FireworksSFTBackend(TinkerSFTBackend):
@@ -105,6 +206,29 @@ class FireworksSFTBackend(TinkerSFTBackend):
             cfg = OmegaConf.merge(cfg, OmegaConf.create(spec.overrides))
         self._align_shape_with_lora_rank(cfg)
         self._require_consistent_model_swap(base, cfg)
+        user = OmegaConf.to_container(OmegaConf.create(spec.overrides), resolve=False) if spec.overrides else {}
+        user_trainer = user.get("trainer") if isinstance(user, dict) else None
+        explicit_override = isinstance(user_trainer, dict) and user_trainer.get("default_local_dir") is not None
+        self._resume_requested = bool(spec.output_dir) or explicit_override
+        configured_job_id = _configured_policy_job_id(cfg)
+        if configured_job_id is not None and not self._resume_requested:
+            raise SFTConfigError(
+                "Reattaching a Fireworks trainer via fireworks_infra.trainers.policy.job_id requires an explicit --output (or trainer.default_local_dir override) containing its local cursor metadata."
+            )
+        if not self._resume_requested:
+            experiment = (
+                re.sub(
+                    r"[^A-Za-z0-9._-]+",
+                    "-",
+                    str(cfg.trainer.get("experiment_name") or "default"),
+                ).strip("-._")
+                or "default"
+            )
+            cfg.trainer.default_local_dir = os.path.join(
+                str(cfg.trainer.default_local_dir),
+                experiment,
+                self._run_leaf,
+            )
         self._config = cfg
         return cfg
 
@@ -183,14 +307,15 @@ class FireworksSFTBackend(TinkerSFTBackend):
         finally:
             doc_path.unlink(missing_ok=True)
 
-        # cleanup_existing/cleanup_on_close mirror the RL backend: rllm provisions
-        # a fresh trainer per run and tears it down on exit.
+        # Provider trainer state is the durable half of the resume contract.
+        # ``infra.close()`` must release local/client handles without deleting a
+        # fresh or reattached trainer after an exception, Ctrl-C, or relaunch.
         return init_fireworks_infra(
             "sft",
             provision_cfg,
             base_url=base_url,
-            cleanup_on_close=True,
-            cleanup_existing=True,
+            cleanup_on_close=False,
+            cleanup_existing=False,
         )
 
     def fit(self) -> None:
@@ -212,16 +337,11 @@ class FireworksSFTBackend(TinkerSFTBackend):
             raise SFTConfigError("FIREWORKS_API_KEY is not set; required for the fireworks SFT backend.")
         base_url = os.environ.get("FIREWORKS_BASE_URL", config.get("fireworks_base_url", "https://api.fireworks.ai"))
 
-        # <local dir>/<experiment>/<run stamp>/ — the template default is a fixed
-        # shared /tmp path, and even an explicit --output collides across
-        # relaunches; a per-run stamp keeps every run's logs/metadata separate.
-        # Safe here: Fireworks SFT resume is server-side (job DCP), not local.
-        run_stamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
-        config.trainer.default_local_dir = os.path.join(
-            config.trainer.default_local_dir,
-            config.trainer.get("experiment_name") or "default",
-            run_stamp,
-        )
+        # A generated path is isolated per backend instance. An explicit path is
+        # stable because Fireworks keeps its exact data cursor locally beside the
+        # run manifest; changing this path would make provider resume ambiguous.
+        if not self._resume_requested and os.path.exists(config.trainer.default_local_dir):
+            raise SFTConfigError("The generated Fireworks run directory already exists; create a new backend instance so a fresh isolated directory can be selected.")
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
         lora_rank = config.model.get("lora_rank", 32)
 
@@ -253,9 +373,10 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 label="train",
                 planned_batches=(
                     (epoch_idx, batch_idx)
-                    for _step, epoch_idx, batch_idx in iter_training_batches(
+                    for _step, epoch_idx, batch_idx in iter_training_batches_from_step(
                         n_batches=n_batches,
                         total_epochs=total_epochs,
+                        start_step=0,
                         max_steps=max_steps,
                     )
                 ),
@@ -263,8 +384,29 @@ class FireworksSFTBackend(TinkerSFTBackend):
             if val_dataset is not None:
                 val_dataset.preflight(label="validation")
 
+            resume_contract = build_fireworks_resume_contract(
+                config,
+                train_dataset,
+                optimizer,
+                n_batches=n_batches,
+                total_steps=total_steps,
+            )
+            configured_job_id = _configured_policy_job_id(config)
+            prepared_manifest = prepare_fireworks_resume_contract(
+                config.trainer.default_local_dir,
+                resume_contract,
+                configured_job_id=configured_job_id,
+            )
+
             infra = self._provision(config, api_key, base_url)
             try:
+                # Persist the provider identity before any checkpoint call, so a
+                # failure during resume discovery cannot orphan a durable job.
+                prepared_manifest = validate_fireworks_resume_contract(
+                    prepared_manifest,
+                    configured_job_id=configured_job_id,
+                    actual_job_id=infra.policy_job_id,
+                )
                 client = infra.policy
                 ckpt = TrainingCheckpoints(
                     client,
@@ -276,7 +418,27 @@ class FireworksSFTBackend(TinkerSFTBackend):
 
                 # Auto-resume from the newest resumable checkpoint, if any.
                 resume = ckpt.resume()
-                start_step = resume.step if resume else 0
+                validate_fireworks_resume_contract(
+                    prepared_manifest,
+                    configured_job_id=configured_job_id,
+                    actual_job_id=infra.policy_job_id,
+                    resume_info=resume,
+                )
+                if resume is not None:
+                    data_consumed = getattr(resume, "data_consumed", None)
+                    if isinstance(data_consumed, bool) or not isinstance(data_consumed, int) or data_consumed <= 0:
+                        raise SFTConfigError(
+                            "Fireworks found a resumable checkpoint without a positive persisted dataset cursor; "
+                            "refusing to replay training data. Use a new trainer job or restore its dataloader.json."
+                        )
+                    # Fireworks may rename the requested checkpoint (for example
+                    # step-42 to step-0), so its name-derived ``step`` is not a
+                    # data cursor. The raw-row cursor persisted by rLLM is.
+                    start_step = train_dataset.step_for_data_cursor(data_consumed)
+                else:
+                    start_step = 0
+                if not 0 <= start_step <= total_steps:
+                    raise SFTConfigError(f"Fireworks checkpoint step {start_step!r} is outside the resolved SFT horizon 0..{total_steps}; use a new trainer job or an intact rLLM checkpoint.")
 
                 logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
 
@@ -291,10 +453,16 @@ class FireworksSFTBackend(TinkerSFTBackend):
                         step=0,
                     )
 
-                # Pipelined sync loop: keep one (fwd_bwd, optim) pair in flight.
-                in_flight: deque = deque()
+                current_epoch: int | None = None
+                pending: _SubmittedFireworksBatch | None = None
 
-                def submit(step: int):
+                def submit_batch(step: int, epoch_idx: int, batch_idx: int):
+                    nonlocal current_epoch
+                    if epoch_idx != current_epoch:
+                        logger.info("Starting epoch %d", epoch_idx)
+                        train_dataset.set_epoch(seed=epoch_idx)
+                        current_epoch = epoch_idx
+                    started_at = time.time()
                     lr = optimizer.learning_rate * sft_lr_multiplier(
                         optimizer.lr_schedule,
                         step,
@@ -310,67 +478,99 @@ class FireworksSFTBackend(TinkerSFTBackend):
                         weight_decay=optimizer.weight_decay,
                         grad_clip_norm=optimizer.grad_clip_norm,
                     )
-                    data = train_dataset.get_batch(step % n_batches)
+                    data = train_dataset.get_batch(batch_idx)
                     fb_fut = client.submit_forward_backward(data, loss_fn="cross_entropy")
                     # Datum weights encode reduction; provider normalization would double-divide token_mean.
                     opt_fut = client.submit_optim_step(adam)
-                    in_flight.append((step, lr, data, fb_fut, opt_fut, time.time()))
+                    return _SubmittedFireworksBatch(
+                        step=step,
+                        data=data,
+                        learning_rate=lr,
+                        started_at=started_at,
+                        fb_future=fb_fut,
+                        opt_future=opt_fut,
+                    )
 
-                def collect():
-                    step, lr, data, fb_fut, opt_fut, t0 = in_flight.popleft()
-                    fb_result = fb_fut.result(timeout=DEFAULT_TIMEOUT_S)
-                    opt_fut.result(timeout=DEFAULT_TIMEOUT_S)
+                def finish_batch(submitted: _SubmittedFireworksBatch):
+                    fb_result = submitted.fb_future.result(timeout=DEFAULT_TIMEOUT_S)
+                    submitted.opt_future.result(timeout=DEFAULT_TIMEOUT_S)
                     # Fireworks exposes only aggregate loss. Divide by the
                     # submitted weight mass, while logging the independent count
                     # of positive-weight tokens (normalization can rescale mass).
                     fb_metrics = getattr(fb_result, "metrics", {}) or {}
-                    n_loss_tokens = count_loss_tokens(data)
-                    loss_weight = sum_loss_weights(data)
+                    n_loss_tokens = count_loss_tokens(submitted.data)
+                    loss_weight = sum_loss_weights(submitted.data)
                     train_loss = (fb_metrics.get("loss:sum", 0.0) / loss_weight) if loss_weight else 0.0
+                    completed_steps = submitted.step + 1
                     metrics = {
-                        "learning_rate": lr,
-                        "progress": min((step + 1) / progress_denominator, 1.0),
-                        "num_sequences": len(data),
+                        "learning_rate": submitted.learning_rate,
+                        "progress": min(completed_steps / progress_denominator, 1.0),
+                        "num_sequences": len(submitted.data),
                         "num_loss_tokens": n_loss_tokens,
                         "train_loss": train_loss,
-                        "time/total": time.time() - t0,
+                        "time/total": time.time() - submitted.started_at,
                     }
-                    completed_steps = step + 1
                     if should_validate_step(
                         completed_steps,
                         eval_every=eval_every,
                         has_validation=val_dataset is not None,
                     ):
                         metrics.update(self._validate(client, val_dataset, DEFAULT_TIMEOUT_S))
+                    if save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps:
+                        logger.info("Saving checkpoint at step %d", completed_steps)
+                        ckpt.save(
+                            f"step-{completed_steps}",
+                            resumable=True,
+                            promotable=False,
+                            data_consumed=train_dataset.data_cursor_for_step(completed_steps),
+                        )
                     tracking_logger.log(data=metrics, step=completed_steps)
-                    logger.info(f"Step {completed_steps}: train_loss={train_loss:.4f}, lr={lr:.2e}")
-                    if save_every > 0 and step % save_every == 0 and step > 0:
-                        logger.info(f"Saving checkpoint at step {step}")
-                        ckpt.save(f"step-{step}", resumable=True, promotable=False)
+                    logger.info(
+                        "Step %d: train_loss=%.4f, lr=%.2e",
+                        completed_steps,
+                        train_loss,
+                        submitted.learning_rate,
+                    )
 
-                for step in range(start_step, total_steps):
-                    if step % n_batches == 0:
-                        train_dataset.set_epoch(seed=step // n_batches)
-                    if in_flight and should_validate_step(
-                        in_flight[0][0] + 1,
+                for step, epoch_idx, batch_idx in iter_training_batches_from_step(
+                    n_batches=n_batches,
+                    total_epochs=total_epochs,
+                    start_step=start_step,
+                    max_steps=max_steps,
+                ):
+                    if pending is None:
+                        pending = submit_batch(step, epoch_idx, batch_idx)
+                        continue
+
+                    if _is_step_boundary(
+                        pending.step + 1,
+                        total_steps,
+                        save_every=save_every,
                         eval_every=eval_every,
                         has_validation=val_dataset is not None,
                     ):
-                        collect()
-                    submit(step)
-                    if len(in_flight) > 1:
-                        collect()
-                while in_flight:
-                    collect()
+                        finish_batch(pending)
+                        pending = submit_batch(step, epoch_idx, batch_idx)
+                    else:
+                        following = submit_batch(step, epoch_idx, batch_idx)
+                        finish_batch(pending)
+                        pending = following
+                if pending is not None:
+                    finish_batch(pending)
 
                 if total_steps > start_step:
                     logger.info(f"Saving final checkpoint at step {total_steps}")
                     # promotable=True writes the servable sampler row that
                     # ``promote_latest`` needs. Without it the weights are a
                     # resumable-only DCP blob, GC'd after the job's ~30-day retention
-                    # window — so promote BEFORE ``finally: infra.close()`` deletes the
+                    # window, so promote it before detaching from the retained
                     # trainer job. Mirrors the RL path and the SDK sft recipe.
-                    ckpt.save(f"step-{total_steps}", resumable=True, promotable=True)
+                    ckpt.save(
+                        f"step-{total_steps}",
+                        resumable=True,
+                        promotable=True,
+                        data_consumed=train_dataset.data_cursor_for_step(total_steps),
+                    )
                     artifact = "LoRA adapter" if lora_rank else "full-weight model"
                     experiment = config.trainer.get("experiment_name") or "default"
                     output_model_id = re.sub(r"[^a-z0-9-]+", "-", f"{config.trainer.get('project_name', 'rllm-sft')}-{experiment}".lower()).strip("-")[:63]
@@ -380,7 +580,7 @@ class FireworksSFTBackend(TinkerSFTBackend):
                     except Exception:
                         logger.exception(
                             "Final %s promotion failed. The promotable sampler checkpoint for job %s "
-                            "survives job deletion for ~30 days; promote it manually via "
+                            "remains available for manual promotion via "
                             "TrainerJobManager.promote_checkpoint(name=<row from list_checkpoints>, "
                             "output_model_id=%r, base_model=%r).",
                             artifact,

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -9,11 +9,16 @@ imports it — stay importable without the tinker stack installed.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import math
 import os
+import re
+import secrets
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -28,9 +33,65 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _CONFIG_FILE = Path(__file__).resolve().parent / "config" / "tinker.yaml"
+_RESUME_CONTRACT_VERSION = 1
+_LOOP_SEMANTICS_VERSION = "deterministic-ceil-batches-v1"
+_RUN_MANIFEST_NAME = "sft-run.json"
 
 # Plain-text renderers that cannot represent reasoning (``<think>``) or tool-calls.
 _PLAIN_RENDERERS = {"role_colon", "llama3"}
+
+
+def _distribution_versions(module_name: str) -> dict[str, str]:
+    """Return installed distributions owning a module, without filesystem paths."""
+    root = module_name.partition(".")[0]
+    distributions = metadata.packages_distributions().get(root, ())
+    versions: dict[str, str] = {}
+    for distribution in sorted(distributions):
+        try:
+            versions[distribution] = metadata.version(distribution)
+        except metadata.PackageNotFoundError:
+            continue
+    return versions
+
+
+def _class_identity(value: Any) -> dict[str, Any]:
+    cls = type(value)
+    return {
+        "class": f"{cls.__module__}.{cls.__qualname__}",
+        "distributions": _distribution_versions(cls.__module__),
+    }
+
+
+def _renderer_identity(renderer: Any) -> dict[str, Any]:
+    """Record the resolved adapter and underlying implementation when exposed."""
+    identity = {"adapter": _class_identity(renderer)}
+    implementation = getattr(renderer, "_inner", renderer)
+    identity["implementation"] = _class_identity(implementation)
+    return identity
+
+
+def _tokenizer_identity(tokenizer: Any) -> dict[str, Any]:
+    """Record stable tokenizer implementation and revision metadata when known."""
+    init_kwargs = getattr(tokenizer, "init_kwargs", None)
+    revision = init_kwargs.get("_commit_hash") if isinstance(init_kwargs, dict) else None
+    revision = revision or getattr(tokenizer, "_commit_hash", None)
+    chat_template = getattr(tokenizer, "chat_template", None)
+    special_ids = getattr(tokenizer, "all_special_ids", None)
+    return {
+        **_class_identity(tokenizer),
+        "name_or_path": str(getattr(tokenizer, "name_or_path", "") or ""),
+        "revision": str(revision) if revision else None,
+        "chat_template_hash": hashlib.sha256(chat_template.encode()).hexdigest() if isinstance(chat_template, str) else None,
+        "special_token_ids": [int(token_id) for token_id in special_ids] if special_ids is not None else None,
+        "runtime_versions": {distribution: version for distribution in ("tokenizers", "transformers") if (version := _installed_version(distribution)) is not None},
+    }
+
+
+def _installed_version(distribution: str) -> str | None:
+    try:
+        return metadata.version(distribution)
+    except metadata.PackageNotFoundError:
+        return None
 
 
 def _guard_renderer_capability(renderer_name: str, renderer_source: str, train_data) -> None:
@@ -121,6 +182,10 @@ def build_sft_data(config, train_data, val_data):
         resolution.source,
         last_only,
     )
+    config.data.resolved_renderer_name = resolution.name
+    config.data.resolved_renderer_source = resolution.source
+    config.data.resolved_renderer_identity = _renderer_identity(renderer)
+    config.data.resolved_tokenizer_identity = _tokenizer_identity(tokenizer)
 
     train_batch_size = config.data.get("train_batch_size", 32)
     val_batch_size = config.data.get("micro_batch_size_per_gpu", train_batch_size)
@@ -195,6 +260,24 @@ def iter_training_batches(
         yield step, epoch, batch
 
 
+def iter_training_batches_from_step(
+    *,
+    n_batches: int,
+    total_epochs: int,
+    start_step: int,
+    max_steps: int | None = None,
+):
+    """Yield the remaining plan from a completed-step (next unseen) cursor."""
+    start_epoch, start_batch = divmod(start_step, n_batches)
+    return iter_training_batches(
+        n_batches=n_batches,
+        total_epochs=total_epochs,
+        start_epoch=start_epoch,
+        start_batch=start_batch,
+        max_steps=max_steps,
+    )
+
+
 def sft_lr_multiplier(
     lr_schedule: str,
     step: int,
@@ -258,6 +341,274 @@ class SFTOptimizerSettings:
     eps: float
     weight_decay: float
     grad_clip_norm: float
+
+
+@dataclass(frozen=True)
+class SFTResumeContract:
+    """Versioned local identity required for an optimizer-state resume."""
+
+    payload: dict[str, Any]
+    digest: str
+
+
+def _stable_digest(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _contract_differences(expected: Any, actual: Any, prefix: str = "") -> list[str]:
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        differences: list[str] = []
+        for key in sorted(set(expected) | set(actual)):
+            path = f"{prefix}.{key}" if prefix else key
+            if key not in expected or key not in actual:
+                differences.append(path)
+            else:
+                differences.extend(_contract_differences(expected[key], actual[key], path))
+        return differences
+    return [] if expected == actual else [prefix or "contract"]
+
+
+def _resume_field(resume_info, field: str, default=None):
+    if hasattr(resume_info, "get"):
+        missing = object()
+        value = resume_info.get(field, missing)
+        if value is not missing:
+            return value
+    return getattr(resume_info, field, default)
+
+
+def _plain_config_value(value: Any) -> Any:
+    return OmegaConf.to_container(value, resolve=True) if OmegaConf.is_config(value) else value
+
+
+def build_hosted_resume_contract(
+    config,
+    train_dataset,
+    optimizer: SFTOptimizerSettings,
+    *,
+    backend: str,
+    n_batches: int,
+    total_steps: int,
+    provider: dict[str, Any] | None = None,
+) -> SFTResumeContract:
+    """Capture local inputs that can change hosted-SFT resume semantics."""
+    rllm_data = config.data.get("rllm", {})
+    optimizer_payload = asdict(optimizer)
+    optimizer_payload["betas"] = list(optimizer_payload["betas"])
+    source_dataset = getattr(train_dataset, "_source_dataset", train_dataset.dataset)
+    payload: dict[str, Any] = {
+        "contract_version": _RESUME_CONTRACT_VERSION,
+        "loop_semantics": _LOOP_SEMANTICS_VERSION,
+        "backend": {
+            "name": backend,
+            "provider": provider or {},
+        },
+        "model": {
+            "base_model": str(config.model.name),
+            "lora_rank": int(config.model.get("lora_rank", 32)),
+            "train_unembed": bool(OmegaConf.select(config, "model.train_unembed", default=True)),
+            "train_attn": bool(OmegaConf.select(config, "model.train_attn", default=True)),
+            "train_mlp": bool(OmegaConf.select(config, "model.train_mlp", default=True)),
+        },
+        "rendering": {
+            "renderer_name": config.data.get("resolved_renderer_name"),
+            "renderer_source": config.data.get("resolved_renderer_source"),
+            "renderer_identity": _plain_config_value(config.data.get("resolved_renderer_identity", {})),
+            "tokenizer_model": str(config.model.get("tokenizer_model") or config.model.name),
+            "tokenizer_identity": _plain_config_value(config.data.get("resolved_tokenizer_identity", {})),
+            "tokenize_and_mask_method": str(rllm_data.get("tokenize_and_mask_method", "cumulative")),
+            "max_length": config.data.get("max_length"),
+            "overlength_policy": str(rllm_data.get("overlength_policy", "truncate")),
+            "loss_reduction": str(rllm_data.get("loss_reduction", "token_mean")),
+        },
+        "dataset": {
+            "fingerprint": train_dataset.content_fingerprint(),
+            "implementation": _class_identity(source_dataset),
+            "row_count": len(source_dataset),
+            "batch_size": int(train_dataset.batch_size),
+        },
+        "optimizer": optimizer_payload,
+        "horizon": {
+            "batches_per_epoch": n_batches,
+            "total_steps": total_steps,
+        },
+    }
+    return SFTResumeContract(payload=payload, digest=_stable_digest(payload))
+
+
+def build_tinker_resume_contract(
+    config,
+    train_dataset,
+    optimizer: SFTOptimizerSettings,
+    *,
+    n_batches: int,
+    total_steps: int,
+) -> SFTResumeContract:
+    return build_hosted_resume_contract(
+        config,
+        train_dataset,
+        optimizer,
+        backend="tinker",
+        n_batches=n_batches,
+        total_steps=total_steps,
+    )
+
+
+@dataclass(frozen=True)
+class PreparedResumeManifest:
+    path: Path
+    data: dict[str, Any]
+
+
+def _expected_resume_manifest(contract: SFTResumeContract) -> dict[str, Any]:
+    return {
+        "contract_hash": contract.digest,
+        "contract": contract.payload,
+    }
+
+
+def _write_resume_manifest(path: Path, data: dict[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(4)}.tmp")
+    try:
+        temporary.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        temporary.replace(path)
+    except OSError as e:
+        temporary.unlink(missing_ok=True)
+        raise SFTConfigError(f"Could not write hosted SFT run identity to {path}: {e}") from e
+
+
+def prepare_hosted_resume_manifest(
+    checkpoint_dir: str,
+    contract: SFTResumeContract,
+    *,
+    require_existing: bool = False,
+) -> PreparedResumeManifest:
+    """Validate or atomically create a local hosted-SFT run manifest."""
+    manifest_path = Path(checkpoint_dir) / _RUN_MANIFEST_NAME
+    expected = _expected_resume_manifest(contract)
+    if not manifest_path.exists():
+        if require_existing:
+            raise SFTConfigError(f"Cannot resume the legacy checkpoint/run in {checkpoint_dir!r}: {_RUN_MANIFEST_NAME} is missing. Use a new output directory.")
+        _write_resume_manifest(manifest_path, expected)
+        return PreparedResumeManifest(manifest_path, expected)
+
+    try:
+        existing = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        raise SFTConfigError(f"Cannot resume from {checkpoint_dir!r}: {_RUN_MANIFEST_NAME} is unreadable ({e}). Use a new output directory.") from e
+    differences = _contract_differences(
+        expected["contract"],
+        existing.get("contract") if isinstance(existing, dict) else None,
+    )
+    if not isinstance(existing, dict) or existing.get("contract_hash") != contract.digest or differences:
+        fields = ", ".join(differences[:8]) or "contract hash"
+        raise SFTConfigError(f"Cannot resume from {checkpoint_dir!r}: run identity mismatch in {fields}. Use a new output directory.")
+    return PreparedResumeManifest(manifest_path, existing)
+
+
+def update_hosted_resume_manifest(
+    prepared: PreparedResumeManifest,
+    **updates: Any,
+) -> PreparedResumeManifest:
+    data = {**prepared.data, **updates}
+    _write_resume_manifest(prepared.path, data)
+    return PreparedResumeManifest(prepared.path, data)
+
+
+def prepare_tinker_resume_contract(
+    checkpoint_dir: str,
+    contract: SFTResumeContract,
+    resume_info,
+) -> None:
+    """Validate or create the local manifest before opening a provider client."""
+    prepare_hosted_resume_manifest(
+        checkpoint_dir,
+        contract,
+        require_existing=resume_info is not None,
+    )
+    if resume_info is not None:
+        checkpoint_hash = _resume_field(resume_info, "contract_hash")
+        if checkpoint_hash != contract.digest:
+            raise SFTConfigError(f"Cannot resume from {checkpoint_dir!r}: checkpoint contract hash is {checkpoint_hash!r}, expected {contract.digest!r}. Use a new output directory.")
+
+
+def validate_tinker_resume_cursor(
+    resume_info,
+    *,
+    n_batches: int,
+    total_steps: int,
+) -> int:
+    """Require a complete, consistent next-unseen completed-step cursor."""
+    values: dict[str, int] = {}
+    for field in ("epoch", "batch", "step"):
+        value = _resume_field(resume_info, field)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise SFTConfigError(f"checkpoint loop_state.{field} must be a non-negative integer, got {value!r}.")
+        if value < 0:
+            raise SFTConfigError(f"checkpoint loop_state.{field} must be non-negative, got {value}.")
+        values[field] = value
+    expected_step = values["epoch"] * n_batches + values["batch"]
+    if values["batch"] >= n_batches or values["step"] != expected_step or values["step"] > total_steps:
+        raise SFTConfigError(
+            "Tinker checkpoint cursor is inconsistent with the resolved SFT batch plan "
+            f"(epoch={values['epoch']}, batch={values['batch']}, step={values['step']}, "
+            f"batches_per_epoch={n_batches}, total_steps={total_steps}). Use a new output directory."
+        )
+    return values["step"]
+
+
+async def validate_tinker_checkpoint_identity(
+    service_client,
+    checkpoint_path: str,
+    config,
+) -> None:
+    """Hard-compare provider checkpoint metadata with the resolved run config."""
+    from tinker_cookbook import checkpoint_utils
+
+    rest_client = service_client.create_rest_client()
+    weights = await rest_client.get_weights_info_by_tinker_path(checkpoint_path)
+    training_run = await rest_client.get_training_run_by_tinker_path_async(checkpoint_path)
+    expected = {
+        "base_model": str(config.model.name),
+        "lora_rank": int(config.model.get("lora_rank", 32)),
+        "train_unembed": bool(OmegaConf.select(config, "model.train_unembed", default=True)),
+        "train_attn": bool(OmegaConf.select(config, "model.train_attn", default=True)),
+        "train_mlp": bool(OmegaConf.select(config, "model.train_mlp", default=True)),
+        "renderer": str(config.data.get("resolved_renderer_name")),
+    }
+    actual = {
+        "base_model": weights.base_model,
+        "lora_rank": weights.lora_rank,
+        "train_unembed": weights.train_unembed if weights.train_unembed is not None else True,
+        "train_attn": weights.train_attn if weights.train_attn is not None else True,
+        "train_mlp": weights.train_mlp if weights.train_mlp is not None else True,
+        "renderer": (training_run.user_metadata or {}).get(checkpoint_utils.RENDERER_NAME_METADATA_KEY),
+    }
+    mismatches = [f"{field}={actual[field]!r} (expected {value!r})" for field, value in expected.items() if actual[field] != value]
+    if mismatches:
+        raise SFTConfigError("Tinker checkpoint identity mismatch: " + "; ".join(mismatches) + ". Use a new output directory.")
+
+
+def _is_step_boundary(
+    completed_steps: int,
+    total_steps: int,
+    *,
+    save_every: int,
+    eval_every: int,
+    has_validation: bool,
+) -> bool:
+    """Whether the one-ahead pipeline must drain at this model boundary."""
+    return (
+        completed_steps >= total_steps
+        or (has_validation and eval_every > 0 and completed_steps % eval_every == 0)
+        or (save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps)
+    )
 
 
 def resolve_sft_optimizer_settings(optim_cfg, *, total_steps: int) -> SFTOptimizerSettings:
@@ -349,6 +700,8 @@ class TinkerSFTBackend(SFTBackend):
     def __init__(self, spec):
         super().__init__(spec)
         self._config: DictConfig | None = None
+        self._run_leaf = f"{time.strftime('%Y%m%d_%H%M%S', time.gmtime())}-{secrets.token_hex(4)}"
+        self._resume_requested = False
 
     # -- contract -----------------------------------------------------------
 
@@ -417,6 +770,24 @@ class TinkerSFTBackend(SFTBackend):
             cfg = OmegaConf.merge(cfg, OmegaConf.create({"trainer": {"default_local_dir": spec.output_dir}}))
         if spec.overrides:
             cfg = OmegaConf.merge(cfg, OmegaConf.create(spec.overrides))
+        user = OmegaConf.to_container(OmegaConf.create(spec.overrides), resolve=False) if spec.overrides else {}
+        user_trainer = user.get("trainer") if isinstance(user, dict) else None
+        explicit_override = isinstance(user_trainer, dict) and user_trainer.get("default_local_dir") is not None
+        self._resume_requested = bool(spec.output_dir) or explicit_override
+        if not self._resume_requested:
+            experiment = (
+                re.sub(
+                    r"[^A-Za-z0-9._-]+",
+                    "-",
+                    str(cfg.trainer.get("experiment_name") or "default"),
+                ).strip("-._")
+                or "default"
+            )
+            cfg.trainer.default_local_dir = os.path.join(
+                str(cfg.trainer.default_local_dir),
+                experiment,
+                self._run_leaf,
+            )
         self._config = cfg
         return cfg
 
@@ -447,12 +818,11 @@ class TinkerSFTBackend(SFTBackend):
         from rllm.utils.tracking import Tracking
 
         config = self._config
+        if not self._resume_requested and os.path.exists(config.trainer.default_local_dir):
+            raise SFTConfigError("The generated Tinker run directory already exists; create a new backend instance so a fresh isolated directory can be selected.")
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
         tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
 
-        resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
-        start_epoch = resume_info.get("epoch", 0) if resume_info else 0
-        start_batch = resume_info.get("batch", 0) if resume_info else 0
         n_batches = len(train_dataset)
         total_epochs = config.trainer.get("total_epochs", 1)
         max_steps = config.trainer.get("max_steps")
@@ -469,8 +839,6 @@ class TinkerSFTBackend(SFTBackend):
                 for _step, epoch_idx, batch_idx in iter_training_batches(
                     n_batches=n_batches,
                     total_epochs=total_epochs,
-                    start_epoch=start_epoch,
-                    start_batch=start_batch,
                     max_steps=max_steps,
                 )
             ),
@@ -478,7 +846,31 @@ class TinkerSFTBackend(SFTBackend):
         if val_dataset is not None:
             val_dataset.preflight(label="validation")
 
-        service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
+        resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir) if self._resume_requested else None
+        resume_contract = build_tinker_resume_contract(
+            config,
+            train_dataset,
+            optimizer,
+            n_batches=n_batches,
+            total_steps=total_steps,
+        )
+        prepare_tinker_resume_contract(
+            config.trainer.default_local_dir,
+            resume_contract,
+            resume_info,
+        )
+        start_step = (
+            validate_tinker_resume_cursor(
+                resume_info,
+                n_batches=n_batches,
+                total_steps=total_steps,
+            )
+            if resume_info is not None
+            else 0
+        )
+        checkpoint_contract = {
+            "contract_hash": resume_contract.digest,
+        }
 
         logger_backend = config.trainer.logger
         if isinstance(logger_backend, str):
@@ -493,9 +885,22 @@ class TinkerSFTBackend(SFTBackend):
         # Wrap the loop so tracking_logger.finish() runs even on failure: the 'ui'
         # backend tees stdout/stderr and holds an open session until finish().
         try:
+            service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
+            user_metadata: dict[str, str] = {}
+            checkpoint_utils.add_renderer_name_to_user_metadata(
+                user_metadata,
+                config.data.get("resolved_renderer_name"),
+            )
             if resume_info:
                 logger.info(f"Resuming from checkpoint: {resume_info}")
-                training_client = await service_client.create_training_client_from_state_async(resume_info["state_path"])
+                state_path = _resume_field(resume_info, "state_path")
+                if not isinstance(state_path, str) or not state_path:
+                    raise SFTConfigError("Tinker checkpoint is missing a provider state_path; use a new output directory.")
+                await validate_tinker_checkpoint_identity(service_client, state_path, config)
+                training_client = await service_client.create_training_client_from_state_with_optimizer_async(
+                    state_path,
+                    user_metadata=user_metadata,
+                )
             else:
                 logger.info("Starting training from scratch")
                 training_client = await service_client.create_lora_training_client_async(
@@ -504,6 +909,7 @@ class TinkerSFTBackend(SFTBackend):
                     train_unembed=OmegaConf.select(config, "model.train_unembed", default=True),
                     train_attn=OmegaConf.select(config, "model.train_attn", default=True),
                     train_mlp=OmegaConf.select(config, "model.train_mlp", default=True),
+                    user_metadata=user_metadata,
                 )
             logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
 
@@ -511,15 +917,21 @@ class TinkerSFTBackend(SFTBackend):
                 0,
                 eval_every=eval_every,
                 has_validation=val_dataset is not None,
-                include_initial=start_epoch == 0 and start_batch == 0,
+                include_initial=start_step == 0,
             ):
                 initial_metrics: dict[str, Any] = {}
                 with timed("validation", initial_metrics):
                     initial_metrics.update(await self._validate(training_client, val_dataset, compute_mean_nll))
                 tracking_logger.log(data=initial_metrics, step=0)
 
-            async def submit_batch(epoch_idx: int, batch_idx: int) -> _SubmittedBatch:
-                step = epoch_idx * n_batches + batch_idx
+            current_epoch: int | None = None
+
+            async def submit_batch(step: int, epoch_idx: int, batch_idx: int) -> _SubmittedBatch:
+                nonlocal current_epoch
+                if epoch_idx != current_epoch:
+                    logger.info(f"Starting epoch {epoch_idx}")
+                    train_dataset.set_epoch(seed=epoch_idx)
+                    current_epoch = epoch_idx
                 batch_start_time = time.time()
                 metrics: dict[str, Any] = {"epoch": epoch_idx, "progress": step / progress_denominator}
                 learning_rate = optimizer.learning_rate * sft_lr_multiplier(
@@ -546,20 +958,19 @@ class TinkerSFTBackend(SFTBackend):
 
                 fwd_bwd_future = await training_client.forward_backward_async(data, loss_fn="cross_entropy")
                 optim_step_future = await training_client.optim_step_async(adam_params)
-                return _SubmittedBatch(fwd_bwd_future, optim_step_future, metrics, data, step, epoch_idx, batch_idx, batch_start_time)
+                return _SubmittedBatch(
+                    fwd_bwd_future=fwd_bwd_future,
+                    optim_step_future=optim_step_future,
+                    metrics=metrics,
+                    data=data,
+                    step=step,
+                    epoch_idx=epoch_idx,
+                    batch_idx=batch_idx,
+                    batch_start_time=batch_start_time,
+                )
 
             async def finish_batch(submitted: _SubmittedBatch) -> None:
                 metrics = submitted.metrics
-                metrics["progress"] = min((submitted.step + 1) / progress_denominator, 1.0)
-                if save_every > 0 and submitted.step % save_every == 0 and submitted.step > 0:
-                    with timed("save_checkpoint", metrics):
-                        await checkpoint_utils.save_checkpoint_async(
-                            training_client=training_client,
-                            name=f"{submitted.step:06d}",
-                            log_path=config.trainer.default_local_dir,
-                            loop_state={"epoch": submitted.epoch_idx, "batch": submitted.batch_idx},
-                            kind="both",
-                        )
                 with timed("step", metrics):
                     fwd_bwd_result = await submitted.fwd_bwd_future.result_async()
                     await submitted.optim_step_future.result_async()
@@ -576,6 +987,7 @@ class TinkerSFTBackend(SFTBackend):
                 metrics["time/total"] = time.time() - submitted.batch_start_time
 
                 completed_steps = submitted.step + 1
+                metrics["progress"] = min(completed_steps / progress_denominator, 1.0)
                 if should_validate_step(
                     completed_steps,
                     eval_every=eval_every,
@@ -585,37 +997,52 @@ class TinkerSFTBackend(SFTBackend):
                         val_metrics = await self._validate(training_client, val_dataset, compute_mean_nll)
                     metrics.update(val_metrics)
 
+                if save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps:
+                    next_epoch, next_batch = divmod(completed_steps, n_batches)
+                    with timed("save_checkpoint", metrics):
+                        await checkpoint_utils.save_checkpoint_async(
+                            training_client=training_client,
+                            name=f"{completed_steps:06d}",
+                            log_path=config.trainer.default_local_dir,
+                            loop_state={
+                                "epoch": next_epoch,
+                                "batch": next_batch,
+                                "step": completed_steps,
+                                **checkpoint_contract,
+                            },
+                            kind="both",
+                        )
+
                 tracking_logger.log(data=metrics, step=completed_steps)
                 logger.info(f"Step {completed_steps}: train_nll={train_nll:.4f}, lr={metrics['learning_rate']:.2e}")
 
             pending: _SubmittedBatch | None = None
-            current_epoch: int | None = None
-            for _step, epoch_idx, batch_idx in iter_training_batches(
+            for step, epoch_idx, batch_idx in iter_training_batches_from_step(
                 n_batches=n_batches,
                 total_epochs=total_epochs,
-                start_epoch=start_epoch,
-                start_batch=start_batch,
+                start_step=start_step,
                 max_steps=max_steps,
             ):
-                if epoch_idx != current_epoch:
-                    logger.info(f"Starting epoch {epoch_idx}")
-                    train_dataset.set_epoch(seed=epoch_idx)
-                    current_epoch = epoch_idx
-                if pending is not None and should_validate_step(
+                if pending is None:
+                    pending = await submit_batch(step, epoch_idx, batch_idx)
+                    continue
+
+                if _is_step_boundary(
                     pending.step + 1,
+                    total_steps,
+                    save_every=save_every,
                     eval_every=eval_every,
                     has_validation=val_dataset is not None,
                 ):
                     await finish_batch(pending)
-                    pending = None
-                submitted = await submit_batch(epoch_idx, batch_idx)
-                if pending is not None:
+                    pending = await submit_batch(step, epoch_idx, batch_idx)
+                else:
+                    following = await submit_batch(step, epoch_idx, batch_idx)
                     await finish_batch(pending)
-                pending = submitted
+                    pending = following
             if pending is not None:
                 await finish_batch(pending)
 
-            start_step = start_epoch * n_batches + start_batch
             if start_step < total_steps:
                 final_epoch, final_batch = divmod(total_steps, n_batches)
                 await checkpoint_utils.save_checkpoint_async(
@@ -623,7 +1050,13 @@ class TinkerSFTBackend(SFTBackend):
                     name="final",
                     log_path=config.trainer.default_local_dir,
                     kind="both",
-                    loop_state={"epoch": final_epoch, "batch": final_batch},
+                    loop_state={
+                        "epoch": final_epoch,
+                        "batch": final_batch,
+                        "step": total_steps,
+                        "final": True,
+                        **checkpoint_contract,
+                    },
                 )
             else:
                 logger.info("Training was already complete; nothing to do")

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -7,6 +7,7 @@ Imported lazily by :class:`rllm.trainer.sft.tinker_backend.TinkerSFTBackend`, so
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -327,7 +328,7 @@ class TinkerSFTDataset(SupervisedDataset):
 
         # Every epoch is derived from this stable source order. This makes the
         # sequence rendered during preflight identical to the sequence consumed
-        # during training, without letting preflight mutate training state.
+        # during training and resume, without letting preflight mutate state.
         self._source_dataset = self.dataset
 
         logger.info(f"Loaded {len(self.dataset)} examples from {source}")
@@ -396,12 +397,61 @@ class TinkerSFTDataset(SupervisedDataset):
         finally:
             self.dataset = original_dataset
 
+    def content_fingerprint(self) -> str:
+        """Hash the ordered source rows that determine rendered training data."""
+
+        def json_default(value):
+            if hasattr(value, "model_dump"):
+                return value.model_dump(mode="json", exclude_none=True)
+            if hasattr(value, "tolist"):
+                return value.tolist()
+            raise TypeError(f"Unsupported value {type(value).__name__} in SFT dataset fingerprint")
+
+        digest = hashlib.sha256()
+        for index in range(len(self._source_dataset)):
+            row = self._source_dataset[index]
+            payload = json.dumps(
+                {"messages": row["messages"], "tools": row.get("tools")},
+                default=json_default,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+            digest.update(len(payload).to_bytes(8, "big"))
+            digest.update(payload)
+        return digest.hexdigest()
+
     def set_epoch(self, seed: int = 0):
         self.dataset = self._source_dataset.shuffle(seed=seed)
         logger.info(f"Shuffled dataset with seed {seed} ({len(self.dataset)} samples)")
 
     def __len__(self) -> int:
         return math.ceil(len(self.dataset) / self.batch_size)
+
+    def data_cursor_for_step(self, completed_steps: int) -> int:
+        """Return the raw-row cursor after ``completed_steps`` batches."""
+        if isinstance(completed_steps, bool) or not isinstance(completed_steps, int) or completed_steps < 0:
+            raise SFTConfigError(f"Completed SFT steps must be a non-negative integer, got {completed_steps!r}.")
+        batches_per_epoch = len(self)
+        if batches_per_epoch == 0:
+            return 0
+        completed_epochs, batches_in_epoch = divmod(completed_steps, batches_per_epoch)
+        rows_per_epoch = len(self._source_dataset)
+        return completed_epochs * rows_per_epoch + min(batches_in_epoch * self.batch_size, rows_per_epoch)
+
+    def step_for_data_cursor(self, data_consumed: int) -> int:
+        """Invert :meth:`data_cursor_for_step` at exact batch boundaries."""
+        if isinstance(data_consumed, bool) or not isinstance(data_consumed, int) or data_consumed < 0:
+            raise SFTConfigError(f"Checkpoint data cursor must be a non-negative integer, got {data_consumed!r}.")
+        rows_per_epoch = len(self._source_dataset)
+        if rows_per_epoch == 0:
+            return 0
+        completed_epochs, rows_in_epoch = divmod(data_consumed, rows_per_epoch)
+        batches_in_epoch = math.ceil(rows_in_epoch / self.batch_size)
+        step = completed_epochs * len(self) + batches_in_epoch
+        if self.data_cursor_for_step(step) != data_consumed:
+            raise SFTConfigError(f"Checkpoint data cursor {data_consumed} is not an exact SFT batch boundary; use a new trainer job or an intact rLLM checkpoint.")
+        return step
 
 
 def create_tinker_sft_datasets(

--- a/tests/trainer/test_sft_resume.py
+++ b/tests/trainer/test_sft_resume.py
@@ -1,0 +1,826 @@
+"""Exact hosted-SFT checkpoint and resume contracts, exercised on fakes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+from rllm.data import Dataset  # noqa: E402
+from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.fireworks_backend import (  # noqa: E402
+    FireworksSFTBackend,
+    build_fireworks_resume_contract,
+    prepare_fireworks_resume_contract,
+    validate_fireworks_resume_contract,
+)
+from rllm.trainer.sft.tinker_backend import (  # noqa: E402
+    SFTResumeContract,
+    TinkerSFTBackend,
+    build_sft_data,
+    build_tinker_resume_contract,
+    iter_training_batches_from_step,
+    prepare_tinker_resume_contract,
+    resolve_sft_optimizer_settings,
+    validate_tinker_checkpoint_identity,
+    validate_tinker_resume_cursor,
+)
+from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset  # noqa: E402
+
+
+class _TokenRenderer:
+    def render(self, messages, *, tools=None, add_generation_prompt=False):
+        from rllm.renderers.types import RenderedTokens
+
+        del tools, add_generation_prompt
+        token = int(messages[-1]["content"])
+        return RenderedTokens(
+            token_ids=[0, token, 0],
+            message_indices=[-1, 1, -1],
+        )
+
+
+def _source(size: int = 7) -> Dataset:
+    return Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": str(index), "trainable": True},
+                ]
+            }
+            for index in range(size)
+        ],
+        name="resume-order",
+        split="train",
+    )
+
+
+def _ordered_batches(dataset, *, total_epochs: int, start_step: int = 0):
+    batches = []
+    current_epoch = None
+    for _, epoch, batch in iter_training_batches_from_step(
+        n_batches=len(dataset),
+        total_epochs=total_epochs,
+        start_step=start_step,
+    ):
+        if epoch != current_epoch:
+            dataset.set_epoch(seed=epoch)
+            current_epoch = epoch
+        datums = dataset.get_batch(batch)
+        batches.append(tuple(datum.model_input.to_ints()[1] for datum in datums))
+    return batches
+
+
+def test_resumed_epoch_order_matches_uninterrupted_next_batches():
+    source = _source()
+    uninterrupted = TinkerSFTDataset(source, _TokenRenderer(), batch_size=3)
+    full_order = _ordered_batches(uninterrupted, total_epochs=3)
+
+    resumed = TinkerSFTDataset(source, _TokenRenderer(), batch_size=3)
+    assert _ordered_batches(resumed, total_epochs=3, start_step=4) == full_order[4:]
+
+
+def test_raw_row_cursor_round_trips_partial_batches_and_epochs():
+    dataset = TinkerSFTDataset(_source(5), _TokenRenderer(), batch_size=2)
+    cursors = [0, 2, 4, 5, 7, 9, 10]
+    assert [dataset.data_cursor_for_step(step) for step in range(7)] == cursors
+    assert [dataset.step_for_data_cursor(cursor) for cursor in cursors] == list(range(7))
+
+    for cursor in (-1, 1, 3, 6):
+        with pytest.raises(SFTConfigError, match="cursor.*non-negative|cursor.*exact"):
+            dataset.step_for_data_cursor(cursor)
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        {"epoch": 0, "batch": 2, "step": 1},
+        {"epoch": 0, "batch": 3, "step": 3},
+        {"epoch": 0, "batch": 1},
+    ],
+)
+def test_tinker_cursor_rejects_off_by_one_or_incomplete_state(cursor):
+    with pytest.raises(SFTConfigError, match="inconsistent|loop_state.step"):
+        validate_tinker_resume_cursor(cursor, n_batches=3, total_steps=3)
+
+
+@pytest.mark.parametrize(
+    ("backend_cls", "default_root"),
+    [
+        (TinkerSFTBackend, "/tmp/rllm-tinker-sft-checkpoints"),
+        (FireworksSFTBackend, "/tmp/rllm-fireworks-sft-checkpoints"),
+    ],
+)
+def test_default_paths_are_isolated_and_explicit_path_is_resume_identity(tmp_path, backend_cls, default_root):
+    first = backend_cls(SFTSpec(train_dataset=_source(), experiment="same"))
+    second = backend_cls(SFTSpec(train_dataset=_source(), experiment="same"))
+    assert first.checkpoint_dir != second.checkpoint_dir
+    assert first.checkpoint_dir.startswith(f"{default_root}/same/")
+
+    explicit_path = str(tmp_path / "resume")
+    explicit = backend_cls(SFTSpec(train_dataset=_source(), output_dir=explicit_path))
+    assert explicit.checkpoint_dir == explicit_path
+
+
+def test_fireworks_reattach_requires_explicit_cursor_directory():
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            overrides={"fireworks_infra": {"trainers": {"policy": {"job_id": "job-1"}}}},
+        )
+    )
+    with pytest.raises(SFTConfigError, match=r"job_id requires.*explicit --output"):
+        backend.build_config()
+
+
+@pytest.mark.parametrize(
+    ("case", "job_id"),
+    [("fresh-run-failure", None), ("reattached-run", "job-1")],
+)
+def test_fireworks_provision_never_requests_trainer_deletion(monkeypatch, tmp_path, case, job_id):
+    provision_module = pytest.importorskip("training.provision")
+
+    overrides = {}
+    if job_id is not None:
+        overrides = {"fireworks_infra": {"trainers": {"policy": {"job_id": job_id}}}}
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path / case),
+            overrides=overrides,
+        )
+    )
+    config = backend.build_config()
+    provision_config = object()
+    returned_infra = object()
+    call = {}
+
+    monkeypatch.setattr(
+        provision_module,
+        "load_yaml_provision",
+        lambda **_kwargs: ("sft", provision_config),
+    )
+
+    def init_fireworks_infra(mode, config_arg, **kwargs):
+        call.update(mode=mode, config=config_arg, **kwargs)
+        return returned_infra
+
+    monkeypatch.setattr(provision_module, "init_fireworks_infra", init_fireworks_infra)
+
+    assert backend._provision(config, "fake-key", "https://example.invalid") is returned_infra
+    assert call["mode"] == "sft"
+    assert call["config"] is provision_config
+    assert call["cleanup_on_close"] is False
+    assert call["cleanup_existing"] is False
+
+
+def test_tinker_manifest_rejects_changed_identity_and_legacy_checkpoint(tmp_path):
+    contract = SFTResumeContract(
+        payload={"contract_version": 1, "dataset": {"fingerprint": "first"}},
+        digest="contract-one",
+    )
+    prepare_tinker_resume_contract(str(tmp_path), contract, None)
+    matching = {
+        "contract_hash": "contract-one",
+    }
+    prepare_tinker_resume_contract(str(tmp_path), contract, matching)
+
+    changed = SFTResumeContract(
+        payload={"contract_version": 1, "dataset": {"fingerprint": "second"}},
+        digest="contract-two",
+    )
+    with pytest.raises(SFTConfigError, match="dataset.fingerprint.*new output"):
+        prepare_tinker_resume_contract(str(tmp_path), changed, matching)
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    with pytest.raises(SFTConfigError, match="legacy checkpoint.*sft-run.json.*missing"):
+        prepare_tinker_resume_contract(str(legacy_dir), contract, {})
+
+
+def test_fireworks_manifest_covers_identity_and_binds_provider_job(tmp_path):
+    dataset = TinkerSFTDataset(_source(5), _TokenRenderer(), batch_size=2)
+    backend = FireworksSFTBackend(SFTSpec(train_dataset=_source(), output_dir=str(tmp_path)))
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3.5"
+    config.data.resolved_renderer_source = "prime"
+    config.data.resolved_renderer_identity = {
+        "adapter": {"class": "renderers.Qwen35Renderer", "distributions": {"renderers": "1.2.3"}},
+        "implementation": {"class": "renderers.Qwen35Renderer", "distributions": {"renderers": "1.2.3"}},
+    }
+    config.data.resolved_tokenizer_identity = {
+        "class": "transformers.QwenTokenizerFast",
+        "name_or_path": "Qwen/Qwen3.5-9B",
+        "revision": "abc123",
+    }
+    optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=3)
+    contract = build_fireworks_resume_contract(
+        config,
+        dataset,
+        optimizer,
+        n_batches=3,
+        total_steps=3,
+    )
+
+    assert contract.payload["backend"] == {
+        "name": "fireworks",
+        "provider": {
+            "training_shape_id": "accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora",
+        },
+    }
+    dataset_identity = contract.payload["dataset"]
+    assert dataset_identity["fingerprint"] == dataset.content_fingerprint()
+    assert dataset_identity["row_count"] == 5
+    assert dataset_identity["batch_size"] == 2
+    implementation = dataset_identity["implementation"]
+    assert implementation["class"] == "rllm.data.dataset.Dataset"
+    assert contract.payload["rendering"]["renderer_source"] == "prime"
+    assert contract.payload["rendering"]["renderer_name"] == "qwen3.5"
+    assert contract.payload["rendering"]["loss_reduction"] == "token_mean"
+    assert contract.payload["rendering"]["tokenizer_model"] == "Qwen/Qwen3.5-9B"
+    assert contract.payload["model"]["base_model"] == "accounts/fireworks/models/qwen3p5-9b"
+    assert contract.payload["model"]["lora_rank"] == 32
+    assert contract.payload["optimizer"]["learning_rate"] == pytest.approx(1e-5)
+    assert contract.payload["horizon"]["total_steps"] == 3
+
+    prepared = prepare_fireworks_resume_contract(
+        str(tmp_path),
+        contract,
+        configured_job_id=None,
+    )
+    bound = validate_fireworks_resume_contract(
+        prepared,
+        configured_job_id=None,
+        actual_job_id="job-1",
+    )
+    assert bound.data["provider_job_id"] == "job-1"
+    resumed = prepare_fireworks_resume_contract(
+        str(tmp_path),
+        contract,
+        configured_job_id="job-1",
+    )
+    validate_fireworks_resume_contract(
+        resumed,
+        configured_job_id="job-1",
+        actual_job_id="job-1",
+        resume_info=SimpleNamespace(data_consumed=2),
+    )
+
+    config.data.resolved_renderer_source = "tinker"
+    changed = build_fireworks_resume_contract(
+        config,
+        dataset,
+        optimizer,
+        n_batches=3,
+        total_steps=3,
+    )
+    with pytest.raises(SFTConfigError, match="rendering.renderer_source.*new output"):
+        prepare_fireworks_resume_contract(
+            str(tmp_path),
+            changed,
+            configured_job_id="job-1",
+        )
+
+
+def test_tinker_resume_identity_covers_data_model_rendering_optimizer_and_horizon():
+    dataset = TinkerSFTDataset(_source(5), _TokenRenderer(), batch_size=2)
+    backend = TinkerSFTBackend(SFTSpec(train_dataset=_source()))
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    config.data.resolved_renderer_source = "prime"
+    config.data.resolved_renderer_identity = {
+        "adapter": {"class": "renderers.Qwen35Renderer", "distributions": {"renderers": "1.2.3"}},
+        "implementation": {"class": "renderers.Qwen35Renderer", "distributions": {"renderers": "1.2.3"}},
+    }
+    config.data.resolved_tokenizer_identity = {
+        "class": "transformers.QwenTokenizerFast",
+        "distributions": {"transformers": "4.0.0"},
+        "name_or_path": "Qwen/Qwen3.5-4B",
+        "revision": "abc123",
+        "runtime_versions": {"tokenizers": "0.1.0", "transformers": "4.0.0"},
+    }
+    optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=3)
+    contract = build_tinker_resume_contract(
+        config,
+        dataset,
+        optimizer,
+        n_batches=3,
+        total_steps=3,
+    )
+
+    assert set(contract.payload) == {
+        "contract_version",
+        "loop_semantics",
+        "backend",
+        "model",
+        "rendering",
+        "dataset",
+        "optimizer",
+        "horizon",
+    }
+    assert contract.payload["dataset"]["batch_size"] == 2
+    assert contract.payload["backend"]["name"] == "tinker"
+    assert contract.payload["model"]["base_model"] == "Qwen/Qwen3.5-4B"
+    assert contract.payload["rendering"]["renderer_name"] == "qwen3_5"
+    assert contract.payload["rendering"]["renderer_source"] == "prime"
+    assert contract.payload["rendering"]["renderer_identity"]["implementation"]["distributions"] == {"renderers": "1.2.3"}
+    assert contract.payload["rendering"]["tokenizer_identity"]["revision"] == "abc123"
+    assert contract.payload["rendering"]["tokenize_and_mask_method"] == "cumulative"
+    assert contract.payload["optimizer"]["learning_rate"] == pytest.approx(1e-5)
+    assert contract.payload["horizon"] == {
+        "batches_per_epoch": 3,
+        "total_steps": 3,
+    }
+
+
+def test_build_sft_data_records_resolved_renderer_and_tokenizer_identity(monkeypatch):
+    import tinker_cookbook.tokenizer_utils as tokenizer_module
+
+    import rllm.renderers as renderer_module
+    import rllm.trainer.sft.tinker_dataset as dataset_module
+
+    class _Tokenizer:
+        name_or_path = "example/tokenizer"
+        init_kwargs = {"_commit_hash": "revision-1"}
+
+    class _Renderer:
+        pass
+
+    tokenizer = _Tokenizer()
+    renderer = _Renderer()
+    resolution = SimpleNamespace(renderer=renderer, source="prime", name="qwen3.5")
+    monkeypatch.setattr(tokenizer_module, "get_tokenizer", lambda _name: tokenizer)
+    monkeypatch.setattr(renderer_module, "resolve", lambda *_args, **_kwargs: resolution)
+    monkeypatch.setattr(dataset_module, "create_tinker_sft_datasets", lambda **_kwargs: ("train", "val"))
+
+    backend = TinkerSFTBackend(SFTSpec(train_dataset=_source()))
+    config = backend.build_config()
+    returned_tokenizer, train, val = build_sft_data(config, _source(), None)
+
+    assert returned_tokenizer is tokenizer
+    assert (train, val) == ("train", "val")
+    assert config.data.resolved_renderer_name == "qwen3.5"
+    assert config.data.resolved_renderer_source == "prime"
+    assert config.data.resolved_renderer_identity.implementation["class"].endswith("._Renderer")
+    assert config.data.resolved_tokenizer_identity.name_or_path == "example/tokenizer"
+    assert config.data.resolved_tokenizer_identity.revision == "revision-1"
+
+
+def test_tinker_provider_identity_mismatch_fails_closed():
+    from tinker_cookbook import checkpoint_utils
+
+    backend = TinkerSFTBackend(SFTSpec(train_dataset=_source()))
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+
+    class _Rest:
+        async def get_weights_info_by_tinker_path(self, path):
+            del path
+            return SimpleNamespace(
+                base_model="wrong/model",
+                lora_rank=8,
+                train_unembed=True,
+                train_attn=True,
+                train_mlp=True,
+            )
+
+        async def get_training_run_by_tinker_path_async(self, path):
+            del path
+            return SimpleNamespace(user_metadata={checkpoint_utils.RENDERER_NAME_METADATA_KEY: "wrong_renderer"})
+
+    service = SimpleNamespace(create_rest_client=lambda: _Rest())
+    with pytest.raises(SFTConfigError, match="base_model=.*lora_rank=.*renderer=.*new output"):
+        asyncio.run(
+            validate_tinker_checkpoint_identity(
+                service,
+                "tinker://run/weights/step",
+                config,
+            )
+        )
+
+
+def _one_datum():
+    import torch
+    from tinker_cookbook.supervised.common import datum_from_model_input_weights
+
+    return datum_from_model_input_weights(
+        tinker.ModelInput.from_ints([1, 2, 3]),
+        torch.tensor([0.0, 1.0, 0.0]),
+        max_length=None,
+        reduction="none",
+    )
+
+
+class _HostedDataset:
+    def __init__(self, events, batches=3, *, batch_size=1, row_count=None):
+        self.events = events
+        self.batches = batches
+        self.batch_size = batch_size
+        self.dataset = [object()] * (row_count if row_count is not None else batches * batch_size)
+        self.datum = _one_datum()
+        self.training_batches = []
+        self.preflighting = False
+
+    def __len__(self):
+        return self.batches
+
+    def get_batch(self, index):
+        if not self.preflighting:
+            self.training_batches.append(index)
+            self.events.append(f"batch-{index}")
+        return [self.datum]
+
+    def set_epoch(self, seed):
+        self.events.append(f"epoch-{seed}")
+
+    def preflight(self, label="train", planned_batches=None):
+        self.preflighting = True
+        self.events.append(f"preflight-{label}")
+        try:
+            if planned_batches is not None:
+                for _epoch, batch in planned_batches:
+                    self.get_batch(batch)
+            else:
+                for batch in range(self.batches):
+                    self.get_batch(batch)
+        finally:
+            self.preflighting = False
+
+    def content_fingerprint(self):
+        return "hosted-dataset"
+
+    def data_cursor_for_step(self, completed_steps):
+        completed_epochs, batches_in_epoch = divmod(completed_steps, self.batches)
+        rows_in_epoch = min(batches_in_epoch * self.batch_size, len(self.dataset))
+        return completed_epochs * len(self.dataset) + rows_in_epoch
+
+    def step_for_data_cursor(self, data_consumed):
+        completed_epochs, rows_in_epoch = divmod(data_consumed, len(self.dataset))
+        batches_in_epoch = (rows_in_epoch + self.batch_size - 1) // self.batch_size
+        step = completed_epochs * self.batches + batches_in_epoch
+        if self.data_cursor_for_step(step) != data_consumed:
+            raise SFTConfigError("checkpoint cursor is not exact")
+        return step
+
+
+class _AsyncFuture:
+    def __init__(self, value, events, event):
+        self.value = value
+        self.events = events
+        self.event = event
+
+    async def result_async(self):
+        self.events.append(self.event)
+        return self.value
+
+
+class _TinkerTrainingClient:
+    def __init__(self, events, datum):
+        self.events = events
+        self.datum = datum
+        self.submitted = 0
+
+    def _output(self):
+        weights = self.datum.loss_fn_inputs["weights"]
+        logprobs = tinker.TensorData(
+            data=[-1.0] * len(weights.data),
+            dtype=weights.dtype,
+            shape=list(weights.shape),
+        )
+        return SimpleNamespace(loss_fn_outputs=[{"logprobs": logprobs}])
+
+    async def forward_backward_async(self, data, loss_fn):
+        del data, loss_fn
+        step = self.submitted
+        self.submitted += 1
+        self.events.append(f"submit-{step}")
+        return _AsyncFuture(self._output(), self.events, f"finish-fb-{step}")
+
+    async def optim_step_async(self, adam):
+        del adam
+        step = self.submitted - 1
+        return _AsyncFuture(SimpleNamespace(metrics={}), self.events, f"finish-opt-{step}")
+
+
+class _Tracking:
+    def __init__(self, **kwargs):
+        del kwargs
+
+    def log(self, data, step):
+        del data, step
+
+    def finish(self):
+        pass
+
+
+def test_tinker_checkpoint_drains_pipeline_and_records_next_unseen_cursor(monkeypatch, tmp_path):
+    from tinker_cookbook import checkpoint_utils, display
+
+    import rllm.trainer.sft.tinker_backend as module
+    import rllm.utils.tracking as tracking_module
+
+    events = []
+    train = _HostedDataset(events)
+    training_client = _TinkerTrainingClient(events, train.datum)
+    saves = []
+
+    class _Service:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        async def create_lora_training_client_async(self, **kwargs):
+            del kwargs
+            return training_client
+
+    async def save_checkpoint(**kwargs):
+        events.append(f"save-{kwargs['name']}")
+        saves.append(kwargs)
+
+    monkeypatch.setattr(module, "build_sft_data", lambda *_: (object(), train, None))
+    monkeypatch.setattr(tinker, "ServiceClient", _Service)
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: None)
+    monkeypatch.setattr(checkpoint_utils, "save_checkpoint_async", save_checkpoint)
+    monkeypatch.setattr(display, "colorize_example", lambda *_: "example")
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 3, "save_freq": 2, "test_freq": -1}},
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    asyncio.run(backend._fit_async())
+
+    assert events.index("finish-opt-1") < events.index("save-000002") < events.index("submit-2")
+    assert events.index("finish-opt-2") < events.index("save-final")
+    assert saves[0]["loop_state"]["epoch"] == 0
+    assert saves[0]["loop_state"]["batch"] == 2
+    assert saves[0]["loop_state"]["step"] == 2
+    assert saves[0]["loop_state"]["contract_hash"]
+    assert saves[1]["loop_state"]["step"] == 3
+    assert saves[1]["loop_state"]["final"] is True
+    assert all(save["kind"] == "both" for save in saves)
+
+
+def test_tinker_resume_restores_optimizer_and_starts_at_next_unseen_batch(monkeypatch, tmp_path):
+    from tinker_cookbook import checkpoint_utils, display
+
+    import rllm.trainer.sft.tinker_backend as module
+    import rllm.utils.tracking as tracking_module
+
+    events = []
+    train = _HostedDataset(events)
+    training_client = _TinkerTrainingClient(events, train.datum)
+    contract = SFTResumeContract(
+        payload={"contract_version": 1, "dataset": {"fingerprint": "same"}},
+        digest="same-contract",
+    )
+    prepare_tinker_resume_contract(str(tmp_path), contract, None)
+
+    class _Checkpoint:
+        state_path = "tinker://run/weights/step"
+
+        def get(self, key, default=None):
+            return {
+                "contract_hash": "same-contract",
+                "epoch": 0,
+                "batch": 2,
+                "step": 2,
+            }.get(key, default)
+
+    class _Rest:
+        async def get_weights_info_by_tinker_path(self, path):
+            assert path == "tinker://run/weights/step"
+            return SimpleNamespace(
+                base_model="Qwen/Qwen3.5-4B",
+                lora_rank=32,
+                train_unembed=True,
+                train_attn=True,
+                train_mlp=True,
+            )
+
+        async def get_training_run_by_tinker_path_async(self, path):
+            assert path == "tinker://run/weights/step"
+            return SimpleNamespace(user_metadata={checkpoint_utils.RENDERER_NAME_METADATA_KEY: "qwen3_5"})
+
+    class _Service:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def create_rest_client(self):
+            return _Rest()
+
+        async def create_training_client_from_state_with_optimizer_async(self, path, **kwargs):
+            del kwargs
+            events.append("resume-with-optimizer")
+            assert path == "tinker://run/weights/step"
+            return training_client
+
+        async def create_training_client_from_state_async(self, *args, **kwargs):
+            del args, kwargs
+            pytest.fail("weights-only resume must never be used")
+
+    async def save_checkpoint(**kwargs):
+        events.append(f"save-{kwargs['name']}")
+
+    monkeypatch.setattr(module, "build_sft_data", lambda *_: (object(), train, None))
+    monkeypatch.setattr(module, "build_tinker_resume_contract", lambda *_args, **_kwargs: contract)
+    monkeypatch.setattr(tinker, "ServiceClient", _Service)
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: _Checkpoint())
+    monkeypatch.setattr(checkpoint_utils, "save_checkpoint_async", save_checkpoint)
+    monkeypatch.setattr(display, "colorize_example", lambda *_: "example")
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 3, "save_freq": -1, "test_freq": -1}},
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    asyncio.run(backend._fit_async())
+
+    assert "resume-with-optimizer" in events
+    assert train.training_batches == [2]
+
+
+class _SyncFuture:
+    def __init__(self, value, events, event):
+        self.value = value
+        self.events = events
+        self.event = event
+
+    def result(self, timeout=None):
+        del timeout
+        self.events.append(self.event)
+        return self.value
+
+
+class _FireworksClient:
+    def __init__(self, events):
+        self.events = events
+        self.submitted = 0
+
+    def submit_forward_backward(self, data, loss_fn):
+        del data, loss_fn
+        step = self.submitted
+        self.submitted += 1
+        self.events.append(f"submit-{step}")
+        result = SimpleNamespace(metrics={"response_tokens": 1, "loss:sum": 1.0})
+        return _SyncFuture(result, self.events, f"finish-fb-{step}")
+
+    def submit_optim_step(self, adam):
+        del adam
+        step = self.submitted - 1
+        return _SyncFuture(None, self.events, f"finish-opt-{step}")
+
+
+class _FireworksCheckpoints:
+    def __init__(self, events, *, data_consumed=None, provider_step=0):
+        self.events = events
+        self.data_consumed = data_consumed
+        self.provider_step = provider_step
+        self.saves = []
+        self.log_path = None
+
+    def resume(self):
+        manifest = json.loads((Path(self.log_path) / "sft-run.json").read_text())
+        assert manifest["provider_job_id"] == "fake-job"
+        if self.data_consumed is None:
+            return None
+        return SimpleNamespace(step=self.provider_step, data_consumed=self.data_consumed)
+
+    def save(self, name, **kwargs):
+        self.events.append(f"save-{name}")
+        self.saves.append((name, kwargs))
+
+    def promote_latest(self, output_model_id, base_model):
+        del base_model
+        return {"name": output_model_id}
+
+
+def _run_fireworks(monkeypatch, tmp_path, *, data_consumed=None, provider_step=0):
+    checkpoint_module = pytest.importorskip("training.utils.checkpoints")
+
+    import rllm.trainer.sft.fireworks_backend as module
+    import rllm.utils.tracking as tracking_module
+
+    events = []
+    # Five rows at batch size three yields cursors 0 -> 3 -> 5 -> 8 across
+    # the partial final batch and the next epoch.
+    train = _HostedDataset(events, batches=2, batch_size=3, row_count=5)
+    client = _FireworksClient(events)
+    checkpoints = _FireworksCheckpoints(
+        events,
+        data_consumed=data_consumed,
+        provider_step=provider_step,
+    )
+    infra = SimpleNamespace(
+        policy=client,
+        service=object(),
+        policy_job_id="fake-job",
+        close=lambda: events.append("infra-close"),
+    )
+
+    overrides = {"trainer": {"max_steps": 3, "save_freq": 2, "test_freq": -1}}
+    if data_consumed is not None:
+        overrides["fireworks_infra"] = {"trainers": {"policy": {"job_id": "fake-job"}}}
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path),
+            epochs=2,
+            overrides=overrides,
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    config.data.resolved_renderer_source = "prime"
+    config.data.resolved_renderer_identity = {"implementation": {"class": "renderers.Qwen35Renderer"}}
+    config.data.resolved_tokenizer_identity = {"class": "transformers.QwenTokenizerFast"}
+    if data_consumed is not None:
+        optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=3)
+        contract = build_fireworks_resume_contract(
+            config,
+            train,
+            optimizer,
+            n_batches=2,
+            total_steps=3,
+        )
+        prepared = prepare_fireworks_resume_contract(
+            str(tmp_path),
+            contract,
+            configured_job_id=None,
+        )
+        validate_fireworks_resume_contract(
+            prepared,
+            configured_job_id=None,
+            actual_job_id="fake-job",
+            resume_info=None,
+        )
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
+    monkeypatch.setattr(module, "build_sft_data", lambda *_: (None, train, None))
+    monkeypatch.setattr(backend, "_provision", lambda *_: infra)
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+
+    def checkpoint_factory(*_args, **kwargs):
+        checkpoints.log_path = kwargs["log_path"]
+        return checkpoints
+
+    monkeypatch.setattr(checkpoint_module, "TrainingCheckpoints", checkpoint_factory)
+    backend.fit()
+    return events, train, checkpoints
+
+
+def test_fireworks_checkpoint_drains_pipeline_and_persists_raw_cursor(monkeypatch, tmp_path):
+    events, _train, checkpoints = _run_fireworks(monkeypatch, tmp_path)
+    assert checkpoints.log_path == str(tmp_path)
+    assert (tmp_path / "sft-run.json").exists()
+    assert events.index("finish-opt-1") < events.index("save-step-2") < events.index("submit-2")
+    assert events.index("finish-opt-2") < events.index("save-step-3")
+    assert checkpoints.saves == [
+        (
+            "step-2",
+            {"resumable": True, "promotable": False, "data_consumed": 5},
+        ),
+        (
+            "step-3",
+            {"resumable": True, "promotable": True, "data_consumed": 8},
+        ),
+    ]
+
+
+def test_fireworks_resume_ignores_provider_renamed_step_and_uses_raw_cursor(monkeypatch, tmp_path):
+    events, train, checkpoints = _run_fireworks(
+        monkeypatch,
+        tmp_path,
+        data_consumed=5,
+        provider_step=999,
+    )
+    assert train.training_batches == [0]
+    assert "epoch-1" in events
+    assert "batch-1" not in events
+    assert checkpoints.saves[-1][1]["data_consumed"] == 8
+
+
+def test_fireworks_resume_rejects_non_boundary_raw_cursor(monkeypatch, tmp_path):
+    with pytest.raises(SFTConfigError, match="cursor is not exact"):
+        _run_fireworks(
+            monkeypatch,
+            tmp_path,
+            data_consumed=1,
+            provider_step=1,
+        )

--- a/tests/trainer/test_sft_validation.py
+++ b/tests/trainer/test_sft_validation.py
@@ -249,6 +249,8 @@ class _LoopDataset:
     def __init__(self, events, batches):
         self.events = events
         self.batches = batches
+        self.dataset = list(batches)
+        self.batch_size = 1
 
     def __len__(self):
         return len(self.batches)
@@ -262,6 +264,12 @@ class _LoopDataset:
 
     def preflight(self, **_kwargs):
         pass
+
+    def content_fingerprint(self):
+        return "validation-loop-dataset"
+
+    def data_cursor_for_step(self, completed_steps):
+        return completed_steps
 
 
 class _LoopTinkerClient:


### PR DESCRIPTION
## Summary

Makes hosted checkpoint resume equivalent to continuing an uninterrupted run.

- Stores the next unseen data cursor after a completed optimizer update.
- Restores deterministic epoch/batch order across partial batches and epoch boundaries.
- Drains pending work before validation, intermediate saves, and final saves.
- Restores Tinker optimizer state as well as weights.
- Isolates implicit fresh-run directories; an explicit output path is intentional resume identity.
- Validates versioned manifests covering data, rendering/tokenizer identity, model/LoRA settings, optimizer, and horizon.
- Persists Fireworks raw-row cursors independently of provider-renamed checkpoint steps.
- Binds Fireworks manifests to the explicit provider job and preserves the trainer after failure or interruption.

## Contract

A resume either continues from the exact next batch with matching optimizer and run identity, or fails closed. Legacy, incomplete, mismatched, or non-boundary cursors are not guessed.

Fireworks reattachment requires both an explicit `--output` path containing the local manifest/cursor metadata and the matching provider job ID.

## Testing

- Focused resume, execution, and validation suite: 87 passed.
- Final canonical stack suite: 162 passed, 11 skipped, 9 deselected.
- Ruff, formatting, and diff checks pass.

## Stack

5 of 5. Depends on #850.
