### PR TITLE
gateway: give the compact stack a live path

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -535,7 +535,7 @@ def main() -> None:
         help="Worker URL (can be repeated)",
     )
     parser.add_argument("--db-path", type=str, default=None)
-    parser.add_argument("--store", type=str, default=None, choices=["sqlite", "memory"])
+    parser.add_argument("--store", type=str, default=None, choices=["sqlite", "memory", "memory-compact"])
     parser.add_argument("--log-level", type=str, default=None)
     parser.add_argument(
         "--model",

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -196,10 +196,12 @@ class GatewayManager:
         self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
         configured_port = gw_cfg.get("port", None)
         self.port: int = int(configured_port) if configured_port is not None else (_find_free_port() if self.tunnel_backend else DEFAULT_GATEWAY_PORT)
-        self.store: str = gw_cfg.get("store", "memory")
+        # RLLM_GATEWAY_STORE overrides the config so a single env var opts a
+        # whole run into the compact store, matching the gateway's own CLI/env.
+        self.store: str = os.environ.get("RLLM_GATEWAY_STORE") or gw_cfg.get("store", "memory")
         self.db_path: str | None = gw_cfg.get("db_path", None)
-        if self.store not in ("memory", "sqlite"):
-            raise ValueError(f"rllm.gateway.store must be 'memory' or 'sqlite', got {self.store!r}")
+        if self.store not in ("memory", "memory-compact", "sqlite"):
+            raise ValueError(f"rllm.gateway.store must be 'memory', 'memory-compact' or 'sqlite', got {self.store!r}")
         if self.store == "memory" and self.db_path:
             raise ValueError("rllm.gateway.db_path is set but store='memory'; set store='sqlite' or clear db_path")
         _model_cfg = config.get("model", {})
@@ -363,9 +365,20 @@ class GatewayManager:
             return f"{base}/sessions/{session_id}/v1"
         return self.client.get_session_url(session_id)
 
+    # Traces fetch format: "compact" ships each unique message/token-id run
+    # once (linear in conversation, vs quadratic for the default list) and the
+    # client expands transparently. Enabled with the compact store, or forced
+    # either way with RLLM_COMPACT_TRACES=1/0.
+    @property
+    def _trace_format(self) -> str | None:
+        env = os.environ.get("RLLM_COMPACT_TRACES")
+        if env is not None:
+            return "compact" if env not in ("0", "false", "") else None
+        return "compact" if self.store == "memory-compact" else None
+
     def get_traces(self, session_id: str) -> list[TraceRecord]:
         self.client.flush()
-        return self.client.get_session_traces(session_id)
+        return self.client.get_session_traces(session_id, format=self._trace_format)
 
     # -- Async session / trace API -------------------------------------------
 
@@ -375,7 +388,7 @@ class GatewayManager:
 
     async def aget_traces(self, session_id: str) -> list[TraceRecord]:
         await self.async_client.flush(timeout=_TRACE_API_TIMEOUT)
-        return await self.async_client.get_session_traces(session_id)
+        return await self.async_client.get_session_traces(session_id, format=self._trace_format)
 
     async def adelete_session(self, session_id: str) -> int:
         """Delete a session and all its accumulated traces. Returns count removed."""

--- a/tests/gateway/test_compact_live_path.py
+++ b/tests/gateway/test_compact_live_path.py
@@ -1,0 +1,45 @@
+"""The compact stack must be reachable end-to-end (audit: 'no live path').
+
+Covers the three wiring points the audit found dead: the manager's store
+allowlist, the RLLM_GATEWAY_STORE env override, and the trace-fetch format
+selection that follows the store (or RLLM_COMPACT_TRACES).
+"""
+
+import pytest
+from omegaconf import OmegaConf
+
+from rllm.gateway.manager import GatewayManager
+
+
+def _mgr(monkeypatch, store=None, env_store=None, env_compact=None):
+    monkeypatch.delenv("RLLM_GATEWAY_STORE", raising=False)
+    monkeypatch.delenv("RLLM_COMPACT_TRACES", raising=False)
+    if env_store is not None:
+        monkeypatch.setenv("RLLM_GATEWAY_STORE", env_store)
+    if env_compact is not None:
+        monkeypatch.setenv("RLLM_COMPACT_TRACES", env_compact)
+    gateway = {} if store is None else {"store": store}
+    return GatewayManager(config=OmegaConf.create({"rllm": {"gateway": gateway}}), mode="thread")
+
+
+def test_memory_compact_is_an_allowed_store(monkeypatch):
+    assert _mgr(monkeypatch, store="memory-compact").store == "memory-compact"
+
+
+def test_env_var_opts_into_compact_store(monkeypatch):
+    assert _mgr(monkeypatch, env_store="memory-compact").store == "memory-compact"
+
+
+def test_unknown_store_still_rejected(monkeypatch):
+    with pytest.raises(ValueError):
+        _mgr(monkeypatch, store="redis")
+
+
+def test_trace_format_follows_store(monkeypatch):
+    assert _mgr(monkeypatch, store="memory-compact")._trace_format == "compact"
+    assert _mgr(monkeypatch, store="memory")._trace_format is None
+
+
+def test_trace_format_env_override(monkeypatch):
+    assert _mgr(monkeypatch, store="memory", env_compact="1")._trace_format == "compact"
+    assert _mgr(monkeypatch, store="memory-compact", env_compact="0")._trace_format is None


### PR DESCRIPTION
**Stacked on #871** → #869 → #868 — fourth in the series, fixing the audit's headline finding: *the compact stack had no live path*.

Three independent blocks, each confirmed by the adversarial audit:
1. `GatewayManager` rejected `store=memory-compact` with `ValueError` (manager.py:201)
2. the gateway CLI's argparse `choices` excluded it — and subprocess mode always passes `--store`, which outranks `RLLM_GATEWAY_STORE`
3. the engine never requested `format=compact` (manager.py:368/378)

## After this PR

```
RLLM_GATEWAY_STORE=memory-compact rllm eval …   # store + wire + fetch all compact
RLLM_EPISODE_SCHEMA=2 …                          # + compact episode files (#871)
```

- manager allowlist gains `memory-compact`; `RLLM_GATEWAY_STORE` honored as an override (both thread and process modes already pass `self.store` through)
- CLI `--store` choices gain `memory-compact`
- `get_traces`/`aget_traces` request `format="compact"` when the store is compact, or per `RLLM_COMPACT_TRACES=1/0`

**Defaults unchanged** — without opting in, store, wire, and fetch behave byte-for-byte as before. 5 wiring tests.

Also in the stack since the audit: #868 gained prompt-token-id delta storage (the second quadratic — full 128k-id prompts per call) + the shared-trace deletion fix; #869 gained cross-session marker resolution, event-loop yields, and id-deltas on the wire; #871's parity test hardened against schema-2 dumps. All parity suites re-run on real data after the fixes: store 152/152, fetch 152/152 over the JSON wire, episodes 282/282 lossless (11.3 GB → 211 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)