### PR TITLE
fix(gateway): bound the upstream read so a silent provider is retryable

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/proxy.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/proxy.py
@@ -389,7 +389,7 @@ class ReverseProxy:
 
     async def start(self) -> None:
         self._http = httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout=None),  # no timeout — LLM calls can be long
+            timeout=httpx.Timeout(connect=10.0, read=600.0, write=600.0, pool=600.0),
             limits=httpx.Limits(max_connections=500, max_keepalive_connections=100),
             follow_redirects=True,
         )
@@ -1443,11 +1443,11 @@ class ReverseProxy:
         for attempt in range(1 + self.max_retries):
             try:
                 resp = await self._http.request(method, url, content=content, headers=headers)
-            except httpx.ConnectError as exc:
+            except httpx.TransportError as exc:
                 last_exc = exc
                 if attempt < self.max_retries:
                     logger.warning(
-                        "Connection error (attempt %d/%d): %s",
+                        "Transport error (attempt %d/%d): %s",
                         attempt + 1,
                         self.max_retries + 1,
                         exc,


### PR DESCRIPTION
## The failure

The proxy's httpx client is constructed with `timeout=None`, so a provider that accepts a request and then goes quiet is indistinguishable from one still generating. The request parks until the 3600s heartbeat budget **cancels** it — and a cancellation is not something `_send_with_retry` can recover from.

By then the damage compounds. Past `heartbeat_initial_delay_s` the status line is already committed as `200`, so the failure can only be reported inside the body:

```json
{"error": {"message": "gateway heartbeat budget of 3600s exhausted waiting for upstream", "code": 504}}
```

The OpenAI SDK builds that with `.construct()`, which skips validation and leaves `choices = None`. The agent's next line is `response.choices[0]`, so the rollout dies on a bare `TypeError: 'NoneType' object is not subscriptable` — a Python type error naming nothing about the actual cause.

Two retry layers exist and neither can fire: the gateway's, because it never sees a failure (still waiting); the SDK's, because it sees a `200`.

## The fix

Two lines.

**Bound the read at 600s.** That is the OpenAI SDK's own default, which would have applied to this stack all along were the heartbeat not resetting the client's clock every 25s. A stall now surfaces as `httpx.ReadTimeout` instead of silence.

**Widen the retry to `TransportError`.** `ReadTimeout` and `RemoteProtocolError` sit on different branches of httpx's exception tree than `ConnectError`, so naming that one alone missed both. `HTTPStatusError` is not a `TransportError`, so the status-code retry path below is untouched.

Neither line works alone — without the timeout the exception is never raised, and without the wider catch it is never handled. Three attempts at 600s fit inside the 3600s heartbeat budget, so the request now fails by **raising** rather than by being cancelled, and the budget returns to being a genuine last resort.

## Impact

Measured over a 220-task evaluation after this landed:

| | |
|---|---|
| requests that stalled | **15** |
| recovered on the first retry | 7 |
| recovered on the second | 2 |
| exhausted all three | 6 |

Before it, every one of those 15 was an hour-long hang that killed its rollout. Retries happen behind the heartbeat, invisibly to the agent — the conversation simply continues.

## Verification

Reproduced against a server that accepts a request and never replies:

```
exception type             -> ReadTimeout
caught by TransportError   -> True     ← the fix
caught by ConnectError     -> False    ← why the old code missed it
retry attempts made        -> 3
```

Gateway unit suite: 270 passed.

## Trade-off

A turn that legitimately exceeds 600s of upstream silence would previously have succeeded and will now be retried. For scale, the heaviest task in these runs averaged ~23s per model call, so 600s is roughly 26× that. Worth naming as a behavioural change; if the threshold is too tight the symptom is visible in the logs as retries on merely-slow turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a2MyDJxQ9JAhcB2SVP7pT