### PR TITLE
fix(traces): preserve provider reasoning content

### DIFF
--- a/rllm/engine/trace_converter.py
+++ b/rllm/engine/trace_converter.py
@@ -37,7 +37,7 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
     - logprobs (per-token)
     """
     content = trace.response_message.get("content", "") or ""
-    reasoning = trace.response_message.get("reasoning", "") or ""
+    reasoning = trace.response_message.get("reasoning") or trace.response_message.get("reasoning_content") or ""
 
     # Extract tool_calls from response message (OpenAI format)
     raw_tool_calls = trace.response_message.get("tool_calls")

--- a/tests/engine/test_trace_converter.py
+++ b/tests/engine/test_trace_converter.py
@@ -170,6 +170,34 @@ class TestTraceRecordToStep:
         assert step.thought == "Let me think..."
         assert step.model_output.reasoning == "Let me think..."
 
+    def test_step_with_reasoning_content_and_tool_call(self):
+        """OpenAI-compatible GLM responses retain reasoning and tool calls."""
+        trace = self._make_trace(
+            response_message={
+                "role": "assistant",
+                "content": "I will inspect the repository.",
+                "reasoning_content": "Let me think through this...",
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "arguments": '{"command": "find . -maxdepth 2 -type d"}',
+                        },
+                    }
+                ],
+            },
+            finish_reason="tool_calls",
+        )
+        step = trace_record_to_step(trace)
+
+        assert step.thought == "Let me think through this..."
+        assert step.model_output.reasoning == "Let me think through this..."
+        assert step.model_output.tool_calls is not None
+        assert step.model_output.tool_calls[0].name == "bash"
+        assert step.model_output.tool_calls[0].arguments == {"command": "find . -maxdepth 2 -type d"}
+
     def test_chat_completions_includes_response(self):
         trace = self._make_trace()
         step = trace_record_to_step(trace)


### PR DESCRIPTION
## Summary

- normalize OpenAI-compatible `reasoning_content` into `Step.thought` and `ModelOutput.reasoning`
- preserve the existing `reasoning` field as the preferred representation
- add a GLM-shaped regression test that also verifies structured tool-call parsing

## Root cause

`trace_record_to_step` only read `response_message["reasoning"]`. Fireworks and ZAI return model thinking under `reasoning_content`, so the raw assistant message retained the thinking while the normalized step silently stored an empty reasoning string.

## Impact

Future external-provider trajectories retain model thinking in the normalized fields used by episode consumers. Existing providers that emit `reasoning` are unchanged, and tool-call parsing remains intact.

## Validation

- `PYTHONPATH=. python -m pytest tests/engine/test_trace_converter.py -q` — 13 passed
- `ruff check rllm/engine/trace_converter.py tests/engine/test_trace_converter.py`
- `ruff format --check rllm/engine/trace_converter.py tests/engine/test_trace_converter.py`
- `git diff --check`
