### PR TITLE
feat(sandbox): collect artifacts out of a sandbox, and bound Modal's snapshot

### DIFF
--- a/rllm/sandbox/artifacts.py
+++ b/rllm/sandbox/artifacts.py
@@ -1,0 +1,43 @@
+"""Helpers for copying generated artifacts out of sandboxes."""
+
+from __future__ import annotations
+
+import shutil
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO
+
+
+def extract_regular_files(archive: BinaryIO, local_path: str, *, root_name: str) -> list[str]:
+    """Safely extract regular files from a sandbox-created tar archive.
+
+    Sandbox backends archive the requested directory itself, so ``root_name``
+    is stripped before files are written under ``local_path``. Links, special
+    files, empty paths, and paths that could escape the destination are ignored.
+    """
+    destination = Path(local_path)
+    destination.mkdir(parents=True, exist_ok=True)
+    destination_resolved = destination.resolve()
+    downloaded: list[str] = []
+
+    with tarfile.open(fileobj=archive, mode="r:*") as bundle:
+        for member in bundle.getmembers():
+            if not member.isfile():
+                continue
+            parts = PurePosixPath(member.name).parts
+            if parts and parts[0] == root_name:
+                parts = parts[1:]
+            if not parts or any(part in {"", ".", ".."} for part in parts):
+                continue
+            target = destination.joinpath(*parts)
+            if destination_resolved not in target.resolve().parents:
+                continue
+            source = bundle.extractfile(member)
+            if source is None:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            downloaded.append(str(target))
+
+    return downloaded

--- a/rllm/sandbox/backends/docker.py
+++ b/rllm/sandbox/backends/docker.py
@@ -7,6 +7,8 @@ import logging
 import os
 import tarfile
 
+from rllm.sandbox.artifacts import extract_regular_files
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,8 +18,7 @@ class DockerSandbox:
     Creates a container with ``sleep infinity``, uploads files via tar archives,
     executes commands via ``exec_run()``, and runs agent processes with ``nohup``.
 
-    Requires the ``docker`` Python package (not in ``[sdk]`` extra — install
-    separately when using ``backend=docker``).
+    Requires the ``docker`` Python package, installed with rLLM.
     """
 
     def __init__(self, name: str, image: str = "python:3.11-slim", **kwargs):
@@ -113,6 +114,18 @@ class DockerSandbox:
             tar.add(local_path, arcname=remote_name)
         tar_stream.seek(0)
         self._container.put_archive(remote_parent, tar_stream)
+
+    def download_dir(self, remote_path: str, local_path: str) -> list[str]:
+        """Download regular files from a container directory.
+
+        Docker returns a tar stream rooted at the requested directory name.
+        Extract files manually so path traversal entries and links are never
+        written to the host.
+        """
+        chunks, _ = self._container.get_archive(remote_path)
+        archive = io.BytesIO(b"".join(chunks))
+        root_name = os.path.basename(remote_path.rstrip("/"))
+        return extract_regular_files(archive, local_path, root_name=root_name)
 
     def is_alive(self) -> bool:
         """Refresh container state from the Docker daemon and check it is running."""

--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -25,6 +25,7 @@ import uuid
 import weakref
 
 from rllm.env import env_float, env_int, rllm_run_id, sandbox_timeout_override_s
+from rllm.sandbox.artifacts import extract_regular_files
 from rllm.sandbox.protocol import SandboxCommandTimeout, SnapshotNotFound
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,10 @@ def _attach_run_tags(sandbox, tags: dict[str, str], name: str) -> None:
     except Exception:
         logger.debug("could not tag sandbox %s", name, exc_info=True)
 
+
+# Wall-clock allowed for capturing a snapshot. Scales with image size, so the
+# SDK's 55s default is far too tight for anything but a minimal image.
+_SNAPSHOT_TIMEOUT = env_int("RLLM_MODAL_SNAPSHOT_TIMEOUT_S", 15 * 60)
 
 # Modal caps an exec's total argv at 64 KiB (ARG_MAX); payloads above this go
 # through a chunked temp-file path instead of being inlined in the command.
@@ -470,6 +475,31 @@ class ModalSandbox:
         self._push_b64(b64, f"base64 -d | tar xzf - --no-same-owner -C {remote_parent}")
         logger.debug("Uploaded dir %s -> %s in sandbox %s (base64 fallback)", local_path, remote_path, self.name)
 
+    def download_dir(self, remote_path: str, local_path: str) -> list[str]:
+        """Download regular files from a Modal sandbox directory.
+
+        Modal's binary exec mode keeps the tar stream byte-for-byte intact.
+        Files are extracted through the shared sandbox artifact helper, which
+        rejects links and paths that could escape ``local_path``.
+        """
+        normalized = remote_path.rstrip("/")
+        remote_parent = os.path.dirname(normalized) or "/"
+        remote_name = os.path.basename(normalized)
+        if not remote_name:
+            raise ValueError("download_dir requires a directory other than the filesystem root")
+
+        process = self._sandbox.exec("tar", "czf", "-", "-C", remote_parent, remote_name, text=False)
+        archive_bytes = process.stdout.read()
+        stderr = process.stderr.read()
+        process.wait()
+        if process.returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"Failed to download {remote_path} from Modal sandbox {self.name}: {detail}")
+
+        downloaded = extract_regular_files(io.BytesIO(archive_bytes), local_path, root_name=remote_name)
+        logger.debug("Downloaded %d file(s) from %s in sandbox %s", len(downloaded), remote_path, self.name)
+        return downloaded
+
     def is_alive(self) -> bool:
         """One API call: ``poll()`` returns ``None`` while the sandbox is still running.
 
@@ -588,12 +618,14 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
 
     # Size the build sandbox's lifetime to the worst-case replay: each RUN is
     # bounded at 900s (a step that hangs against a prebuilt image burns its
-    # full bound), plus the install bound and pull/capture slack — floored at
-    # the rollout default. Without this floor, two hung steps killed the
-    # sandbox mid-build. A from_dockerfile build replays nothing.
+    # full bound), plus the install bound, the snapshot capture, and pull
+    # slack — floored at the rollout default. Without this floor, two hung
+    # steps killed the sandbox mid-build; without the capture budget the
+    # sandbox can expire during the snapshot, which is the thing being
+    # captured. A from_dockerfile build replays nothing.
     install_budget = env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900) if install_script else 0
     n_replay = 0 if dockerfile is not None else (len(_dockerfile_run_commands(task)) if _should_replay_dockerfile(task) else 0)
-    build_timeout = max(_default_sandbox_timeout(), 900 * n_replay + install_budget + 600)
+    build_timeout = max(_default_sandbox_timeout(), 900 * n_replay + install_budget + _SNAPSHOT_TIMEOUT + 600)
     sb = _create_base_sandbox(
         task,
         "modal",
@@ -606,7 +638,10 @@ def build_modal_snapshot(task, key: str, prior_ref: str | None = None, *, force:
             _replay_dockerfile(task, sb, "modal")
         if install_script:
             sb.exec(install_script, timeout=env_int("RLLM_HARNESS_INSTALL_TIMEOUT_S", 900), user="root")
-        image = sb._sandbox.snapshot_filesystem()  # noqa: SLF001 — modal.Image
+        # snapshot_filesystem() defaults to a 55s bound, which only ever fits a
+        # small image — a multi-GB one blows it and surfaces as a bare
+        # "Timeout expired" with no indication of which phase failed.
+        image = sb._sandbox.snapshot_filesystem(timeout=_SNAPSHOT_TIMEOUT)  # noqa: SLF001 — modal.Image
         logger.info("modal snapshot built: %s -> %s", key, image.object_id)
         return image.object_id
     finally:

--- a/tests/sandbox/test_docker_artifacts.py
+++ b/tests/sandbox/test_docker_artifacts.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import io
+import tarfile
+
+from rllm.sandbox.backends.docker import DockerSandbox
+
+
+def _archive() -> bytes:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as bundle:
+        content = b"workbook"
+        item = tarfile.TarInfo("deliverables/nested/Sample.xlsx")
+        item.size = len(content)
+        bundle.addfile(item, io.BytesIO(content))
+
+        traversal = tarfile.TarInfo("deliverables/../escape.txt")
+        traversal.size = len(content)
+        bundle.addfile(traversal, io.BytesIO(content))
+    return stream.getvalue()
+
+
+def test_download_dir_extracts_regular_files_without_path_traversal(tmp_path):
+    class Container:
+        def get_archive(self, remote_path):
+            assert remote_path == "/home/user/deliverables"
+            return iter([_archive()]), {}
+
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox._container = Container()
+
+    downloaded = sandbox.download_dir("/home/user/deliverables", str(tmp_path))
+
+    expected = tmp_path / "nested" / "Sample.xlsx"
+    assert downloaded == [str(expected)]
+    assert expected.read_bytes() == b"workbook"
+    assert not (tmp_path.parent / "escape.txt").exists()

--- a/tests/sandbox/test_modal_artifacts.py
+++ b/tests/sandbox/test_modal_artifacts.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from rllm.sandbox.backends.modal_backend import ModalSandbox
+
+
+def _archive() -> bytes:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w:gz") as bundle:
+        content = b"presentation"
+        item = tarfile.TarInfo("deliverables/nested/slides.pptx")
+        item.size = len(content)
+        bundle.addfile(item, io.BytesIO(content))
+
+        traversal = tarfile.TarInfo("deliverables/../escape.txt")
+        traversal.size = len(content)
+        bundle.addfile(traversal, io.BytesIO(content))
+    return stream.getvalue()
+
+
+class _Reader:
+    def __init__(self, value: bytes):
+        self.value = value
+
+    def read(self) -> bytes:
+        return self.value
+
+
+class _Process:
+    def __init__(self, stdout: bytes, stderr: bytes = b"", returncode: int = 0):
+        self.stdout = _Reader(stdout)
+        self.stderr = _Reader(stderr)
+        self.returncode = returncode
+        self.waited = False
+
+    def wait(self) -> None:
+        self.waited = True
+
+
+def test_download_dir_streams_binary_tar_and_extracts_safe_files(tmp_path):
+    process = _Process(_archive())
+
+    class Sandbox:
+        def exec(self, *args, **kwargs):
+            assert args == ("tar", "czf", "-", "-C", "/home/user", "deliverables")
+            assert kwargs == {"text": False}
+            return process
+
+    sandbox = ModalSandbox.__new__(ModalSandbox)
+    sandbox.name = "test-modal"
+    sandbox._sandbox = Sandbox()
+
+    downloaded = sandbox.download_dir("/home/user/deliverables/", str(tmp_path))
+
+    expected = tmp_path / "nested" / "slides.pptx"
+    assert downloaded == [str(expected)]
+    assert expected.read_bytes() == b"presentation"
+    assert not (tmp_path.parent / "escape.txt").exists()
+    assert process.waited
+
+
+def test_download_dir_surfaces_modal_tar_failure(tmp_path):
+    process = _Process(b"", stderr=b"tar: deliverables: Cannot stat", returncode=2)
+
+    class Sandbox:
+        def exec(self, *args, **kwargs):
+            return process
+
+    sandbox = ModalSandbox.__new__(ModalSandbox)
+    sandbox.name = "test-modal"
+    sandbox._sandbox = Sandbox()
+
+    with pytest.raises(RuntimeError, match="Cannot stat"):
+        sandbox.download_dir("/home/user/deliverables", str(tmp_path))
+
+
+def test_download_dir_rejects_filesystem_root(tmp_path):
+    sandbox = ModalSandbox.__new__(ModalSandbox)
+
+    with pytest.raises(ValueError, match="other than the filesystem root"):
+        sandbox.download_dir("/", str(tmp_path))
+
+
+def test_snapshot_capture_is_given_a_workable_timeout():
+    """modal's snapshot_filesystem() defaults to 55s.
+
+    That only ever fits a minimal image; a multi-GB one fails with a bare
+    "Timeout expired" that names neither the phase nor the bound. The capture
+    must be given an explicit budget, and the sandbox has to outlive it.
+    """
+    import inspect
+
+    import modal
+
+    from rllm.sandbox.backends import modal_backend
+
+    sdk_default = inspect.signature(modal.Sandbox.snapshot_filesystem).parameters["timeout"].default
+    assert sdk_default <= 60, "SDK default changed; revisit whether an override is still needed"
+
+    assert modal_backend._SNAPSHOT_TIMEOUT >= 600
+    source = inspect.getsource(modal_backend.build_modal_snapshot)
+    assert "snapshot_filesystem(timeout=_SNAPSHOT_TIMEOUT)" in source
+    # The sandbox is what is being captured, so its lifetime must cover it.
+    assert "_SNAPSHOT_TIMEOUT + 600" in source

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -348,7 +348,9 @@ def test_modal_build_reuses_or_rebuilds(monkeypatch, ref_alive, force, expected)
             object_id = "im-new"
 
         class _SB:
-            _sandbox = type("S", (), {"snapshot_filesystem": staticmethod(lambda: _Img())})()
+            # Takes the explicit capture timeout the backend passes: modal's own
+            # default is 55s, which no multi-GB image can meet.
+            _sandbox = type("S", (), {"snapshot_filesystem": staticmethod(lambda timeout=None: _Img())})()
 
             def close(self):
                 pass


### PR DESCRIPTION
Sandbox plumbing only — no harness or benchmark is referenced.

## Getting files back out

Both backends could push files *into* a sandbox but had no way to pull them back out, so a benchmark could only score what the agent **said**, never what it produced.

`download_dir` closes that: tar the remote directory, stream it out, and extract through a shared helper in `rllm/sandbox/artifacts.py` that rejects links and any path that would escape the destination. Both backends enforce the same rules rather than each inventing its own idea of a safe path.

Modal's transport needs the binary exec mode to keep the archive byte-for-byte intact; docker's `get_archive` already streams a tar.

## Modal's snapshot timeout

`snapshot_filesystem()` defaults to **55 seconds**, which only ever fits a small image. A multi-GB one blows through it and surfaces as a bare `Timeout expired` naming no phase.

Worse, the build sandbox's own lifetime did not cover the capture — so the sandbox could expire *during* the snapshot, destroying the very thing being captured. Both now use the same 15-minute budget, overridable with `RLLM_MODAL_SNAPSHOT_TIMEOUT_S`.

## Verification

`tests/sandbox` — 85 passed. Full suite against `terminal-rl`: same 28 pre-existing failures, none introduced.

Exercised over a 220-task evaluation collecting deliverables (xlsx, pdf, docx) out of Modal sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a2MyDJxQ9JAhcB2SVP7pT