### PR TITLE
Support SFT chat template kwargs

### DIFF
--- a/rllm/renderers/registry.py
+++ b/rllm/renderers/registry.py
@@ -17,6 +17,7 @@ This resolution is used by both the gateway (turns 1+ bridge) and FireworksEngin
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -94,7 +95,12 @@ def _infer_model_name(model: str | None, tokenizer: Any) -> str:
     return model or getattr(tokenizer, "name_or_path", "") or ""
 
 
-def _try_prime(tokenizer: Any, family: str) -> Any | None:
+def _try_prime(
+    tokenizer: Any,
+    family: str,
+    *,
+    chat_template_kwargs: Mapping[str, Any] | None = None,
+) -> Any | None:
     """prime-rl native renderer, or None if it falls back to DefaultRenderer."""
     try:
         import renderers as prime_renderers  # type: ignore
@@ -102,7 +108,11 @@ def _try_prime(tokenizer: Any, family: str) -> Any | None:
         return None
 
     config = prime_renderers.config_from_name(family)
-    renderer = prime_renderers.create_renderer(tokenizer, config)
+    renderer = prime_renderers.create_renderer(
+        tokenizer,
+        config,
+        chat_template_kwargs=chat_template_kwargs,
+    )
     if type(renderer).__name__ == "DefaultRenderer":
         return None
     return renderer
@@ -144,6 +154,7 @@ def resolve(
     backend: Backend | str | None = None,
     family: str = "auto",
     renderer_name: str | None = None,
+    chat_template_kwargs: Mapping[str, Any] | None = None,
 ) -> RendererResolution:
     name = _infer_model_name(model, tokenizer)
 
@@ -153,7 +164,7 @@ def resolve(
     if renderer_name:
         prime_family = _PRIME_FAMILY_ALIASES.get(renderer_name)
         if prime_family:
-            renderer = _try_prime(tokenizer, prime_family)
+            renderer = _try_prime(tokenizer, prime_family, chat_template_kwargs=chat_template_kwargs)
             if renderer is not None:
                 return RendererResolution(renderer, "prime", prime_family)
         return RendererResolution(
@@ -164,13 +175,13 @@ def resolve(
 
     # 1b. Explicit prime-rl family.
     if family and family != "auto":
-        renderer = _try_prime(tokenizer, family)
+        renderer = _try_prime(tokenizer, family, chat_template_kwargs=chat_template_kwargs)
         if renderer is not None:
             return RendererResolution(renderer, "prime", family)
         logger.warning("prime-rl family=%r did not resolve a native renderer; continuing auto-resolution.", family)
 
     # 2. prime-rl native by exact model match.
-    renderer = _try_prime(tokenizer, "auto")
+    renderer = _try_prime(tokenizer, "auto", chat_template_kwargs=chat_template_kwargs)
     if renderer is not None:
         return RendererResolution(renderer, "prime", type(renderer).__name__)
 

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -94,15 +94,21 @@ def build_sft_data(config, train_data, val_data):
     # Training and serving resolve through the same production renderer layer
     # with the same template-faithful history policy.
     explicit = config.data.get("renderer_name", None)
+    chat_template_kwargs = config.data.get("chat_template_kwargs", None)
     try:
         if explicit:
             resolution = resolve(
                 tokenizer_name,
                 tokenizer,
                 renderer_name=explicit,
+                chat_template_kwargs=chat_template_kwargs,
             )
         else:
-            resolution = resolve(tokenizer_name, tokenizer)
+            resolution = resolve(
+                tokenizer_name,
+                tokenizer,
+                chat_template_kwargs=chat_template_kwargs,
+            )
     except Exception as e:  # noqa: BLE001 - surface renderer setup as config
         raise SFTConfigError(f"Could not initialize SFT renderer for {tokenizer_name!r}: {e}") from e
     _guard_renderer_capability(resolution.name, resolution.source, train_data)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -319,7 +319,7 @@ def test_resolve_legacy_name_through_pinned_typed_factory(monkeypatch, renderer_
         "renderers",
         SimpleNamespace(
             config_from_name=config_from_name,
-            create_renderer=lambda tokenizer, renderer_config: calls.append((tokenizer, renderer_config)) or NativeRenderer(),
+            create_renderer=lambda tokenizer, renderer_config, **_kwargs: calls.append((tokenizer, renderer_config)) or NativeRenderer(),
         ),
     )
     tokenizer = object()
@@ -329,6 +329,33 @@ def test_resolve_legacy_name_through_pinned_typed_factory(monkeypatch, renderer_
     assert result.source == "prime"
     assert lookups == [prime_name]
     assert calls == [(tokenizer, config)]
+
+
+def test_resolve_passes_chat_template_kwargs_to_prime_renderer(monkeypatch):
+    calls = []
+    config = object()
+
+    class NativeRenderer: ...
+
+    monkeypatch.setitem(
+        sys.modules,
+        "renderers",
+        SimpleNamespace(
+            config_from_name=lambda _name: config,
+            create_renderer=lambda tokenizer, renderer_config, *, chat_template_kwargs=None: calls.append((tokenizer, renderer_config, chat_template_kwargs)) or NativeRenderer(),
+        ),
+    )
+    tokenizer = object()
+
+    result = resolve(
+        "model",
+        tokenizer,
+        renderer_name="nemotron3",
+        chat_template_kwargs={"truncate_history_thinking": False},
+    )
+
+    assert result.source == "prime"
+    assert calls == [(tokenizer, config, {"truncate_history_thinking": False})]
 
 
 def test_resolve_prime_native_for_qwen(qwen_tokenizer):

--- a/tests/trainer/test_sft_dispatcher.py
+++ b/tests/trainer/test_sft_dispatcher.py
@@ -77,8 +77,9 @@ def test_output_dir_and_checkpoint_dir():
 
 
 def test_overrides_escape_hatch():
-    cfg = TinkerSFTBackend(_spec(overrides={"data": {"renderer_name": "qwen3"}})).build_config()
+    cfg = TinkerSFTBackend(_spec(overrides={"data": {"renderer_name": "qwen3", "chat_template_kwargs": {"enable_thinking": True}}})).build_config()
     assert cfg.data.renderer_name == "qwen3"
+    assert cfg.data.chat_template_kwargs.enable_thinking is True
 
 
 def test_validate_spec_accepts_messages():
@@ -162,6 +163,38 @@ def test_build_sft_data_rejects_structured_chat_template_fallback(monkeypatch):
     for train_data, val_data in ((structured, None), (_ds(), structured)):
         with pytest.raises(SFTConfigError, match="cannot represent reasoning"):
             build_sft_data(config, train_data, val_data)
+
+
+def test_build_sft_data_passes_chat_template_kwargs(monkeypatch):
+    config = OmegaConf.create(
+        {
+            "model": {"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"},
+            "data": {
+                "renderer_name": "nemotron3",
+                "chat_template_kwargs": {"truncate_history_thinking": False},
+                "rllm": {"tokenize_and_mask_method": "cumulative"},
+            },
+        }
+    )
+    captured = {}
+    renderer = object()
+
+    monkeypatch.setattr("tinker_cookbook.tokenizer_utils.get_tokenizer", lambda _: object())
+
+    def fake_resolve(*_args, **kwargs):
+        captured["chat_template_kwargs"] = kwargs.get("chat_template_kwargs")
+        return SimpleNamespace(renderer=renderer, name="nemotron-3", source="prime")
+
+    monkeypatch.setattr("rllm.renderers.resolve", fake_resolve)
+    monkeypatch.setattr(
+        "rllm.trainer.sft.tinker_dataset.create_tinker_sft_datasets",
+        lambda **kwargs: (kwargs["renderer"], None),
+    )
+
+    _, train_dataset, _ = build_sft_data(config, _ds(), None)
+
+    assert train_dataset is renderer
+    assert captured["chat_template_kwargs"] == {"truncate_history_thinking": False}
 
 
 def test_dispatch_tinker_runs_lifecycle(monkeypatch):


### PR DESCRIPTION
## Summary

- add reusable `data.chat_template_kwargs` configuration to hosted SFT
- pass template kwargs through renderer resolution to native Prime renderers

## Why

Native chat templates can define training-relevant history policies, such as Nemotron's `truncate_history_thinking`. The hosted SFT configuration previously selected the native renderer but could not pass its template kwargs, so users could not explicitly preserve historical reasoning during rendering.

This keeps the existing behavior unchanged when the mapping is omitted while allowing Tinker and Fireworks user configurations such as:

```yaml
data:
  renderer_name: nemotron3
  chat_template_kwargs:
    truncate_history_thinking: false
```

This PR only changes SFT/preflight rendering. It does not change `rllm eval` inference requests.

## Validation

- `pytest tests/test_renderers.py tests/trainer/test_sft_dispatcher.py -q -k 'not verl'` (`48 passed, 9 skipped, 7 deselected`)
- the two new regression tests plus config-merge coverage directly (`3 passed`)
- Ruff check and format check on changed Python files
- `git diff --check origin/terminal-rl...HEAD`

The four excluded Verl tests cannot compose `verl.trainer.config` in this environment because Verl is only partially installed; they are unrelated to this change.
