### PR TITLE
sft: make preflight explicit

### DIFF
--- a/rllm/cli/sft.py
+++ b/rllm/cli/sft.py
@@ -60,6 +60,7 @@ from rllm.cli._ui import console, fail
     type=click.Path(exists=True),
     help="YAML escape hatch merged ON TOP of the backend config: file keys beat equivalent CLI flags (--renderer/--gpus still win). For backend knobs without a flag.",
 )
+@click.option("--preflight", is_flag=True, help="Render and validate the dataset, then exit without starting training.")
 def sft_cmd(
     dataset: str | None,
     train_file: str | None,
@@ -86,6 +87,7 @@ def sft_cmd(
     enable_ui: bool | None,
     output_dir: str | None,
     config_file: str | None,
+    preflight: bool,
 ):
     """Fine-tune a model with supervised learning (SFT).
 
@@ -248,6 +250,10 @@ def sft_cmd(
     console.print()
 
     try:
+        if preflight:
+            trainer.preflight()
+            console.print("[green]Preflight passed.[/green]")
+            return
         trainer.train()
     except SFTConfigError as e:
         fail(str(e))

--- a/rllm/trainer/agent_sft_trainer.py
+++ b/rllm/trainer/agent_sft_trainer.py
@@ -65,6 +65,10 @@ class AgentSFTTrainer:
         else:
             backend.fit()
 
+    def preflight(self) -> None:
+        """Validate SFT rendering locally without launching training."""
+        self.prepare().preflight()
+
     def _make_backend(self) -> SFTBackend:
         name = self.backend_name
         if name == "tinker":

--- a/rllm/trainer/sft/backend.py
+++ b/rllm/trainer/sft/backend.py
@@ -93,6 +93,10 @@ class SFTBackend(ABC):
     def fit(self) -> None:
         """Run the full SFT training loop."""
 
+    def preflight(self) -> None:
+        """Render and validate the dataset without starting a trainer."""
+        raise SFTConfigError(f"SFT preflight is not supported by the {self.name!r} backend.")
+
     @property
     @abstractmethod
     def checkpoint_dir(self) -> str:

--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -35,7 +35,6 @@ from rllm.trainer.sft.tinker_backend import (
     TinkerSFTBackend,
     build_adam_params,
     build_sft_data,
-    iter_training_batches,
     resolve_sft_optimizer_settings,
     resolve_training_steps,
     sft_lr_multiplier,
@@ -248,20 +247,6 @@ class FireworksSFTBackend(TinkerSFTBackend):
             optimizer = resolve_sft_optimizer_settings(config.optim, total_steps=total_steps)
             save_every = config.trainer.get("save_freq", 20)
             eval_every = config.trainer.get("test_freq", 10)
-
-            train_dataset.preflight(
-                label="train",
-                planned_batches=(
-                    (epoch_idx, batch_idx)
-                    for _step, epoch_idx, batch_idx in iter_training_batches(
-                        n_batches=n_batches,
-                        total_epochs=total_epochs,
-                        max_steps=max_steps,
-                    )
-                ),
-            )
-            if val_dataset is not None:
-                val_dataset.preflight(label="validation")
 
             infra = self._provision(config, api_key, base_url)
             try:

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -424,6 +424,19 @@ class TinkerSFTBackend(SFTBackend):
         # Tinker consumes the in-memory Dataset objects directly; nothing to do.
         pass
 
+    def preflight(self) -> None:
+        """Render each hosted-SFT row once without starting a trainer."""
+        if self._config is None:
+            self.build_config()
+        _tokenizer, train_dataset, val_dataset = build_sft_data(
+            self._config,
+            self.spec.train_dataset,
+            self.spec.val_dataset,
+        )
+        train_dataset.preflight(label="train")
+        if val_dataset is not None:
+            val_dataset.preflight(label="validation")
+
     @property
     def checkpoint_dir(self) -> str:
         cfg = self._config or self.build_config()
@@ -461,22 +474,6 @@ class TinkerSFTBackend(SFTBackend):
         optimizer = resolve_sft_optimizer_settings(config.get("optim", {}), total_steps=total_steps)
         save_every = config.trainer.get("save_freq", 20)
         eval_every = config.trainer.get("test_freq", 10)
-
-        train_dataset.preflight(
-            label="train",
-            planned_batches=(
-                (epoch_idx, batch_idx)
-                for _step, epoch_idx, batch_idx in iter_training_batches(
-                    n_batches=n_batches,
-                    total_epochs=total_epochs,
-                    start_epoch=start_epoch,
-                    start_batch=start_batch,
-                    max_steps=max_steps,
-                )
-            ),
-        )
-        if val_dataset is not None:
-            val_dataset.preflight(label="validation")
 
         service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
 

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -118,6 +118,7 @@ def conversation_to_datum(
     tools: list[dict] | None = None,
     overlength_policy: Literal["error", "truncate"] = "truncate",
     loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
+    validate_prefix_stability: bool = True,
 ) -> tinker.Datum:
     """Convert a conversation (list of messages) to a Tinker Datum.
 
@@ -141,13 +142,14 @@ def conversation_to_datum(
             tools=renderer_tools,
         )
         _validate_rendered_attribution(rendered, len(messages))
-        _validate_trainable_targets_represented(
-            renderer,
-            renderer_messages,
-            messages,
-            rendered,
-            tools=renderer_tools,
-        )
+        if validate_prefix_stability:
+            _validate_trainable_targets_represented(
+                renderer,
+                renderer_messages,
+                messages,
+                rendered,
+                tools=renderer_tools,
+            )
     except SFTSchemaError as e:
         raise SFTConfigError(f"SFT row failed schema normalization: {e}\n  row={_row_context(conversation)}") from e
     except (TypeError, ValueError) as e:
@@ -339,7 +341,7 @@ class TinkerSFTDataset(SupervisedDataset):
             loss_reduction,
         )
 
-    def get_batch(self, index: int) -> list[tinker.Datum]:
+    def get_batch(self, index: int, *, validate_prefix_stability: bool = False) -> list[tinker.Datum]:
         start_idx = index * self.batch_size
         end_idx = min(start_idx + self.batch_size, len(self.dataset))
         datums = []
@@ -355,6 +357,7 @@ class TinkerSFTDataset(SupervisedDataset):
                         tools=row.get("tools"),
                         overlength_policy=self.overlength_policy,
                         loss_reduction=self.loss_reduction,
+                        validate_prefix_stability=validate_prefix_stability,
                     )
                 )
             except SFTConfigError as e:
@@ -377,7 +380,7 @@ class TinkerSFTDataset(SupervisedDataset):
             if planned_batches is None:
                 for batch_idx in range(len(self)):
                     try:
-                        if not self.get_batch(batch_idx):
+                        if not self.get_batch(batch_idx, validate_prefix_stability=True):
                             raise SFTConfigError("rendered batch is empty")
                     except SFTConfigError as e:
                         raise SFTConfigError(f"{label} preflight failed at batch {batch_idx}: {e}") from e
@@ -389,7 +392,7 @@ class TinkerSFTDataset(SupervisedDataset):
                     self.set_epoch(seed=epoch_idx)
                     current_epoch = epoch_idx
                 try:
-                    if not self.get_batch(batch_idx):
+                    if not self.get_batch(batch_idx, validate_prefix_stability=True):
                         raise SFTConfigError("rendered batch is empty")
                 except SFTConfigError as e:
                     raise SFTConfigError(f"{label} preflight failed at epoch {epoch_idx}, batch {batch_idx}: {e}") from e

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import logging
 import math
-from collections.abc import Iterable
 from typing import Literal
 
 import datasets
@@ -367,38 +366,16 @@ class TinkerSFTDataset(SupervisedDataset):
             _normalize_token_mean(datums)
         return datums
 
-    def preflight(
-        self,
-        *,
-        label: str,
-        planned_batches: Iterable[tuple[int, int]] | None = None,
-    ) -> None:
-        """Render planned batches without changing the order used for training."""
+    def preflight(self, *, label: str) -> None:
+        """Render every dataset batch once."""
         if len(self) == 0:
             raise SFTConfigError(f"{label} preflight failed: dataset contains no batches.")
-        original_dataset = self.dataset
-        try:
-            if planned_batches is None:
-                for batch_idx in range(len(self)):
-                    try:
-                        if not self.get_batch(batch_idx, validate_prefix_stability=True):
-                            raise SFTConfigError("rendered batch is empty")
-                    except SFTConfigError as e:
-                        raise SFTConfigError(f"{label} preflight failed at batch {batch_idx}: {e}") from e
-                return
-
-            current_epoch: int | None = None
-            for epoch_idx, batch_idx in planned_batches:
-                if epoch_idx != current_epoch:
-                    self.set_epoch(seed=epoch_idx)
-                    current_epoch = epoch_idx
-                try:
-                    if not self.get_batch(batch_idx, validate_prefix_stability=True):
-                        raise SFTConfigError("rendered batch is empty")
-                except SFTConfigError as e:
-                    raise SFTConfigError(f"{label} preflight failed at epoch {epoch_idx}, batch {batch_idx}: {e}") from e
-        finally:
-            self.dataset = original_dataset
+        for batch_idx in range(len(self)):
+            try:
+                if not self.get_batch(batch_idx, validate_prefix_stability=True):
+                    raise SFTConfigError("rendered batch is empty")
+            except SFTConfigError as e:
+                raise SFTConfigError(f"{label} preflight failed at batch {batch_idx}: {e}") from e
 
     def set_epoch(self, seed: int = 0):
         self.dataset = self._source_dataset.shuffle(seed=seed)

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -118,7 +118,7 @@ def conversation_to_datum(
     tools: list[dict] | None = None,
     overlength_policy: Literal["error", "truncate"] = "truncate",
     loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
-    validate_prefix_stability: bool = True,
+    validate_prefix_stability: bool = False,
 ) -> tinker.Datum:
     """Convert a conversation (list of messages) to a Tinker Datum.
 
@@ -130,7 +130,8 @@ def conversation_to_datum(
     the default for source rows without a complete explicit mask.
 
     Schema/validation failures are re-raised as :class:`SFTConfigError` with the
-    failing row's context.
+    failing row's context. Prefix-stability rerenders are disabled unless an
+    explicit dataset preflight requests them.
     """
     default_trainable = "last" if last_only else "all"
     try:

--- a/tests/cli/test_sft_command.py
+++ b/tests/cli/test_sft_command.py
@@ -67,6 +67,21 @@ def test_sft_registered_in_cli():
     assert "Fine-tune a model" in result.output
 
 
+def test_sft_preflight_checks_without_training(runner, tmp_rllm_home, monkeypatch):
+    from rllm.trainer.agent_sft_trainer import AgentSFTTrainer
+
+    calls: list[str] = []
+    monkeypatch.setattr(AgentSFTTrainer, "preflight", lambda self: calls.append("preflight"))
+    monkeypatch.setattr(AgentSFTTrainer, "train", lambda self: pytest.fail("--preflight must not train"))
+
+    name = _register_toy("preflight-toy")
+    result = runner.invoke(cli, ["sft", name, "--backend", "tinker", "--preflight", "--no-ui"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == ["preflight"]
+    assert "Preflight passed" in result.output
+
+
 def test_sft_requires_a_source(runner, tmp_rllm_home):
     result = runner.invoke(cli, ["sft"])
     assert result.exit_code == 1

--- a/tests/trainer/test_sft_preflight.py
+++ b/tests/trainer/test_sft_preflight.py
@@ -2,10 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import sys
-import types
-
 import pytest
 
 tinker = pytest.importorskip("tinker")
@@ -82,6 +78,46 @@ def test_preflight_renders_the_exact_planned_training_order():
     assert renderer.seen == preflight_order
 
 
+def test_training_batch_skips_prefix_stability_preflight():
+    class _PrefixRenderer:
+        def __init__(self):
+            self.seen: list[int] = []
+
+        def render(self, messages, *, tools=None, add_generation_prompt=False):
+            from rllm.renderers.types import RenderedTokens
+
+            del tools, add_generation_prompt
+            self.seen.append(len(messages))
+            return RenderedTokens(
+                token_ids=list(range(len(messages))),
+                message_indices=list(range(len(messages))),
+            )
+
+    source = Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q1", "trainable": False},
+                    {"role": "assistant", "content": "a1", "trainable": True},
+                    {"role": "user", "content": "q2", "trainable": False},
+                    {"role": "assistant", "content": "a2", "trainable": True},
+                ]
+            }
+        ],
+        name="prefixes",
+        split="train",
+    )
+    renderer = _PrefixRenderer()
+    dataset = TinkerSFTDataset(source, renderer=renderer, batch_size=1)
+
+    dataset.get_batch(0)
+    assert renderer.seen == [4]
+
+    renderer.seen.clear()
+    dataset.preflight(label="train")
+    assert renderer.seen == [4, 2]
+
+
 def test_validation_preflight_checks_every_batch():
     dataset = TinkerSFTDataset(
         _dataset([2, 20]),
@@ -95,9 +131,7 @@ def test_validation_preflight_checks_every_batch():
         dataset.preflight(label="validation")
 
 
-def test_tinker_preflight_failure_precedes_service_client(monkeypatch, tmp_path):
-    from tinker_cookbook import checkpoint_utils
-
+def test_tinker_explicit_preflight_does_not_create_service_client(monkeypatch, tmp_path):
     import rllm.trainer.sft.tinker_backend as backend_module
 
     train = TinkerSFTDataset(
@@ -106,7 +140,6 @@ def test_tinker_preflight_failure_precedes_service_client(monkeypatch, tmp_path)
         batch_size=2,
     )
     monkeypatch.setattr(backend_module, "build_sft_data", lambda *_: (object(), train, None))
-    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: None)
     monkeypatch.setattr(tinker, "ServiceClient", lambda **_: pytest.fail("provider client must not be created"))
 
     backend = TinkerSFTBackend(
@@ -119,13 +152,12 @@ def test_tinker_preflight_failure_precedes_service_client(monkeypatch, tmp_path)
     )
     backend.build_config()
 
-    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
-        asyncio.run(backend._fit_async())
+    with pytest.raises(SFTConfigError, match="train preflight.*batch 0"):
+        backend.preflight()
 
 
-def test_fireworks_preflight_failure_precedes_provision(monkeypatch, tmp_path):
-    import rllm.trainer.sft.fireworks_backend as backend_module
-    import rllm.utils.tracking as tracking_module
+def test_fireworks_explicit_preflight_does_not_provision(monkeypatch, tmp_path):
+    import rllm.trainer.sft.tinker_backend as backend_module
 
     train = TinkerSFTDataset(
         _dataset([0, 2, 0, 2]),
@@ -142,27 +174,8 @@ def test_fireworks_preflight_failure_precedes_provision(monkeypatch, tmp_path):
     )
     backend.build_config()
 
-    class _Tracking:
-        def __init__(self, **_kwargs):
-            pass
-
-        def finish(self):
-            pass
-
-    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
-    training = types.ModuleType("training")
-    training_utils = types.ModuleType("training.utils")
-    checkpoints = types.ModuleType("training.utils.checkpoints")
-    checkpoints.TrainingCheckpoints = object
-    client = types.ModuleType("training.utils.client")
-    client.DEFAULT_TIMEOUT_S = 1
-    monkeypatch.setitem(sys.modules, "training", training)
-    monkeypatch.setitem(sys.modules, "training.utils", training_utils)
-    monkeypatch.setitem(sys.modules, "training.utils.checkpoints", checkpoints)
-    monkeypatch.setitem(sys.modules, "training.utils.client", client)
-    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
     monkeypatch.setattr(backend_module, "build_sft_data", lambda *_: (None, train, None))
     monkeypatch.setattr(backend, "_provision", lambda *_: pytest.fail("provider trainer must not be provisioned"))
 
-    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
-        backend.fit()
+    with pytest.raises(SFTConfigError, match="train preflight.*batch 0"):
+        backend.preflight()

--- a/tests/trainer/test_sft_preflight.py
+++ b/tests/trainer/test_sft_preflight.py
@@ -47,37 +47,6 @@ def _dataset(lengths):
     )
 
 
-def test_preflight_checks_planned_shuffle_and_restores_source_order():
-    source = _dataset([0, 2, 0, 2])
-    dataset = TinkerSFTDataset(source, renderer=_TokenRenderer(), batch_size=2)
-
-    with pytest.raises(SFTConfigError, match="train preflight.*epoch 0.*batch 0"):
-        dataset.preflight(label="train", planned_batches=[(0, 0), (0, 1)])
-
-    assert dataset.dataset is source
-
-
-def test_preflight_renders_the_exact_planned_training_order():
-    source = _dataset([2, 3, 4, 5])
-    renderer = _TokenRenderer()
-    dataset = TinkerSFTDataset(source, renderer=renderer, batch_size=2)
-    plan = [(0, 0), (0, 1), (1, 0)]
-
-    dataset.preflight(label="train", planned_batches=plan)
-    preflight_order = renderer.seen.copy()
-    assert dataset.dataset is source
-
-    renderer.seen.clear()
-    current_epoch = None
-    for epoch_idx, batch_idx in plan:
-        if epoch_idx != current_epoch:
-            dataset.set_epoch(seed=epoch_idx)
-            current_epoch = epoch_idx
-        dataset.get_batch(batch_idx)
-
-    assert renderer.seen == preflight_order
-
-
 def test_training_batch_skips_prefix_stability_preflight():
     class _PrefixRenderer:
         def __init__(self):

--- a/tests/trainer/test_sft_render_path.py
+++ b/tests/trainer/test_sft_render_path.py
@@ -190,6 +190,7 @@ def test_renderer_rejects_rewritten_trainable_target(with_content_metadata):
             ],
             HistoryRewritingRenderer(),
             max_length=None,
+            validate_prefix_stability=True,
         )
 
 


### PR DESCRIPTION
## What changed

- add `rllm sft ... --preflight` to render and validate hosted SFT datasets, then exit
- remove automatic dataset preflight from normal Tinker and Fireworks training startup
- run prefix-stability rerenders only during explicit preflight; normal batches render each full row once

## Behavior

- `rllm sft ... --preflight`: local dataset validation only; no provider client, trainer, W&B run, or optimizer step
- `rllm sft ...`: starts the normal training path without preflight
- unsupported backends return an explicit preflight error

## Why

Prefix-stability validation rerenders every earlier trainable prefix in a trajectory. That is useful as an explicit data/renderer check, but it makes startup and ordinary batches unnecessarily expensive for repeated 256K-context runs over already-validated data.

## Validation

- `64 passed` in the focused SFT data/render/preflight/validation and CLI suite
- Ruff check and format check pass for all changed files
- `py_compile` passes for all changed production modules
- the broader `tests/trainer` collection is blocked in this environment by unavailable optional Verl/Ray packages (`ray._private`, `verl.DataProto`)
