### PR TITLE
Add built-in no-op evaluation harness

### DIFF
--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -518,7 +518,7 @@ class AgentFlowEngine:
                 # upstream returned nothing (dead litellm proxy, gateway "no healthy
                 # workers", or the model itself). Surface it loudly — otherwise the
                 # run silently produces garbage (every rollout scores 0).
-                if episode is not None:
+                if episode is not None and getattr(self.agent_flow, "makes_llm_calls", True):
                     _steps = [s for t in (episode.trajectories or []) for s in (t.steps or [])]
                     if _steps and all(not (s.model_response or "").strip() for s in _steps):
                         n_empty_rollouts += 1

--- a/rllm/harnesses/nop.py
+++ b/rllm/harnesses/nop.py
@@ -10,7 +10,6 @@ class NopHarness(SandboxedAgentFlow):
     """Make no agent-side changes before the task evaluator runs."""
 
     name = "nop"
-    sandbox_backend = "docker"
     makes_llm_calls = False
 
     def run(self, task: Task, config: AgentConfig, *, env) -> Episode:

--- a/rllm/harnesses/nop.py
+++ b/rllm/harnesses/nop.py
@@ -1,0 +1,28 @@
+"""No-op harness for grading an untouched sandbox."""
+
+from __future__ import annotations
+
+from rllm.sandbox.sandboxed_flow import SandboxedAgentFlow
+from rllm.types import AgentConfig, Episode, Step, Task, Trajectory
+
+
+class NopHarness(SandboxedAgentFlow):
+    """Make no agent-side changes before the task evaluator runs."""
+
+    name = "nop"
+    sandbox_backend = "docker"
+    makes_llm_calls = False
+
+    def run(self, task: Task, config: AgentConfig, *, env) -> Episode:
+        step = Step(input=str(task.instruction), output="[nop] no changes applied")
+        trajectory = Trajectory(
+            uid=config.session_uid,
+            name=self.name,
+            task=task.id,
+            steps=[step],
+        )
+        return Episode(
+            id=config.session_uid,
+            task=task.id,
+            trajectories=[trajectory],
+        )

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -56,6 +56,11 @@
       "function": "OracleHarness",
       "description": "Run the task's reference solution (solution/solve.sh) without an LLM. Smoke-test for verifier + image."
     },
+    "nop": {
+      "module": "rllm.harnesses.nop",
+      "function": "NopHarness",
+      "description": "Make no agent-side changes and grade the untouched sandbox."
+    },
     "zeroclaw": {
       "module": "rllm.harnesses.zeroclaw",
       "function": "ZeroClawHarness",

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -281,12 +281,13 @@ def test_llm_free_harness_opts_out_of_the_empty_completion_canary():
     assert getattr(MiniSweAgentHarness, "makes_llm_calls", True) is True
 
 
-@pytest.mark.parametrize(("makes_llm_calls", "warns"), [(False, False), (True, True)])
+@pytest.mark.parametrize(("makes_llm_calls", "warns"), [(None, True), (False, False), (True, True)])
 def test_empty_completion_progress_canary_respects_llm_free_flows(monkeypatch, makes_llm_calls, warns):
     from rllm.types import Step
 
     agent = _Agent()
-    agent.makes_llm_calls = makes_llm_calls
+    if makes_llm_calls is not None:
+        agent.makes_llm_calls = makes_llm_calls
     gateway = _Gateway()
     engine = AgentFlowEngine(
         agent_flow=agent,

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -281,6 +281,40 @@ def test_llm_free_harness_opts_out_of_the_empty_completion_canary():
     assert getattr(MiniSweAgentHarness, "makes_llm_calls", True) is True
 
 
+@pytest.mark.parametrize(("makes_llm_calls", "warns"), [(False, False), (True, True)])
+def test_empty_completion_progress_canary_respects_llm_free_flows(monkeypatch, makes_llm_calls, warns):
+    from rllm.types import Step
+
+    agent = _Agent()
+    agent.makes_llm_calls = makes_llm_calls
+    gateway = _Gateway()
+    engine = AgentFlowEngine(
+        agent_flow=agent,
+        evaluator=_Evaluator(),
+        gateway=gateway,
+        model="test-model",
+        n_parallel_tasks=1,
+    )
+    episode = Episode(
+        id="task:0",
+        trajectories=[Trajectory(name="solver", steps=[Step(output="[model-free diagnostic]")])],
+    )
+
+    async def process_task_with_retry(task, task_id, rollout_idx, result_idx, is_validation=False):
+        return task_id, rollout_idx, result_idx, episode
+
+    engine.process_task_with_retry = process_task_with_retry
+    warnings = []
+    monkeypatch.setattr("rllm.engine.agentflow_engine.colorful_print", lambda message, **kwargs: warnings.append(message))
+
+    try:
+        asyncio.run(engine.execute_tasks([task_from_row({"question": "q"}, "task")], task_ids=["task"]))
+    finally:
+        engine.shutdown()
+
+    assert bool(warnings) is warns
+
+
 def test_infra_taxonomy_membership_and_mapping():
     from rllm.types import INFRA_ERROR_REASONS, TerminationReason, termination_reason_from_error
 

--- a/tests/harnesses/test_nop.py
+++ b/tests/harnesses/test_nop.py
@@ -1,0 +1,28 @@
+"""Tests for the model-free no-op harness."""
+
+from rllm.eval.agent_loader import load_agent
+from rllm.harnesses.nop import NopHarness
+from rllm.types import AgentConfig, Task
+
+
+class _UntouchedEnv:
+    def __getattr__(self, name):
+        raise AssertionError(f"nop harness accessed sandbox attribute {name!r}")
+
+
+def test_nop_harness_leaves_sandbox_untouched():
+    harness = NopHarness()
+    task = Task(id="task-1", instruction="Do nothing")
+    config = AgentConfig(base_url="", model="none", session_uid="task-1:0")
+
+    episode = harness.run(task, config, env=_UntouchedEnv())
+
+    assert episode.id == "task-1:0"
+    assert episode.task == "task-1"
+    assert episode.trajectories[0].name == "nop"
+    assert episode.trajectories[0].steps[0].output == "[nop] no changes applied"
+    assert harness.makes_llm_calls is False
+
+
+def test_nop_harness_is_available_by_builtin_name():
+    assert isinstance(load_agent("nop"), NopHarness)


### PR DESCRIPTION
## Summary

- add a built-in, model-free `nop` harness that makes no agent-side sandbox changes
- register it as `--agent nop`
- suppress false `EMPTY COMPLETIONS` progress warnings for model-free flows
- test both untouched-sandbox behavior and built-in agent loading

## Why

Oracle/no-op differential validation currently requires a temporary custom harness. A built-in no-op harness makes the pristine-baseline leg reproducible while preserving the normal task setup, artifact collection, and verifier flow.

## Usage

```bash
rllm eval <dataset> \
  --agent nop \
  --sandbox-backend modal \
  --model none
```

## Validation

- `pytest tests/engine/test_agentflow_engine.py tests/harnesses/test_nop.py tests/eval/test_agent_loader.py -q` (31 passed)
- `ruff check rllm/harnesses/nop.py tests/harnesses/test_nop.py`
- `ruff format --check rllm/harnesses/nop.py tests/harnesses/test_nop.py`
