### PR TITLE
gateway: preserve lone-surrogate JSON strings

### DIFF
--- a/rllm-model-gateway/src/rllm_model_gateway/fastjson.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/fastjson.py
@@ -5,15 +5,33 @@ concurrency JSON (de)serialization is the gateway event loop's dominant
 per-request CPU cost (see the loop-health monitor). All helpers return/accept
 ``bytes`` (orjson-native); callers that need ``str`` decode explicitly.
 
-``dumps``/``dumps_sorted`` fall back to the stdlib on any type orjson can't
-serialize natively (with ``default=str``), so swapping in this module never
-changes *which* payloads serialize successfully — only how fast.
+The stdlib fallback accepts lone surrogate escapes that ``orjson`` rejects and
+escapes them again on output. It still rejects non-finite constants and float
+overflow, so only surrogate handling broadens accepted input.
 """
 
 from __future__ import annotations
 
 import json as _json
+import math
 from typing import Any
+
+
+def _dumps_stdlib(obj: Any, *, sort_keys: bool = False) -> bytes:
+    rendered = _json.dumps(obj, sort_keys=sort_keys, ensure_ascii=False, allow_nan=False, default=str)
+    return rendered.encode("utf-8", errors="backslashreplace")
+
+
+def _reject_nonfinite(value: str) -> None:
+    raise ValueError(f"non-finite number is not valid JSON: {value}")
+
+
+def _parse_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        _reject_nonfinite(value)
+    return parsed
+
 
 try:
     import orjson
@@ -25,29 +43,32 @@ try:
         try:
             return orjson.dumps(obj)
         except TypeError:
-            return _json.dumps(obj, ensure_ascii=False, default=str).encode("utf-8")
+            return _dumps_stdlib(obj)
 
     def dumps_sorted(obj: Any) -> bytes:
         """Serialize *obj* with sorted keys (stable) to UTF-8 JSON bytes."""
         try:
             return orjson.dumps(obj, option=_OPT_SORT)
         except TypeError:
-            return _json.dumps(obj, sort_keys=True, ensure_ascii=False, default=str).encode("utf-8")
+            return _dumps_stdlib(obj, sort_keys=True)
 
     def loads(data: bytes | str) -> Any:
-        return orjson.loads(data)
+        try:
+            return orjson.loads(data)
+        except orjson.JSONDecodeError:
+            return _json.loads(data, parse_constant=_reject_nonfinite, parse_float=_parse_float)
 
     HAVE_ORJSON = True
 
 except ImportError:  # pragma: no cover - orjson is a declared dep; fallback for safety
 
     def dumps(obj: Any) -> bytes:
-        return _json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        return _dumps_stdlib(obj)
 
     def dumps_sorted(obj: Any) -> bytes:
-        return _json.dumps(obj, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        return _dumps_stdlib(obj, sort_keys=True)
 
     def loads(data: bytes | str) -> Any:
-        return _json.loads(data)
+        return _json.loads(data, parse_constant=_reject_nonfinite, parse_float=_parse_float)
 
     HAVE_ORJSON = False

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import gc
+import json
 import logging
 import os
 import uuid
@@ -25,6 +26,14 @@ from rllm_model_gateway.session_router import SessionRouter
 from rllm_model_gateway.store.base import TraceStore
 
 logger = logging.getLogger(__name__)
+
+
+class SurrogateSafeJSONResponse(JSONResponse):
+    """Render the stdlib JSON dialect while escaping lone surrogates."""
+
+    def render(self, content: Any) -> bytes:
+        rendered = json.dumps(content, ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+        return rendered.encode("utf-8", errors="backslashreplace")
 
 
 # ------------------------------------------------------------------
@@ -208,7 +217,7 @@ def create_app(
         await proxy.stop()
         await store.close()
 
-    app = FastAPI(title="rllm-model-gateway", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(title="rllm-model-gateway", version="0.1.0", lifespan=lifespan, default_response_class=SurrogateSafeJSONResponse)
 
     # -- Middleware ---------------------------------------------------------
 

--- a/rllm-model-gateway/tests/unit/test_strict_json_bodies.py
+++ b/rllm-model-gateway/tests/unit/test_strict_json_bodies.py
@@ -1,0 +1,73 @@
+"""Lone surrogate escapes must survive the gateway intact.
+
+JSON.stringify emits ``\\ud83d`` as pure ASCII whenever a string is sliced
+through an astral character, e.g. truncated tool output. orjson rejects it,
+but the stdlib and inference workers preserve it.
+"""
+
+import json
+
+import httpx
+import pytest
+from rllm_model_gateway import GatewayConfig, create_app, fastjson
+
+from tests.helpers.gateway_server import GatewayServer
+
+SURROGATE_BODY = '{"model":"mock-model","messages":[{"role":"user","content":"tool out \\ud83d"}]}'
+
+
+def test_surrogate_round_trip_matches_the_stdlib():
+    body = '{"c":"x \\ud83d"}'
+    assert json.loads(fastjson.dumps(fastjson.loads(body))) == json.loads(body)
+
+
+@pytest.mark.parametrize("body", ['{"c":NaN}', '{"c":Infinity}', '{"c":-Infinity}', '{"c":1e400}'])
+def test_load_fallback_does_not_accept_nonfinite_numbers(body):
+    with pytest.raises(ValueError):
+        fastjson.loads(body)
+
+
+def test_malformed_bodies_still_raise():
+    with pytest.raises(ValueError):
+        fastjson.loads("not json")
+
+
+def test_dumps_round_trips_a_lone_surrogate():
+    """orjson refuses to emit one and UTF-8 cannot encode it, so the stdlib
+    fallback must escape rather than raise (dumps_sorted keys message identity)."""
+    payload = {"content": "x \ud83d"}
+    for dump in (fastjson.dumps, fastjson.dumps_sorted):
+        assert json.loads(dump(payload)) == payload
+
+
+@pytest.fixture
+def gateway(mock_vllm):
+    config = GatewayConfig(
+        store_worker="memory",
+        workers=[{"url": f"{mock_vllm.url}/v1", "worker_id": "w0"}],
+        health_check_interval=999,
+        sync_traces=True,
+    )
+    server = GatewayServer(create_app(config), port=0)
+    server.start()
+    yield server
+    server.stop()
+
+
+def test_surrogate_body_is_traced_and_readable(gateway, mock_vllm):
+    """End to end: the trace keeps its conversation, and reading it back works
+    (Starlette's default renderer 500s on the stored surrogate)."""
+    posted = httpx.post(
+        f"{gateway.url}/sessions/s/v1/chat/completions",
+        content=SURROGATE_BODY.encode(),
+        headers={"content-type": "application/json"},
+        timeout=30.0,
+    )
+    assert posted.status_code == 200
+    expected = [{"role": "user", "content": "tool out \ud83d"}]
+    assert mock_vllm.request_log[-1]["messages"] == expected
+
+    traces = httpx.get(f"{gateway.url}/sessions/s/traces", timeout=30.0)
+    assert traces.status_code == 200
+    assert b"\\ud83d" in traces.content
+    assert traces.json()[0]["messages"] == expected


### PR DESCRIPTION
## The bug

orjson rejects lone surrogate escapes; the stdlib — and the inference workers we forward to — accept them.

`orjson.JSONDecodeError` subclasses `ValueError`, so both parse sites (`middleware.py`, `proxy.handle`) swallow the failure and substitute an empty dict. **But the raw bytes still go upstream**, where vLLM parses them and answers normally, so the persist gate is true and `messages=request_body.get("messages", [])` yields `[]`.

The stored trace has a **real response and an empty conversation**. That combination passes `is_empty_response_trace` (which requires response_message, finish_reason and completion ids to *all* be empty), so it becomes a training step whose prompt is silently missing. No error, no warning, no log line.

`JSON.stringify` emits a lone surrogate as **pure-ASCII** `\ud83d` whenever a string is sliced through an astral character — confirmed on node v22.13.1. That is what width-limited truncation of terminal/tool output produces, and every Node-based CLI harness (opencode, codex, qwen-code, kimi-cli, claude-code) posts through the gateway.

In cumulative-token mode it also cascades: `messages == []` classifies as PREFIX_CHANGED, so the session forks a new lineage with `turn_count = 0`, the turn is never bridged, and the *next* turn bridges off stale tokens — dropping a whole turn from `prompt_token_ids`.

## The fix

**Parsing** — `fastjson.loads` falls back to the stdlib parser when orjson rejects a body, so the gateway and the worker agree on what a body said. The parser does not edit its input: the trace records what the client actually sent.

**Scope: surrogates only.** Non-finite constants (`NaN`, `±Infinity`) and float overflow (`1e400`) stay **rejected**, via `parse_constant`/`parse_float`. Accepting them would be worse than rejecting: the middleware reserializes the parsed body through orjson, which emits non-finite floats as `null`, silently rewriting both the worker-visible request and the stored trace. And no JSON dialect our consumers read can represent them, so a trace response carrying `NaN` would be invalid JSON and break strict readers such as `rllm view`. Behavior for these inputs is unchanged from today.

**Serializing** — storing a surrogate faithfully exposes a second, pre-existing defect: Starlette's `JSONResponse.render` uses `ensure_ascii=False`, which cannot encode an unpaired surrogate, so reading the traces back returns **500**. `SurrogateSafeJSONResponse` encodes with `backslashreplace`: one serialization pass (no double render of large trace payloads), and `\ud83d` is a valid JSON escape, so content stays **byte-exact** and unrelated Unicode is not escaped. The `dumps` fallbacks in `fastjson` carried the same latent `UnicodeEncodeError` and are fixed on **both** the orjson and no-orjson paths.

## Verification

`test_strict_json_bodies.py` (8 tests): surrogate round-trip parity with the stdlib; `NaN`/`Infinity`/`-Infinity`/`1e400` all raise; malformed bodies still raise; `dumps`/`dumps_sorted` round-trip a surrogate; and end-to-end through a real gateway + mock worker — the worker receives the surrogate intact, and the trace read returns 200 with `\ud83d` escaped in the wire bytes.

| | before | after |
|---|---|---|
| `trace["messages"]` | `[]` | the user turn, byte-exact |
| worker-visible `messages` | `[]` | the user turn, byte-exact |
| `GET /sessions/{sid}/traces` | 500 `UnicodeEncodeError` | 200 |
| `NaN` / `Infinity` body | rejected | rejected (unchanged) |

Also verified by loading `fastjson` with orjson forced unavailable: `HAVE_ORJSON=False`, both dump helpers escape the surrogate and round-trip, and non-finite input is rejected identically.

**No regressions.** Gateway unit suite: baseline `42 failed, 153 passed` → `42 failed, 161 passed`; identical failures, all pre-existing (`test_concurrent_sessions`/`test_error_resilience`/`test_server` additionally fail to import because `pytest_asyncio` is absent from the venv). Ruff format/check and `git diff --check` clean.

Note: the gateway test workflow triggers on PRs into `main`, so only Pre-commit ran here.

## Has this actually corrupted data? No — searched, and not found

Stated plainly, because it changes how you should weigh this PR: **this is a code-audit finding, not an incident.** I searched every saved artifact on the training machine — 155 GB of `eval_results` and 118 GB of `train_batches`, 8,725 files carrying `chat_completions` (5,898 eval + 2,827 train):

- **Corruption fingerprint — 0 hits.** The bug leaves a detectable mark: a step with an empty conversation *but a real response*. 1,319 files do contain `"chat_completions": []`, and every one is benign — episodes that made no LLM call at all (`prompt_ids=0, response_ids=0, model_response=none`, mostly `env_done`). Not one has an empty conversation alongside a real response.
- **Truncation premise — 0 hits.** Zero *unpaired* surrogates anywhere in either tree. The only surrogate escapes found (117, all in one file) are well-formed pairs — `\ud83d\udc7e`, `\ud83d\ude04` — inside the source fixtures of a `superjson-error-stack-serialization` task, i.e. emoji written as escapes in JavaScript test code, not truncated output.

So the failure mode is reachable in code and reproducible in a test, but there is no evidence it has ever fired here. Note the fingerprint *is* detectable — a corrupted trace keeps its response — so the zero above is evidence of absence, not merely absence of evidence.

The case for merging anyway is that the fix is three lines on a path that only executes when orjson has already failed, the fast path is untouched, and the failure it prevents is silent and produces a training example that looks structurally valid. Cheap insurance against an expensive-to-detect failure. It should be read as preventative hardening, not as a response to known-bad data.

## Found by

An adversarial multi-agent audit of the claim "a persisted TraceRecord always carries its conversation". The same audit surfaced separate issues left for their own PRs: session `sampling_params` can overwrite `messages` (no key whitelist in `_mutate`), a replay against a failing upstream overwrites a good trace in place, and streaming vs non-streaming disagree on which failures get persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
