### PR TITLE
eval: pin the gateway port so concurrent evals can share a host

### DIFF
--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -24,6 +24,56 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Per-run override for the port the gateway binds behind a tunnel. Sibling to
+#: ``RLLM_GATEWAY_TUNNEL``: whoever supplies the public URL is the only one who
+#: knows which port it forwards to, so the two travel together.
+ENV_GATEWAY_PORT = "RLLM_GATEWAY_PORT"
+
+
+def resolve_gateway_port(tunnel_url: str) -> int:
+    """Port the gateway must bind so *tunnel_url* reaches it.
+
+    A tunnel URL means an already-running forwarder, so the gateway has to bind
+    wherever that forwarder points — a free-port pick would leave the tunnel
+    aimed at nothing.
+
+    Resolution order: ``$RLLM_GATEWAY_PORT`` → the ``rllm tunnel up`` daemon's
+    recorded upstream (only when its URL matches) → the setup config's port.
+
+    The env var comes first because the other two are process-wide: one daemon
+    state file, one config file, one value each. Owned per-run tunnels already
+    coexist — they pick a free port and never reach here — but a *bring your own
+    forwarder* setup does, and concurrent evals behind separate hostnames would
+    otherwise all read the same number and collide on bind. That is the case
+    ``RLLM_GATEWAY_TUNNEL`` exists for, and the only one without an escape hatch.
+    """
+    from rllm.env import env_int
+
+    override = env_int(ENV_GATEWAY_PORT, 0)
+    if override:
+        return override
+
+    from urllib.parse import urlparse
+
+    from rllm.gateway.tunnel import live_tunnel
+
+    state = live_tunnel() or {}
+    upstream = state.get("upstream") if state.get("url") == tunnel_url else None
+    port = urlparse(upstream).port if upstream else None
+    if port is not None:
+        return port
+
+    from rllm.eval.config import load_tunnel_config
+
+    port = int(load_tunnel_config().get("port") or 9090)
+    logger.warning(
+        "Tunnel URL %s has no matching daemon state; binding the gateway to port %d from the tunnel config — it must match the port that URL forwards to. Set %s to override.",
+        tunnel_url,
+        port,
+        ENV_GATEWAY_PORT,
+    )
+    return port
+
 
 async def run_dataset(
     tasks: list,  # list[rllm.types.Task]
@@ -103,27 +153,7 @@ async def run_dataset(
             if tunnel_warning:
                 logger.warning(tunnel_warning)
             if gateway_tunnel.startswith(("http://", "https://")):
-                # A tunnel URL means an already-running forwarder; the gateway
-                # must bind wherever it forwards (a free-port pick would leave
-                # the tunnel pointing at nothing). The daemon's recorded
-                # ``upstream`` is authoritative; a URL supplied some other way
-                # (env var) falls back to the setup config's port.
-                from urllib.parse import urlparse
-
-                from rllm.gateway.tunnel import live_tunnel
-
-                state = live_tunnel() or {}
-                upstream = state.get("upstream") if state.get("url") == gateway_tunnel else None
-                gateway_port = urlparse(upstream).port if upstream else None
-                if gateway_port is None:
-                    from rllm.eval.config import load_tunnel_config
-
-                    gateway_port = int(load_tunnel_config().get("port") or 9090)
-                    logger.warning(
-                        "Tunnel URL %s has no matching daemon state; binding the gateway to port %d from the tunnel config — it must match the port that URL forwards to.",
-                        gateway_tunnel,
-                        gateway_port,
-                    )
+                gateway_port = resolve_gateway_port(gateway_tunnel)
         gateway = EvalGatewayManager(upstream_url=base_url, model=model, tunnel=gateway_tunnel, port=gateway_port)
         gateway.start()
 

--- a/tests/eval/test_gateway_port_resolution.py
+++ b/tests/eval/test_gateway_port_resolution.py
@@ -1,0 +1,116 @@
+"""Port resolution for an eval gateway sitting behind a tunnel.
+
+Concurrent evals against *remote* sandboxes each need their own tunnel on
+their own port. Daemon state and the setup config are both process-wide
+singletons, so without an explicit override every run reads the same port and
+the second one dies on bind. ``RLLM_GATEWAY_PORT`` is that override.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import rllm.eval.runner as runner_mod
+from rllm.eval.runner import ENV_GATEWAY_PORT, resolve_gateway_port
+
+URL = "https://gw.example.test"
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_override(monkeypatch):
+    monkeypatch.delenv(ENV_GATEWAY_PORT, raising=False)
+
+
+def _daemon(monkeypatch, *, url: str, port: int) -> None:
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setattr(tunnel_mod, "live_tunnel", lambda: {"backend": "ngrok", "url": url, "pid": 1, "upstream": f"http://127.0.0.1:{port}"})
+
+
+def _config_port(monkeypatch, port: int) -> None:
+    import rllm.eval.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_tunnel_config", lambda: {"port": port})
+
+
+def test_env_override_wins_over_daemon_state(monkeypatch):
+    """The whole point: two runs sharing one daemon still get distinct ports."""
+    _daemon(monkeypatch, url=URL, port=9091)
+    monkeypatch.setenv(ENV_GATEWAY_PORT, "9092")
+
+    assert resolve_gateway_port(URL) == 9092
+
+
+def test_daemon_upstream_used_when_url_matches(monkeypatch):
+    _daemon(monkeypatch, url=URL, port=9091)
+    _config_port(monkeypatch, 4321)
+
+    assert resolve_gateway_port(URL) == 9091
+
+
+def test_daemon_ignored_when_url_differs(monkeypatch):
+    """A daemon forwarding somewhere else says nothing about this tunnel."""
+    _daemon(monkeypatch, url="https://stale.example.test", port=9091)
+    _config_port(monkeypatch, 4321)
+
+    assert resolve_gateway_port(URL) == 4321
+
+
+def test_falls_back_to_config_and_warns(monkeypatch, caplog):
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setattr(tunnel_mod, "live_tunnel", lambda: None)
+    _config_port(monkeypatch, 4321)
+
+    with caplog.at_level("WARNING", logger=runner_mod.__name__):
+        assert resolve_gateway_port(URL) == 4321
+
+    assert ENV_GATEWAY_PORT in caplog.text
+
+
+def test_resolved_port_reaches_the_gateway(monkeypatch):
+    """The resolved port must actually be handed to the gateway.
+
+    Resolution being correct is worthless if ``run_dataset`` drops the value on
+    the way to ``EvalGatewayManager`` — the gateway would then pick a free port
+    and the tunnel would forward to nothing. Guards the wiring against a future
+    refactor, which unit-testing the resolver alone cannot do.
+    """
+    import asyncio
+
+    import rllm.gateway.manager as manager_mod
+    import rllm.gateway.tunnel as tunnel_mod
+
+    monkeypatch.setenv(ENV_GATEWAY_PORT, "9137")
+    monkeypatch.setattr(tunnel_mod, "resolve_auto_tunnel", lambda: (URL, None))
+    monkeypatch.setattr(tunnel_mod, "is_local_sandbox_backend", lambda name: False)
+    monkeypatch.setattr(runner_mod, "is_local_sandbox_backend", lambda name: False, raising=False)
+
+    seen: dict = {}
+
+    class _Gateway:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+        def start(self):
+            raise _Stop
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr(manager_mod, "EvalGatewayManager", _Gateway)
+    monkeypatch.setattr(runner_mod, "EvalGatewayManager", _Gateway, raising=False)
+
+    with pytest.raises(_Stop):
+        asyncio.run(
+            runner_mod.run_dataset(
+                tasks=[],
+                agent_flow=object(),
+                base_url="http://127.0.0.1:1/v1",
+                model="m",
+                sandbox_backend="modal",
+            )
+        )
+
+    assert seen["port"] == 9137
+    assert seen["tunnel"] == URL


### PR DESCRIPTION
## The problem

Two evals on one machine fight over the gateway port whenever `RLLM_GATEWAY_TUNNEL` is supplied.

A tunnel URL means an **already-running forwarder**, so the gateway cannot pick a port freely — it has to bind wherever that forwarder points, or the tunnel aims at nothing. The two places the port could otherwise come from are both process-wide:

- the `rllm tunnel up` daemon's state file — one entry
- the setup config — one value

Runs with their own per-run tunnel never hit this. They call `_find_free_port()`, create their own route, and never reach this code. But a **bring-your-own-forwarder** setup does, and concurrent evals behind separate hostnames all read the same number and collide on bind.

## The change

`RLLM_GATEWAY_PORT` resolves first, ahead of the daemon state and the config, so each run can be told explicitly where its own tunnel points:

```
$RLLM_GATEWAY_PORT  →  daemon state (only when its URL matches)  →  setup config
```

The env var comes first precisely because the other two cannot distinguish between concurrent runs. It is a sibling to `RLLM_GATEWAY_TUNNEL`: whoever supplies the public URL is the only one who knows which port it forwards to, so the two travel together.

## Note on the diff size

Most of it is not new logic:

```
rllm/eval/runner.py                        +52 −21    net +31
tests/eval/test_gateway_port_resolution.py +116  −0
```

The 21 deleted lines are the **same resolution logic**, previously inline inside a conditional in a long function and untested. This lifts it into a named `resolve_gateway_port()` and adds one step at the front — the env-var check. The remainder is a docstring explaining why the order is what it is, and tests pinning it: env var wins, then matching daemon state, then config fallback, plus the non-matching-URL case.

That ordering is the kind of thing that breaks silently when someone reorders it later, which is what the tests are for.

## Verification

`tests/eval/test_gateway_port_resolution.py` — 5 passed. Full suite unchanged against `terminal-rl`: same 28 pre-existing failures, none introduced.

Used in practice to run four concurrent GDPval evaluations behind separate Cloudflare hostnames on one host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a2MyDJxQ9JAhcB2SVP7pT