### PR TITLE
feat(eval): add OrcaRouter as a named provider

### DIFF
--- a/rllm/eval/config.py
+++ b/rllm/eval/config.py
@@ -275,6 +275,35 @@ PROVIDER_REGISTRY: list[ProviderInfo] = [
         ],
         base_url=TINKER_OAI_BASE_URL,
     ),
+    # --- OrcaRouter — OpenAI-compatible routing gateway ---
+    ProviderInfo(
+        id="orcarouter",
+        label="OrcaRouter",
+        # Route through LiteLLM's OpenAI-compatible adapter pinned to
+        # OrcaRouter's api_base (same pattern as Tinker). OrcaRouter exposes
+        # 150+ router-prefixed model ids (openai/gpt-5.5, anthropic/...,
+        # deepseek/...) behind one endpoint; ``litellm_prefix="openai"`` sends
+        # the namespaced id verbatim to the gateway.
+        litellm_prefix="openai",
+        env_key="ORCAROUTER_API_KEY",
+        default_model="openai/gpt-5.5",
+        models=[
+            "openai/gpt-5.5",
+            "openai/gpt-5.2",
+            "anthropic/claude-sonnet-4.6",
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-haiku-4.5",
+            "deepseek/deepseek-v4-pro",
+            "deepseek/deepseek-v4-flash",
+            "google/gemini-3.1-pro-preview",
+            "qwen/qwen3.5-plus",
+            "minimax/minimax-m2.7",
+            "z-ai/glm-5.1",
+            "kimi/kimi-k2.6",
+            "grok/grok-4.3",
+        ],
+        base_url="https://api.orcarouter.ai/v1",
+    ),
     # --- Custom endpoint (last) ---
     ProviderInfo(
         id="custom",

--- a/tests/eval/test_eval_config.py
+++ b/tests/eval/test_eval_config.py
@@ -237,3 +237,49 @@ class TestConstants:
         """MiniMax should have an entry in DEFAULT_MODELS."""
         assert "minimax" in DEFAULT_MODELS
         assert DEFAULT_MODELS["minimax"] == "MiniMax-M3"
+
+    def test_orcarouter_provider_info(self):
+        """OrcaRouter provider should have correct metadata."""
+        info = get_provider_info("orcarouter")
+        assert info is not None
+        assert info.label == "OrcaRouter"
+        assert info.litellm_prefix == "openai"
+        assert info.env_key == "ORCAROUTER_API_KEY"
+
+    def test_orcarouter_base_url(self):
+        """OrcaRouter routes through the OpenAI adapter pinned to its api_base."""
+        info = get_provider_info("orcarouter")
+        assert info is not None
+        assert info.base_url == "https://api.orcarouter.ai/v1"
+
+    def test_orcarouter_default_model(self):
+        """OrcaRouter default model should be the GPT-5.5 flagship."""
+        info = get_provider_info("orcarouter")
+        assert info is not None
+        assert info.default_model == "openai/gpt-5.5"
+
+    def test_orcarouter_models_are_namespaced(self):
+        """OrcaRouter model ids carry the router namespace (e.g. openai/...)."""
+        info = get_provider_info("orcarouter")
+        assert info is not None
+        assert len(info.models) >= 5
+        for mid in info.models:
+            assert "/" in mid, f"{mid} must be router-prefixed"
+        assert "openai/gpt-5.5" in info.models
+        assert "anthropic/claude-sonnet-4.6" in info.models
+        assert "deepseek/deepseek-v4-pro" in info.models
+
+    def test_orcarouter_config_validates(self):
+        """A complete OrcaRouter config should pass validation."""
+        config = RllmConfig(
+            provider="orcarouter",
+            api_keys={"orcarouter": "sk-orca-test"},
+            model="openai/gpt-5.5",
+        )
+        assert config.is_configured()
+        assert config.validate() == []
+
+    def test_orcarouter_in_default_models(self):
+        """OrcaRouter should have an entry in DEFAULT_MODELS."""
+        assert "orcarouter" in DEFAULT_MODELS
+        assert DEFAULT_MODELS["orcarouter"] == "openai/gpt-5.5"

--- a/tests/eval/test_eval_proxy.py
+++ b/tests/eval/test_eval_proxy.py
@@ -94,3 +94,14 @@ class TestEvalProxyManager:
         r = repr(pm)
         assert "minimax" in r
         assert "MiniMax-M2.7" in r
+
+    def test_build_proxy_config_orcarouter(self):
+        """OrcaRouter should route through the OpenAI adapter pinned to its api_base."""
+        pm = EvalProxyManager(provider="orcarouter", model_name="openai/gpt-5.5", api_key="ok-orca-key")
+        config = pm.build_proxy_config()
+
+        entry = config["model_list"][0]
+        assert entry["model_name"] == "openai/gpt-5.5"
+        assert entry["litellm_params"]["model"] == "openai/openai/gpt-5.5"
+        assert entry["litellm_params"]["api_key"] == "ok-orca-key"
+        assert entry["litellm_params"]["api_base"] == "https://api.orcarouter.ai/v1"


### PR DESCRIPTION
## Summary

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint: screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named provider so users can opt in directly.

I'm an engineer on the OrcaRouter team.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Docs
- [ ] Refactor
- [ ] Example / Project
- [ ] Infra / CI

## What changed

- `rllm/eval/config.py`: register `orcarouter` in `PROVIDER_REGISTRY` (labeled "OrcaRouter"), routed through LiteLLM's OpenAI-compatible adapter pinned to `https://api.orcarouter.ai/v1` with `ORCAROUTER_API_KEY`, mirroring the existing Tinker fixed-endpoint pattern and the OpenRouter named-aggregator entry.
- `tests/eval/test_eval_config.py`: coverage for provider metadata, default model, namespaced model ids, config validation, and the `DEFAULT_MODELS` entry.
- `tests/eval/test_eval_proxy.py`: coverage for proxy config generation pinning the OpenAI adapter to the OrcaRouter `api_base`.

## Validation

- [x] `pre-commit run --all-files` (ruff lint + ruff-format on the changed files, pinned 0.11.4 matching `.pre-commit-config.yaml`)
- [x] Targeted tests: `pytest tests/eval/test_eval_config.py`
- [x] Manual validation performed
- [ ] Not run (reason below)

Validation details:
- `pytest tests/eval/test_eval_config.py`: 40 passed, 1 failed (`test_save_sets_permissions` asserts a 0o600 mode; this is a pre-existing Windows-only `os.chmod` limitation that reproduces on the pristine HEAD, unrelated to this change, and does not affect Linux CI).
- Proxy config generation verified: `EvalProxyManager(provider="orcarouter", model_name="openai/gpt-5.5", api_key=...)` yields `litellm_params` `{"model": "openai/openai/gpt-5.5", "api_key": ..., "api_base": "https://api.orcarouter.ai/v1"}`; existing providers (Tinker, MiniMax) are unchanged.
- Live API: with a real key, `litellm.completion(model="openai/openai/gpt-5.5", api_base="https://api.orcarouter.ai/v1", ...)` returns 200 with content, and direct `POST https://api.orcarouter.ai/v1/chat/completions` for `openai/gpt-5.5` and `deepseek/deepseek-v4-pro` both return 200.

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed
- [ ] Updated docs
- [ ] Updated examples
- [ ] Follow-up docs needed

## Related issues / PRs

- None
