### PR TITLE
fix(sft): preflight data before provider launch

### DIFF
--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -35,6 +35,7 @@ from rllm.trainer.sft.tinker_backend import (
     TinkerSFTBackend,
     build_adam_params,
     build_sft_data,
+    iter_training_batches,
     resolve_sft_optimizer_settings,
     resolve_training_steps,
     sft_lr_multiplier,
@@ -238,6 +239,29 @@ class FireworksSFTBackend(TinkerSFTBackend):
         try:
             _tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
 
+            n_batches = len(train_dataset)
+            total_epochs = config.trainer.get("total_epochs", 1)
+            max_steps = config.trainer.get("max_steps")
+            total_steps = resolve_training_steps(n_batches, total_epochs, max_steps)
+            progress_denominator = total_steps
+            optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=total_steps)
+            save_every = config.trainer.get("save_freq", 20)
+            eval_every = config.trainer.get("test_freq", 10)
+
+            train_dataset.preflight(
+                label="train",
+                planned_batches=(
+                    (epoch_idx, batch_idx)
+                    for _step, epoch_idx, batch_idx in iter_training_batches(
+                        n_batches=n_batches,
+                        total_epochs=total_epochs,
+                        max_steps=max_steps,
+                    )
+                ),
+            )
+            if val_dataset is not None:
+                val_dataset.preflight(label="validation")
+
             infra = self._provision(config, api_key, base_url)
             try:
                 client = infra.policy
@@ -253,21 +277,7 @@ class FireworksSFTBackend(TinkerSFTBackend):
                 resume = ckpt.resume()
                 start_step = resume.step if resume else 0
 
-                # len(dataset) floors examples//batch_size; keep the final partial
-                # batch when the dataset is smaller than one batch (else 0 steps).
-                n_batches = max(1, len(train_dataset))
-                total_epochs = config.trainer.get("total_epochs", 1)
-                total_steps = resolve_training_steps(
-                    n_batches,
-                    total_epochs,
-                    config.trainer.get("max_steps"),
-                )
-                progress_denominator = total_steps if total_steps > 0 else 1
                 logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
-
-                optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=total_steps)
-                save_every = config.trainer.get("save_freq", 20)
-                eval_every = config.trainer.get("test_freq", 10)
 
                 if should_validate_step(
                     0,

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -439,6 +439,36 @@ class TinkerSFTBackend(SFTBackend):
 
         config = self._config
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
+        tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
+
+        resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
+        start_epoch = resume_info.get("epoch", 0) if resume_info else 0
+        start_batch = resume_info.get("batch", 0) if resume_info else 0
+        n_batches = len(train_dataset)
+        total_epochs = config.trainer.get("total_epochs", 1)
+        max_steps = config.trainer.get("max_steps")
+        total_steps = resolve_training_steps(n_batches, total_epochs, max_steps)
+        progress_denominator = total_steps
+        optimizer = resolve_sft_optimizer_settings(config.get("optim", {}), total_steps=total_steps)
+        save_every = config.trainer.get("save_freq", 20)
+        eval_every = config.trainer.get("test_freq", 10)
+
+        train_dataset.preflight(
+            label="train",
+            planned_batches=(
+                (epoch_idx, batch_idx)
+                for _step, epoch_idx, batch_idx in iter_training_batches(
+                    n_batches=n_batches,
+                    total_epochs=total_epochs,
+                    start_epoch=start_epoch,
+                    start_batch=start_batch,
+                    max_steps=max_steps,
+                )
+            ),
+        )
+        if val_dataset is not None:
+            val_dataset.preflight(label="validation")
+
         service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
 
         logger_backend = config.trainer.logger
@@ -454,14 +484,9 @@ class TinkerSFTBackend(SFTBackend):
         # Wrap the loop so tracking_logger.finish() runs even on failure: the 'ui'
         # backend tees stdout/stderr and holds an open session until finish().
         try:
-            tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
-
-            resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
             if resume_info:
                 logger.info(f"Resuming from checkpoint: {resume_info}")
                 training_client = await service_client.create_training_client_from_state_async(resume_info["state_path"])
-                start_epoch = resume_info.get("epoch", 0)
-                start_batch = resume_info.get("batch", 0)
             else:
                 logger.info("Starting training from scratch")
                 training_client = await service_client.create_lora_training_client_async(
@@ -471,21 +496,7 @@ class TinkerSFTBackend(SFTBackend):
                     train_attn=OmegaConf.select(config, "model.train_attn", default=True),
                     train_mlp=OmegaConf.select(config, "model.train_mlp", default=True),
                 )
-                start_epoch = 0
-                start_batch = 0
-
-            # len(dataset) floors examples//batch_size; keep the final partial batch
-            # when the dataset is smaller than one batch (else 0 steps).
-            n_batches = max(1, len(train_dataset))
-            total_epochs = config.trainer.get("total_epochs", 1)
-            max_steps = config.trainer.get("max_steps")
-            total_steps = resolve_training_steps(n_batches, total_epochs, max_steps)
-            progress_denominator = total_steps if total_steps > 0 else 1
             logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
-
-            optimizer = resolve_sft_optimizer_settings(config.get("optim", {}), total_steps=total_steps)
-            save_every = config.trainer.get("save_freq", 20)
-            eval_every = config.trainer.get("test_freq", 10)
 
             if should_validate_step(
                 0,

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Iterable
 from typing import Literal
 
 import datasets
@@ -247,6 +248,37 @@ class TinkerSFTDataset(SupervisedDataset):
         elif datums and count_loss_tokens(datums) == 0:
             raise SFTConfigError("SFT batch has no trainable tokens after rendering and masking.")
         return datums
+
+    def preflight(
+        self,
+        *,
+        label: str,
+        planned_batches: Iterable[tuple[int, int]] | None = None,
+    ) -> None:
+        """Render planned batches without changing the order used for training."""
+        original_dataset = self.dataset
+        try:
+            if planned_batches is None:
+                for batch_idx in range(len(self)):
+                    try:
+                        if not self.get_batch(batch_idx):
+                            raise SFTConfigError("rendered batch is empty")
+                    except SFTConfigError as e:
+                        raise SFTConfigError(f"{label} preflight failed at batch {batch_idx}: {e}") from e
+                return
+
+            current_epoch: int | None = None
+            for epoch_idx, batch_idx in planned_batches:
+                if epoch_idx != current_epoch:
+                    self.set_epoch(seed=epoch_idx)
+                    current_epoch = epoch_idx
+                try:
+                    if not self.get_batch(batch_idx):
+                        raise SFTConfigError("rendered batch is empty")
+                except SFTConfigError as e:
+                    raise SFTConfigError(f"{label} preflight failed at epoch {epoch_idx}, batch {batch_idx}: {e}") from e
+        finally:
+            self.dataset = original_dataset
 
     def set_epoch(self, seed: int = 0):
         self.dataset = self.dataset.shuffle(seed=seed)

--- a/tests/trainer/test_sft_preflight.py
+++ b/tests/trainer/test_sft_preflight.py
@@ -1,0 +1,131 @@
+"""Hosted SFT data is rendered before a provider is started."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+from rllm.data import Dataset  # noqa: E402
+from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.fireworks_backend import FireworksSFTBackend  # noqa: E402
+from rllm.trainer.sft.tinker_backend import TinkerSFTBackend  # noqa: E402
+from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset  # noqa: E402
+
+
+class _TokenRenderer:
+    def build_supervised_example(self, messages, train_on_what):
+        import torch
+
+        del train_on_what
+        count = int(messages[-1]["content"][0]["text"])
+        return tinker.ModelInput.from_ints(list(range(count + 2))), torch.tensor(
+            [0.0, *([1.0] * count), 0.0],
+            dtype=torch.float32,
+        )
+
+
+def _dataset(lengths):
+    return Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": str(length), "trainable": True},
+                ]
+            }
+            for length in lengths
+        ],
+        name="lengths",
+        split="train",
+    )
+
+
+def test_preflight_checks_planned_shuffle_and_restores_source_order():
+    source = _dataset([0, 2, 0, 2])
+    dataset = TinkerSFTDataset(source, renderer=_TokenRenderer(), batch_size=2)
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        dataset.preflight(label="train", planned_batches=[(0, 0), (0, 1)])
+
+    assert dataset.dataset is source
+
+
+def test_validation_preflight_checks_every_batch():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 20]),
+        renderer=_TokenRenderer(),
+        batch_size=1,
+        max_length=10,
+        overlength_policy="error",
+    )
+
+    with pytest.raises(SFTConfigError, match="validation preflight.*batch 1.*max_length=10"):
+        dataset.preflight(label="validation")
+
+
+def test_tinker_preflight_failure_precedes_service_client(monkeypatch, tmp_path):
+    from tinker_cookbook import checkpoint_utils
+
+    import rllm.trainer.sft.tinker_backend as backend_module
+
+    train = TinkerSFTDataset(
+        _dataset([0, 2, 0, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+    )
+    monkeypatch.setattr(backend_module, "build_sft_data", lambda *_: (object(), train, None))
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: None)
+    monkeypatch.setattr(tinker, "ServiceClient", lambda **_: pytest.fail("provider client must not be created"))
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_dataset([2]),
+            output_dir=str(tmp_path),
+            batch_size=2,
+            overrides={"trainer": {"max_steps": 2}},
+        )
+    )
+    backend.build_config()
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        asyncio.run(backend._fit_async())
+
+
+def test_fireworks_preflight_failure_precedes_provision(monkeypatch, tmp_path):
+    import rllm.trainer.sft.fireworks_backend as backend_module
+    import rllm.utils.tracking as tracking_module
+
+    train = TinkerSFTDataset(
+        _dataset([0, 2, 0, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+    )
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_dataset([2]),
+            output_dir=str(tmp_path),
+            batch_size=2,
+            overrides={"trainer": {"max_steps": 2}},
+        )
+    )
+    backend.build_config()
+
+    class _Tracking:
+        def __init__(self, **_kwargs):
+            pass
+
+        def finish(self):
+            pass
+
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+    monkeypatch.setattr(backend_module, "build_sft_data", lambda *_: (None, train, None))
+    monkeypatch.setattr(backend, "_provision", lambda *_: pytest.fail("provider trainer must not be provisioned"))
+
+    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
+        backend.fit()


### PR DESCRIPTION
Part 11 of 11 in the draft stack replacing #809.

Base: `agent/sft-optimizer-controls`
Previous: #852

## Change

Render the exact planned training batches and every validation batch before creating a Tinker client or provisioning a Fireworks trainer. Preflight restores dataset order after validation.

## Why it matters

Malformed schema, overlength examples, empty supervision, or invalid planning fail before paid provider resources start.

## Verification

- `pytest tests/trainer/test_sft_preflight.py -q`
- full stacked tip: 152 passed, 22 skipped