### PR TITLE
eval: allow per-run provider override

### DIFF
--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -1,6 +1,6 @@
 """Eval CLI command.
 
-``rllm eval <benchmark> --agent <name> [--evaluator <name>] [--base-url <url>] [--model <name>]``
+``rllm eval <benchmark> --agent <name> [--evaluator <name>] [--provider <name>] [--base-url <url>] [--model <name>]``
 
 When ``--base-url`` is omitted, a LiteLLM proxy is auto-started using the
 configuration from ``rllm setup`` (stored in ``~/.rllm/config.json``).
@@ -19,9 +19,12 @@ from rllm import paths
 from rllm.cli._pull import load_dataset_catalog, pull_dataset
 from rllm.cli._sampling import SAMPLING_PARAMS_HELP as _SAMPLING_PARAMS_HELP
 from rllm.cli._ui import console, fail, info_panel, not_found, parse_index_spec
+from rllm.eval.config import SUPPORTED_PROVIDERS
 from rllm.types import Task
 
 logger = logging.getLogger(__name__)
+
+_EVAL_PROVIDERS = [provider for provider in SUPPORTED_PROVIDERS if provider != "custom"]
 
 
 def _suggest_benchmarks(name: str, catalog_names: list[str], max_suggestions: int = 3) -> list[str]:
@@ -591,7 +594,14 @@ def _run_eval(
 @click.option(
     "--proxy-port", "proxy_port", default=None, type=int, help="Pin the auto-started LiteLLM proxy to this port. Default: a free port is picked automatically (so concurrent eval jobs don't collide)."
 )
-@click.option("--model", default=None, help="Model name to evaluate. Defaults to configured model from 'rllm setup'.")
+@click.option(
+    "--provider",
+    "provider_override",
+    default=None,
+    type=click.Choice(_EVAL_PROVIDERS, case_sensitive=False),
+    help="Provider to use for this run, overriding 'rllm setup' without changing it. Requires --model and uses the provider's stored API key.",
+)
+@click.option("--model", default=None, help="Model name to evaluate. Defaults to the configured model unless --provider or --base-url is used.")
 @click.option("--split", default=None, help="Dataset split (default: from catalog eval_split).")
 @click.option("--concurrency", default=64, type=int, help="Number of parallel requests.")
 @click.option("--attempts", default=1, type=int, help="Independent rollouts per task; reports pass@k for k=1..N (default: 1).")
@@ -643,6 +653,7 @@ def eval_cmd(
     evaluator_name: str | None,
     base_url: str | None,
     proxy_port: int | None,
+    provider_override: str | None,
     model: str | None,
     split: str | None,
     concurrency: int,
@@ -688,6 +699,8 @@ def eval_cmd(
     proxy_manager = None
 
     if base_url is not None:
+        if provider_override is not None:
+            fail("--provider cannot be used with --base-url; the direct endpoint already defines routing.")
         # Direct mode: user provided --base-url, require --model too
         if model is None:
             fail("--model is required when --base-url is provided.")
@@ -698,6 +711,10 @@ def eval_cmd(
         from rllm.eval.config import load_config
 
         config = load_config()
+        if provider_override is not None and model is None:
+            fail("--model is required when --provider is provided.")
+        if provider_override is not None:
+            config.provider = provider_override
 
         # A ``tinker://`` sampler-checkpoint path (produced by ``rllm sft`` on the
         # tinker backend) is served by the Tinker OAI endpoint, which the built-in

--- a/tests/cli/test_eval_command.py
+++ b/tests/cli/test_eval_command.py
@@ -7,7 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from rllm.cli.main import cli
-from rllm.eval.config import RllmConfig
+from rllm.eval.config import RllmConfig, load_config, save_config
 from rllm.eval.types import EvalOutput, Signal
 from rllm.types import AgentConfig, Episode, Step, Task, Trajectory
 
@@ -64,6 +64,20 @@ class _MockEvaluator:
         return EvalOutput(reward=1.0, is_correct=True, signals=[Signal(name="accuracy", value=1.0)])
 
 
+def _invoke_rejected_eval(runner: CliRunner, args: list[str]):
+    """Invoke an invalid eval command and assert it never starts evaluation."""
+    with (
+        patch("rllm.eval.proxy.EvalProxyManager") as mock_pm_cls,
+        patch("rllm.cli.eval._run_eval") as mock_run,
+    ):
+        result = runner.invoke(cli, ["eval", "test_math", *args])
+
+    assert result.exit_code != 0
+    mock_pm_cls.assert_not_called()
+    mock_run.assert_not_called()
+    return result
+
+
 def test_eval_missing_config(runner, tmp_rllm_home):
     """Eval without --base-url and no config should tell user to run 'rllm setup'."""
     with patch("rllm.eval.config.load_config", return_value=RllmConfig()):
@@ -104,6 +118,92 @@ def test_eval_with_proxy_mode(runner, tmp_rllm_home, mock_dataset):
     assert result.exit_code == 0
     mock_pm.start_proxy_subprocess.assert_called_once()
     mock_pm.shutdown_proxy.assert_called_once()
+
+
+def test_eval_provider_override_uses_stored_key_for_run(runner, tmp_rllm_home):
+    """--provider should route through that provider without changing config."""
+    original = RllmConfig(
+        provider="openai",
+        model="gpt-5-mini",
+        api_keys={"openai": "sk-openai", "fireworks": "fw-test"},
+    )
+    save_config(original)
+
+    mock_pm = MagicMock()
+    mock_pm.get_proxy_url.return_value = "http://127.0.0.1:4000/v1"
+    mock_pm.build_proxy_config.return_value = {"model_list": []}
+    model = "accounts/fireworks/models/kimi-k3"
+
+    with (
+        patch("rllm.eval.proxy.EvalProxyManager", return_value=mock_pm) as mock_pm_cls,
+        patch("rllm.cli.eval._run_eval"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "eval",
+                "test_math",
+                "--agent",
+                "math",
+                "--provider",
+                "fireworks",
+                "--model",
+                model,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_pm_cls.call_args.kwargs
+    assert kwargs["provider"] == "fireworks"
+    assert kwargs["model_name"] == model
+    assert kwargs["api_key"] == "fw-test"
+    mock_pm.start_proxy_subprocess.assert_called_once()
+    mock_pm.shutdown_proxy.assert_called_once()
+    assert load_config() == original
+
+
+def test_eval_provider_override_requires_model(runner, tmp_rllm_home):
+    """A provider override must not reuse the configured model implicitly."""
+    save_config(
+        RllmConfig(
+            provider="openai",
+            model="gpt-5-mini",
+            api_keys={"openai": "sk-openai", "fireworks": "fw-test"},
+        )
+    )
+
+    result = _invoke_rejected_eval(runner, ["--provider", "fireworks"])
+
+    assert "--model is required when --provider is provided" in result.output
+
+
+def test_eval_provider_override_requires_stored_key(runner, tmp_rllm_home):
+    """A provider override should fail before launch when its key is missing."""
+    save_config(RllmConfig(provider="openai", model="gpt-5-mini", api_keys={"openai": "sk-openai"}))
+
+    result = _invoke_rejected_eval(
+        runner,
+        ["--provider", "fireworks", "--model", "accounts/fireworks/models/kimi-k3"],
+    )
+
+    assert "No configuration found" in result.output
+
+
+def test_eval_provider_cannot_be_used_with_base_url(runner, tmp_rllm_home):
+    """Direct endpoints already define routing, so --provider is ambiguous."""
+    result = _invoke_rejected_eval(
+        runner,
+        [
+            "--provider",
+            "fireworks",
+            "--base-url",
+            "http://localhost:8000/v1",
+            "--model",
+            "test-model",
+        ],
+    )
+
+    assert "--provider cannot be used with --base-url" in result.output
 
 
 def test_eval_base_url_skips_proxy(runner, tmp_rllm_home, mock_dataset):


### PR DESCRIPTION
## What changed

- add `rllm eval --provider <name>` as a run-local provider override
- reuse the selected provider's existing stored key and existing configuration validation
- require an explicit `--model` with `--provider`
- reject ambiguous combinations with `--base-url`
- leave `~/.rllm/config.json` unchanged

## Why

Previously, `--model` changed only the model string while provider routing still came from the active `rllm setup` configuration. A Fireworks model ID could therefore be sent to OpenRouter and fail as an invalid model. This option makes the route explicit without requiring a persistent provider swap.

## Validation

- `67 passed` across `tests/cli/test_eval_command.py`, `tests/eval/test_eval_config.py`, and `tests/eval/test_eval_proxy.py`
- Ruff check and format check
- pre-commit on both changed files
- `git diff --check`
