### PR TITLE
[superseded — slot reserved: peripheral readers] delta-aware writers, metrics, viewers

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/client.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/client.py
@@ -7,7 +7,7 @@ import httpx
 from rllm_model_gateway.models import TraceRecord, WorkerInfo
 
 
-def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
+def _expand_compact_traces(payload: dict[str, Any], *, expand_prompt_ids: bool = True) -> list[dict[str, Any]]:
     """Rebuild full per-trace message lists from a compact traces payload.
 
     Nodes are materialized once and *shared*: every trace whose conversation
@@ -15,6 +15,13 @@ def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
     linear in unique messages even though the expanded lists repeat them.
     Reconstruction is exact — parity-tested byte-for-byte against the default
     format on real eval dumps.
+
+    With ``expand_prompt_ids=False`` the per-trace prompt token lists are NOT
+    materialized (that materialization is the remaining O(n^2)): a trace whose
+    ids arrived as a delta keeps them as the step-form marker
+    ``{"__prompt_ids_delta__": [lcp, suffix]}`` relative to the previous trace
+    of the same lineage, which is what the packed trainers consume natively.
+    Only prompt lengths are tracked, so validation stays exact.
     """
     nodes = payload.get("nodes", {})
     out: list[dict[str, Any]] = []
@@ -46,6 +53,29 @@ def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
         return base
 
     ids_memo: dict[str | None, list[int]] = {None: []}
+    # Delta-keeping state: full prompt lengths per trace (exact validation
+    # without materialization), recorded deltas for the rare rebase walk, and
+    # the previous trace id per lineage (step-form deltas resolve against the
+    # lineage predecessor, which the store's chain predecessor always is —
+    # verified per trace, rebased if ever not).
+    len_memo: dict[str | None, int] = {None: 0}
+    delta_memo: dict[str, tuple[str | None, int, list[int]]] = {}
+    prev_in_lineage: dict[Any, str | None] = {}
+
+    def _materialize(tid: str | None) -> list[int]:
+        """Rebuild one trace's full prompt ids from recorded deltas (rebase
+        fallback only — never runs on the store's chain order)."""
+        chain: list[tuple[int, list[int]]] = []
+        cursor = tid
+        while cursor is not None and cursor not in ids_memo:
+            prev, lcp, suffix = delta_memo[cursor]
+            chain.append((lcp, suffix))
+            cursor = prev
+        full = list(ids_memo.get(cursor, []))
+        for lcp, suffix in reversed(chain):
+            full = full[:lcp] + list(suffix)
+        return full
+
     for trace in payload.get("traces", []):
         ref = trace.get("messages_ref")
         if ref is None:
@@ -59,16 +89,34 @@ def _expand_compact_traces(payload: dict[str, Any]) -> list[dict[str, Any]]:
         expanded.pop("messages_ref", None)
         expanded["messages"] = messages
         ids_ref = expanded.pop("prompt_ids_delta", None)
+        tid = expanded.pop("_tid", None) or expanded.get("trace_id")
         if ids_ref is not None:
             # Delta against an earlier trace in this payload: prefix + suffix.
             prev_tid, lcp, suffix = ids_ref
-            prev_full = ids_memo.get(prev_tid)
-            if prev_full is None or lcp > len(prev_full):
-                raise ValueError(f"prompt-id delta references unknown/short ancestor {prev_tid!r}")
-            expanded["prompt_token_ids"] = prev_full[:lcp] + list(suffix)
-        tid = expanded.pop("_tid", None) or expanded.get("trace_id")
+            if expand_prompt_ids:
+                prev_full = ids_memo.get(prev_tid)
+                if prev_full is None or lcp > len(prev_full):
+                    raise ValueError(f"prompt-id delta references unknown/short ancestor {prev_tid!r}")
+                expanded["prompt_token_ids"] = prev_full[:lcp] + list(suffix)
+            else:
+                prev_len = len_memo.get(prev_tid)
+                if prev_len is None or lcp > prev_len:
+                    raise ValueError(f"prompt-id delta references unknown/short ancestor {prev_tid!r}")
+                lineage = expanded.get("lineage_id")
+                if prev_in_lineage.get(lineage) == prev_tid:
+                    expanded["prompt_token_ids"] = {"__prompt_ids_delta__": [lcp, list(suffix)]}
+                else:
+                    # Chain predecessor is not this lineage's previous trace:
+                    # rebase to a full list so step-form consumers stay exact.
+                    expanded["prompt_token_ids"] = _materialize(prev_tid)[:lcp] + list(suffix)
+                if tid is not None:
+                    len_memo[tid] = lcp + len(suffix)
+                    delta_memo[tid] = (prev_tid, lcp, list(suffix))
         if tid is not None and isinstance(expanded.get("prompt_token_ids"), list):
             ids_memo[tid] = expanded["prompt_token_ids"]
+            len_memo[tid] = len(expanded["prompt_token_ids"])
+        if tid is not None:
+            prev_in_lineage[expanded.get("lineage_id")] = tid
         out.append(expanded)
     return out
 
@@ -155,6 +203,7 @@ class GatewayClient:
         since: float | None = None,
         limit: int | None = None,
         format: str | None = None,
+        expand_prompt_ids: bool = True,
     ) -> list[TraceRecord]:
         params: dict[str, Any] = {}
         if since is not None:
@@ -171,7 +220,7 @@ class GatewayClient:
             # every message dict and destroy the cross-trace sharing the
             # expansion just built. The payload is gateway-produced, not user
             # input, so skipping validation is safe here.
-            return [TraceRecord.model_construct(**t) for t in _expand_compact_traces(data)]
+            return [TraceRecord.model_construct(**t) for t in _expand_compact_traces(data, expand_prompt_ids=expand_prompt_ids)]
         return [TraceRecord(**t) for t in data]
 
     def get_trace(self, trace_id: str) -> TraceRecord:
@@ -312,6 +361,7 @@ class AsyncGatewayClient:
         since: float | None = None,
         limit: int | None = None,
         format: str | None = None,
+        expand_prompt_ids: bool = True,
     ) -> list[TraceRecord]:
         params: dict[str, Any] = {}
         if since is not None:
@@ -326,7 +376,7 @@ class AsyncGatewayClient:
         if isinstance(data, dict) and data.get("format") == "compact":
             # See the sync client: model_construct preserves the shared node
             # dicts that validation would copy away.
-            return [TraceRecord.model_construct(**t) for t in _expand_compact_traces(data)]
+            return [TraceRecord.model_construct(**t) for t in _expand_compact_traces(data, expand_prompt_ids=expand_prompt_ids)]
         return [TraceRecord(**t) for t in data]
 
     async def get_trace(self, trace_id: str) -> TraceRecord:

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -197,7 +197,7 @@ def enrich_episode_with_traces(
     # rollout — at high MAX_TURNS the failure rate would exhaust retries.
     if agent_populates_steps and len(training_steps) > n_agent_steps:
         extra = training_steps[n_agent_steps:]
-        extras_all_malformed = all(not s.model_output.prompt_ids or not s.model_output.completion_ids for s in extra)
+        extras_all_malformed = all((not s.model_output.prompt_ids and s.prompt_delta is None) or not s.model_output.completion_ids for s in extra)
         if extras_all_malformed:
             logger.warning(
                 "[%s] dropping %d trailing malformed trace(s); keeping %d aligned with agent_steps",
@@ -207,7 +207,7 @@ def enrich_episode_with_traces(
             )
             training_steps = training_steps[:n_agent_steps]
 
-    empty_prompt = sum(1 for s in training_steps if not s.model_output.prompt_ids)
+    empty_prompt = sum(1 for s in training_steps if not s.model_output.prompt_ids and s.prompt_delta is None)
     empty_compl = sum(1 for s in training_steps if not s.model_output.completion_ids)
     # Only enforce step-count parity when the agent actually populates steps.
     # Trajectories with no agent steps absorb remaining traces wholesale

--- a/rllm/engine/trace_converter.py
+++ b/rllm/engine/trace_converter.py
@@ -60,15 +60,27 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
     raw_tool_calls = trace.response_message.get("tool_calls")
     tool_calls = _parse_openai_tool_calls(raw_tool_calls) if raw_tool_calls else None
 
+    # In compact mode the client keeps prompt ids as the step-form delta
+    # marker {"__prompt_ids_delta__": [lcp, suffix]} instead of the full
+    # list — the marker rides on step.prompt_ids and model_output carries
+    # only the exact length; nothing here materializes the expansion.
+    raw_prompt_ids = trace.prompt_token_ids
+    ids_delta = raw_prompt_ids.get("__prompt_ids_delta__") if isinstance(raw_prompt_ids, dict) else None
+    if ids_delta is not None:
+        lcp, suffix = ids_delta
+        full_prompt_ids, prompt_length = None, lcp + len(suffix)
+    else:
+        full_prompt_ids, prompt_length = raw_prompt_ids, len(raw_prompt_ids)
+
     model_output = ModelOutput(
         content=content,
         reasoning=reasoning,
         tool_calls=tool_calls,
-        prompt_ids=trace.prompt_token_ids,
+        prompt_ids=full_prompt_ids,
         completion_ids=trace.completion_token_ids,
         logprobs=trace.logprobs or [],
         routing_matrices=trace.routing_matrices,
-        prompt_length=len(trace.prompt_token_ids),
+        prompt_length=prompt_length,
         completion_length=len(trace.completion_token_ids),
         finish_reason=trace.finish_reason,
         weight_version=trace.weight_version,
@@ -93,6 +105,7 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
     # history type is the planned enforcement (native-compact follow-up).
     step = Step(
         id=trace.trace_id,
+        prompt_ids=raw_prompt_ids if ids_delta is not None else [],
         # Assigned below, AFTER construction: pydantic field validation copies
         # each message dict, which would re-materialize the full conversation
         # prefix per step even with the deepcopy skipped (audit: the root
@@ -112,7 +125,7 @@ def trace_record_to_step(trace: TraceRecord) -> Step:
 def compute_step_metrics(trajectories: list[Trajectory]) -> dict:
     """Standard training metrics from trajectories (shared by local and remote engines)."""
     all_response_lens = [len(s.response_ids) for t in trajectories for s in t.steps]
-    all_prompt_lens = [len(s.prompt_ids) for t in trajectories for s in t.steps]
+    all_prompt_lens = [s.prompt_len for t in trajectories for s in t.steps]
     return {
         "traj_per_episode": len(trajectories),
         "steps_used": sum(len(t.steps) for t in trajectories),

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -381,7 +381,10 @@ class GatewayManager:
 
     def get_traces(self, session_id: str) -> list[TraceRecord]:
         self.client.flush()
-        return self.client.get_session_traces(session_id, format=self._trace_format)
+        # Compact mode keeps prompt-id deltas in step form instead of
+        # materializing the O(n^2) per-trace token lists; the packed trainers
+        # consume them natively.
+        return self.client.get_session_traces(session_id, format=self._trace_format, expand_prompt_ids=self._trace_format != "compact")
 
     # -- Async session / trace API -------------------------------------------
 
@@ -391,7 +394,7 @@ class GatewayManager:
 
     async def aget_traces(self, session_id: str) -> list[TraceRecord]:
         await self.async_client.flush(timeout=_TRACE_API_TIMEOUT)
-        return await self.async_client.get_session_traces(session_id, format=self._trace_format)
+        return await self.async_client.get_session_traces(session_id, format=self._trace_format, expand_prompt_ids=self._trace_format != "compact")
 
     async def adelete_session(self, session_id: str) -> int:
         """Delete a session and all its accumulated traces. Returns count removed."""

--- a/rllm/trainer/algorithms/visualization.py
+++ b/rllm/trainer/algorithms/visualization.py
@@ -161,6 +161,23 @@ def _format_token(token: str, style: dict[str, Any]) -> str:
     return click.style(display_token, **style)
 
 
+def _resolve_prompt_ids(trajectory) -> list:
+    """Full prompt ids of a trajectory's last step, resolving compact
+    delta-form steps by replaying the trajectory (display-time only)."""
+    last_step = trajectory.steps[-1]
+    if last_step.prompt_delta is None:
+        return last_step.prompt_ids
+    cur: list = []
+    for step in trajectory.steps:
+        delta = step.prompt_delta
+        if delta is None:
+            cur = list(step.prompt_ids)
+        else:
+            lcp, suffix = delta
+            cur = cur[: min(lcp, len(cur))] + list(suffix)
+    return cur
+
+
 def _visualize_metadata(trajectory: Trajectory, metadata: dict, config: VisualizationConfig):
     """
     Visualizes workflow metadata for a given trajectory.
@@ -234,7 +251,7 @@ def visualize_trajectory_last_steps(
         # 3. Render Prompt and Response
         last_step = trajectory.steps[-1]
         # extract the prompt and response
-        prompt_ids = last_step.prompt_ids
+        prompt_ids = _resolve_prompt_ids(trajectory)
         response_ids = last_step.response_ids
 
         # special handling for prompt ids, we will skip any non-int elements

--- a/rllm/trainer/buffer.py
+++ b/rllm/trainer/buffer.py
@@ -391,7 +391,7 @@ class TrajectoryGroupBuffer:
 
             # Episode-level totals across all trajectories
             total_turns = sum(len(traj.steps) for traj in ep.trajectories)
-            total_prompt_tokens = sum(len(s.prompt_ids) for traj in ep.trajectories for s in traj.steps)
+            total_prompt_tokens = sum(s.prompt_len for traj in ep.trajectories for s in traj.steps)
             total_response_tokens = sum(len(s.response_ids) for traj in ep.trajectories for s in traj.steps)
             self._aggregator.record("episode/num_turns", total_turns)
             self._aggregator.record("episode/prompt_tokens", total_prompt_tokens)
@@ -461,11 +461,31 @@ class TrajectoryGroupBuffer:
         """
         full: list[int] | None = None
         segments = 0
+        have_prev = False
+        prev_prompt_len = 0
+        prev_response: list | None = None
         for step in traj.steps:
-            ids = list(step.prompt_ids)
-            if full is None or ids[: len(full)] != full:
-                segments += 1
-            full = ids + list(step.response_ids)
+            delta = step.prompt_delta
+            if delta is not None:
+                # Delta-form step: extends the running sequence iff it purely
+                # extends the previous prompt and its suffix begins with the
+                # previous response — same rule as the packed builders.
+                lcp, suffix = delta
+                extends = have_prev and lcp == prev_prompt_len and prev_response is not None and len(suffix) >= len(prev_response) and list(suffix[: len(prev_response)]) == list(prev_response)
+                if not extends:
+                    segments += 1
+                full = None  # content untracked past a delta step
+            else:
+                ids = list(step.prompt_ids)
+                if full is None or ids[: len(full)] != full:
+                    # full is also None right after a delta step: a full-list
+                    # step there conservatively starts a new segment (mixed
+                    # forms don't occur in one fetched trajectory).
+                    segments += 1
+                full = ids + list(step.response_ids)
+            have_prev = True
+            prev_prompt_len = step.prompt_len
+            prev_response = list(step.response_ids)
         return max(segments, 1)
 
     def _log_prompt_group_finished(

--- a/rllm/trainer/distill/advantage.py
+++ b/rllm/trainer/distill/advantage.py
@@ -117,6 +117,8 @@ async def compute_step_distill_advantage(
     student_completion_ids = step.response_ids
     student_logprobs = step.logprobs
 
+    if step.prompt_delta is not None:
+        raise NotImplementedError("Distillation requires full prompt_ids; compact delta-form steps are not supported here — run with RLLM_GATEWAY_STORE unset for distillation.")
     if not student_prompt_ids:
         raise ValueError("Missing prompt_ids on step for distillation.")
     if not student_completion_ids or not student_logprobs:

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -232,6 +232,25 @@ class Step(BaseModel):
     weight_version: int | None = None  # weight version at time of generation (async staleness)
 
     @property
+    def prompt_delta(self) -> tuple[int, list] | None:
+        """(lcp, suffix) when prompt_ids is the compact delta marker, else None."""
+        raw = self.prompt_ids
+        if isinstance(raw, dict):
+            delta = raw.get("__prompt_ids_delta__")
+            if delta is not None:
+                lcp, suffix = delta
+                return lcp, suffix
+        return None
+
+    @property
+    def prompt_len(self) -> int:
+        """Full prompt length in tokens, delta-form or not."""
+        delta = self.prompt_delta
+        if delta is not None:
+            return delta[0] + len(delta[1])
+        return len(self.prompt_ids)
+
+    @property
     def info(self) -> dict:
         """Alias for metadata. Auto-initializes to {} if None so mutation works."""
         if self.metadata is None:

--- a/tests/gateway/test_producer_delta_pipeline.py
+++ b/tests/gateway/test_producer_delta_pipeline.py
@@ -1,0 +1,159 @@
+"""Producer flip: the compact fetch keeps prompt-id deltas in step form and
+the whole pipeline consumes them without materializing O(n^2) token lists.
+
+The expanded path is retained ONLY as the parity instrument: the same store
+contents fetched both ways must produce identical steps (up to form) and —
+via the packed builder — identical training datums.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "rllm-model-gateway" / "src"))
+
+from rllm_model_gateway.client import _expand_compact_traces  # noqa: E402
+from rllm_model_gateway.models import TraceRecord  # noqa: E402
+from rllm_model_gateway.store.memory_store import MemoryTraceStore  # noqa: E402
+
+from rllm.engine.trace_converter import compute_step_metrics, trace_record_to_step  # noqa: E402
+from rllm.types import Trajectory  # noqa: E402
+
+
+def _store_session(lineages=1, turns=6):
+    """A compact store holding cumulative conversations with growing ids."""
+    store = MemoryTraceStore(compact=True)
+
+    async def fill():
+        for lin in range(lineages):
+            ids: list[int] = [7000 + lin, 7001 + lin]
+            messages = [{"role": "user", "content": f"q-{lin}"}]
+            for turn in range(turns):
+                ids = ids + [100 * lin + turn, 100 * lin + turn + 1]
+                await store.store_trace(
+                    f"t-{lin}-{turn}",
+                    "s",
+                    {
+                        "trace_id": f"t-{lin}-{turn}",
+                        "session_id": "s",
+                        "lineage_id": f"lin{lin}",
+                        "messages": list(messages),
+                        "response_message": {"role": "assistant", "content": f"a-{lin}-{turn}"},
+                        "prompt_token_ids": list(ids),
+                        "completion_token_ids": [900 + turn, 901 + turn],
+                        "logprobs": [-0.1, -0.2],
+                    },
+                )
+                messages = messages + [
+                    {"role": "assistant", "content": f"a-{lin}-{turn}"},
+                    {"role": "user", "content": f"q-{lin}-{turn}"},
+                ]
+                ids = ids + [900 + turn, 901 + turn]  # + response, cumulative
+        return json.loads(json.dumps(await store.get_session_traces_compact("s"), default=str))
+
+    return asyncio.run(fill())
+
+
+def _resolve_marker_ids(traces):
+    """Reference resolution of kept markers back to full lists, per lineage."""
+    cur: dict = {}
+    out = []
+    for t in traces:
+        ids = t["prompt_token_ids"]
+        lin = t.get("lineage_id")
+        if isinstance(ids, dict):
+            lcp, suffix = ids["__prompt_ids_delta__"]
+            cur[lin] = cur.get(lin, [])[:lcp] + list(suffix)
+        else:
+            cur[lin] = list(ids)
+        out.append(cur[lin])
+    return out
+
+
+def test_kept_deltas_resolve_to_the_expanded_lists():
+    payload = _store_session(lineages=2, turns=6)
+    expanded = _expand_compact_traces(payload)
+    kept = _expand_compact_traces(payload, expand_prompt_ids=False)
+    assert [t["trace_id"] for t in kept] == [t["trace_id"] for t in expanded]
+    # every non-root trace kept its ids as the step-form marker
+    marked = [t for t in kept if isinstance(t["prompt_token_ids"], dict)]
+    assert len(marked) == len(kept) - 2  # one full-list root per lineage
+    assert _resolve_marker_ids(kept) == [t["prompt_token_ids"] for t in expanded]
+
+
+def test_kept_delta_memory_is_linear_not_quadratic():
+    payload = _store_session(lineages=1, turns=40)
+    expanded = _expand_compact_traces(payload)
+    kept = _expand_compact_traces(payload, expand_prompt_ids=False)
+    n_expanded = sum(len(t["prompt_token_ids"]) for t in expanded)
+    n_kept = sum(len(t["prompt_token_ids"]["__prompt_ids_delta__"][1]) if isinstance(t["prompt_token_ids"], dict) else len(t["prompt_token_ids"]) for t in kept)
+    assert n_expanded > 5 * n_kept  # quadratic vs linear at 40 turns
+
+
+def test_chain_not_lineage_predecessor_rebases_to_full_list():
+    """Defensive path: a delta whose ancestor is not the lineage's previous
+    trace must be rebased to a full list, never kept as a broken marker."""
+    payload = {
+        "format": "compact",
+        "nodes": {"n1": {"p": None, "m": {"role": "user", "content": "x"}}},
+        "traces": [
+            {"trace_id": "a", "_tid": "a", "lineage_id": None, "messages_ref": ["n1", 1], "prompt_token_ids": [1, 2, 3], "response_message": {}},
+            {"trace_id": "b", "_tid": "b", "lineage_id": None, "messages_ref": ["n1", 1], "prompt_ids_delta": ["a", 3, [4]], "response_message": {}},
+            # c's chain ancestor is a, but its lineage predecessor is b
+            {"trace_id": "c", "_tid": "c", "lineage_id": None, "messages_ref": ["n1", 1], "prompt_ids_delta": ["a", 2, [9]], "response_message": {}},
+        ],
+    }
+    kept = _expand_compact_traces(payload, expand_prompt_ids=False)
+    assert kept[1]["prompt_token_ids"] == {"__prompt_ids_delta__": [3, [4]]}
+    assert kept[2]["prompt_token_ids"] == [1, 2, 9]  # rebased, exact
+
+
+def test_trace_record_to_step_keeps_marker_and_exact_length():
+    payload = _store_session(lineages=1, turns=4)
+    kept = _expand_compact_traces(payload, expand_prompt_ids=False)
+    expanded = _expand_compact_traces(payload)
+    for k, e in zip(kept, expanded, strict=True):
+        step = trace_record_to_step(TraceRecord.model_construct(**k))
+        assert step.prompt_len == len(e["prompt_token_ids"])  # exact, no expansion
+        if isinstance(k["prompt_token_ids"], dict):
+            assert step.prompt_delta is not None
+            assert step.model_output.prompt_ids is None  # nothing materialized
+            assert step.model_output.prompt_length == len(e["prompt_token_ids"])
+        else:
+            assert step.prompt_delta is None
+            assert list(step.prompt_ids) == list(e["prompt_token_ids"])
+
+
+def test_step_metrics_identical_both_forms():
+    payload = _store_session(lineages=1, turns=5)
+    mk = lambda traces: Trajectory(steps=[trace_record_to_step(TraceRecord.model_construct(**t)) for t in traces])  # noqa: E731
+    m_kept = compute_step_metrics([mk(_expand_compact_traces(payload, expand_prompt_ids=False))])
+    m_full = compute_step_metrics([mk(_expand_compact_traces(payload))])
+    assert m_kept == m_full
+
+
+def test_end_to_end_datums_identical_both_forms():
+    """THE gate: store → keep-mode fetch → steps → packed datums must equal
+    the expanded-path datums exactly. The expansion exists only as this
+    reference."""
+    tinker = pytest.importorskip("tinker")  # noqa: F841
+    from rllm.trainer.tinker.transform import trajectory_to_datums
+
+    payload = _store_session(lineages=2, turns=6)
+
+    def datums(expand):
+        traces = _expand_compact_traces(payload, expand_prompt_ids=expand)
+        steps = [trace_record_to_step(TraceRecord.model_construct(**t)) for t in traces]
+        for s in steps:
+            s.advantage = 0.5
+        return trajectory_to_datums(Trajectory(steps=steps))
+
+    ref, new = datums(True), datums(False)
+    assert len(ref) == len(new) == 2  # one packed datum per lineage
+    for a, b in zip(ref, new, strict=True):
+        assert list(a.model_input.to_ints()) == list(b.model_input.to_ints())
+        for key in a.loss_fn_inputs:
+            assert list(a.loss_fn_inputs[key].data) == list(b.loss_fn_inputs[key].data), key


### PR DESCRIPTION
The content currently on this branch is from a discarded design iteration and is NOT current. Per the redesign plan documented on #871, this slot is reserved for the final PR of the stack: peripheral readers — episode writers/dumps (suffix-native, expander only for legacy export), delta-aware step metrics and buffer segment estimation, per-lineage visualization replay, and a clear gate on distillation. Do not review the current diff.