### PR TITLE
fix(renderers): normalize serving output tool calls

### DIFF
--- a/rllm/engine/rollout/tinker_engine.py
+++ b/rllm/engine/rollout/tinker_engine.py
@@ -128,21 +128,40 @@ def _parse_tinker_message(message: Message) -> tuple[str, str, list[Any]]:
     else:  # no reasoning parsed
         content = tinker_content
         reasoning = ""
-    # Convert tinker-cookbook ToolCall (function.name/function.arguments) to rllm ToolCall (name/arguments)
-    raw_tool_calls = message.get("tool_calls", [])
-    tool_calls = []
-    for tc in raw_tool_calls:
-        if hasattr(tc, "function"):
-            # tinker-cookbook ToolCall: ToolCall(function=FunctionBody(name, arguments), id)
-            args = tc.function.arguments
-            tool_calls.append(ToolCall(name=tc.function.name, arguments=json.loads(args) if isinstance(args, str) else args))
-        elif isinstance(tc, ToolCall):
-            tool_calls.append(tc)
-        elif isinstance(tc, dict):
-            tool_calls.append(ToolCall(name=tc.get("name", ""), arguments=tc.get("arguments", {})))
+    return content, reasoning, _to_rllm_tool_calls(message.get("tool_calls", []))
+
+
+def _to_rllm_tool_calls(raw_tool_calls: list[Any] | None) -> list[ToolCall]:
+    """Normalize parser-owned tool calls before they enter ``ModelOutput``."""
+    normalized: list[ToolCall] = []
+    for index, tool_call in enumerate(raw_tool_calls or []):
+        status = tool_call.get("status") if isinstance(tool_call, dict) else getattr(tool_call, "status", None)
+        if status is not None and getattr(status, "value", status) != "ok":
+            continue
+        if isinstance(tool_call, ToolCall):
+            normalized.append(tool_call)
+            continue
+
+        if isinstance(tool_call, dict):
+            function = tool_call.get("function")
+            source = function if isinstance(function, dict) else tool_call
+            name = source.get("name", "")
+            arguments = source.get("arguments", {})
         else:
-            raise TypeError(f"Unrecognized tool_call type: {type(tc)}")
-    return content, reasoning, tool_calls
+            function = getattr(tool_call, "function", None)
+            source = function if function is not None else tool_call
+            name = getattr(source, "name", "")
+            arguments = getattr(source, "arguments", {})
+
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"tool call {index} has invalid JSON arguments") from error
+        if not isinstance(arguments, dict):
+            raise ValueError(f"tool call {index} arguments must decode to an object")
+        normalized.append(ToolCall(name=name, arguments=arguments))
+    return normalized
 
 
 class TinkerEngine(RolloutEngine):
@@ -407,13 +426,13 @@ class TinkerEngine(RolloutEngine):
             parsed = self.unified_renderer.parse_response(response_tokens)
             content = parsed.content or ""
             reasoning = parsed.reasoning_content or ""
-            tool_calls = parsed.tool_calls or []
+            tool_calls = _to_rllm_tool_calls(parsed.tool_calls)
         elif self.bypass_render_with_parser:
             assert self.chat_parser is not None, "chat_parser must be set when bypass_render_with_parser=True"
             parsed_output = self.chat_parser.parse_completion(response_tokens)
             content = parsed_output.get("content", "")
             reasoning = parsed_output.get("reasoning", "")
-            tool_calls = parsed_output.get("tool_calls", [])
+            tool_calls = _to_rllm_tool_calls(parsed_output.get("tool_calls", []))
         else:
             assert isinstance(self.renderer, renderers.Renderer), "self.renderer must be a valid Tinker Renderer"
             response_message, _ = self.renderer.parse_response(response_tokens)

--- a/rllm/renderers/adapters.py
+++ b/rllm/renderers/adapters.py
@@ -11,17 +11,77 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from .bridging import BridgingRendererMixin
 from .types import ParsedResponse, RenderedTokens
 
 
-def _to_parsed(content: str, reasoning: str | None, tool_calls: Any) -> ParsedResponse:
+def _flatten_parts(content: Any) -> tuple[str, str]:
+    """Split structured renderer content into visible text and thinking."""
+    if not isinstance(content, list):
+        return content or "", ""
+    text = "".join(part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text")
+    thinking = "".join(part.get("thinking", "") for part in content if isinstance(part, dict) and part.get("type") == "thinking")
+    return text, thinking
+
+
+def _to_openai_tool_call(tool_call: Any) -> dict[str, Any]:
+    """Normalize renderer-owned tool calls to the canonical nested shape."""
+    if isinstance(tool_call, dict):
+        function = tool_call.get("function")
+        if isinstance(function, dict):
+            return {
+                "id": tool_call.get("id"),
+                "type": tool_call.get("type", "function"),
+                "function": {
+                    "name": function.get("name", ""),
+                    "arguments": function.get("arguments", "{}"),
+                },
+            }
+        name = tool_call.get("name", "")
+        arguments = tool_call.get("arguments", "{}")
+        tool_call_id = tool_call.get("id")
+    else:
+        function = getattr(tool_call, "function", None)
+        source = function if function is not None else tool_call
+        name = getattr(source, "name", "")
+        arguments = getattr(source, "arguments", "{}")
+        tool_call_id = getattr(tool_call, "id", None)
+    return {
+        "id": tool_call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _to_versioned_tool_call(tool_call: Any) -> Any:
+    """Return the tool-call type required by the installed renderer API."""
+    normalized = _to_openai_tool_call(tool_call)
+    try:
+        from renderers import ParsedToolCall  # type: ignore
+    except ImportError:
+        return normalized
+    if isinstance(tool_call, ParsedToolCall):
+        return tool_call
+    function = normalized["function"]
+    return ParsedToolCall(
+        raw=json.dumps(normalized, separators=(",", ":")),
+        name=function["name"],
+        arguments=function["arguments"],
+        id=normalized["id"],
+    )
+
+
+def _to_parsed(content: Any, reasoning: str | None, tool_calls: Any) -> ParsedResponse:
+    if isinstance(content, list):
+        content, thinking = _flatten_parts(content)
+        reasoning = reasoning or thinking
     return ParsedResponse(
         content=content or "",
         reasoning_content=reasoning or None,
-        tool_calls=list(tool_calls) if tool_calls else None,
+        tool_calls=[_to_versioned_tool_call(tool_call) for tool_call in tool_calls or []],
     )
 
 
@@ -61,7 +121,7 @@ class TinkerRendererAdapter(BridgingRendererMixin):
     def get_stop_token_ids(self) -> list[int]:
         return [int(t) for t in self._inner.get_stop_sequences()]
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(self, token_ids: list[int], *, tools=None) -> ParsedResponse:
         msg, _term = self._inner.parse_response(list(token_ids))
         get = msg.get if isinstance(msg, dict) else (lambda k, d=None: getattr(msg, k, d))
         return _to_parsed(get("content", ""), get("reasoning_content"), get("tool_calls"))
@@ -88,5 +148,5 @@ class ChatTemplateAdapter(BridgingRendererMixin):
     def get_stop_token_ids(self) -> list[int]:
         return list(self.close_token_ids)
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(self, token_ids: list[int], *, tools=None) -> ParsedResponse:
         return _to_parsed(self._tok.decode(list(token_ids), skip_special_tokens=True), None, None)

--- a/tests/engine/test_tinker_engine.py
+++ b/tests/engine/test_tinker_engine.py
@@ -1,17 +1,22 @@
 """Tests for tinker_engine OpenAI-to-renderer conversion helpers."""
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from tinker_cookbook.renderers import get_renderer
 from tinker_cookbook.renderers.base import ToolCall as TinkerToolCall
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
+from rllm.engine.rollout.rollout_engine import ModelOutput
 from rllm.engine.rollout.tinker_engine import (
+    TinkerEngine,
     _convert_openai_messages,
     _parse_tinker_message,
     _prepare_messages_with_tools,
+    _to_rllm_tool_calls,
 )
+from rllm.renderers.types import ParsedResponse
 from rllm.tools.tool_base import ToolCall as RllmToolCall
 
 # ------------------------------------------------------------------
@@ -158,6 +163,62 @@ class TestPrepareMessagesWithTools:
 
 
 class TestParseTinkerMessage:
+    @pytest.mark.parametrize(
+        "tool_call",
+        [
+            pytest.param(_make_tinker_tool_call(), id="cookbook-object"),
+            pytest.param(
+                {"id": "call_0", "type": "function", "function": {"name": "calculator", "arguments": '{"expression": "2+2"}'}},
+                id="nested-dict",
+            ),
+            pytest.param({"name": "calculator", "arguments": {"expression": "2+2"}}, id="flat-dict"),
+        ],
+    )
+    def test_tool_call_shapes_are_serializable_model_output(self, tool_call):
+        engine = object.__new__(TinkerEngine)
+        engine.unified_renderer = SimpleNamespace(
+            parse_response=lambda _tokens: ParsedResponse(
+                content="",
+                reasoning_content=None,
+                tool_calls=[tool_call],
+            )
+        )
+        engine.bypass_render_with_parser = False
+        engine.tokenizer = SimpleNamespace(decode=lambda *_args, **_kwargs: "")
+        sampled = SimpleNamespace(tokens=[7], logprobs=[0.0], stop_reason="stop")
+
+        output = engine.assemble_model_output([1], sampled)
+
+        assert output.to_dict()["tool_calls"] == [{"name": "calculator", "arguments": {"expression": "2+2"}}]
+
+    def test_invalid_json_arguments_fail_at_parser_boundary(self):
+        with pytest.raises(ValueError, match="invalid JSON arguments"):
+            _to_rllm_tool_calls([{"function": {"name": "calculator", "arguments": "{"}}])
+
+    def test_non_ok_parsed_tool_calls_are_not_executed(self):
+        renderers = pytest.importorskip("renderers")
+        parsed_tool_call_type = getattr(renderers, "ParsedToolCall", None)
+        status_type = getattr(renderers, "ToolCallParseStatus", None)
+        if parsed_tool_call_type is None or status_type is None:
+            pytest.skip("installed renderer API does not expose typed tool-call status")
+
+        valid = parsed_tool_call_type(
+            raw='<tool_call>{"name":"calculator","arguments":{"expression":"2+2"}}</tool_call>',
+            name="calculator",
+            arguments={"expression": "2+2"},
+            status=status_type.OK,
+        )
+        malformed = parsed_tool_call_type(
+            raw='<tool_call>{"name":"calculator","arguments":{</tool_call>',
+            name="calculator",
+            arguments="{",
+            status=status_type.INVALID_JSON,
+        )
+
+        normalized = _to_rllm_tool_calls([valid, malformed])
+
+        assert ModelOutput(tool_calls=normalized).to_dict()["tool_calls"] == [{"name": "calculator", "arguments": {"expression": "2+2"}}]
+
     def test_tinker_tool_calls_converted_to_rllm(self):
         """Tinker ToolCall(function=FunctionBody(...)) should become rllm ToolCall(name, arguments)."""
         tc = _make_tinker_tool_call()

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -8,6 +8,7 @@ are skipped if it (or tinker_cookbook) is unavailable. Run offline.
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,7 +16,7 @@ os.environ.setdefault("HF_HUB_OFFLINE", "1")
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 from rllm.renderers import BridgingRendererMixin, get_renderer, resolve  # noqa: E402
-from rllm.renderers.adapters import ChatTemplateAdapter  # noqa: E402
+from rllm.renderers.adapters import ChatTemplateAdapter, TinkerRendererAdapter  # noqa: E402
 
 QWEN = "Qwen/Qwen3-0.6B"
 
@@ -124,6 +125,54 @@ def test_tinker_adapter_renders(qwen_tokenizer):
     ids = a.render_ids([{"role": "user", "content": "hi"}], add_generation_prompt=True)
     assert ids and isinstance(ids[0], int)
     assert a.get_stop_token_ids()  # non-empty
+
+
+def test_tinker_parse_normalizes_structured_content_and_tool_calls():
+    class CookbookRenderer:
+        @staticmethod
+        def get_stop_sequences():
+            return [99]
+
+        @staticmethod
+        def parse_response(_token_ids):
+            return (
+                {
+                    "content": [
+                        {"type": "thinking", "thinking": "first\n"},
+                        {"type": "thinking", "thinking": "second"},
+                        {"type": "text", "text": "answer "},
+                        {"type": "text", "text": "body"},
+                    ],
+                    "tool_calls": [
+                        SimpleNamespace(
+                            id="call_1",
+                            function=SimpleNamespace(name="bash", arguments='{"command":"ls"}'),
+                        )
+                    ],
+                },
+                None,
+            )
+
+    parsed = TinkerRendererAdapter(CookbookRenderer()).parse_response([1, 2, 3], tools=[])
+
+    assert parsed.reasoning_content == "first\nsecond"
+    assert parsed.content == "answer body"
+    import renderers
+
+    parsed_tool_call_type = getattr(renderers, "ParsedToolCall", None)
+    if parsed_tool_call_type is None:
+        assert parsed.tool_calls == [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+            }
+        ]
+    else:
+        assert isinstance(parsed.tool_calls[0], parsed_tool_call_type)
+        assert parsed.tool_calls[0].name == "bash"
+        assert parsed.tool_calls[0].arguments == '{"command":"ls"}'
+        assert parsed.tool_calls[0].status.value == "ok"
 
 
 def test_tinker_adapter_bridge_matches_prime(qwen_tokenizer):


### PR DESCRIPTION
## Why

Renderer versions and cookbook adapters return different parsed tool-call objects. Those objects must become rLLM `ToolCall` values before they enter `ModelOutput`; otherwise trajectory serialization can fail, and malformed parser attempts can be mistaken for executable calls.

## Change

- Flattens structured renderer response parts into the canonical parsed response fields.
- Emits the tool-call type required by both the legacy and typed `renderers` APIs.
- Converts dictionary, cookbook, and typed parser outputs to rLLM `ToolCall` values at the engine boundary.
- Ignores typed parser attempts whose status is not `OK` and fails clearly on invalid executable arguments.

## Boundary

This PR changes serving output normalization only. It does not change the SFT schema, training renderer, loss mask, validation, optimizer loop, or checkpoint behavior.

## Testing

- Focused tests pass against both the legacy and typed renderer APIs.
- The engine-boundary test verifies that parsed tool calls survive `assemble_model_output()` and `ModelOutput.to_dict()`.
- Ruff, formatting, and diff checks pass.

## Stack

1 of 5. Based on `terminal-rl`, which includes #842. Followed by #845.
