### PR TITLE
sft: drop incomplete training batches by default

### DIFF
--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -296,6 +296,7 @@ class TinkerSFTDataset(SupervisedDataset):
         max_samples: int = -1,
         overlength_policy: Literal["error", "truncate"] = "truncate",
         loss_reduction: Literal["none", "sequence_mean", "token_mean"] = "none",
+        drop_last: bool = True,
     ):
         self.renderer = renderer
         if batch_size <= 0:
@@ -311,6 +312,7 @@ class TinkerSFTDataset(SupervisedDataset):
         self.last_only = last_only
         self.overlength_policy = overlength_policy
         self.loss_reduction = loss_reduction
+        self.drop_last = drop_last
 
         if isinstance(dataset_or_files, str | list):
             if isinstance(dataset_or_files, str):
@@ -335,8 +337,9 @@ class TinkerSFTDataset(SupervisedDataset):
         logger.info(f"Loaded {len(self.dataset)} examples from {source}")
         logger.info(f"Masking: CUSTOMIZED (derive last_only={last_only} for flag-less rows)")
         logger.info(
-            "Batching: batch_size=%d, final partial batch included; overlength=%s; loss_reduction=%s",
+            "Batching: batch_size=%d, drop_last=%s; overlength=%s; loss_reduction=%s",
             batch_size,
+            drop_last,
             overlength_policy,
             loss_reduction,
         )
@@ -382,6 +385,8 @@ class TinkerSFTDataset(SupervisedDataset):
         logger.info(f"Shuffled dataset with seed {seed} ({len(self.dataset)} samples)")
 
     def __len__(self) -> int:
+        if self.drop_last:
+            return len(self.dataset) // self.batch_size
         return math.ceil(len(self.dataset) / self.batch_size)
 
 
@@ -424,6 +429,7 @@ def create_tinker_sft_datasets(
             max_samples=max_val_samples,
             overlength_policy=overlength_policy,
             loss_reduction="none",
+            drop_last=False,
         )
 
     return train_dataset, val_dataset

--- a/tests/trainer/test_sft_data_semantics.py
+++ b/tests/trainer/test_sft_data_semantics.py
@@ -15,6 +15,7 @@ from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
 from rllm.trainer.sft.tinker_dataset import (  # noqa: E402
     TinkerSFTDataset,
     count_loss_tokens,
+    create_tinker_sft_datasets,
 )
 
 
@@ -90,14 +91,37 @@ def test_hosted_configs_default_to_token_mean(backend):
     assert config.data.rllm.loss_reduction == "token_mean"
 
 
-def test_final_partial_batch_is_not_dropped():
+def test_final_partial_batch_is_dropped_by_default():
     dataset = TinkerSFTDataset(
         _dataset([2, 2, 2]),
         renderer=_TokenRenderer(),
         batch_size=2,
     )
+    assert len(dataset) == 1
+
+
+def test_drop_last_false_keeps_final_partial_batch():
+    dataset = TinkerSFTDataset(
+        _dataset([2, 2, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        drop_last=False,
+    )
     assert len(dataset) == 2
     assert len(dataset.get_batch(1)) == 1
+
+
+def test_validation_keeps_final_partial_batch():
+    _, val = create_tinker_sft_datasets(
+        train_data=_dataset([2, 2]),
+        val_data=_dataset([2, 2, 2]),
+        renderer=_TokenRenderer(),
+        batch_size=2,
+        val_batch_size=2,
+    )
+    assert val is not None
+    assert len(val) == 2
+    assert len(val.get_batch(1)) == 1
 
 
 def test_overlength_error_is_explicit_opt_in():


### PR DESCRIPTION
## What changed

- make hosted-SFT datasets drop an incomplete final batch by default
- explicitly retain incomplete validation batches so validation still covers every row
- add focused coverage for both default training behavior and the validation opt-out

## Why

Optimizer steps should use a consistent configured sequence batch size. Previously, training silently included a smaller final batch whenever the row count was not divisible by the batch size.

For the 222-row DeepSWE training split, this keeps B2 unchanged while dropping the 2-row tail for B4 and the 6-row tail for B8 on each epoch shuffle.

## Validation

- `python -m pytest tests/trainer/test_sft_data_semantics.py tests/trainer/test_sft_preflight.py tests/trainer/test_sft_training_horizon.py -q` — 26 passed
- `ruff check rllm/trainer/sft/tinker_dataset.py tests/trainer/test_sft_data_semantics.py`
- `git diff --check`
