### PR TITLE
eval: fix consumer criticals — runner retention, C-encoder writes, index cache, logger schema

### DIFF
--- a/rllm/eval/episode_store.py
+++ b/rllm/eval/episode_store.py
@@ -107,10 +107,15 @@ class EvalEpisodeStore:
         # 113-task run); schema 2 stores each unique message once. Readers
         # (visualizer, curation) expand transparently; conversion back is
         # lossless (see rllm.eval.episode_codec and its real-dump parity test).
+        indent: int | None = 2
         if os.environ.get("RLLM_EPISODE_SCHEMA") == "2":
             from rllm.eval.episode_codec import compact_episode
 
             data = compact_episode(data)
+            # indent=2 disables CPython's C encoder (audit: multi-second
+            # event-loop stalls on 100 MB+ dumps). Compact files are small and
+            # machine-read; write them dense. Legacy stays indent=2 byte-for-byte.
+            indent = None
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, default=_json_default)
+            json.dump(data, f, indent=indent, default=_json_default)
         return path

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -176,7 +176,6 @@ async def run_dataset(
     # Aggregate per-rollout EvalItems for the report; with attempts > 1 the
     # expanded index folds back to (task index, attempt).
     items: list[EvalItem] = []
-    surviving_episodes: list = []
     for idx, episode in enumerate(episodes):
         task_idx, attempt = divmod(idx, attempts) if attempts > 1 else (idx, 0)
         if episode is None:
@@ -219,7 +218,7 @@ async def run_dataset(
                 termination_reason=reason.value if reason is not None else None,
             )
         )
-        if error_msg is None:
-            surviving_episodes.append(episode)
-
-    return (EvalResult.from_items(dataset_name, model, agent_name, items, attempts=attempts), surviving_episodes)
+    # NOTE: episodes are persisted/streamed via on_episode_complete; retaining
+    # them here doubled the run's peak RSS for a return value the CLI never
+    # read (audit finding). The second element stays for signature stability.
+    return (EvalResult.from_items(dataset_name, model, agent_name, items, attempts=attempts), [])

--- a/rllm/eval/visualizer.py
+++ b/rllm/eval/visualizer.py
@@ -139,11 +139,23 @@ def _scan_runs(root: Path) -> list[dict[str, Any]]:
     return out
 
 
+# path -> ((mtime_ns, size), index_row). Parsing a 400 MB episode file for
+# five headline fields on EVERY index request was the audit's per-request
+# quadratic; rows are immutable for a finished episode, so cache by stat.
+_INDEX_CACHE: dict[Path, tuple[tuple[int, int], dict[str, Any]]] = {}
+
+
 def _build_episode_index(episodes_dir: Path) -> list[dict[str, Any]]:
     """Read just the headline fields from every episode file in a run."""
     index = []
     for path in sorted(episodes_dir.glob("episode_*.json")):
         try:
+            st = path.stat()
+            stamp = (st.st_mtime_ns, st.st_size)
+            cached = _INDEX_CACHE.get(path)
+            if cached is not None and cached[0] == stamp:
+                index.append(cached[1])
+                continue
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
         except Exception:
@@ -152,7 +164,7 @@ def _build_episode_index(episodes_dir: Path) -> list[dict[str, Any]]:
         n_steps = sum(len(t.get("steps") or []) for t in (data.get("trajectories") or []))
         rewards = [t.get("reward") for t in (data.get("trajectories") or []) if t.get("reward") is not None]
         avg_reward = sum(rewards) / len(rewards) if rewards else None
-        index.append(
+        row = (
             {
                 "filename": path.name,
                 "eval_idx": data.get("eval_idx"),
@@ -165,6 +177,8 @@ def _build_episode_index(episodes_dir: Path) -> list[dict[str, Any]]:
                 "instruction_preview": _preview(task.get("instruction") if isinstance(task, dict) else None),
             }
         )
+        _INDEX_CACHE[path] = (stamp, row)
+        index.append(row)
     return index
 
 

--- a/rllm/utils/episode_logger.py
+++ b/rllm/utils/episode_logger.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -128,9 +129,17 @@ class EpisodeLogger:
         filename = self.get_episode_filename(episode, step)
         filepath = step_dir / filename
 
+        # Same opt-in as eval dumps: schema-2 stores each unique message once
+        # (a training debug episode is otherwise quadratic in steps).
+        indent: int | None = 2
+        if os.environ.get("RLLM_EPISODE_SCHEMA") == "2":
+            from rllm.eval.episode_codec import compact_episode
+
+            episode_data = compact_episode(episode_data)
+            indent = None
         try:
             with open(filepath, "w") as f:
-                json_str = json.dumps(episode_data, indent=2, default=str)
+                json_str = json.dumps(episode_data, indent=indent, default=str)
                 f.write(json_str + "\n")
                 f.flush()  # Ensure data is written to disk
         except Exception as e:


### PR DESCRIPTION
**Stacked on #872** → #871 → #869 → #868 — fifth in the series: the four audit criticals in episode-consuming paths.

| finding | fix |
|---|---|
| `run_dataset` retained every Episode for a return the CLI never reads (~2× peak RSS) | stop retaining; `on_episode_complete` already persists/streams |
| `episode_store.write` `indent=2` disables the C encoder → multi-second event-loop stalls on 100 MB dumps | schema-2 writes dense; legacy stays `indent=2` byte-for-byte |
| visualizer parses full 400 MB files for 5 headline fields on **every** index request | `(mtime_ns, size)`-keyed row cache; verified fresh/cached/invalidated |
| `episode_logger` training dumps quadratic per step | honors `RLLM_EPISODE_SCHEMA=2` via the same codec |

Defaults unchanged throughout. 527 eval/gateway tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)