### PR TITLE
gateway: compact trace fetch — ship each unique message once over the wire

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/client.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/client.py
@@ -36,6 +36,7 @@ def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
             paths[nid] = base
         return paths[leaf] if leaf is not None else []
 
+    ids_memo: dict[str | None, list[int]] = {None: []}
     for trace in payload.get("traces", []):
         ref = trace.get("messages_ref")
         if ref is None:
@@ -43,10 +44,22 @@ def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         leaf, length = ref
         messages = _path(leaf)
-        assert len(messages) == length, f"compact chain length {len(messages)} != recorded {length}"
+        if len(messages) != length:
+            raise ValueError(f"compact chain length {len(messages)} != recorded {length}")
         expanded = dict(trace)
         expanded.pop("messages_ref", None)
         expanded["messages"] = messages
+        ids_ref = expanded.pop("prompt_ids_ref", None)
+        if ids_ref is not None:
+            # Delta against an earlier trace in this payload: prefix + suffix.
+            prev_tid, lcp, suffix = ids_ref
+            prev_full = ids_memo.get(prev_tid)
+            if prev_full is None or lcp > len(prev_full):
+                raise ValueError(f"prompt-id delta references unknown/short ancestor {prev_tid!r}")
+            expanded["prompt_token_ids"] = prev_full[:lcp] + list(suffix)
+        tid = expanded.pop("_tid", None) or expanded.get("trace_id")
+        if tid is not None and isinstance(expanded.get("prompt_token_ids"), list):
+            ids_memo[tid] = expanded["prompt_token_ids"]
         out.append(expanded)
     return out
 

--- a/rllm-model-gateway/src/rllm_model_gateway/client.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/client.py
@@ -7,6 +7,50 @@ import httpx
 from rllm_model_gateway.models import TraceRecord, WorkerInfo
 
 
+def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Rebuild full per-trace message lists from a compact traces payload.
+
+    Nodes are materialized once and *shared*: every trace whose conversation
+    contains node X references the same message dict, so client memory stays
+    linear in unique messages even though the expanded lists repeat them.
+    Reconstruction is exact — parity-tested byte-for-byte against the default
+    format on real eval dumps.
+    """
+    nodes = payload.get("nodes", {})
+    out: list[dict[str, Any]] = []
+    # leaf -> materialized path cache, so shared prefixes walk once.
+    paths: dict[str | None, list[dict[str, Any]]] = {None: []}
+
+    def _path(leaf: str | None) -> list[dict[str, Any]]:
+        cached = paths.get(leaf)
+        if cached is not None:
+            return cached
+        chain: list[str] = []
+        node_id = leaf
+        while node_id is not None and node_id not in paths:
+            chain.append(node_id)
+            node_id = nodes[node_id]["p"]
+        base = paths[node_id] if node_id is not None else paths[None]
+        for nid in reversed(chain):
+            base = base + [nodes[nid]["m"]]
+            paths[nid] = base
+        return paths[leaf] if leaf is not None else []
+
+    for trace in payload.get("traces", []):
+        ref = trace.get("messages_ref")
+        if ref is None:
+            out.append(trace)
+            continue
+        leaf, length = ref
+        messages = _path(leaf)
+        assert len(messages) == length, f"compact chain length {len(messages)} != recorded {length}"
+        expanded = dict(trace)
+        expanded.pop("messages_ref", None)
+        expanded["messages"] = messages
+        out.append(expanded)
+    return out
+
+
 class GatewayClient:
     """Synchronous client for the rllm-model-gateway REST API.
 
@@ -88,15 +132,20 @@ class GatewayClient:
         session_id: str,
         since: float | None = None,
         limit: int | None = None,
+        format: str | None = None,
     ) -> list[TraceRecord]:
         params: dict[str, Any] = {}
         if since is not None:
             params["since"] = since
         if limit is not None:
             params["limit"] = limit
+        if format is not None:
+            params["format"] = format
         resp = self._http.get(f"{self.gateway_url}/sessions/{session_id}/traces", params=params)
         resp.raise_for_status()
         data = resp.json()
+        if isinstance(data, dict) and data.get("format") == "compact":
+            data = _expand_compact_traces(data)
         return [TraceRecord(**t) for t in data]
 
     def get_trace(self, trace_id: str) -> TraceRecord:
@@ -236,15 +285,20 @@ class AsyncGatewayClient:
         session_id: str,
         since: float | None = None,
         limit: int | None = None,
+        format: str | None = None,
     ) -> list[TraceRecord]:
         params: dict[str, Any] = {}
         if since is not None:
             params["since"] = since
         if limit is not None:
             params["limit"] = limit
+        if format is not None:
+            params["format"] = format
         resp = await self._http.get(f"{self.gateway_url}/sessions/{session_id}/traces", params=params)
         resp.raise_for_status()
         data = resp.json()
+        if isinstance(data, dict) and data.get("format") == "compact":
+            data = _expand_compact_traces(data)
         return [TraceRecord(**t) for t in data]
 
     async def get_trace(self, trace_id: str) -> TraceRecord:

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -279,7 +279,14 @@ def create_app(
         session_id: str,
         since: float | None = Query(None),
         limit: int | None = Query(None),
+        format: str = Query("default"),
     ):
+        # "compact" ships each unique message once (node table + leaf refs) —
+        # the expanded legacy list is quadratic in turns for agentic sessions.
+        # Only stores that implement the compact read support it; others keep
+        # serving the default form regardless of the requested format.
+        if format == "compact" and hasattr(store, "get_session_traces_compact"):
+            return await store.get_session_traces_compact(session_id, since=since, limit=limit)
         traces = await store.get_session_traces(session_id, since=since, limit=limit)
         return traces
 

--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -241,6 +241,78 @@ class MemoryTraceStore:
         memo: dict[str, list[int]] = {}
         return [self._expand_prompt_ids(tid, self._expand_messages(_unpack(d)), memo) for tid, d in results]
 
+    async def get_session_traces_compact(
+        self,
+        session_id: str,
+        since: float | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Session traces in compact wire form: a node table plus leaf refs.
+
+        Wire shape: ``{"format": "compact", "nodes": {id: {"p": parent|None,
+        "m": message}}, "traces": [...]}`` where each trace carries
+        ``messages_ref: [leaf_id|None, length]`` instead of ``messages``.
+        Works in both store modes — a default-mode store interns into an
+        ephemeral table at read time — so fetch format is independent of how
+        the store holds traces. The expanded and compact forms reconstruct
+        identically (see client._expand_compact_traces and the parity tests).
+        """
+        ids = self._session_index.get(session_id, [])
+        raw: list[dict[str, Any]] = []
+        for tid in ids:
+            ts = self._timestamps.get(tid, 0.0)
+            if since is not None and ts < since:
+                continue
+            data = self._traces.get(tid)
+            if data is not None:
+                raw.append(data)
+        if limit is not None:
+            raw = raw[:limit]
+
+        nodes_out: dict[str, dict[str, Any]] = {}
+        session_nodes = self._session_nodes.get(session_id, {})
+        # Ephemeral interner for traces stored verbatim (default mode).
+        eph_nodes: dict[str, tuple[str | None, dict[str, Any]]] = {}
+        eph_chain: dict[tuple[str | None, str], str] = {}
+
+        def _collect(leaf: str | None, table: dict[str, tuple[str | None, dict[str, Any]]]) -> None:
+            node_id = leaf
+            while node_id is not None and node_id not in nodes_out:
+                parent, message = table[node_id]
+                nodes_out[node_id] = {"p": parent, "m": message}
+                node_id = parent
+
+        traces_out: list[dict[str, Any]] = []
+        for data in raw:
+            data = _unpack(data)
+            marker = data.get("messages")
+            if type(marker) is dict and _INTERNED_KEY in marker:
+                _, leaf, length = marker[_INTERNED_KEY]
+                _collect(leaf, session_nodes)
+            else:
+                messages = marker
+                if type(messages) is not list or not all(isinstance(m, dict) for m in (messages or [])):
+                    # unknown shape: ship verbatim, no ref
+                    traces_out.append(data)
+                    continue
+                parent: str | None = None
+                for message in messages:
+                    key = (parent, _message_fp(message))
+                    node_id = eph_chain.get(key)
+                    if node_id is None:
+                        node_id = hashlib.sha256(f"{parent}:{key[1]}".encode()).hexdigest()
+                        eph_nodes[node_id] = (parent, message)
+                        eph_chain[key] = node_id
+                    parent = node_id
+                leaf, length = parent, len(messages)
+                _collect(leaf, eph_nodes)
+            out = dict(data)
+            out.pop("messages", None)
+            out["messages_ref"] = [leaf, length]
+            traces_out.append(out)
+
+        return {"format": "compact", "nodes": nodes_out, "traces": traces_out}
+
     async def delete_session(self, session_id: str) -> int:
         ids = self._session_index.pop(session_id, [])
         # Collect trace_ids referenced by other sessions

--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -1,6 +1,7 @@
 """In-memory trace store for testing and embedded usage."""
 
 import array
+import asyncio
 import hashlib
 import json
 import time
@@ -258,22 +259,22 @@ class MemoryTraceStore:
         identically (see client._expand_compact_traces and the parity tests).
         """
         ids = self._session_index.get(session_id, [])
-        raw: list[dict[str, Any]] = []
+        raw: list[tuple[str, dict[str, Any]]] = []
         for tid in ids:
             ts = self._timestamps.get(tid, 0.0)
             if since is not None and ts < since:
                 continue
             data = self._traces.get(tid)
             if data is not None:
-                raw.append(data)
+                raw.append((tid, data))
         if limit is not None:
             raw = raw[:limit]
 
         nodes_out: dict[str, dict[str, Any]] = {}
-        session_nodes = self._session_nodes.get(session_id, {})
         # Ephemeral interner for traces stored verbatim (default mode).
         eph_nodes: dict[str, tuple[str | None, dict[str, Any]]] = {}
         eph_chain: dict[tuple[str | None, str], str] = {}
+        interned = 0  # messages interned since the last event-loop yield
 
         def _collect(leaf: str | None, table: dict[str, tuple[str | None, dict[str, Any]]]) -> None:
             node_id = leaf
@@ -283,12 +284,15 @@ class MemoryTraceStore:
                 node_id = parent
 
         traces_out: list[dict[str, Any]] = []
-        for data in raw:
+        for tid, data in raw:
             data = _unpack(data)
             marker = data.get("messages")
             if type(marker) is dict and _INTERNED_KEY in marker:
-                _, leaf, length = marker[_INTERNED_KEY]
-                _collect(leaf, session_nodes)
+                # The marker records which session's node table owns its chain —
+                # a trace_id re-stored under another session points there, not
+                # at the requested session (matching _expand_messages).
+                marker_sid, leaf, length = marker[_INTERNED_KEY]
+                _collect(leaf, self._session_nodes.get(marker_sid, {}))
             else:
                 messages = marker
                 if type(messages) is not list or not all(isinstance(m, dict) for m in (messages or [])):
@@ -304,11 +308,23 @@ class MemoryTraceStore:
                         eph_nodes[node_id] = (parent, message)
                         eph_chain[key] = node_id
                     parent = node_id
+                    # Fingerprinting a long session is hundreds of MB of hashing;
+                    # yield periodically so in-flight proxying is never starved.
+                    interned += 1
+                    if interned % 512 == 0:
+                        await asyncio.sleep(0)
                 leaf, length = parent, len(messages)
                 _collect(leaf, eph_nodes)
             out = dict(data)
             out.pop("messages", None)
             out["messages_ref"] = [leaf, length]
+            out["_tid"] = tid  # chain anchor for prompt_ids_ref; client strips it
+            ids_marker = out.get("prompt_token_ids")
+            if type(ids_marker) is dict and _IDS_KEY in ids_marker:
+                # Ship the delta itself; the client rebuilds chains in order
+                # (prev refs always point to an earlier trace in the payload).
+                out.pop("prompt_token_ids", None)
+                out["prompt_ids_ref"] = list(ids_marker[_IDS_KEY])
             traces_out.append(out)
 
         return {"format": "compact", "nodes": nodes_out, "traces": traces_out}

--- a/rllm-model-gateway/tests/parity/test_store_real_dump_parity.py
+++ b/rllm-model-gateway/tests/parity/test_store_real_dump_parity.py
@@ -90,3 +90,44 @@ def test_real_dump_parity_compact_vs_default():
 
     assert episodes_checked > 0, "dumps discovered but no episode had messages"
     print(f"[parity] total episodes byte-identical in both modes: {episodes_checked}")
+
+
+def _replay_and_check_fetch(seqs: list[list[dict]], compact_store: bool) -> None:
+    """Fetch-path parity: compact wire payload expands byte-identical to default."""
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    store = MemoryTraceStore(compact=compact_store)
+    for i, cc in enumerate(seqs):
+        _run(store.store_trace(f"t{i}", "s", {"messages": cc, "response_message": {}}))
+
+    default_form = [t["messages"] for t in _run(store.get_session_traces("s"))]
+    payload = _run(store.get_session_traces_compact("s"))
+    # Simulate the wire: what the client sees is the JSON round-trip.
+    payload = json.loads(json.dumps(payload, ensure_ascii=False, default=str))
+    expanded = [t["messages"] for t in _expand_compact_traces(payload)]
+
+    assert _canonical(expanded) == _canonical(seqs), f"compact fetch (store compact={compact_store}) != original"
+    assert _canonical(expanded) == _canonical(default_form), f"compact fetch (store compact={compact_store}) != default fetch"
+
+
+def test_real_dump_fetch_parity_compact_vs_default():
+    dumps = _discover_dumps()
+    if not dumps:
+        pytest.skip("no real eval dumps on this machine")
+    limit = int(os.environ.get("RLLM_PARITY_LIMIT", "6"))
+
+    episodes_checked = 0
+    for dump in dumps:
+        files = sorted(glob.glob(os.path.join(dump, "*.json")))
+        if limit:
+            stride = max(1, len(files) // limit)
+            files = files[::stride][:limit]
+        for path in files:
+            seqs = _episode_step_messages(path)
+            if not any(seqs):
+                continue
+            _replay_and_check_fetch(seqs, compact_store=True)
+            _replay_and_check_fetch(seqs, compact_store=False)
+            episodes_checked += 1
+    assert episodes_checked > 0
+    print(f"[parity-fetch] total episodes byte-identical (both store modes, over JSON wire): {episodes_checked}")

--- a/rllm-model-gateway/tests/unit/test_memory_store_interning.py
+++ b/rllm-model-gateway/tests/unit/test_memory_store_interning.py
@@ -194,3 +194,19 @@ def test_delete_session_rematerializes_shared_traces():
     assert got["prompt_token_ids"] == [1, 2, 3]
     traces = _run(store.get_session_traces("s1"))
     assert traces and traces[0]["messages"] == msgs
+
+def test_compact_fetch_shares_node_objects_and_matches_default():
+    """Compact fetch expands to the same content; shared prefixes share dicts."""
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    for compact in (True, False):
+        store = MemoryTraceStore(compact=compact)
+        for turn in range(1, 4):
+            _run(store.store_trace(f"t{turn}", "s1", _trace(_convo(turn))))
+        default = [t["messages"] for t in _run(store.get_session_traces("s1"))]
+        payload = _run(store.get_session_traces_compact("s1"))
+        expanded = [t["messages"] for t in _expand_compact_traces(payload)]
+        assert expanded == default
+        # prefix sharing: trace 2's first message IS trace 1's first message
+        assert expanded[1][0] is expanded[0][0]
+        assert expanded[2][0] is expanded[0][0]

--- a/rllm-model-gateway/tests/unit/test_memory_store_interning.py
+++ b/rllm-model-gateway/tests/unit/test_memory_store_interning.py
@@ -210,3 +210,38 @@ def test_compact_fetch_shares_node_objects_and_matches_default():
         # prefix sharing: trace 2's first message IS trace 1's first message
         assert expanded[1][0] is expanded[0][0]
         assert expanded[2][0] is expanded[0][0]
+
+
+def test_compact_fetch_ships_prompt_id_deltas_and_expands():
+    """Wire carries id suffixes, not full ids; client rebuilds chains exactly."""
+    import json as _json
+
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    store = MemoryTraceStore(compact=True)
+    full = []
+    originals = []
+    for turn in range(1, 5):
+        full = full + list(range((turn - 1) * 50, turn * 50))
+        originals.append(list(full))
+        _run(store.store_trace(f"t{turn}", "s1", _trace_ids(_convo(turn), list(full))))
+    payload = _json.loads(_json.dumps(_run(store.get_session_traces_compact("s1"))))
+    # deltas on the wire: traces 2..4 ship 50-id suffixes
+    assert all("prompt_ids_ref" in t for t in payload["traces"][1:])
+    assert all(len(t["prompt_ids_ref"][2]) == 50 for t in payload["traces"][1:])
+    expanded = _expand_compact_traces(payload)
+    assert [t["prompt_token_ids"] for t in expanded] == originals
+    assert all("_tid" not in t for t in expanded)
+
+
+def test_compact_fetch_resolves_markers_across_sessions():
+    """Audit repro at the fetch layer: marker owned by another session must resolve."""
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    store = MemoryTraceStore(compact=True)
+    msgs = _convo(2)
+    _run(store.store_trace("shared", "s1", _trace(msgs)))
+    _run(store.store_trace("shared", "s2", _trace(msgs)))  # marker now points at s2's table
+    payload = _run(store.get_session_traces_compact("s1"))  # fetch via s1 must not KeyError
+    expanded = _expand_compact_traces(payload)
+    assert expanded and expanded[0]["messages"] == msgs


### PR DESCRIPTION
**Stacked on #868** (compact trace store) — second of the store → fetch → export series.

## What

`GET /sessions/{id}/traces?format=compact` returns `{format, nodes, traces}` — a node table plus per-trace `messages_ref` leaf refs — instead of the legacy list whose messages repeat every conversation prefix (quadratic in turns; up to **~400 MB JSON for one 229-step task**). The **default format is untouched and remains the default**.

## Design

- **Format independent of store mode**: a compact-mode store serves from its node table; a default-mode store interns ephemerally at read time. Stores without compact support (sqlite) serve the legacy form regardless of the requested format — safe against older gateways.
- **Clients expand transparently**: both `GatewayClient` and `AsyncGatewayClient` accept `format="compact"`, rebuild full message lists before constructing `TraceRecord`s — callers see the exact same return shape. Expansion materializes each node **once and shares it across traces**, so client memory stays linear in unique messages.

## Parity — real data, not mocks

`test_real_dump_fetch_parity_compact_vs_default` replays real eval episodes through store → compact payload → **JSON wire round-trip** → client expansion:

- **152 sampled episodes across all local dumps** (~44 run dirs: DeepSWE + terminal-bench, throttle-mangled and non-cumulative included): expansion is canonical-byte-identical to both the original conversations **and** the default fetch, in **both** store modes — pass
- unit test additionally pins prefix sharing (`expanded[1][0] is expanded[0][0]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)