### PR TITLE
eval: run Harbor agents (OpenHands) on remote sandboxes end-to-end [tracking]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ code-tools = [
 ]
 
 harbor = [
-    "harbor==0.3.0 ; python_version >= '3.12'",
+    "harbor==0.21.0 ; python_version >= '3.12'",
 ]
 
 [tool.uv.sources]

--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -306,6 +306,15 @@ class EvalProxyManager(_ProxyManagerBase):
 
         def _monitor() -> None:
             rc = proc.wait()  # blocks until the proxy process exits
+            # A terminal Ctrl+C signals the whole foreground process group, so
+            # the proxy usually exits (cleanly, code 0) BEFORE the parent's
+            # interrupt handling reaches shutdown_proxy() and sets the flag.
+            # Give teardown a moment to declare itself before alarming.
+            deadline = time.monotonic() + 3.0
+            while not getattr(self, "_shutting_down", False):
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(0.05)
             if getattr(self, "_shutting_down", False):
                 return  # expected teardown at end of run
             tail = self._read_stderr_tail(max_lines=60)

--- a/rllm/integrations/harbor/runtime.py
+++ b/rllm/integrations/harbor/runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import Any
 
 from rllm.env import env_float
@@ -24,6 +25,13 @@ from rllm.integrations.harbor.trial_helper import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_SESSION_TIMEOUT_S = env_float("RLLM_HARBOR_SESSION_TIMEOUT_S", 900.0)  # set env var: export RLLM_HARBOR_SESSION_TIMEOUT_S=xxx
+
+
+def _sanitize_trial_name(name: str) -> str:
+    """Harbor uses trial_name as the environment session id; Modal rejects the
+    ``:`` in rLLM's ``<task_id>:<attempt>``. Same character class rLLM already
+    applies to its own sandbox names (eval/_resolution.py)."""
+    return re.sub(r"[^a-zA-Z0-9_.-]", "-", name)
 
 
 class HarborRuntime:
@@ -122,7 +130,7 @@ class HarborRuntime:
             verifier_timeout_multiplier=self.verifier_timeout_multiplier,
             agent_setup_timeout_multiplier=self.agent_setup_timeout_multiplier,
             environment_build_timeout_multiplier=self.environment_build_timeout_multiplier,
-            trial_name=trial_name,
+            trial_name=_sanitize_trial_name(trial_name),
             timeout=timeout,
         )
 

--- a/rllm/integrations/harbor/runtime.py
+++ b/rllm/integrations/harbor/runtime.py
@@ -49,6 +49,14 @@ class HarborRuntime:
     # Used by run_dataset / Runner to cap concurrency.
     max_concurrent: int = 64
 
+    # Harbor installed agents run their LLM client INSIDE the sandbox, so the
+    # engine must hand them the publicly-reachable gateway URL (the tunnel on
+    # remote backends). Without this the default host-local URL gets the
+    # docker-only host.docker.internal rewrite, which does not resolve on
+    # modal/daytona/e2b — the agent fails its first LLM call with
+    # "OpenAIException - Connection error".
+    llm_inside_env: bool = True
+
     def __init__(
         self,
         agent_name: str = "mini-swe-agent",

--- a/rllm/integrations/harbor/trial_helper.py
+++ b/rllm/integrations/harbor/trial_helper.py
@@ -104,6 +104,29 @@ def _infer_provider_prefix(model_name: str) -> str:
     return f"openai/{model_name}"
 
 
+def _litellm_routable(model_name: str) -> str:
+    """Make *model_name* parseable by the litellm inside the Harbor agent.
+
+    litellm reads the text before the first "/" as the provider. Served model
+    names like ``nvidia/nemotron-3-ultra-550b-a55b`` carry a first segment that
+    is NOT a litellm provider, so the agent fails before making any request
+    ("LLM Provider NOT provided"). Wrapping as ``openai/<name>`` routes the
+    call to ``LLM_BASE_URL`` (rLLM's proxy/tunnel) with the FULL name on the
+    wire — which is exactly the name the proxy serves. Names whose first
+    segment is a real provider (``anthropic/``, ``openai/``, ...) keep their
+    existing routing.
+    """
+    if "/" not in model_name:
+        return _infer_provider_prefix(model_name)
+    first = model_name.split("/", 1)[0]
+    try:
+        from litellm import provider_list
+    except ImportError:  # litellm always ships with the eval extra; be safe
+        return model_name
+    known = {str(getattr(p, "value", p)) for p in provider_list}
+    return model_name if first in known else f"openai/{model_name}"
+
+
 def build_harbor_trial_config(
     task_path: str,
     agent_name: str,
@@ -150,9 +173,9 @@ def build_harbor_trial_config(
         TrialConfig,
     )
 
-    # Ensure model_name has provider/ prefix (Harbor agents require it)
-    if model_name and "/" not in model_name:
-        model_name = _infer_provider_prefix(model_name)
+    # Ensure model_name is litellm-routable (Harbor agents call through litellm)
+    if model_name:
+        model_name = _litellm_routable(model_name)
 
     env: dict[str, str] = {}
     if inference_url:

--- a/tests/eval/test_proxy_shutdown_race.py
+++ b/tests/eval/test_proxy_shutdown_race.py
@@ -1,0 +1,56 @@
+"""The proxy monitor must not report a death for a Ctrl+C teardown.
+
+A terminal SIGINT reaches the whole foreground process group, so the LiteLLM
+proxy child usually exits (cleanly, code 0) before the parent's interrupt
+handling calls shutdown_proxy() and sets _shutting_down — which made the
+monitor print its 🚨 PROXY DIED banner on every user interrupt.
+"""
+
+import logging
+import threading
+import time
+
+from rllm.eval.proxy import EvalProxyManager
+
+
+class _ExitedProc:
+    """Stub for a proxy process that has already exited cleanly."""
+
+    def wait(self):
+        return 0
+
+
+def _manager_with_stub() -> EvalProxyManager:
+    mgr = EvalProxyManager.__new__(EvalProxyManager)  # skip real startup
+    mgr._proxy_process = _ExitedProc()
+    mgr._read_stderr_tail = lambda max_lines=60: ""
+    return mgr
+
+
+def _run_monitor(mgr) -> None:
+    mgr._start_proxy_monitor()
+    for t in threading.enumerate():
+        if t.name == "rllm-proxy-monitor":
+            t.join(timeout=10.0)
+
+
+def test_interrupt_teardown_is_not_reported_as_death(caplog):
+    """Flag set shortly AFTER the child exits — the Ctrl+C ordering."""
+    mgr = _manager_with_stub()
+
+    def late_shutdown():
+        time.sleep(0.3)
+        mgr._shutting_down = True
+
+    threading.Thread(target=late_shutdown).start()
+    with caplog.at_level(logging.ERROR, logger="rllm.eval.proxy"):
+        _run_monitor(mgr)
+    assert "PROXY DIED" not in caplog.text
+
+
+def test_genuine_death_is_still_reported(caplog):
+    """No teardown ever declared — the banner must still fire."""
+    mgr = _manager_with_stub()
+    with caplog.at_level(logging.ERROR, logger="rllm.eval.proxy"):
+        _run_monitor(mgr)
+    assert "PROXY DIED" in caplog.text

--- a/tests/integrations/test_harbor_model_prefix.py
+++ b/tests/integrations/test_harbor_model_prefix.py
@@ -1,0 +1,37 @@
+"""Model names handed to Harbor agents must be parseable by litellm.
+
+The agent inside the sandbox calls the model through litellm, which reads the
+text before the first "/" as the provider. A served name like
+``nvidia/nemotron-3-ultra-550b-a55b`` fails before any request is made:
+
+    litellm.BadRequestError: LLM Provider NOT provided. ...
+    You passed model=nvidia/nemotron-3-ultra-550b-a55b
+
+Wrapping as ``openai/<name>`` routes to LLM_BASE_URL (rLLM's proxy/tunnel)
+with the full name on the wire — the exact name the proxy serves.
+"""
+
+from rllm.integrations.harbor.trial_helper import MODEL_PLACEHOLDER, _litellm_routable
+
+
+def test_unknown_provider_prefix_is_wrapped():
+    assert _litellm_routable("nvidia/nemotron-3-ultra-550b-a55b") == "openai/nvidia/nemotron-3-ultra-550b-a55b"
+
+
+def test_known_provider_prefixes_are_untouched():
+    for name in ("anthropic/claude-sonnet-4-6", "openai/gpt-4o", "openrouter/qwen/qwen3-coder", "hosted_vllm/my-model"):
+        assert _litellm_routable(name) == name
+
+
+def test_wrapping_is_idempotent():
+    once = _litellm_routable("nvidia/nemotron-3-ultra-550b-a55b")
+    assert _litellm_routable(once) == once
+
+
+def test_bare_names_keep_the_existing_inference():
+    assert _litellm_routable("claude-sonnet-4-6") == "anthropic/claude-sonnet-4-6"
+    assert _litellm_routable("my-local-model") == "openai/my-local-model"
+
+
+def test_training_placeholder_is_untouched():
+    assert _litellm_routable(MODEL_PLACEHOLDER) == MODEL_PLACEHOLDER

--- a/tests/integrations/test_harbor_runtime_flags.py
+++ b/tests/integrations/test_harbor_runtime_flags.py
@@ -1,0 +1,15 @@
+"""HarborRuntime must ask the engine for the publicly-reachable gateway URL.
+
+Harbor installed agents run their LLM client inside the sandbox. The engine
+keys this off ``llm_inside_env`` (agentflow_engine.py); without it the agent
+env gets the host-local URL with the docker-only ``host.docker.internal``
+rewrite, which does not resolve on modal/daytona/e2b — every task fails its
+first LLM call with "OpenAIException - Connection error".
+"""
+
+from rllm.integrations.harbor.runtime import HarborRuntime
+
+
+def test_harbor_agents_declare_llm_inside_env():
+    assert HarborRuntime.llm_inside_env is True
+    assert HarborRuntime(agent_name="openhands-sdk").llm_inside_env is True

--- a/tests/integrations/test_harbor_trial_name.py
+++ b/tests/integrations/test_harbor_trial_name.py
@@ -1,0 +1,29 @@
+"""Harbor trial names must satisfy Modal's sandbox naming rule.
+
+rLLM session ids are ``<task_id>:<attempt>``; Modal rejects the colon, so every
+trial failed at sandbox creation. Harbor's Docker backend sanitizes internally
+and hid the problem.
+"""
+
+import re
+
+from rllm.integrations.harbor.runtime import _sanitize_trial_name
+
+# Modal's rule, quoted from its InvalidError message.
+MODAL_ALLOWED = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+
+def test_reported_failure_is_fixed():
+    sid = "django__django-14534:0"  # from a swebench-verified run that failed
+    assert not MODAL_ALLOWED.match(sid)
+    assert _sanitize_trial_name(sid) == "django__django-14534-0"
+
+
+def test_attempts_stay_distinct():
+    """Retries must not collide onto one sandbox name."""
+    assert len({_sanitize_trial_name(f"t:{i}") for i in range(3)}) == 3
+
+
+def test_safe_names_are_unchanged():
+    for name in ("swebench-verified", "task_1.2-3"):
+        assert _sanitize_trial_name(name) == name


### PR DESCRIPTION
**Tracking PR — not intended to merge as-is.** Consolidates the full chain of fixes needed to run `rllm eval harbor:swebench-verified --agent harbor:openhands-sdk --sandbox-backend modal` end-to-end. Each fix was found by running the pipeline, hitting the next failure, and diagnosing it live; each one unmasked the next.

| # | failure (observed live) | fix | commit |
|---|---|---|---|
| 1 | Modal rejects every sandbox: `InvalidError: Invalid Sandbox name: 'django__django-14534:0'` — rLLM session ids carry `:`, Harbor's Modal env passes them raw to `Sandbox.create(name=)`; its Docker env sanitizes internally, which hid this | sanitize `trial_name` in `HarborRuntime._run_one` with the char class rLLM's own sandbox path already uses; nothing anywhere parses the id back on `:` (`Episode.task_id`/`rollout_idx` split `config.session_uid`, which is untouched) | d6eb1066 |
| 2 | OpenHands-SDK can't install: `ERROR: Ignored the following versions that require a different python version: ... Requires-Python >=3.12` — harbor 0.3.0 installs the SDK with the task image's own python; SWE-bench images ship 3.6–3.8 | bump harbor 0.3.0 → 0.21.0, which installs via uv with a managed Python 3.12; full rLLM import surface verified compatible | a2dd8e37 |
| 3 | Agent dies before any request: `litellm.BadRequestError: LLM Provider NOT provided. You passed model=nvidia/nemotron-3-ultra-550b-a55b` — litellm inside the sandbox parses the first path segment as a provider; `nvidia` isn't one | wrap served names whose first segment isn't in `litellm.provider_list` as `openai/<name>` → routes to `LLM_BASE_URL` with the full name on the wire, exactly what the proxy serves | b648b2c9 |
| 4 | Agent calls a dead host: `OpenAIException - Connection error`, agent env recorded `LLM_BASE_URL=http://host.docker.internal:54668/...` while the ngrok tunnel sat unused — `HarborRuntime` never declared `llm_inside_env`, so the engine handed it the host-local URL and the docker-only rewrite | declare `llm_inside_env = True` (as `cli_harness.py` does); remote backends now get the public tunnel URL, docker unchanged | bb9d8d91 |
| 5 | Every user Ctrl+C prints `🚨 LITELLM PROXY DIED MID-RUN (exit code 0)` — terminal SIGINT reaches the proxy child before the parent sets `_shutting_down` | monitor gives teardown a 3s grace window; genuine deaths still alarm | efdee1c6 |

Known-remaining upstream issue (not fixable here): harbor 0.21.0 *still* passes the raw session id as the Modal sandbox name, so fix 1 stays necessary at the rLLM layer regardless of harbor version.

Tests: 11 passing across the chain (trial-name sanitization, model-prefix routing, `llm_inside_env` contract, proxy shutdown race).

Supersedes #883, #884, #885, #886 (closed, kept for per-fix discussion history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)