### PR TITLE
[superseded — slot reserved: producer PR] enrichment emits TrajectoryDelta

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/client.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/client.py
@@ -7,6 +7,72 @@ import httpx
 from rllm_model_gateway.models import TraceRecord, WorkerInfo
 
 
+def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Rebuild full per-trace message lists from a compact traces payload.
+
+    Nodes are materialized once and *shared*: every trace whose conversation
+    contains node X references the same message dict, so client memory stays
+    linear in unique messages even though the expanded lists repeat them.
+    Reconstruction is exact — parity-tested byte-for-byte against the default
+    format on real eval dumps.
+    """
+    nodes = payload.get("nodes", {})
+    out: list[dict[str, Any]] = []
+    # Cache only REQUESTED leaves: caching every intermediate prefix made a
+    # single deep chain cost O(M^2) allocations (review); walking to the
+    # nearest cached ancestor and extending once keeps shared-prefix reuse
+    # while a lone leaf costs O(M).
+    paths: dict[str | None, list[dict[str, Any]]] = {None: []}
+
+    def _path(leaf: str | None) -> list[dict[str, Any]]:
+        cached = paths.get(leaf)
+        if cached is not None:
+            return cached
+        chain: list[str] = []
+        node_id = leaf
+        seen: set[str] = set()
+        while node_id is not None and node_id not in paths:
+            if node_id in seen:
+                raise ValueError(f"message node cycle at {node_id!r}")
+            seen.add(node_id)
+            chain.append(node_id)
+            entry = nodes.get(node_id)
+            if entry is None:
+                raise ValueError(f"dangling message node reference {node_id!r}")
+            node_id = entry["p"]
+        base = list(paths[node_id] if node_id is not None else paths[None])
+        base.extend(nodes[nid]["m"] for nid in reversed(chain))
+        paths[leaf] = base
+        return base
+
+    ids_memo: dict[str | None, list[int]] = {None: []}
+    for trace in payload.get("traces", []):
+        ref = trace.get("messages_ref")
+        if ref is None:
+            out.append(trace)
+            continue
+        leaf, length = ref
+        messages = _path(leaf)
+        if len(messages) != length:
+            raise ValueError(f"compact chain length {len(messages)} != recorded {length}")
+        expanded = dict(trace)
+        expanded.pop("messages_ref", None)
+        expanded["messages"] = messages
+        ids_ref = expanded.pop("prompt_ids_delta", None)
+        if ids_ref is not None:
+            # Delta against an earlier trace in this payload: prefix + suffix.
+            prev_tid, lcp, suffix = ids_ref
+            prev_full = ids_memo.get(prev_tid)
+            if prev_full is None or lcp > len(prev_full):
+                raise ValueError(f"prompt-id delta references unknown/short ancestor {prev_tid!r}")
+            expanded["prompt_token_ids"] = prev_full[:lcp] + list(suffix)
+        tid = expanded.pop("_tid", None) or expanded.get("trace_id")
+        if tid is not None and isinstance(expanded.get("prompt_token_ids"), list):
+            ids_memo[tid] = expanded["prompt_token_ids"]
+        out.append(expanded)
+    return out
+
+
 class GatewayClient:
     """Synchronous client for the rllm-model-gateway REST API.
 
@@ -88,15 +154,24 @@ class GatewayClient:
         session_id: str,
         since: float | None = None,
         limit: int | None = None,
+        format: str | None = None,
     ) -> list[TraceRecord]:
         params: dict[str, Any] = {}
         if since is not None:
             params["since"] = since
         if limit is not None:
             params["limit"] = limit
+        if format is not None:
+            params["format"] = format
         resp = self._http.get(f"{self.gateway_url}/sessions/{session_id}/traces", params=params)
         resp.raise_for_status()
         data = resp.json()
+        if isinstance(data, dict) and data.get("format") == "compact":
+            # model_construct skips validation, which would otherwise re-create
+            # every message dict and destroy the cross-trace sharing the
+            # expansion just built. The payload is gateway-produced, not user
+            # input, so skipping validation is safe here.
+            return [TraceRecord.model_construct(**t) for t in _expand_compact_traces(data)]
         return [TraceRecord(**t) for t in data]
 
     def get_trace(self, trace_id: str) -> TraceRecord:
@@ -236,15 +311,22 @@ class AsyncGatewayClient:
         session_id: str,
         since: float | None = None,
         limit: int | None = None,
+        format: str | None = None,
     ) -> list[TraceRecord]:
         params: dict[str, Any] = {}
         if since is not None:
             params["since"] = since
         if limit is not None:
             params["limit"] = limit
+        if format is not None:
+            params["format"] = format
         resp = await self._http.get(f"{self.gateway_url}/sessions/{session_id}/traces", params=params)
         resp.raise_for_status()
         data = resp.json()
+        if isinstance(data, dict) and data.get("format") == "compact":
+            # See the sync client: model_construct preserves the shared node
+            # dicts that validation would copy away.
+            return [TraceRecord.model_construct(**t) for t in _expand_compact_traces(data)]
         return [TraceRecord(**t) for t in data]
 
     async def get_trace(self, trace_id: str) -> TraceRecord:

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -88,6 +88,12 @@ def create_store(config: GatewayConfig) -> TraceStore:
         from rllm_model_gateway.store.memory_store import MemoryTraceStore
 
         return MemoryTraceStore()
+    elif worker == "compact":
+        # Message-compaction variant — see MemoryTraceStore(compact=True).
+        # Same external contract as "memory"; opt-in via RLLM_GATEWAY_STORE.
+        from rllm_model_gateway.store.memory_store import MemoryTraceStore
+
+        return MemoryTraceStore(compact=True)
     else:
         raise ValueError(f"Unknown store worker: {worker}")
 
@@ -273,7 +279,14 @@ def create_app(
         session_id: str,
         since: float | None = Query(None),
         limit: int | None = Query(None),
+        format: str = Query("default"),
     ):
+        # "compact" ships each unique message once (node table + leaf refs) —
+        # the expanded legacy list is quadratic in turns for agentic sessions.
+        # Only stores that implement the compact read support it; others keep
+        # serving the default form regardless of the requested format.
+        if format == "compact" and hasattr(store, "get_session_traces_compact"):
+            return await store.get_session_traces_compact(session_id, since=since, limit=limit)
         traces = await store.get_session_traces(session_id, since=since, limit=limit)
         return traces
 
@@ -522,7 +535,7 @@ def main() -> None:
         help="Worker URL (can be repeated)",
     )
     parser.add_argument("--db-path", type=str, default=None)
-    parser.add_argument("--store", type=str, default=None, choices=["sqlite", "memory"])
+    parser.add_argument("--store", type=str, default=None, choices=["sqlite", "memory", "compact"])
     parser.add_argument("--log-level", type=str, default=None)
     parser.add_argument(
         "--model",

--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -1,13 +1,16 @@
 """In-memory trace store for testing and embedded usage."""
 
 import array
+import asyncio
+import hashlib
+import json
 import time
 from collections import defaultdict
 from typing import Any
 
 # Token-id / logprob lists dominate trace memory. As Python list[int]/list[float]
 # each element costs ~32-36 B (an 8 B pointer plus a boxed int/float object) since
-# vocab ids exceed CPython's small-int intern cap (256). Packed into array.array
+# vocab ids exceed CPython's small-int compact cap (256). Packed into array.array
 # they cost 4-8 B/element with no per-item object — ~9x smaller for ids, ~4x for
 # logprobs — and collapse N objects into 1, cutting GC pressure. We pack on store
 # and unpack on read so the external dict contract (plain lists) is unchanged.
@@ -50,19 +53,214 @@ def _unpack(data: dict[str, Any]) -> dict[str, Any]:
     return out if out is not None else data
 
 
-class MemoryTraceStore:
-    """Ephemeral in-memory store.  Useful for tests and short-lived processes."""
+# Sentinel key marking an compacted ``messages`` field: [session_id, leaf_node_id, length].
+# Present only inside the store; readers always see the expanded list.
+_MESSAGES_REF_KEY = "__messages_ref__"
 
-    def __init__(self) -> None:
+# Sentinel for delta-stored prompt token ids: [prev_trace_id | None, lcp, suffix].
+# Messages were only half the quadratic — every trace also carries the FULL
+# prompt token ids of its call (up to ~128k ids), which repeat the previous
+# call's ids almost entirely. Compact mode stores only the suffix beyond the
+# longest common prefix with the session's previous trace; reads rebuild the
+# full list by walking the chain. LCP against the actual previous ids makes
+# this lossless regardless of renderer behavior: a non-extending prompt just
+# gets lcp=0 and stores verbatim.
+_PROMPT_IDS_DELTA_KEY = "__prompt_ids_delta__"
+
+
+def _message_fingerprint(message: dict[str, Any]) -> str:
+    """Fingerprint of one message (order-sensitive JSON → sha256).
+
+    Deliberately order-SENSITIVE: equal content under different key order
+    stays a distinct node, so reads reproduce exactly what was stored —
+    byte-for-byte — rather than a semantically-equal reordering.
+    """
+    payload = json.dumps(message, separators=(",", ":"), ensure_ascii=False, default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+class MemoryTraceStore:
+    """Ephemeral in-memory store.  Useful for tests and short-lived processes.
+
+    ``compact=True`` (the ``compact`` store worker) opts into message
+    compaction: agentic clients resend the whole conversation on every call, so
+    trace N of a session carries the same N-1 leading messages as trace N-1 —
+    storing each trace's ``messages`` verbatim makes a session's memory
+    quadratic in turns (measured 30–400 MB per task on DeepSWE-length
+    rollouts). Like ``_pack`` does for token-id lists, compact mode compacts on
+    write: each unique (parent, content) pair is kept once in a per-session
+    node table and the trace stores only its leaf reference; reads expand back
+    to the full list, so the external contract is unchanged. Node identity
+    hashes the *parent chain* as well as content (a Merkle chain) so identical
+    content at different positions — e.g. repeated empty completions from
+    throttled calls — keeps distinct nodes and reconstruction is exact.
+
+    The default mode stores traces verbatim, exactly as before.
+    """
+
+    def __init__(self, compact: bool = False) -> None:
+        self._compact = compact
         # trace_id -> data dict
         self._traces: dict[str, dict[str, Any]] = {}
         # trace_id -> created_at
         self._timestamps: dict[str, float] = {}
         # session_id -> list[trace_id]  (insertion order)
         self._session_index: dict[str, list[str]] = defaultdict(list)
+        # session_id -> {node_id: (parent_node_id | None, message)}
+        self._session_nodes: dict[str, dict[str, tuple[str | None, dict[str, Any]]]] = defaultdict(dict)
+        # session_id -> {(parent_node_id | None, content_fp): node_id} — O(1)
+        # re-compaction of prefixes without walking or re-storing them.
+        self._session_node_lookup: dict[str, dict[tuple[str | None, str], str]] = defaultdict(dict)
+        # (session_id, lineage_id) -> (trace_id, full prompt ids of that
+        # lineage's latest trace) — the LCP reference for prompt-id delta
+        # storage. Keyed per lineage so interleaved parent/subagent
+        # conversations never delta against each other's prompts.
+        self._session_last_prompt_ids: dict[tuple[str, str | None], tuple[str, list[int]]] = {}
+
+    def _messages_to_nodes(self, session_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Return ``data`` with ``messages`` replaced by a leaf reference."""
+        messages = data.get("messages")
+        if type(messages) is not list or not messages or not all(isinstance(m, dict) for m in messages):
+            return data  # empty/unknown shape: store verbatim
+        nodes = self._session_nodes[session_id]
+        chain = self._session_node_lookup[session_id]
+        parent: str | None = None
+        for message in messages:
+            key = (parent, _message_fingerprint(message))
+            node_id = chain.get(key)
+            if node_id is None:
+                # Merkle id: parent chain + content, so position matters.
+                node_id = hashlib.sha256(f"{parent}:{key[1]}".encode()).hexdigest()
+                nodes[node_id] = (parent, message)
+                chain[key] = node_id
+            parent = node_id
+        out = dict(data)
+        out["messages"] = {_MESSAGES_REF_KEY: [session_id, parent, len(messages)]}
+        return out
+
+    def _nodes_to_messages(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Inverse of :meth:`_messages_to_nodes` — rebuild the full message list."""
+        marker = data.get("messages")
+        if type(marker) is not dict or _MESSAGES_REF_KEY not in marker:
+            return data
+        session_id, leaf, length = marker[_MESSAGES_REF_KEY]
+        nodes = self._session_nodes.get(session_id, {})
+        messages: list[dict[str, Any]] = []
+        node_id = leaf
+        seen: set[str] = set()
+        while node_id is not None:
+            if node_id in seen:
+                raise ValueError(f"message node cycle at {node_id!r}")
+            seen.add(node_id)
+            entry = nodes.get(node_id)
+            if entry is None:
+                raise ValueError(f"dangling message node reference {node_id!r}")
+            parent, message = entry
+            messages.append(message)
+            node_id = parent
+        messages.reverse()
+        if len(messages) != length:
+            raise ValueError(f"compacted chain length {len(messages)} != recorded {length}")
+        out = dict(data)
+        out["messages"] = messages
+        return out
+
+    def _rebase_delta_dependents(self, session_id: str, trace_id: str) -> None:
+        """Materialize any trace whose delta references *trace_id* to verbatim ids.
+
+        Called before a trace is overwritten (replay re-stores reuse trace
+        ids): a dependent's delta encodes a prefix of the OLD content, so it
+        must be pinned to full ids first or reconstruction would read the
+        overwritten trace and could even form a cycle (t1 -> t2 -> t1).
+        """
+        memo: dict[str, list[int]] = {}
+        # Trace ids are global (self._traces), so dependents may live in ANY
+        # session — a session-scoped scan would leave other sessions' deltas
+        # pointing at the new content and reconstructing garbage.
+        for tid, stored in list(self._traces.items()):
+            if tid == trace_id:
+                continue
+            marker = stored.get("prompt_token_ids")
+            if type(marker) is dict and _PROMPT_IDS_DELTA_KEY in marker and marker[_PROMPT_IDS_DELTA_KEY][0] == trace_id:
+                self._traces[tid] = _pack(self._delta_to_prompt_ids(tid, _unpack(stored), memo))
+        # An anchor caches the previous trace's FULL ids; one pointing at the
+        # overwritten trace would LCP against stale content and mint deltas
+        # that reconstruct silently wrong ids. Anchors live per (session,
+        # lineage) but reference GLOBAL trace ids — drop them everywhere
+        # (third instance of the session-scoped-state-on-global-ids bug).
+        for key, (anchor_tid, _) in list(self._session_last_prompt_ids.items()):
+            if anchor_tid == trace_id:
+                del self._session_last_prompt_ids[key]
+
+    def _prompt_ids_to_delta(self, session_id: str, trace_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Store only the suffix of ``prompt_token_ids`` beyond the previous trace's."""
+        ids = data.get("prompt_token_ids")
+        if type(ids) is not list or not ids:
+            return data
+        if trace_id in self._traces:  # replay overwrite: pin dependents first, store verbatim
+            self._rebase_delta_dependents(session_id, trace_id)
+            self._session_last_prompt_ids[(session_id, data.get("lineage_id"))] = (trace_id, ids)
+            return data
+        key = (session_id, data.get("lineage_id"))
+        prev = self._session_last_prompt_ids.get(key)
+        out = dict(data)
+        if prev is not None and prev[0] not in self._traces:
+            prev = None  # anchor points at a deleted trace: never delta against it
+        if prev is not None and prev[0] != trace_id:
+            prev_tid, prev_ids = prev
+            lcp = 0
+            n = min(len(ids), len(prev_ids))
+            while lcp < n and ids[lcp] == prev_ids[lcp]:
+                lcp += 1
+            if lcp > 0:
+                out["prompt_token_ids"] = {_PROMPT_IDS_DELTA_KEY: [prev_tid, lcp, ids[lcp:]]}
+        self._session_last_prompt_ids[key] = (trace_id, ids)
+        return out
+
+    def _full_prompt_ids(self, trace_id: str, memo: dict[str, list[int]]) -> list[int]:
+        """Full prompt ids of *trace_id*, resolving delta chains iteratively."""
+        if trace_id in memo:
+            return memo[trace_id]
+        # Walk back to the first non-delta ancestor, then rebuild forward.
+        chain: list[str] = []
+        visiting: set[str] = set()
+        tid = trace_id
+        while tid not in memo:
+            if tid in visiting:
+                raise ValueError(f"prompt-id delta cycle at trace {tid!r}")
+            visiting.add(tid)
+            data = self._traces.get(tid)
+            marker = None if data is None else data.get("prompt_token_ids")
+            if type(marker) is not dict or _PROMPT_IDS_DELTA_KEY not in marker:
+                base = _unpack(data or {}).get("prompt_token_ids") or []
+                memo[tid] = base if isinstance(base, list) else list(base)
+                break
+            chain.append(tid)
+            tid = marker[_PROMPT_IDS_DELTA_KEY][0]
+            if tid is None:
+                memo[None] = []  # type: ignore[index]
+                break
+        for tid in reversed(chain):
+            prev_tid, lcp, suffix = self._traces[tid]["prompt_token_ids"][_PROMPT_IDS_DELTA_KEY]
+            prev_full = memo[prev_tid]
+            if lcp > len(prev_full):
+                raise ValueError(f"prompt-id delta lcp {lcp} exceeds ancestor length {len(prev_full)}")
+            memo[tid] = prev_full[:lcp] + list(suffix)
+        return memo[trace_id]
+
+    def _delta_to_prompt_ids(self, trace_id: str, data: dict[str, Any], memo: dict[str, list[int]] | None = None) -> dict[str, Any]:
+        """Inverse of :meth:`_prompt_ids_to_delta` for one trace dict."""
+        marker = data.get("prompt_token_ids")
+        if type(marker) is not dict or _PROMPT_IDS_DELTA_KEY not in marker:
+            return data
+        out = dict(data)
+        out["prompt_token_ids"] = self._full_prompt_ids(trace_id, {} if memo is None else memo)
+        return out
 
     async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
         now = time.time()
+        if self._compact:
+            data = self._prompt_ids_to_delta(session_id, trace_id, self._messages_to_nodes(session_id, data))
         self._traces[trace_id] = _pack(data)
         if trace_id not in self._timestamps:
             self._timestamps[trace_id] = now
@@ -72,7 +270,9 @@ class MemoryTraceStore:
 
     async def get_trace(self, trace_id: str) -> dict[str, Any] | None:
         data = self._traces.get(trace_id)
-        return _unpack(data) if data is not None else None
+        if data is None:
+            return None
+        return self._delta_to_prompt_ids(trace_id, self._nodes_to_messages(_unpack(data)))
 
     async def get_session_traces(
         self,
@@ -81,17 +281,113 @@ class MemoryTraceStore:
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
         ids = self._session_index.get(session_id, [])
-        results: list[dict[str, Any]] = []
+        results: list[tuple[str, dict[str, Any]]] = []
         for tid in ids:
             ts = self._timestamps.get(tid, 0.0)
             if since is not None and ts < since:
                 continue
             data = self._traces.get(tid)
             if data is not None:
-                results.append(data)
+                results.append((tid, data))
         if limit is not None:
             results = results[:limit]
-        return [_unpack(d) for d in results]
+        memo: dict[str, list[int]] = {}
+        return [self._delta_to_prompt_ids(tid, self._nodes_to_messages(_unpack(d)), memo) for tid, d in results]
+
+    async def get_session_traces_compact(
+        self,
+        session_id: str,
+        since: float | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Session traces in compact wire form: a node table plus leaf refs.
+
+        Wire shape: ``{"format": "compact", "nodes": {id: {"p": parent|None,
+        "m": message}}, "traces": [...]}`` where each trace carries
+        ``messages_ref: [leaf_id|None, length]`` instead of ``messages``.
+        Works in both store modes — a default-mode store compacts into an
+        ephemeral table at read time — so fetch format is independent of how
+        the store holds traces. The expanded and compact forms reconstruct
+        identically (see client._expand_compact_traces and the parity tests).
+        """
+        ids = self._session_index.get(session_id, [])
+        raw: list[tuple[str, dict[str, Any]]] = []
+        for tid in ids:
+            ts = self._timestamps.get(tid, 0.0)
+            if since is not None and ts < since:
+                continue
+            data = self._traces.get(tid)
+            if data is not None:
+                raw.append((tid, data))
+        if limit is not None:
+            raw = raw[:limit]
+
+        nodes_out: dict[str, dict[str, Any]] = {}
+        included_tids = {tid for tid, _ in raw}
+        ids_memo: dict[str, list[int]] = {}
+        # Ephemeral compacter for traces stored verbatim (default mode).
+        eph_nodes: dict[str, tuple[str | None, dict[str, Any]]] = {}
+        eph_lookup: dict[tuple[str | None, str], str] = {}
+        compacted = 0  # messages compacted since the last event-loop yield
+
+        def _collect(leaf: str | None, table: dict[str, tuple[str | None, dict[str, Any]]]) -> None:
+            node_id = leaf
+            while node_id is not None and node_id not in nodes_out:
+                parent, message = table[node_id]
+                nodes_out[node_id] = {"p": parent, "m": message}
+                node_id = parent
+
+        traces_out: list[dict[str, Any]] = []
+        for tid, data in raw:
+            data = _unpack(data)
+            marker = data.get("messages")
+            if type(marker) is dict and _MESSAGES_REF_KEY in marker:
+                # The marker records which session's node table owns its chain —
+                # a trace_id re-stored under another session points there, not
+                # at the requested session (matching _nodes_to_messages).
+                marker_sid, leaf, length = marker[_MESSAGES_REF_KEY]
+                _collect(leaf, self._session_nodes.get(marker_sid, {}))
+            else:
+                messages = marker
+                if type(messages) is not list or not all(isinstance(m, dict) for m in (messages or [])):
+                    # unknown shape: ship verbatim, no ref
+                    traces_out.append(data)
+                    continue
+                parent: str | None = None
+                for message in messages:
+                    key = (parent, _message_fingerprint(message))
+                    node_id = eph_lookup.get(key)
+                    if node_id is None:
+                        node_id = hashlib.sha256(f"{parent}:{key[1]}".encode()).hexdigest()
+                        eph_nodes[node_id] = (parent, message)
+                        eph_lookup[key] = node_id
+                    parent = node_id
+                    # Fingerprinting a long session is hundreds of MB of hashing;
+                    # yield periodically so in-flight proxying is never starved.
+                    compacted += 1
+                    if compacted % 512 == 0:
+                        await asyncio.sleep(0)
+                leaf, length = parent, len(messages)
+                _collect(leaf, eph_nodes)
+            out = dict(data)
+            out.pop("messages", None)
+            out["messages_ref"] = [leaf, length]
+            out["_tid"] = tid  # chain anchor for prompt_ids_delta; client strips it
+            ids_marker = out.get("prompt_token_ids")
+            if type(ids_marker) is dict and _PROMPT_IDS_DELTA_KEY in ids_marker:
+                prev_tid = ids_marker[_PROMPT_IDS_DELTA_KEY][0]
+                if prev_tid in included_tids:
+                    # Ship the delta; the client rebuilds chains in order
+                    # (prev refs point to an earlier trace in the payload).
+                    out.pop("prompt_token_ids", None)
+                    out["prompt_ids_delta"] = list(ids_marker[_PROMPT_IDS_DELTA_KEY])
+                else:
+                    # since/limit excluded the ancestor: rebase to full ids so
+                    # the payload is self-contained.
+                    out["prompt_token_ids"] = self._full_prompt_ids(tid, ids_memo)
+            traces_out.append(out)
+
+        return {"format": "compact", "nodes": nodes_out, "traces": traces_out}
 
     async def delete_session(self, session_id: str) -> int:
         ids = self._session_index.pop(session_id, [])
@@ -99,6 +395,18 @@ class MemoryTraceStore:
         referenced: set[str] = set()
         for sid, tids in self._session_index.items():
             referenced.update(tids)
+        # Traces surviving via another session may hold markers into the
+        # tables about to be dropped (a trace_id re-stored under two sessions
+        # points at whichever session stored it last). Re-materialize them to
+        # verbatim form first, or they would be unreadable afterwards.
+        memo: dict[str, list[int]] = {}
+        for tid in ids:
+            if tid in referenced and tid in self._traces:
+                self._traces[tid] = _pack(self._delta_to_prompt_ids(tid, self._nodes_to_messages(_unpack(self._traces[tid])), memo))
+        self._session_nodes.pop(session_id, None)
+        self._session_node_lookup.pop(session_id, None)
+        for key in [k for k in self._session_last_prompt_ids if k[0] == session_id]:
+            del self._session_last_prompt_ids[key]
         deleted = 0
         for tid in ids:
             if tid not in referenced:

--- a/rllm-model-gateway/tests/parity/test_store_real_dump_parity.py
+++ b/rllm-model-gateway/tests/parity/test_store_real_dump_parity.py
@@ -1,0 +1,132 @@
+"""Real-data parity: compact store mode vs default mode vs the original bytes.
+
+Replays the per-step conversation snapshots of real ``rllm eval`` episode
+dumps through both store modes and requires exact byte parity:
+
+    original -> store(compact) -> read  ==  original   (canonical JSON bytes)
+    original -> store(default) -> read  ==  original   (canonical JSON bytes)
+
+Real dumps — not mocks — are the fixture, because the adversarial shapes
+(throttle-retry empty messages, non-cumulative rewrites, 200+ step sessions)
+only occur in the wild. Dumps are discovered from ``RLLM_PARITY_DUMPS``
+(colon-separated run dirs) or ``~/.rllm/eval_results/*/episodes``; the test
+skips when none exist (CI has no dumps). ``RLLM_PARITY_LIMIT`` caps episodes
+per dump (default 6 for test-suite runs; 0 = every episode, used for full
+sweeps before a release).
+
+Run a full sweep with:
+    RLLM_PARITY_LIMIT=0 pytest tests/parity/test_store_real_dump_parity.py -s
+"""
+
+import asyncio
+import glob
+import json
+import os
+
+import pytest
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+
+_run = asyncio.run
+
+
+def _canonical(obj) -> bytes:
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False, default=str).encode()
+
+
+def _discover_dumps() -> list[str]:
+    env = os.environ.get("RLLM_PARITY_DUMPS")
+    if env:
+        return [d for d in env.split(":") if os.path.isdir(d)]
+    dirs = glob.glob(os.path.expanduser("~/.rllm/eval_results/*/episodes"))
+    return sorted(d for d in dirs if glob.glob(os.path.join(d, "*.json")))
+
+
+def _episode_step_messages(path: str) -> list[list[dict]]:
+    """Per-step conversation snapshots of one episode (may be non-cumulative)."""
+    with open(path, encoding="utf-8") as f:
+        ep = json.load(f)
+    trajectories = ep.get("trajectories") or []
+    if not trajectories:
+        return []
+    steps = trajectories[0].get("steps") or []
+    return [s.get("chat_completions") or [] for s in steps]
+
+
+def _replay_and_check(seqs: list[list[dict]], compact: bool) -> None:
+    store = MemoryTraceStore(compact=compact)
+    for i, cc in enumerate(seqs):
+        _run(store.store_trace(f"t{i}", "s", {"messages": cc, "response_message": {}}))
+    # Single-trace reads
+    for i, cc in enumerate(seqs):
+        got = _run(store.get_trace(f"t{i}"))["messages"]
+        assert _canonical(got) == _canonical(cc), f"trace {i} (compact={compact}) not byte-identical"
+    # Bulk read preserves order and content
+    bulk = [t["messages"] for t in _run(store.get_session_traces("s"))]
+    assert _canonical(bulk) == _canonical(seqs), f"bulk read (compact={compact}) not byte-identical"
+
+
+def test_real_dump_parity_compact_vs_default():
+    dumps = _discover_dumps()
+    if not dumps:
+        pytest.skip("no real eval dumps on this machine")
+    limit = int(os.environ.get("RLLM_PARITY_LIMIT", "6"))
+
+    episodes_checked = 0
+    for dump in dumps:
+        files = sorted(glob.glob(os.path.join(dump, "*.json")))
+        if limit:
+            # spread across the dump rather than taking the first N
+            stride = max(1, len(files) // limit)
+            files = files[::stride][:limit]
+        for path in files:
+            seqs = _episode_step_messages(path)
+            if not any(seqs):
+                continue
+            _replay_and_check(seqs, compact=True)
+            _replay_and_check(seqs, compact=False)
+            episodes_checked += 1
+        print(f"[parity] {os.path.basename(os.path.dirname(dump))}: {len(files)} episodes checked")
+
+    assert episodes_checked > 0, "dumps discovered but no episode had messages"
+    print(f"[parity] total episodes byte-identical in both modes: {episodes_checked}")
+
+
+def _replay_and_check_fetch(seqs: list[list[dict]], compact_store: bool) -> None:
+    """Fetch-path parity: compact wire payload expands byte-identical to default."""
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    store = MemoryTraceStore(compact=compact_store)
+    for i, cc in enumerate(seqs):
+        _run(store.store_trace(f"t{i}", "s", {"messages": cc, "response_message": {}}))
+
+    default_form = [t["messages"] for t in _run(store.get_session_traces("s"))]
+    payload = _run(store.get_session_traces_compact("s"))
+    # Simulate the wire: what the client sees is the JSON round-trip.
+    payload = json.loads(json.dumps(payload, ensure_ascii=False, default=str))
+    expanded = [t["messages"] for t in _expand_compact_traces(payload)]
+
+    assert _canonical(expanded) == _canonical(seqs), f"compact fetch (store compact={compact_store}) != original"
+    assert _canonical(expanded) == _canonical(default_form), f"compact fetch (store compact={compact_store}) != default fetch"
+
+
+def test_real_dump_fetch_parity_compact_vs_default():
+    dumps = _discover_dumps()
+    if not dumps:
+        pytest.skip("no real eval dumps on this machine")
+    limit = int(os.environ.get("RLLM_PARITY_LIMIT", "6"))
+
+    episodes_checked = 0
+    for dump in dumps:
+        files = sorted(glob.glob(os.path.join(dump, "*.json")))
+        if limit:
+            stride = max(1, len(files) // limit)
+            files = files[::stride][:limit]
+        for path in files:
+            seqs = _episode_step_messages(path)
+            if not any(seqs):
+                continue
+            _replay_and_check_fetch(seqs, compact_store=True)
+            _replay_and_check_fetch(seqs, compact_store=False)
+            episodes_checked += 1
+    assert episodes_checked > 0
+    print(f"[parity-fetch] total episodes byte-identical (both store modes, over JSON wire): {episodes_checked}")

--- a/rllm-model-gateway/tests/unit/test_memory_store_compact.py
+++ b/rllm-model-gateway/tests/unit/test_memory_store_compact.py
@@ -1,0 +1,346 @@
+"""Message compaction in MemoryTraceStore.
+
+Agentic sessions resend the whole conversation each call; the store must keep
+each unique (parent, content) message once while every read returns the exact
+list the writer stored. The adversarial shapes here are taken from real
+DeepSWE runs: strict prefix growth, identical empty messages at different
+positions (throttled-call retries), and mid-run history rewrites
+(non-cumulative steps).
+
+Tests drive the async store API through ``asyncio.run`` so they need no
+pytest-asyncio plugin and run in both the gateway and root test environments.
+"""
+
+import asyncio
+
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+
+_run = asyncio.run
+
+
+def _trace(messages, completion="ok"):
+    return {
+        "messages": messages,
+        "response_message": {"role": "assistant", "content": completion},
+        "prompt_token_ids": [1, 2, 3],
+        "completion_token_ids": [4],
+    }
+
+
+def _convo(n):
+    """A cumulative conversation: system + n user/assistant pairs."""
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(n):
+        msgs.append({"role": "user", "content": f"observation {i}"})
+        msgs.append({"role": "assistant", "content": f"action {i}"})
+    return msgs
+
+
+def test_roundtrip_exact_for_cumulative_session():
+    store = MemoryTraceStore(compact=True)
+    originals = []
+    for turn in range(1, 6):
+        msgs = _convo(turn)
+        originals.append(msgs)
+        _run(store.store_trace(f"t{turn}", "s1", _trace(msgs)))
+
+    for turn, msgs in enumerate(originals, start=1):
+        assert _run(store.get_trace(f"t{turn}"))["messages"] == msgs
+
+    traces = _run(store.get_session_traces("s1"))
+    assert [t["messages"] for t in traces] == originals
+
+
+def test_compaction_stores_each_unique_message_once():
+    store = MemoryTraceStore(compact=True)
+    for turn in range(1, 11):
+        _run(store.store_trace(f"t{turn}", "s1", _trace(_convo(turn))))
+    # 10 turns resend a growing prefix: stored verbatim that is ~110 messages;
+    # the node table holds only the 21 unique ones.
+    assert len(store._session_nodes["s1"]) == len(_convo(10))
+
+
+def test_identical_content_at_different_positions_stays_distinct():
+    """Repeated empty assistant messages (throttle retries) must not collapse."""
+    store = MemoryTraceStore(compact=True)
+    msgs = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": "retry"},
+        {"role": "assistant", "content": ""},  # same content, different position
+    ]
+    _run(store.store_trace("t1", "s1", _trace(msgs)))
+    assert _run(store.get_trace("t1"))["messages"] == msgs
+    assert len(store._session_nodes["s1"]) == 4  # Merkle identity: 4 nodes, not 3
+
+
+def test_history_rewrite_forks_and_roundtrips():
+    """Non-cumulative step: a rewritten prefix forks the chain; both reads stay exact."""
+    store = MemoryTraceStore(compact=True)
+    a = [{"role": "user", "content": "start"}, {"role": "assistant", "content": "v1"}]
+    b = [
+        {"role": "user", "content": "start"},
+        {"role": "assistant", "content": "COMPACTED"},
+        {"role": "user", "content": "next"},
+    ]
+    _run(store.store_trace("t1", "s1", _trace(a)))
+    _run(store.store_trace("t2", "s1", _trace(b)))
+    assert _run(store.get_trace("t1"))["messages"] == a
+    assert _run(store.get_trace("t2"))["messages"] == b
+    # shared "start" root, then forked tails: 1 + 1 + 2
+    assert len(store._session_nodes["s1"]) == 4
+
+
+def test_sessions_do_not_share_nodes_and_delete_frees_them():
+    store = MemoryTraceStore(compact=True)
+    msgs = _convo(3)
+    _run(store.store_trace("t1", "s1", _trace(msgs)))
+    _run(store.store_trace("t2", "s2", _trace(msgs)))
+    assert len(store._session_nodes["s1"]) == len(msgs)
+    assert len(store._session_nodes["s2"]) == len(msgs)
+
+    _run(store.delete_session("s1"))
+    assert "s1" not in store._session_nodes
+    assert "s1" not in store._session_node_lookup
+    # s2 unaffected
+    assert _run(store.get_trace("t2"))["messages"] == msgs
+
+
+def test_empty_and_nonlist_messages_stored_verbatim():
+    store = MemoryTraceStore(compact=True)
+    for tid, messages in (("t1", []), ("t2", None), ("t3", "raw-prompt")):
+        data = _trace([])
+        data["messages"] = messages
+        _run(store.store_trace(tid, "s1", data))
+        assert _run(store.get_trace(tid))["messages"] == messages
+
+
+def test_compaction_composes_with_token_id_packing():
+    """Both store-side transforms apply; reads restore both."""
+    store = MemoryTraceStore(compact=True)
+    msgs = _convo(2)
+    _run(store.store_trace("t1", "s1", _trace(msgs)))
+    got = _run(store.get_trace("t1"))
+    assert got["messages"] == msgs
+    assert got["prompt_token_ids"] == [1, 2, 3]  # unpacked back to a plain list
+    assert isinstance(got["prompt_token_ids"], list)
+
+
+def test_default_mode_stores_verbatim_and_builds_no_tables():
+    """Without compact=True the store behaves exactly as before this change."""
+    store = MemoryTraceStore()
+    msgs = _convo(3)
+    _run(store.store_trace("t1", "s1", _trace(msgs)))
+    assert _run(store.get_trace("t1"))["messages"] == msgs
+    assert len(store._session_nodes) == 0
+    assert len(store._session_node_lookup) == 0
+    # compactal representation is the verbatim list, not a leaf marker
+    assert isinstance(store._traces["t1"]["messages"], list)
+
+
+def _trace_ids(messages, prompt_ids):
+    d = _trace(messages)
+    d["prompt_token_ids"] = prompt_ids
+    return d
+
+
+def test_prompt_ids_delta_roundtrip_and_dedup():
+    """Prompt token ids repeat the previous call's — compact stores suffixes only."""
+    store = MemoryTraceStore(compact=True)
+    full = []
+    originals = []
+    for turn in range(1, 6):
+        full = full + list(range((turn - 1) * 100, turn * 100))
+        originals.append(list(full))
+        _run(store.store_trace(f"t{turn}", "s1", _trace_ids(_convo(turn), list(full))))
+    # every read reconstructs the full ids
+    for turn, ids in enumerate(originals, start=1):
+        assert _run(store.get_trace(f"t{turn}"))["prompt_token_ids"] == ids
+    bulk = _run(store.get_session_traces("s1"))
+    assert [t["prompt_token_ids"] for t in bulk] == originals
+    # storage is linear: traces 2..5 hold only 100-id suffixes
+    for turn in range(2, 6):
+        marker = store._traces[f"t{turn}"]["prompt_token_ids"]
+        assert isinstance(marker, dict)
+        _, lcp, suffix = marker["__prompt_ids_delta__"]
+        assert lcp == (turn - 1) * 100 and len(suffix) == 100
+
+
+def test_prompt_ids_non_prefix_falls_back_verbatim():
+    """A rewritten prompt (no shared prefix) stores verbatim — lossless always."""
+    store = MemoryTraceStore(compact=True)
+    _run(store.store_trace("t1", "s1", _trace_ids(_convo(1), [1, 2, 3])))
+    _run(store.store_trace("t2", "s1", _trace_ids(_convo(2), [9, 8, 7, 6])))
+    assert _run(store.get_trace("t1"))["prompt_token_ids"] == [1, 2, 3]
+    assert _run(store.get_trace("t2"))["prompt_token_ids"] == [9, 8, 7, 6]
+
+
+def test_restore_same_trace_id_does_not_self_chain():
+    store = MemoryTraceStore(compact=True)
+    _run(store.store_trace("t1", "s1", _trace_ids(_convo(1), [1, 2, 3])))
+    _run(store.store_trace("t1", "s1", _trace_ids(_convo(1), [1, 2, 3, 4])))  # retry re-store
+    assert _run(store.get_trace("t1"))["prompt_token_ids"] == [1, 2, 3, 4]
+
+
+def test_delete_session_rematerializes_shared_traces():
+    """Audit repro: trace stored under two sessions must survive either deletion."""
+    store = MemoryTraceStore(compact=True)
+    msgs = _convo(2)
+    _run(store.store_trace("shared", "s1", _trace_ids(msgs, [1, 2, 3])))
+    _run(store.store_trace("shared", "s2", _trace_ids(msgs, [1, 2, 3])))  # re-store repoints markers at s2
+    _run(store.delete_session("s2"))
+    got = _run(store.get_trace("shared"))  # must not KeyError into s2's dropped tables
+    assert got["messages"] == msgs
+    assert got["prompt_token_ids"] == [1, 2, 3]
+    traces = _run(store.get_session_traces("s1"))
+    assert traces and traces[0]["messages"] == msgs
+
+
+def test_compact_fetch_shares_node_objects_and_matches_default():
+    """Compact fetch expands to the same content; shared prefixes share dicts."""
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    for compact in (True, False):
+        store = MemoryTraceStore(compact=compact)
+        for turn in range(1, 4):
+            _run(store.store_trace(f"t{turn}", "s1", _trace(_convo(turn))))
+        default = [t["messages"] for t in _run(store.get_session_traces("s1"))]
+        payload = _run(store.get_session_traces_compact("s1"))
+        expanded = [t["messages"] for t in _expand_compact_traces(payload)]
+        assert expanded == default
+        # prefix sharing: trace 2's first message IS trace 1's first message
+        assert expanded[1][0] is expanded[0][0]
+        assert expanded[2][0] is expanded[0][0]
+
+
+def test_compact_fetch_ships_prompt_id_deltas_and_expands():
+    """Wire carries id suffixes, not full ids; client rebuilds chains exactly."""
+    import json as _json
+
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    store = MemoryTraceStore(compact=True)
+    full = []
+    originals = []
+    for turn in range(1, 5):
+        full = full + list(range((turn - 1) * 50, turn * 50))
+        originals.append(list(full))
+        _run(store.store_trace(f"t{turn}", "s1", _trace_ids(_convo(turn), list(full))))
+    payload = _json.loads(_json.dumps(_run(store.get_session_traces_compact("s1"))))
+    # deltas on the wire: traces 2..4 ship 50-id suffixes
+    assert all("prompt_ids_delta" in t for t in payload["traces"][1:])
+    assert all(len(t["prompt_ids_delta"][2]) == 50 for t in payload["traces"][1:])
+    expanded = _expand_compact_traces(payload)
+    assert [t["prompt_token_ids"] for t in expanded] == originals
+    assert all("_tid" not in t for t in expanded)
+
+
+def test_compact_fetch_resolves_markers_across_sessions():
+    """Audit repro at the fetch layer: marker owned by another session must resolve."""
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    store = MemoryTraceStore(compact=True)
+    msgs = _convo(2)
+    _run(store.store_trace("shared", "s1", _trace(msgs)))
+    _run(store.store_trace("shared", "s2", _trace(msgs)))  # marker now points at s2's table
+    payload = _run(store.get_session_traces_compact("s1"))  # fetch via s1 must not KeyError
+    expanded = _expand_compact_traces(payload)
+    assert expanded and expanded[0]["messages"] == msgs
+
+
+def test_replay_restore_cannot_form_delta_cycle():
+    """Review repro: t1, t2(delta->t1), re-store t1 must not create t1->t2->t1."""
+    store = MemoryTraceStore(compact=True)
+    _run(store.store_trace("t1", "s", {"messages": [{"role": "user", "content": "a"}], "prompt_token_ids": [1, 2, 3]}))
+    _run(store.store_trace("t2", "s", {"messages": [{"role": "user", "content": "b"}], "prompt_token_ids": [1, 2, 3, 4]}))
+    _run(store.store_trace("t1", "s", {"messages": [{"role": "user", "content": "a"}], "prompt_token_ids": [1, 2, 3, 4, 5]}))
+    # t2 must still reconstruct against t1's OLD content; t1 returns its new ids
+    assert _run(store.get_trace("t2"))["prompt_token_ids"] == [1, 2, 3, 4]
+    assert _run(store.get_trace("t1"))["prompt_token_ids"] == [1, 2, 3, 4, 5]
+    bulk = _run(store.get_session_traces("s"))
+    assert [t["prompt_token_ids"] for t in bulk] == [[1, 2, 3, 4, 5], [1, 2, 3, 4]]
+
+
+def test_interleaved_lineages_anchor_independently():
+    store = MemoryTraceStore(compact=True)
+    _run(store.store_trace("p1", "s", {"messages": [{"role": "user", "content": "p"}], "prompt_token_ids": [1, 2], "lineage_id": "parent"}))
+    _run(store.store_trace("c1", "s", {"messages": [{"role": "user", "content": "c"}], "prompt_token_ids": [9, 8], "lineage_id": "child"}))
+    _run(store.store_trace("p2", "s", {"messages": [{"role": "user", "content": "p2"}], "prompt_token_ids": [1, 2, 3], "lineage_id": "parent"}))
+    # p2 deltas against p1 (its lineage), not against c1
+    marker = store._traces["p2"]["prompt_token_ids"]
+    assert isinstance(marker, dict) and marker["__prompt_ids_delta__"][0] == "p1"
+    assert _run(store.get_trace("p2"))["prompt_token_ids"] == [1, 2, 3]
+
+
+def test_since_filter_rebases_orphaned_deltas():
+    """Review repro: excluding a delta ancestor must yield a self-contained payload."""
+    import json as _json
+
+    from rllm_model_gateway.client import _expand_compact_traces
+
+    store = MemoryTraceStore(compact=True)
+    for i, ids in enumerate(([1, 2], [1, 2, 3], [1, 2, 3, 4])):
+        _run(store.store_trace(f"t{i}", "s", {"messages": [{"role": "user", "content": str(i)}], "prompt_token_ids": ids}))
+    store._timestamps["t0"] = 1.0
+    store._timestamps["t1"] = 2.0
+    store._timestamps["t2"] = 3.0
+    payload = _json.loads(_json.dumps(_run(store.get_session_traces_compact("s", since=1.5)), default=str))
+    out = _expand_compact_traces(payload)
+    assert [t["prompt_token_ids"] for t in out] == [[1, 2, 3], [1, 2, 3, 4]]
+
+
+def test_cycle_guard_raises_instead_of_hanging():
+    store = MemoryTraceStore(compact=True)
+    # forge a corrupt two-node cycle directly
+    store._traces["a"] = {"prompt_token_ids": {"__prompt_ids_delta__": ["b", 1, [2]]}}
+    store._traces["b"] = {"prompt_token_ids": {"__prompt_ids_delta__": ["a", 1, [3]]}}
+    store._session_index["s"] = ["a", "b"]
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError, match="cycle"):
+        _run(store.get_trace("a"))
+
+
+def test_delete_then_reuse_session_never_deltas_against_deleted_traces():
+    """Review F1: tuple-keyed anchors must die with their session."""
+    store = MemoryTraceStore(compact=True)
+    _run(store.store_trace("a1", "sess", {"messages": [{"role": "user", "content": "x"}], "prompt_token_ids": list(range(1013))}))
+    _run(store.delete_session("sess"))
+    assert len(store._session_last_prompt_ids) == 0  # no anchor leak
+    _run(store.store_trace("b1", "sess", {"messages": [{"role": "user", "content": "y"}], "prompt_token_ids": list(range(1701))}))
+    assert _run(store.get_trace("b1"))["prompt_token_ids"] == list(range(1701))
+
+
+def test_cross_session_trace_id_overwrite_rebases_all_dependents():
+    """Review F2: dependents in OTHER sessions must be pinned before overwrite."""
+    store = MemoryTraceStore(compact=True)
+    _run(store.store_trace("shared", "s1", {"messages": [{"role": "user", "content": "a"}], "prompt_token_ids": list(range(1013))}))
+    _run(store.store_trace("dep", "s1", {"messages": [{"role": "user", "content": "b"}], "prompt_token_ids": list(range(1701))}))
+    _run(store.store_trace("shared", "s2", {"messages": [{"role": "user", "content": "c"}], "prompt_token_ids": list(range(997))}))
+    assert _run(store.get_trace("dep"))["prompt_token_ids"] == list(range(1701))
+    assert _run(store.get_trace("shared"))["prompt_token_ids"] == list(range(997))
+
+
+def test_stale_anchor_in_other_session_cannot_mint_corrupt_deltas():
+    """Review P1a repro: silent [9,9,x] corruption via a cross-session overwrite."""
+    store = MemoryTraceStore(compact=True)
+    _run(store.store_trace("shared", "s1", {"messages": [{"role": "u", "content": "a"}], "prompt_token_ids": [1, 2, 3]}))
+    _run(store.store_trace("shared", "s2", {"messages": [{"role": "u", "content": "b"}], "prompt_token_ids": [9, 9, 9]}))
+    _run(store.store_trace("next", "s1", {"messages": [{"role": "u", "content": "c"}], "prompt_token_ids": [1, 2, 3, 4]}))
+    assert _run(store.get_trace("next"))["prompt_token_ids"] == [1, 2, 3, 4]
+
+
+def test_message_walk_guards_cycles_and_dangling():
+    """Review P2f: forged cycles must raise, not hang the event loop."""
+    import pytest as _pytest
+
+    store = MemoryTraceStore(compact=True)
+    store._session_nodes["s"] = {"a": ("b", {"role": "u", "content": "1"}), "b": ("a", {"role": "u", "content": "2"})}
+    store._traces["t"] = {"messages": {"__messages_ref__": ["s", "a", 2]}}
+    store._session_index["s"] = ["t"]
+    with _pytest.raises(ValueError, match="cycle"):
+        _run(store.get_trace("t"))
+    store._traces["t2"] = {"messages": {"__messages_ref__": ["s", "missing", 1]}}
+    store._session_index["s"].append("t2")
+    with _pytest.raises(ValueError, match="dangling"):
+        _run(store.get_trace("t2"))

--- a/rllm/engine/trace_converter.py
+++ b/rllm/engine/trace_converter.py
@@ -86,9 +86,18 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
     if lineage_id is not None:
         metadata["lineage_id"] = lineage_id
 
-    return Step(
+    # CONTRACT (review): the assigned message dicts are SHARED across every
+    # Step whose conversation contains them. They must be treated as
+    # immutable — mutating one through any Step mutates the shared prefix of
+    # all later Steps. No engine/trainer path mutates them today; a frozen
+    # history type is the planned enforcement (native-compact follow-up).
+    step = Step(
         id=trace.trace_id,
-        chat_completions=chat_completions,
+        # Assigned below, AFTER construction: pydantic field validation copies
+        # each message dict, which would re-materialize the full conversation
+        # prefix per step even with the deepcopy skipped (audit: the root
+        # amplifier). Plain attribute assignment keeps the shared references.
+        chat_completions=[],
         model_output=model_output,
         model_response=content,
         output=content,
@@ -96,6 +105,8 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
         metadata=metadata,
         weight_version=trace.weight_version,
     )
+    step.chat_completions = chat_completions
+    return step
 
 
 def compute_step_metrics(trajectories: list[Trajectory]) -> dict:

--- a/rllm/eval/curation.py
+++ b/rllm/eval/curation.py
@@ -430,7 +430,10 @@ def _load_step_message_lists(ref: _AttemptRef, trajectory_name: str | None, stat
             episode = json.load(f)
     except (OSError, json.JSONDecodeError):
         return []
-    return _episode_to_step_message_lists(episode, trajectory_name, stats)
+    # Schema-2 episodes store deduplicated messages; identity on legacy files.
+    from rllm.eval.episode_compact import expand_episode
+
+    return _episode_to_step_message_lists(expand_episode(episode), trajectory_name, stats)
 
 
 def _content_len(messages: list[dict]) -> int:

--- a/rllm/eval/episode_compact.py
+++ b/rllm/eval/episode_compact.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Sequence
 from typing import Any
 
 # Episode-level format tag. Absent means the legacy verbatim format.
@@ -191,3 +192,148 @@ def expand_episode(data: dict[str, Any]) -> dict[str, Any]:
     if "trajectories" in data:
         out["trajectories"] = out_trajectories
     return out
+
+
+# ---------------------------------------------------------------------------
+# Compact-native episode model
+# ---------------------------------------------------------------------------
+
+
+class MessageHistory(Sequence):
+    """A step's conversation as a lazy view into a node table.
+
+    Sequence-compatible stand-in for the eager ``list[dict]`` a step used to
+    carry: ``len`` is O(1), iteration walks the chain once and caches,
+    ``history[:-k]`` returns another O(k) view (an ancestor reference — no
+    copy), and equality works against plain lists. Materialization
+    (:meth:`to_list`) happens only when a consumer genuinely needs a list,
+    e.g. serializing one step — never as a side effect of construction.
+    """
+
+    __slots__ = ("_nodes", "_leaf", "_length", "_cache")
+
+    def __init__(self, nodes: dict[str, dict[str, Any]], leaf: str | None, length: int) -> None:
+        self._nodes = nodes
+        self._leaf = leaf
+        self._length = length
+        self._cache: tuple | None = None
+
+    def _walk(self) -> tuple:
+        if self._cache is None:
+            out: list[dict[str, Any]] = []
+            node_id, seen = self._leaf, set()
+            while node_id is not None:
+                if node_id in seen:
+                    raise ValueError(f"message node cycle at {node_id!r}")
+                seen.add(node_id)
+                node = self._nodes.get(node_id)
+                if node is None:
+                    raise ValueError(f"dangling message node reference {node_id!r}")
+                out.append(node["m"])
+                node_id = node["p"]
+            out.reverse()
+            if len(out) != self._length:
+                raise ValueError(f"chain length {len(out)} != recorded {self._length}")
+            self._cache = tuple(out)
+        return self._cache
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            start, stop, stride = index.indices(self._length)
+            if start == 0 and stride == 1:
+                # Prefix slice: walk UP (length - stop) parents — O(suffix),
+                # so the common ``history[:-1]`` is O(1) and copies nothing.
+                node_id, up = self._leaf, self._length - stop
+                for _ in range(up):
+                    node_id = self._nodes[node_id]["p"] if node_id is not None else None
+                return MessageHistory(self._nodes, node_id, stop)
+            return list(self._walk()[index])
+        return self._walk()[index]
+
+    def __iter__(self):
+        return iter(self._walk())
+
+    def __reversed__(self):
+        node_id = self._leaf
+        while node_id is not None:
+            node = self._nodes[node_id]
+            yield node["m"]
+            node_id = node["p"]
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, MessageHistory):
+            if other._leaf == self._leaf and other._length == self._length:
+                return True
+            other = other.to_list()
+        if isinstance(other, list | tuple):
+            return len(other) == self._length and list(self._walk()) == list(other)
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return f"MessageHistory(len={self._length})"
+
+    def to_list(self) -> list[dict[str, Any]]:
+        return list(self._walk())
+
+
+class CompactEpisode:
+    """An episode held natively in the compact format.
+
+    Wraps the compact dict form (the same shape the file format uses): each
+    unique message is one node, each step holds a leaf reference. Loading a
+    compact file materializes nothing; histories are served as
+    :class:`MessageHistory` views on demand; and the legacy representation
+    exists only when explicitly exported.
+
+    - :meth:`from_dict` accepts either format (legacy input is compacted).
+    - :meth:`to_dict` returns the compact form — what should be persisted.
+    - :meth:`to_legacy` exports the old format losslessly (the existing
+      converter pair, so every parity guarantee carries over verbatim).
+    """
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        if data.get(FORMAT_KEY) != COMPACT_FORMAT:
+            data = compact_episode(data)
+        self._data = data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CompactEpisode:
+        return cls(data)
+
+    @classmethod
+    def load(cls, path) -> CompactEpisode:
+        with open(path, encoding="utf-8") as f:
+            return cls(json.load(f))
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._data
+
+    def to_legacy(self) -> dict[str, Any]:
+        return expand_episode(self._data)
+
+    # -- native, expansion-free access -----------------------------------
+
+    @property
+    def trajectories(self) -> list[dict[str, Any]]:
+        return self._data.get("trajectories") or []
+
+    def steps(self, trajectory: int = 0) -> list[dict[str, Any]]:
+        trajs = self.trajectories
+        return (trajs[trajectory].get("steps") or []) if trajectory < len(trajs) else []
+
+    def history(self, trajectory: int = 0, step: int = -1) -> MessageHistory | list:
+        """The conversation of one step as a lazy view (no expansion).
+
+        Falls back to the plain list for steps stored verbatim (legacy
+        trajectories that refused compaction keep eager lists).
+        """
+        traj = self.trajectories[trajectory]
+        st = (traj.get("steps") or [])[step]
+        cc = st.get("chat_completions")
+        if type(cc) is dict and _REF_MARKER in cc:
+            leaf, length = cc[_REF_MARKER]
+            return MessageHistory(traj.get(_NODES_KEY) or {}, leaf, length)
+        return cc if isinstance(cc, list) else []

--- a/rllm/eval/episode_compact.py
+++ b/rllm/eval/episode_compact.py
@@ -1,0 +1,193 @@
+"""Lossless compact converter for saved episode JSON (episode compact format).
+
+Eval episodes store every step's full ``chat_completions`` snapshot, so a
+saved episode repeats each message once per subsequent step — quadratic in
+steps (measured 9.3 GB for one 113-task DeepSWE run, 396 MB for a single
+229-step episode). The compact format stores each unique message once per trajectory in
+a Merkle-chained node table and replaces per-step lists with a leaf
+reference; :func:`expand_episode` restores legacy-format exactly.
+
+The invariant is strict losslessness: ``expand_episode(compact_episode(x))``
+equals ``x`` — verified canonical-byte-for-byte against every real eval dump
+in ``tests/eval/test_episode_compact.py``, including non-cumulative
+histories (rewrites fork the chain) and repeated identical content at
+different positions (node identity hashes the parent chain plus content, so
+positions never collapse).
+
+Wire/store cousins: the same node-table shape backs the gateway's compact
+trace store and ``?format=compact`` fetch (rllm-model-gateway). This module
+is dependency-free of both so episode files stand alone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+# Episode-level format tag. Absent means the legacy verbatim format.
+FORMAT_KEY = "episode_format"
+COMPACT_FORMAT = "compact"
+# Encoding version, stamped alongside the tag. Bumped whenever node identity
+# or marker shape changes, so recompression differences across versions are
+# detectable instead of silent (review: the fingerprint scheme changed during
+# development while the tag stayed constant).
+VERSION_KEY = "compact_version"
+COMPACT_VERSION = 1
+
+_NODES_KEY = "message_nodes"
+# In compact form a step keeps its "chat_completions" KEY but the value is a
+# marker dict {"messages_ref": [leaf, length]} — a value swap, not a key swap,
+# so expanding restores the file byte-for-byte including dict key order.
+_REF_MARKER = "messages_ref"
+
+
+def _message_fp(message: dict[str, Any]) -> str:
+    # Deliberately order-SENSITIVE (no sort_keys): two messages with equal
+    # content but different key order must stay distinct nodes, or expansion
+    # would return the first-seen dict for both and the file would no longer
+    # be byte-identical after a round trip (found by file-byte parity against
+    # real dumps that mix role-first and content-first messages).
+    payload = json.dumps(message, separators=(",", ":"), ensure_ascii=False, default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def compact_episode(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the compact-format form of a legacy-format episode dict (idempotent)."""
+    if data.get(FORMAT_KEY) == COMPACT_FORMAT:
+        return data
+    if FORMAT_KEY in data or VERSION_KEY in data:
+        return data  # reserved keys already in use: refuse, stay legacy (lossless)
+    out = dict(data)
+    out_trajectories = []
+    for trajectory in data.get("trajectories") or []:
+        if _NODES_KEY in trajectory:
+            # reserved key already present: keep this trajectory verbatim
+            out_trajectories.append(trajectory)
+            continue
+        steps = trajectory.get("steps") or []
+        marked = 0
+        nodes: dict[str, dict[str, Any]] = {}
+        chain: dict[tuple[str | None, str], str] = {}
+        out_steps = []
+        compactable = True
+        for step in steps:
+            cc = step.get("chat_completions")
+            if type(cc) is not list or not all(isinstance(m, dict) for m in cc):
+                compactable = False
+                break
+            parent: str | None = None
+            for message in cc:
+                key = (parent, _message_fp(message))
+                node_id = chain.get(key)
+                if node_id is None:
+                    node_id = hashlib.sha256(f"{parent}:{key[1]}".encode()).hexdigest()
+                    nodes[node_id] = {"p": parent, "m": message}
+                    chain[key] = node_id
+                parent = node_id
+            marker = {_REF_MARKER: [parent, len(cc)]}
+            marked += 1
+            out_step = {k: (marker if k == "chat_completions" else v) for k, v in step.items()}
+            out_steps.append(out_step)
+        if not compactable or marked == 0:
+            # Unknown step shape, or nothing to compact (e.g. zero steps):
+            # keep this trajectory verbatim — expand passes it through, so no
+            # empty node table may be introduced (symmetry, byte-exactness).
+            out_trajectories.append(trajectory)
+            continue
+        out_trajectory = dict(trajectory)
+        out_trajectory["steps"] = out_steps
+        out_trajectory[_NODES_KEY] = nodes
+        out_trajectories.append(out_trajectory)
+    if "trajectories" in data:
+        out["trajectories"] = out_trajectories
+    out[FORMAT_KEY] = COMPACT_FORMAT
+    out[VERSION_KEY] = COMPACT_VERSION
+    return out
+
+
+def expand_episode(data: dict[str, Any]) -> dict[str, Any]:
+    """Inverse of :func:`compact_episode`; identity on legacy-format dicts."""
+    if data.get(FORMAT_KEY) != COMPACT_FORMAT:
+        return data
+    version = data.get(VERSION_KEY)
+    if version is not None and version != COMPACT_VERSION:
+        raise ValueError(f"unsupported {VERSION_KEY} {version!r}; this build reads <= {COMPACT_VERSION}")
+    prerelease = version is None  # unversioned = pre-release local artifacts
+    out = dict(data)
+    out.pop(FORMAT_KEY)
+    out.pop(VERSION_KEY, None)
+    out_trajectories = []
+    for trajectory in data.get("trajectories") or []:
+        nodes = trajectory.get(_NODES_KEY)
+        if nodes is None:
+            out_trajectories.append(trajectory)
+            continue
+        # leaf -> materialized list; shared prefixes walk once, share objects.
+        paths: dict[str | None, list[dict[str, Any]]] = {None: []}
+
+        def _path(leaf: str | None, *, nodes=nodes, paths=paths) -> list[dict[str, Any]]:
+            # Cache only REQUESTED leaves: caching every intermediate prefix
+            # made one deep chain cost O(M^2) allocations (review); extending
+            # once from the nearest cached ancestor keeps shared-prefix reuse
+            # while a lone leaf costs O(M).
+            if leaf in paths:
+                return paths[leaf]
+            todo: list[str] = []
+            seen: set[str] = set()
+            node_id = leaf
+            while node_id is not None and node_id not in paths:
+                if node_id in seen:
+                    raise ValueError(f"message node cycle at {node_id!r}")
+                seen.add(node_id)
+                todo.append(node_id)
+                node = nodes.get(node_id)
+                if node is None:
+                    raise ValueError(f"dangling message node reference {node_id!r}")
+                node_id = node["p"]
+            base = list(paths[node_id if node_id is not None else None])
+            base.extend(nodes[nid]["m"] for nid in reversed(todo))
+            paths[leaf] = base
+            return base
+
+        out_steps = []
+        resolved_any = False
+        for step in trajectory.get("steps") or []:
+            marker = step.get("chat_completions")
+            if prerelease and (type(marker) is not dict or _REF_MARKER not in marker) and type(step.get("chat_completions_ref")) is list:
+                # pre-release artifact (early development head): the ref lived
+                # under its own key instead of swapping the value in place.
+                marker = {_REF_MARKER: step["chat_completions_ref"]}
+                step = {k: v for k, v in step.items() if k != "chat_completions_ref"}
+            if type(marker) is not dict or _REF_MARKER not in marker:
+                out_steps.append(step)
+                continue
+            resolved_any = True
+            leaf, length = marker[_REF_MARKER]
+            messages = _path(leaf)
+            if len(messages) != length:
+                raise ValueError(f"compact chain length {len(messages)} != recorded {length}")
+            if "chat_completions" in step:
+                out_step = {k: (messages if k == "chat_completions" else v) for k, v in step.items()}
+            else:  # pre-release artifact: the key was removed, not value-swapped
+                out_step = dict(step)
+                out_step["chat_completions"] = messages
+            out_steps.append(out_step)
+        if not resolved_any:
+            if prerelease and nodes == {}:
+                # Pre-release writers stamped empty node tables onto zero-step
+                # trajectories; strip them so the export is true legacy.
+                out_trajectory = {k: v for k, v in trajectory.items() if k != _NODES_KEY}
+                out_trajectories.append(out_trajectory)
+                continue
+            # A trajectory can carry a user "message_nodes" key without any
+            # compact markers (compaction refuses those) — pass it through.
+            out_trajectories.append(trajectory)
+            continue
+        out_trajectory = dict(trajectory)
+        out_trajectory.pop(_NODES_KEY)
+        out_trajectory["steps"] = out_steps
+        out_trajectories.append(out_trajectory)
+    if "trajectories" in data:
+        out["trajectories"] = out_trajectories
+    return out

--- a/rllm/eval/episode_store.py
+++ b/rllm/eval/episode_store.py
@@ -20,6 +20,7 @@ The store is consumed by :mod:`rllm.eval.visualizer` for read-back.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -101,6 +102,15 @@ class EvalEpisodeStore:
         # Stamp the eval-time idx into the saved episode so consumers
         # (e.g. the visualizer) can cross-reference EvalResult.items.
         data["eval_idx"] = idx
+        # Opt-in compact schema: per-step chat_completions snapshots repeat
+        # every conversation prefix (quadratic in steps — 9.3 GB for one
+        # 113-task run); compact format stores each unique message once. Readers
+        # (visualizer, curation) expand transparently; conversion back is
+        # lossless (see rllm.eval.episode_compact and its real-dump parity test).
+        if os.environ.get("RLLM_GATEWAY_STORE") == "compact":
+            from rllm.eval.episode_compact import compact_episode
+
+            data = compact_episode(data)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, default=_json_default)
         return path

--- a/rllm/eval/visualizer.py
+++ b/rllm/eval/visualizer.py
@@ -139,11 +139,23 @@ def _scan_runs(root: Path) -> list[dict[str, Any]]:
     return out
 
 
+# path -> ((mtime_ns, size), index_row). Parsing a 400 MB episode file for
+# five headline fields on EVERY index request was the audit's per-request
+# quadratic; rows are immutable for a finished episode, so cache by stat.
+_INDEX_CACHE: dict[Path, tuple[tuple[int, int], dict[str, Any]]] = {}
+
+
 def _build_episode_index(episodes_dir: Path) -> list[dict[str, Any]]:
     """Read just the headline fields from every episode file in a run."""
     index = []
     for path in sorted(episodes_dir.glob("episode_*.json")):
         try:
+            st = path.stat()
+            stamp = (st.st_mtime_ns, st.st_size)
+            cached = _INDEX_CACHE.get(path)
+            if cached is not None and cached[0] == stamp:
+                index.append(cached[1])
+                continue
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
         except Exception:
@@ -152,19 +164,19 @@ def _build_episode_index(episodes_dir: Path) -> list[dict[str, Any]]:
         n_steps = sum(len(t.get("steps") or []) for t in (data.get("trajectories") or []))
         rewards = [t.get("reward") for t in (data.get("trajectories") or []) if t.get("reward") is not None]
         avg_reward = sum(rewards) / len(rewards) if rewards else None
-        index.append(
-            {
-                "filename": path.name,
-                "eval_idx": data.get("eval_idx"),
-                "task_id": task.get("id") if isinstance(task, dict) else None,
-                "is_correct": data.get("is_correct"),
-                "termination_reason": data.get("termination_reason"),
-                "n_trajectories": len(data.get("trajectories") or []),
-                "n_steps": n_steps,
-                "reward": avg_reward,
-                "instruction_preview": _preview(task.get("instruction") if isinstance(task, dict) else None),
-            }
-        )
+        row = {
+            "filename": path.name,
+            "eval_idx": data.get("eval_idx"),
+            "task_id": task.get("id") if isinstance(task, dict) else None,
+            "is_correct": data.get("is_correct"),
+            "termination_reason": data.get("termination_reason"),
+            "n_trajectories": len(data.get("trajectories") or []),
+            "n_steps": n_steps,
+            "reward": avg_reward,
+            "instruction_preview": _preview(task.get("instruction") if isinstance(task, dict) else None),
+        }
+        _INDEX_CACHE[path] = (stamp, row)
+        index.append(row)
     return index
 
 
@@ -908,6 +920,14 @@ def _make_handler(root_path: Path, html_factory):
             except OSError:
                 self.send_error(404, "Not Found")
                 return
+            # Compact (compact-format) episodes must be expanded for the browser —
+            # its renderer reads step.chat_completions. Legacy files stream
+            # untouched; the needle probe keeps the fast path parse-free, and
+            # a false hit is harmless (expand_episode is identity on legacy).
+            if b'"episode_format"' in data:
+                from rllm.eval.episode_compact import expand_episode
+
+                data = json.dumps(expand_episode(json.loads(data))).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Content-Length", str(len(data)))

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -196,12 +196,19 @@ class GatewayManager:
         self.public_url, self.tunnel_backend = parse_tunnel(gw_cfg.get("tunnel", None))
         configured_port = gw_cfg.get("port", None)
         self.port: int = int(configured_port) if configured_port is not None else (_find_free_port() if self.tunnel_backend else DEFAULT_GATEWAY_PORT)
-        self.store: str = gw_cfg.get("store", "memory")
+        # RLLM_GATEWAY_STORE overrides the config so a single env var opts a
+        # whole run into the compact store, matching the gateway's own CLI/env.
+        self.store: str = os.environ.get("RLLM_GATEWAY_STORE") or gw_cfg.get("store", "memory")
+        if self.store == "compact":
+            # One trigger for the whole pipeline: a config-selected compact
+            # store must also activate the episode writers, which consult the
+            # env var (review: config-only left episode files quadratic).
+            os.environ["RLLM_GATEWAY_STORE"] = "compact"
         self.db_path: str | None = gw_cfg.get("db_path", None)
-        if self.store not in ("memory", "sqlite"):
-            raise ValueError(f"rllm.gateway.store must be 'memory' or 'sqlite', got {self.store!r}")
-        if self.store == "memory" and self.db_path:
-            raise ValueError("rllm.gateway.db_path is set but store='memory'; set store='sqlite' or clear db_path")
+        if self.store not in ("memory", "compact", "sqlite"):
+            raise ValueError(f"rllm.gateway.store must be 'memory', 'compact' or 'sqlite', got {self.store!r}")
+        if self.store in ("memory", "compact") and self.db_path:
+            raise ValueError(f"rllm.gateway.db_path is set but store={self.store!r} is in-memory; set store='sqlite' or clear db_path")
         _model_cfg = config.get("model", {})
         self.model: str | None = _model_cfg.get("tokenizer_model") or _model_cfg.get("name", None)
 
@@ -363,9 +370,18 @@ class GatewayManager:
             return f"{base}/sessions/{session_id}/v1"
         return self.client.get_session_url(session_id)
 
+    # Traces fetch format: "compact" ships each unique message/token-id run
+    # once (linear in conversation, vs quadratic for the default list) and the
+    # client expands transparently. There is exactly ONE trigger for the whole
+    # compact pipeline — RLLM_GATEWAY_STORE=compact (or gateway.store config);
+    # with it unset, store, wire and fetch behave byte-for-byte as before.
+    @property
+    def _trace_format(self) -> str | None:
+        return "compact" if self.store == "compact" else None
+
     def get_traces(self, session_id: str) -> list[TraceRecord]:
         self.client.flush()
-        return self.client.get_session_traces(session_id)
+        return self.client.get_session_traces(session_id, format=self._trace_format)
 
     # -- Async session / trace API -------------------------------------------
 
@@ -375,7 +391,7 @@ class GatewayManager:
 
     async def aget_traces(self, session_id: str) -> list[TraceRecord]:
         await self.async_client.flush(timeout=_TRACE_API_TIMEOUT)
-        return await self.async_client.get_session_traces(session_id)
+        return await self.async_client.get_session_traces(session_id, format=self._trace_format)
 
     async def adelete_session(self, session_id: str) -> int:
         """Delete a session and all its accumulated traces. Returns count removed."""

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -141,9 +141,31 @@ def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[
     data: list[tinker.Datum] = []
     for lineage_steps in _partition_steps_by_lineage(traj.steps):
         SequenceAccumulator.clear()  # each lineage merges independently
+        # The lineage's latest full prompt, maintained INCREMENTALLY: a delta
+        # step extends it in place (O(new tokens)), so no step ever needs a
+        # materialized full-prefix list and no full-sequence prefix compare
+        # runs. Delta form: prompt_ids == {"__prompt_ids_delta__": [lcp,
+        # suffix]} relative to this lineage's previous step prompt — the same
+        # structure the compact store/wire already carry.
+        cur_prompt: list = []
+        prev_response: list | None = None
         for step in lineage_steps:
-            token_input = cast(TinkerTokenInput, step.prompt_ids)
-            token_input_flat = _flatten_token_input(token_input)
+            raw = step.prompt_ids
+            delta_suffix: list | None = None
+            if isinstance(raw, dict) and "__prompt_ids_delta__" in raw:
+                lcp, suffix = raw["__prompt_ids_delta__"]
+                if lcp > len(cur_prompt):
+                    raise ValueError(f"prompt delta lcp {lcp} exceeds previous prompt length {len(cur_prompt)}")
+                if lcp == len(cur_prompt):
+                    delta_suffix = list(suffix)  # pure extension of the previous prompt
+                    cur_prompt.extend(suffix)
+                else:
+                    cur_prompt = cur_prompt[:lcp] + list(suffix)
+                token_input_flat = cur_prompt
+            else:
+                token_input = cast(TinkerTokenInput, raw)
+                token_input_flat = _flatten_token_input(token_input)
+                cur_prompt = token_input_flat if isinstance(token_input_flat, list) else list(token_input_flat)
 
             output_token_ids, output_logprobs = step.response_ids, step.logprobs
             assert len(output_logprobs) > 0, "output_logprobs is empty. Cannot build Tinker Datum for training."
@@ -158,6 +180,13 @@ def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[
 
             if len(SequenceAccumulator.full_sequence) == 0:
                 delta_token_input_flat = token_input_flat
+            elif delta_suffix is not None and prev_response is not None and len(delta_suffix) >= len(prev_response) and delta_suffix[: len(prev_response)] == prev_response:
+                # Delta fast path, O(new tokens): the accumulated stream is
+                # prev_prompt + prev_response; this step's prompt is
+                # prev_prompt + delta_suffix, so it prefix-extends the stream
+                # iff the suffix starts with the previous response — no
+                # full-sequence comparison, no materialized prefix.
+                delta_token_input_flat = delta_suffix[len(prev_response) :]
             elif _is_prefix(SequenceAccumulator.full_sequence, token_input_flat):
                 delta_token_input_flat = token_input_flat[len(SequenceAccumulator.full_sequence) :]
             else:
@@ -171,6 +200,7 @@ def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[
             SequenceAccumulator.sampled_logprobs.extend([0.0] * delta_token_input_length + output_logprobs)
             SequenceAccumulator.advantages.extend([0] * delta_token_input_length + advantages)
             SequenceAccumulator.mask.extend([0.0] * delta_token_input_length + [1.0] * len(output_token_ids))
+            prev_response = list(output_token_ids)
             if router_replay:
                 step_rm = step.routing_matrices or []
                 SequenceAccumulator.routing_matrices.extend([""] * delta_token_input_length + (list(step_rm) if step_rm else [""] * len(output_token_ids)))

--- a/rllm/trainer/verl/transform.py
+++ b/rllm/trainer/verl/transform.py
@@ -310,10 +310,14 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
     traj_reward = 0.0 if trajectory.reward is None else trajectory.reward
 
     # Drop steps without valid model_output up-front; the merge logic below
-    # assumes every entry has prompt_ids and completion_ids.
+    # assumes every entry has prompt_ids and completion_ids. A step may carry
+    # its prompt as the compact delta marker on ``step.prompt_ids`` instead of
+    # a full list on ``model_output.prompt_ids``; model_output is still
+    # required for the response side (completion_ids, logprobs, ...).
     valid_steps = []
     for step_idx, step in enumerate(trajectory.steps):
-        if step.model_output is None or step.model_output.prompt_ids is None:
+        has_delta = isinstance(step.prompt_ids, dict) and "__prompt_ids_delta__" in step.prompt_ids
+        if step.model_output is None or (step.model_output.prompt_ids is None and not has_delta):
             logger.warning(f"Step {step_idx} in trajectory {trajectory_id} has no valid model_output, skipping")
             continue
         valid_steps.append(step)
@@ -336,8 +340,8 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
     # that segment. ``full_seq`` tracks prompt+all-action-and-obs tokens
     # so we can detect prefix-extension on the next step.
 
-    def _new_segment(step):
-        prompt = list(step.model_output.prompt_ids)
+    def _new_segment(step, prompt):
+        prompt = list(prompt)
         action = list(step.model_output.completion_ids)
         action_lp = list(step.model_output.logprobs or [])
         # If logprobs missing/short, pad to action length with zeros so
@@ -393,13 +397,50 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
 
     def _merge_lineage(steps) -> int:
         """Linear-merge one lineage's steps into segments; return rows emitted."""
-        seg = _new_segment(steps[0])
+        # ``cur_prompt`` is the one incremental prompt buffer for the lineage,
+        # so delta-form steps ({"__prompt_ids_delta__": [lcp, suffix]} on
+        # step.prompt_ids) resolve without materializing O(n^2) prompt lists.
+        # Invariant after each step: full_seq == cur_prompt + that step's action.
+        cur_prompt: list = []
+        prev_action: list | None = None
+
+        def _step_prompt(step):
+            """Resolve this step's prompt. Returns (prompt, delta_suffix) where
+            delta_suffix is non-None iff the step arrived in delta form and
+            purely extends the previous prompt (the O(new) merge case)."""
+            nonlocal cur_prompt
+            raw = step.prompt_ids
+            if isinstance(raw, dict) and "__prompt_ids_delta__" in raw:
+                lcp, suffix = raw["__prompt_ids_delta__"]
+                if lcp > len(cur_prompt):
+                    raise ValueError(f"prompt delta lcp {lcp} exceeds previous prompt length {len(cur_prompt)}")
+                if lcp == len(cur_prompt):
+                    delta_suffix = list(suffix)
+                    cur_prompt.extend(suffix)
+                    return cur_prompt, delta_suffix
+                cur_prompt = cur_prompt[:lcp] + list(suffix)
+                return cur_prompt, None
+            prompt_ids = list(step.model_output.prompt_ids)
+            cur_prompt = prompt_ids
+            return prompt_ids, None
+
+        first_prompt, _ = _step_prompt(steps[0])
+        seg = _new_segment(steps[0], first_prompt)
+        prev_action = list(steps[0].model_output.completion_ids)
         emitted = 0
         for step in steps[1:]:
-            prompt_ids = list(step.model_output.prompt_ids)
-            if len(prompt_ids) >= len(seg["full_seq"]) and prompt_ids[: len(seg["full_seq"])] == seg["full_seq"]:
+            prompt_ids, delta_suffix = _step_prompt(step)
+            if delta_suffix is not None:
+                # Delta fast path, O(new tokens): full_seq is
+                # prev_prompt + prev_action and this prompt is
+                # prev_prompt + delta_suffix, so it extends full_seq iff the
+                # suffix begins with the previous action — no full compare.
+                extends = len(delta_suffix) >= len(prev_action) and delta_suffix[: len(prev_action)] == prev_action
+            else:
+                extends = len(prompt_ids) >= len(seg["full_seq"]) and prompt_ids[: len(seg["full_seq"])] == seg["full_seq"]
+            if extends:
                 # Cumulative — extend the current segment.
-                delta_obs = prompt_ids[len(seg["full_seq"]) :]
+                delta_obs = delta_suffix[len(prev_action) :] if delta_suffix is not None else prompt_ids[len(seg["full_seq"]) :]
                 action = list(step.model_output.completion_ids)
                 action_lp = list(step.model_output.logprobs or [])
                 if action_lp and len(action_lp) != len(action):
@@ -420,7 +461,8 @@ def _process_trajectory(trajectory: Trajectory, task_id: str, accumulated: Accum
                 # Non-cumulative — close out current segment, start a new one.
                 _emit(seg)
                 emitted += 1
-                seg = _new_segment(step)
+                seg = _new_segment(step, prompt_ids)
+            prev_action = list(step.model_output.completion_ids)
         _emit(seg)
         emitted += 1
         return emitted

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -215,7 +215,10 @@ class Step(BaseModel):
     metadata: dict | None = None
 
     # Training-side payloads
-    prompt_ids: list[int] | list[Any] = Field(default_factory=list)
+    # prompt_ids may also carry a compact delta marker
+    # {"__prompt_ids_delta__": [lcp, suffix]} instead of the full token list;
+    # packed trainers consume it without materializing the O(n^2) expansion.
+    prompt_ids: list[int] | list[Any] | dict[str, Any] = Field(default_factory=list)
     response_ids: list[int] = Field(default_factory=list)
     logprobs: list[float] = Field(default_factory=list)
     routing_matrices: list[str] | None = None  # per-token routing matrices (R3, transient)

--- a/rllm/utils/episode_logger.py
+++ b/rllm/utils/episode_logger.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -128,6 +129,12 @@ class EpisodeLogger:
         filename = self.get_episode_filename(episode, step)
         filepath = step_dir / filename
 
+        # Same opt-in as eval dumps: the compact format stores each unique
+        # message once (a training debug episode is otherwise quadratic in steps).
+        if os.environ.get("RLLM_GATEWAY_STORE") == "compact":
+            from rllm.eval.episode_compact import compact_episode
+
+            episode_data = compact_episode(episode_data)
         try:
             with open(filepath, "w") as f:
                 json_str = json.dumps(episode_data, indent=2, default=str)

--- a/tests/engine/test_gateway_manager.py
+++ b/tests/engine/test_gateway_manager.py
@@ -37,7 +37,7 @@ class TestGatewayStoreSelection:
 
 class TestGatewayStoreValidation:
     def test_unknown_store_raises(self):
-        with pytest.raises(ValueError, match="must be 'memory' or 'sqlite'"):
+        with pytest.raises(ValueError, match="must be 'memory', 'compact' or 'sqlite'"):
             GatewayManager(_make_config(store="postgres"), mode="thread")
 
     def test_memory_with_db_path_raises(self):

--- a/tests/engine/test_step_message_sharing.py
+++ b/tests/engine/test_step_message_sharing.py
@@ -1,0 +1,53 @@
+"""Gateway-produced Steps must share message objects end-to-end.
+
+The full integration path the review demanded: compact store -> compact
+payload over a JSON wire round trip -> client expansion -> TraceRecords
+(model_construct, no validation copies) -> trace_record_to_step. Sharing
+must survive every hop; user-constructed Steps keep the defensive copy —
+there is deliberately NO public flag to bypass it.
+"""
+
+import asyncio
+import json
+import sys
+
+sys.path.insert(0, "rllm-model-gateway/src")
+
+from rllm_model_gateway.client import _expand_compact_traces
+from rllm_model_gateway.models import TraceRecord
+from rllm_model_gateway.store.memory_store import MemoryTraceStore
+
+from rllm.engine.trace_converter import trace_record_to_step
+from rllm.types import Step
+
+
+def _payload():
+    async def build():
+        store = MemoryTraceStore(compact=True)
+        base = [{"role": "system", "content": "sys"}]
+        for i in range(3):
+            base = base + [{"role": "user", "content": f"u{i}"}, {"role": "assistant", "content": f"a{i}"}]
+            await store.store_trace(f"t{i}", "s", {"trace_id": f"t{i}", "session_id": "s", "messages": list(base[:-1]), "response_message": base[-1]})
+        return json.loads(json.dumps(await store.get_session_traces_compact("s"), default=str))
+
+    return asyncio.run(build())
+
+
+def test_sharing_survives_wire_expansion_records_and_steps():
+    records = [TraceRecord.model_construct(**t) for t in _expand_compact_traces(_payload())]
+    # cross-record sharing after expansion + model_construct
+    assert records[1].messages[0] is records[0].messages[0]
+    assert records[2].messages[0] is records[0].messages[0]
+    steps = [trace_record_to_step(r) for r in records]
+    # cross-STEP sharing: the same system-message dict object in every step
+    assert steps[1].chat_completions[0] is steps[0].chat_completions[0]
+    assert steps[2].chat_completions[0] is steps[0].chat_completions[0]
+    # and steps share with their source records (no copy anywhere on the path)
+    assert steps[0].chat_completions[0] is records[0].messages[0]
+
+
+def test_user_steps_keep_defensive_copy_and_no_bypass_exists():
+    msgs = [{"role": "user", "content": "x"}]
+    step = Step(chat_completions=list(msgs), metadata={"shared_messages": True})  # flag must be inert
+    msgs[0]["content"] = "mutated"
+    assert step.chat_completions[0]["content"] == "x"

--- a/tests/eval/test_episode_compact.py
+++ b/tests/eval/test_episode_compact.py
@@ -221,3 +221,87 @@ def test_unknown_compact_version_rejected():
     ep["compact_version"] = 999
     with pytest.raises(ValueError, match="unsupported"):
         expand_episode(ep)
+
+
+# ---------------------------------------------------------------------------
+# Compact-native model
+# ---------------------------------------------------------------------------
+
+
+def _model_episode(n_steps=4):
+    convo = [{"role": "system", "content": "sys"}]
+    ccs = []
+    for i in range(n_steps):
+        convo = convo + [{"role": "user", "content": f"u{i}"}, {"role": "assistant", "content": f"a{i}"}]
+        ccs.append(list(convo))
+    return _episode(ccs), ccs
+
+
+def test_compact_episode_stores_native_and_exports_legacy():
+    from rllm.eval.episode_compact import CompactEpisode
+
+    ep, _ = _model_episode()
+    model = CompactEpisode.from_dict(json.loads(json.dumps(ep)))
+    # native storage: the compact dict, unique nodes only
+    assert model.to_dict()["episode_format"] == "compact"
+    assert len(model.to_dict()["trajectories"][0]["message_nodes"]) == 9  # unique msgs
+    # legacy export on demand, lossless
+    assert _canonical(model.to_legacy()) == _canonical(ep)
+    # loading an already-compact dict is identity (no rework)
+    again = CompactEpisode.from_dict(model.to_dict())
+    assert again.to_dict() is model.to_dict()
+
+
+def test_message_history_op_matrix_matches_lists():
+    """Every operation consumers perform must equal the eager-list result."""
+    from rllm.eval.episode_compact import CompactEpisode, MessageHistory
+
+    ep, ccs = _model_episode()
+    model = CompactEpisode.from_dict(ep)
+    for i, expected in enumerate(ccs):
+        h = model.history(0, i)
+        assert isinstance(h, MessageHistory)
+        assert len(h) == len(expected)  # len
+        assert h == expected  # equality vs list
+        assert h[-1] == expected[-1] and h[0] == expected[0]  # indexing
+        assert list(h) == expected  # iteration
+        assert list(reversed(h)) == list(reversed(expected))  # reversed
+        assert h[:-1] == expected[:-1]  # distill's slice
+        assert h.to_list() == expected  # explicit materialization
+        assert json.dumps(h.to_list()) == json.dumps(expected)
+
+
+def test_message_history_prefix_slice_is_a_view_not_a_copy():
+    from rllm.eval.episode_compact import CompactEpisode, MessageHistory
+
+    ep, ccs = _model_episode()
+    h = CompactEpisode.from_dict(ep).history(0, -1)
+    prefix = h[:-1]
+    assert isinstance(prefix, MessageHistory)  # a view, not a list
+    assert prefix._cache is None  # and it materialized nothing
+    assert prefix == ccs[-1][:-1]
+
+
+def test_history_laziness_and_step_sharing():
+    """len/prefix operations must not materialize; shared prefixes share dicts."""
+    from rllm.eval.episode_compact import CompactEpisode
+
+    ep, _ = _model_episode()
+    model = CompactEpisode.from_dict(ep)
+    h_last = model.history(0, -1)
+    assert h_last._cache is None
+    _ = len(h_last)
+    _ = h_last[:-2]
+    assert h_last._cache is None  # still nothing materialized
+    # steps share the actual message dict objects through the node table
+    a, b = model.history(0, 0), model.history(0, -1)
+    assert a[0] is b[0]
+
+
+def test_history_guards_cycles_and_dangling():
+    from rllm.eval.episode_compact import MessageHistory
+
+    with pytest.raises(ValueError, match="cycle"):
+        MessageHistory({"a": {"p": "a", "m": {}}}, "a", 1).to_list()
+    with pytest.raises(ValueError, match="dangling"):
+        MessageHistory({}, "missing", 1).to_list()

--- a/tests/eval/test_episode_compact.py
+++ b/tests/eval/test_episode_compact.py
@@ -1,0 +1,223 @@
+"""Episode converter: compact-format compaction must be exactly lossless.
+
+Unit tests cover the adversarial shapes observed in real dumps (repeated
+identical content, non-cumulative rewrites, empty conversations); the parity
+test then replays *real* saved episodes — discovered from
+``~/.rllm/eval_results/*/episodes`` or ``RLLM_PARITY_DUMPS`` — and requires
+``expand_episode(compact_episode(x))`` to be canonical-byte-identical to
+``x``. It skips on machines without dumps (CI). ``RLLM_PARITY_LIMIT`` caps
+episodes per dump (default 6; 0 = all).
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+
+import pytest
+
+from rllm.eval.episode_compact import COMPACT_FORMAT, FORMAT_KEY, compact_episode, expand_episode
+
+
+def _canonical(obj) -> bytes:
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False, default=str).encode()
+
+
+def _episode(step_ccs, extra_step_fields=None):
+    steps = [dict({"id": f"s{i}", "chat_completions": cc, "reward": 0.0}, **(extra_step_fields or {})) for i, cc in enumerate(step_ccs)]
+    return {
+        "id": "ep",
+        "is_correct": True,
+        "trajectories": [{"uid": "t", "name": "agent", "steps": steps, "reward": 1.0}],
+        "metrics": {"f2p": 1.0},
+    }
+
+
+def _roundtrip(ep):
+    compacted = compact_episode(ep)
+    assert compacted[FORMAT_KEY] == COMPACT_FORMAT
+    restored = expand_episode(compacted)
+    assert _canonical(restored) == _canonical(ep)
+    return compacted
+
+
+def test_cumulative_roundtrip_and_dedup():
+    convo = [{"role": "system", "content": "sys"}]
+    ccs = []
+    for i in range(5):
+        convo = convo + [{"role": "user", "content": f"u{i}"}, {"role": "assistant", "content": f"a{i}"}]
+        ccs.append(list(convo))
+    compacted = _roundtrip(_episode(ccs))
+    assert len(compacted["trajectories"][0]["message_nodes"]) == len(convo)  # unique only
+
+
+def test_repeated_identical_content_keeps_positions():
+    ccs = [[{"role": "user", "content": "go"}, {"role": "assistant", "content": ""}, {"role": "user", "content": "retry"}, {"role": "assistant", "content": ""}]]
+    compacted = _roundtrip(_episode(ccs))
+    assert len(compacted["trajectories"][0]["message_nodes"]) == 4
+
+
+def test_noncumulative_rewrite_forks():
+    ccs = [
+        [{"role": "user", "content": "start"}, {"role": "assistant", "content": "v1"}],
+        [{"role": "user", "content": "start"}, {"role": "assistant", "content": "SUMMARY"}, {"role": "user", "content": "next"}],
+    ]
+    compacted = _roundtrip(_episode(ccs))
+    assert len(compacted["trajectories"][0]["message_nodes"]) == 4  # shared root + 3
+
+
+def test_empty_and_missing_conversations():
+    _roundtrip(_episode([[], [{"role": "user", "content": "hi"}]]))
+    _roundtrip({"id": "ep", "trajectories": []})
+    _roundtrip({"id": "ep"})
+
+
+def test_compact_is_idempotent_and_expand_is_identity_on_legacy():
+    ep = _episode([[{"role": "user", "content": "x"}]])
+    once = compact_episode(ep)
+    assert compact_episode(once) is once
+    assert expand_episode(ep) is ep
+
+
+def test_unknown_step_shape_kept_verbatim():
+    ep = _episode([[{"role": "user", "content": "x"}]])
+    ep["trajectories"].append({"uid": "weird", "steps": [{"chat_completions": "not-a-list"}]})
+    compacted = compact_episode(ep)
+    assert compacted["trajectories"][1] == ep["trajectories"][1]
+    assert _canonical(expand_episode(compacted)) == _canonical(ep)
+
+
+def _discover_dumps() -> list[str]:
+    env = os.environ.get("RLLM_PARITY_DUMPS")
+    if env:
+        return [d for d in env.split(":") if os.path.isdir(d)]
+    dirs = glob.glob(os.path.expanduser("~/.rllm/eval_results/*/episodes"))
+    return sorted(d for d in dirs if glob.glob(os.path.join(d, "*.json")))
+
+
+def test_real_dump_episode_parity():
+    if not (os.environ.get("RLLM_PARITY_DUMPS") or os.environ.get("RLLM_PARITY_SCAN") == "1"):
+        pytest.skip("real-dump parity is opt-in: set RLLM_PARITY_SCAN=1 or RLLM_PARITY_DUMPS (scans local eval artifacts)")
+    dumps = _discover_dumps()
+    if not dumps:
+        pytest.skip("no real eval dumps on this machine")
+    max_bytes = int(os.environ.get("RLLM_PARITY_MAX_MB", "4000")) * 1_000_000
+    scanned = 0
+    limit = int(os.environ.get("RLLM_PARITY_LIMIT", "6"))
+
+    checked = 0
+    raw_bytes = compact_bytes = 0
+    for dump in dumps:
+        files = sorted(glob.glob(os.path.join(dump, "*.json")))
+        if limit:
+            stride = max(1, len(files) // limit)
+            files = files[::stride][:limit]
+        for path in files:
+            scanned += os.path.getsize(path)
+            if scanned > max_bytes:
+                break
+            with open(path, encoding="utf-8") as f:
+                ep = json.load(f)
+            # A dump may itself be compact-format (written with RLLM_EPISODE_FORMAT=compact).
+            # compact is identity on those, so round-trip through the EXPANDED
+            # form — the invariant is expand(compact(x)) == x for legacy-format x.
+            raw = open(path, "rb").read()
+            was_compact = ep.get("episode_format") == "compact"
+            ep = expand_episode(ep)
+            if was_compact:
+                # A compact artifact must export TRUE legacy: no compact-only
+                # keys may survive expansion (review: seven zero-step artifacts
+                # kept message_nodes and one kept refs — invisible when the
+                # expanded form is treated as its own baseline).
+                s = json.dumps(ep)
+                assert '"message_nodes"' not in s and '"messages_ref"' not in s and '"chat_completions_ref"' not in s, f"compact residue after expand: {path}"
+            compacted = compact_episode(ep)
+            restored = expand_episode(compacted)
+            assert _canonical(restored) == _canonical(ep), f"not lossless: {path}"
+            # Stricter: a legacy file converted and back must reproduce the
+            # exact bytes the previous pipeline wrote (same writer settings) —
+            # this catches key-order regressions canonical comparison hides.
+            if not was_compact:
+                import json as _json
+
+                from rllm.eval.episode_store import _json_default
+
+                back = _json.dumps(restored, indent=2, default=_json_default).encode()
+                assert back == raw, f"not byte-identical: {path}"
+            raw_bytes += os.path.getsize(path)
+            compact_bytes += len(json.dumps(compacted))
+            checked += 1
+    assert checked > 0
+    print(f"[parity-episode] {checked} real episodes lossless; {raw_bytes / 1e6:.0f} MB -> {compact_bytes / 1e6:.0f} MB ({raw_bytes / max(compact_bytes, 1):.0f}x)")
+
+
+def test_reserved_keys_refuse_compaction_losslessly():
+    ep = _episode([[{"role": "user", "content": "x"}]])
+    ep["episode_format"] = "something-else"
+    assert compact_episode(ep) is ep  # refused, unchanged
+    ep2 = _episode([[{"role": "user", "content": "x"}]])
+    ep2["trajectories"][0]["message_nodes"] = {"user": "data"}
+    c = compact_episode(ep2)
+    assert c["trajectories"][0] == ep2["trajectories"][0]  # trajectory verbatim
+    assert _canonical(expand_episode(c)) == _canonical(ep2)
+
+
+def test_expand_guards_cycles_and_dangling_refs():
+    ep = _episode([[{"role": "user", "content": "x"}]])
+    c = compact_episode(ep)
+    nodes = c["trajectories"][0]["message_nodes"]
+    nid = next(iter(nodes))
+    broken = json.loads(json.dumps(c))
+    broken["trajectories"][0]["message_nodes"][nid]["p"] = nid  # self-cycle
+    with pytest.raises(ValueError, match="cycle"):
+        expand_episode(broken)
+    broken2 = json.loads(json.dumps(c))
+    broken2["trajectories"][0]["message_nodes"][nid]["p"] = "missing-node"
+    with pytest.raises(ValueError, match="dangling"):
+        expand_episode(broken2)
+
+
+def test_single_trigger_env_gates_episode_writes(tmp_path, monkeypatch):
+    """RLLM_GATEWAY_STORE=compact is the ONLY trigger; unset writes byte-exact legacy."""
+    import json as _json
+
+    from rllm.eval.episode_store import EvalEpisodeStore, _json_default
+    from rllm.types import Episode, Trajectory
+    from rllm.types import Step as _Step
+
+    ep = Episode(trajectories=[Trajectory(steps=[_Step(chat_completions=[{"role": "user", "content": "x"}])])])
+    monkeypatch.delenv("RLLM_GATEWAY_STORE", raising=False)
+    p1 = EvalEpisodeStore(tmp_path / "legacy").write(0, ep)
+    legacy = p1.read_bytes()
+    data = _json.loads(legacy)
+    assert "episode_format" not in data
+    # legacy output is exactly the pre-change writer's format (indent=2, same encoder)
+    expected = _json.dumps(data, indent=2, default=_json_default).encode()
+    assert legacy == expected
+
+    monkeypatch.setenv("RLLM_GATEWAY_STORE", "compact")
+    p2 = EvalEpisodeStore(tmp_path / "compact").write(0, ep)
+    assert _json.loads(p2.read_bytes()).get("episode_format") == "compact"
+
+
+def test_user_reserved_like_fields_survive_on_versioned_files():
+    """Review P2c: healing is for unversioned pre-release artifacts ONLY."""
+    # user's own compact_version at top level → compaction refuses, lossless
+    ep = _episode([[{"role": "user", "content": "x"}]])
+    ep["compact_version"] = "user-data"
+    assert compact_episode(ep) is ep
+    # versioned compact file: user-ish chat_completions_ref / empty message_nodes pass through
+    base = compact_episode(_episode([[{"role": "user", "content": "x"}]]))
+    base["trajectories"].append({"uid": "w", "steps": [{"chat_completions": [{"role": "u", "content": "y"}], "chat_completions_ref": ["custom"], "reward": 0.0}]})
+    out = expand_episode(json.loads(json.dumps(base)))
+    weird = out["trajectories"][1]["steps"][0]
+    assert weird["chat_completions_ref"] == ["custom"]  # untouched
+    assert weird["chat_completions"] == [{"role": "u", "content": "y"}]
+
+
+def test_unknown_compact_version_rejected():
+    ep = compact_episode(_episode([[{"role": "user", "content": "x"}]]))
+    ep["compact_version"] = 999
+    with pytest.raises(ValueError, match="unsupported"):
+        expand_episode(ep)

--- a/tests/gateway/test_compact_live_path.py
+++ b/tests/gateway/test_compact_live_path.py
@@ -1,0 +1,55 @@
+"""The compact stack must be reachable end-to-end (audit: 'no live path').
+
+Covers the three wiring points the audit found dead: the manager's store
+allowlist, the RLLM_GATEWAY_STORE env override, and the trace-fetch format
+selection that follows the store — the single trigger for the pipeline.
+"""
+
+import pytest
+from omegaconf import OmegaConf
+
+from rllm.gateway.manager import GatewayManager
+
+
+def _mgr(monkeypatch, store=None, env_store=None):
+    monkeypatch.delenv("RLLM_GATEWAY_STORE", raising=False)
+    if env_store is not None:
+        monkeypatch.setenv("RLLM_GATEWAY_STORE", env_store)
+    gateway = {} if store is None else {"store": store}
+    return GatewayManager(config=OmegaConf.create({"rllm": {"gateway": gateway}}), mode="thread")
+
+
+def test_memory_compact_is_an_allowed_store(monkeypatch):
+    assert _mgr(monkeypatch, store="compact").store == "compact"
+
+
+def test_env_var_opts_into_compact_store(monkeypatch):
+    assert _mgr(monkeypatch, env_store="compact").store == "compact"
+
+
+def test_unknown_store_still_rejected(monkeypatch):
+    with pytest.raises(ValueError):
+        _mgr(monkeypatch, store="redis")
+
+
+def test_trace_format_follows_store(monkeypatch):
+    assert _mgr(monkeypatch, store="compact")._trace_format == "compact"
+    assert _mgr(monkeypatch, store="memory")._trace_format is None
+
+
+def test_no_env_means_legacy_everywhere(monkeypatch):
+    """The contract: RLLM_GATEWAY_STORE is the ONLY trigger. Unset it and the
+    manager selects the default store and the legacy fetch format."""
+    mgr = _mgr(monkeypatch)
+    assert mgr.store == "memory"
+    assert mgr._trace_format is None
+
+
+def test_config_selected_compact_activates_the_whole_pipeline(monkeypatch):
+    """Review P1b: gateway.store=compact in config must reach the episode
+    writers too — the manager propagates it to the single-trigger env var."""
+    import os
+
+    mgr = _mgr(monkeypatch, store="compact")
+    assert mgr.store == "compact"
+    assert os.environ.get("RLLM_GATEWAY_STORE") == "compact"

--- a/tests/trainer/test_packed_datum_delta.py
+++ b/tests/trainer/test_packed_datum_delta.py
@@ -1,0 +1,125 @@
+"""Delta-fed datum building must equal full-list-fed building exactly.
+
+The conversion to full lists exists ONLY as the parity instrument here: the
+same trajectory is expressed both ways and the resulting Datums must match
+token-for-token (inputs, targets, logprobs, advantages, masks). In
+production the full-list form is never constructed.
+"""
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+
+from rllm.trainer.tinker.transform import trajectory_to_datums  # noqa: E402
+from rllm.types import Step, Trajectory  # noqa: E402
+
+
+def _mk_step(prompt, response, adv=0.5):
+    return Step(
+        prompt_ids=prompt,
+        response_ids=list(response),
+        logprobs=[-0.1] * len(response),
+        advantage=adv,
+    )
+
+
+def _both_forms(prompts_full, responses):
+    """The same trajectory as (full-list steps, delta steps)."""
+    full = [_mk_step(list(p), r) for p, r in zip(prompts_full, responses, strict=True)]
+    deltas = []
+    prev = []
+    for p, r in zip(prompts_full, responses, strict=True):
+        lcp = 0
+        while lcp < min(len(prev), len(p)) and prev[lcp] == p[lcp]:
+            lcp += 1
+        deltas.append(_mk_step({"__prompt_ids_delta__": [lcp, list(p[lcp:])]}, r))
+        prev = p
+    return Trajectory(steps=full), Trajectory(steps=deltas)
+
+
+def _datum_key(d):
+    return (
+        list(d.model_input.to_ints()),
+        list(d.loss_fn_inputs["target_tokens"].data),
+        list(d.loss_fn_inputs["logprobs"].data),
+        list(d.loss_fn_inputs["advantages"].data),
+        list(d.loss_fn_inputs["mask"].data),
+    )
+
+
+def _assert_equal_datums(a, b):
+    assert len(a) == len(b)
+    for x, y in zip(a, b, strict=True):
+        assert _datum_key(x) == _datum_key(y)
+
+
+def test_cumulative_trajectory_delta_equals_full():
+    """5 turns, each prompt = previous prompt + previous response + new user."""
+    prompts, responses = [], []
+    p = [1, 2, 3]
+    for i in range(5):
+        prompts.append(list(p))
+        r = [100 + i, 200 + i]
+        responses.append(r)
+        p = p + r + [50 + i]  # next prompt: + response + one user token
+    t_full, t_delta = _both_forms(prompts, responses)
+    _assert_equal_datums(trajectory_to_datums(t_full), trajectory_to_datums(t_delta))
+    # and the merge really packed: one datum for the whole lineage
+    assert len(trajectory_to_datums(t_delta)) == 1
+
+
+def test_fork_trajectory_delta_equals_full():
+    """A mid-trajectory context reset (lcp drops) must fork identically."""
+    prompts = [[1, 2], [1, 2, 100, 3], [9, 9, 9], [9, 9, 9, 300, 4]]
+    responses = [[100], [101], [300], [301]]
+    t_full, t_delta = _both_forms(prompts, responses)
+    a, b = trajectory_to_datums(t_full), trajectory_to_datums(t_delta)
+    _assert_equal_datums(a, b)
+    assert len(a) == 2  # the reset produced exactly one fork both ways
+
+
+def test_mixed_full_and_delta_steps():
+    """Producers may migrate incrementally: mixed forms in one trajectory."""
+    prompts = [[1, 2], [1, 2, 100, 3], [1, 2, 100, 3, 101, 4]]
+    responses = [[100], [101], [102]]
+    t_full, t_delta = _both_forms(prompts, responses)
+    mixed = Trajectory(steps=[t_full.steps[0], t_delta.steps[1], t_full.steps[2]])
+    _assert_equal_datums(trajectory_to_datums(t_full), trajectory_to_datums(mixed))
+
+
+def test_bad_delta_raises():
+    with pytest.raises(ValueError, match="exceeds previous prompt length"):
+        trajectory_to_datums(Trajectory(steps=[_mk_step({"__prompt_ids_delta__": [5, [1]]}, [7])]))
+
+
+def test_delta_path_never_runs_full_prefix_compare(monkeypatch):
+    """Pure-extension delta steps must merge in O(new): the full-sequence
+    prefix compare must not run at all."""
+    import rllm.trainer.tinker.transform as tf
+
+    def _boom(*a, **k):
+        raise AssertionError("_is_prefix called on the delta fast path")
+
+    monkeypatch.setattr(tf, "_is_prefix", _boom)
+    prompts, responses = [], []
+    p = [1, 2, 3]
+    for i in range(4):
+        prompts.append(list(p))
+        r = [100 + i]
+        responses.append(r)
+        p = p + r + [50 + i]
+    _, t_delta = _both_forms(prompts, responses)
+    assert len(trajectory_to_datums(t_delta)) == 1
+
+
+def test_conversion_does_not_mutate_steps():
+    """Converting twice must give identical results: the incremental prompt
+    buffer must never alias or mutate Step.prompt_ids."""
+    prompts = [[1, 2], [1, 2, 100, 3]]
+    responses = [[100], [101]]
+    t_full, t_delta = _both_forms(prompts, responses)
+    mixed = Trajectory(steps=[t_full.steps[0], t_delta.steps[1]])
+    first = [_datum_key(d) for d in trajectory_to_datums(mixed)]
+    second = [_datum_key(d) for d in trajectory_to_datums(mixed)]
+    assert first == second
+    assert mixed.steps[0].prompt_ids == [1, 2]

--- a/tests/trainer/verl/test_packed_row_delta.py
+++ b/tests/trainer/verl/test_packed_row_delta.py
@@ -1,0 +1,135 @@
+"""Delta-fed verl rows must equal full-list-fed rows exactly.
+
+The full-list form exists ONLY as the parity instrument: the same trajectory
+is expressed both ways and the resulting DataProto tensors must match. The
+delta feed carries NO full prompt list anywhere (``model_output.prompt_ids``
+is None), which is the point — conversion works without the O(n^2)
+expansion ever existing.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+pytest.importorskip("verl")
+
+from rllm.agents.agent import Episode, Step, Trajectory
+from rllm.engine.rollout import ModelOutput
+from rllm.trainer.verl.transform import transform_episodes_to_dataproto
+
+
+def _engine(pad_token_id: int = 0):
+    engine = MagicMock()
+    engine.tokenizer.pad_token_id = pad_token_id
+    engine.processor = None
+    return engine
+
+
+def _full_step(prompt, response, logprobs):
+    return Step(
+        prompt_ids=list(prompt),
+        response_ids=list(response),
+        model_output=ModelOutput(prompt_ids=list(prompt), completion_ids=list(response), logprobs=list(logprobs)),
+    )
+
+
+def _delta_step(lcp, suffix, response, logprobs):
+    """A step whose prompt exists ONLY as a delta marker: no full list anywhere."""
+    return Step(
+        prompt_ids={"__prompt_ids_delta__": [lcp, list(suffix)]},
+        response_ids=list(response),
+        model_output=ModelOutput(prompt_ids=None, completion_ids=list(response), logprobs=list(logprobs)),
+    )
+
+
+def _both_forms(prompts_full, responses):
+    """The same trajectory as (full-list steps, delta-only steps)."""
+    lps = [[-0.1 * (i + 1)] * len(r) for i, r in enumerate(responses)]
+    full = [_full_step(p, r, lp) for p, r, lp in zip(prompts_full, responses, lps, strict=True)]
+    deltas = []
+    prev: list[int] = []
+    for p, r, lp in zip(prompts_full, responses, lps, strict=True):
+        lcp = 0
+        while lcp < min(len(prev), len(p)) and prev[lcp] == p[lcp]:
+            lcp += 1
+        deltas.append(_delta_step(lcp, p[lcp:], r, lp))
+        prev = list(p)
+    return full, deltas
+
+
+def _episode(steps, eid="task_0:0"):
+    traj = Trajectory(steps=steps, reward=1.0)
+    return Episode(id=eid, trajectories=[traj], is_correct=True)
+
+
+def _to_batch(steps):
+    proto = transform_episodes_to_dataproto([_episode(steps)], _engine(), max_prompt_length=64, max_response_length=64)
+    return proto.batch
+
+
+def _assert_equal_batches(a, b):
+    assert set(a.keys()) == set(b.keys())
+    for k in a.keys():
+        assert torch.equal(a[k], b[k]), f"tensor mismatch: {k}"
+
+
+def _cumulative(turns):
+    prompts, responses = [], []
+    p = [1, 2, 3]
+    for i in range(turns):
+        prompts.append(list(p))
+        r = [100 + i, 200 + i]
+        responses.append(r)
+        p = p + r + [50 + i]  # + previous response + one observation token
+    return prompts, responses
+
+
+def test_cumulative_trajectory_delta_equals_full():
+    full, deltas = _both_forms(*_cumulative(5))
+    a, b = _to_batch(full), _to_batch(deltas)
+    _assert_equal_batches(a, b)
+    assert a["input_ids"].shape[0] == 1  # the whole lineage merged into one row
+
+
+def test_fork_trajectory_delta_equals_full():
+    """A mid-trajectory context reset (lcp drops) must fork identically."""
+    prompts = [[1, 2], [1, 2, 100, 3], [9, 9, 9], [9, 9, 9, 300, 4]]
+    responses = [[100], [101], [300], [301]]
+    full, deltas = _both_forms(prompts, responses)
+    a, b = _to_batch(full), _to_batch(deltas)
+    _assert_equal_batches(a, b)
+    assert a["input_ids"].shape[0] == 2  # the reset produced exactly one fork
+
+
+def test_mixed_full_and_delta_steps():
+    """Producers may migrate incrementally: mixed forms in one trajectory."""
+    prompts = [[1, 2], [1, 2, 100, 3], [1, 2, 100, 3, 101, 4]]
+    responses = [[100], [101], [102]]
+    full, deltas = _both_forms(prompts, responses)
+    mixed = [full[0], deltas[1], full[2]]
+    _assert_equal_batches(_to_batch(full), _to_batch(mixed))
+
+
+def test_delta_feed_carries_no_full_prompt_lists():
+    """The delta feed converts with model_output.prompt_ids=None on every
+    step: the merge provably never reads a materialized prompt list."""
+    _, deltas = _both_forms(*_cumulative(4))
+    assert all(s.model_output.prompt_ids is None for s in deltas)
+    assert _to_batch(deltas)["input_ids"].shape[0] == 1
+
+
+def test_conversion_does_not_mutate_steps():
+    """Converting twice must give identical results: the incremental prompt
+    buffer must never alias or mutate step data."""
+    full, deltas = _both_forms(*_cumulative(3))
+    mixed = [full[0], deltas[1], deltas[2]]
+    first, second = _to_batch(mixed), _to_batch(mixed)
+    _assert_equal_batches(first, second)
+    assert mixed[0].prompt_ids == full[0].prompt_ids
+
+
+def test_bad_delta_raises():
+    step = _delta_step(5, [1], [7], [-0.1])
+    with pytest.raises(ValueError, match="exceeds previous prompt length"):
+        _to_batch([step])


### PR DESCRIPTION
The content currently on this branch is from a discarded design iteration and is NOT current. Per the redesign plan documented on #871, this slot is reserved for the next PR of the stack: the producer — enrichment mapping gateway TraceDeltas to TrajectoryDelta near-identity, with chunk-boundary steps materialized as base deltas at the positional split, gated on resolve() matching the flat path byte-exactly on real runs. Do not review the current diff.