### PR TITLE
eval: don't report a Ctrl+C teardown as a proxy death

### DIFF
--- a/rllm/eval/proxy.py
+++ b/rllm/eval/proxy.py
@@ -306,6 +306,15 @@ class EvalProxyManager(_ProxyManagerBase):
 
         def _monitor() -> None:
             rc = proc.wait()  # blocks until the proxy process exits
+            # A terminal Ctrl+C signals the whole foreground process group, so
+            # the proxy usually exits (cleanly, code 0) BEFORE the parent's
+            # interrupt handling reaches shutdown_proxy() and sets the flag.
+            # Give teardown a moment to declare itself before alarming.
+            deadline = time.monotonic() + 3.0
+            while not getattr(self, "_shutting_down", False):
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(0.05)
             if getattr(self, "_shutting_down", False):
                 return  # expected teardown at end of run
             tail = self._read_stderr_tail(max_lines=60)

--- a/tests/eval/test_proxy_shutdown_race.py
+++ b/tests/eval/test_proxy_shutdown_race.py
@@ -1,0 +1,56 @@
+"""The proxy monitor must not report a death for a Ctrl+C teardown.
+
+A terminal SIGINT reaches the whole foreground process group, so the LiteLLM
+proxy child usually exits (cleanly, code 0) before the parent's interrupt
+handling calls shutdown_proxy() and sets _shutting_down — which made the
+monitor print its 🚨 PROXY DIED banner on every user interrupt.
+"""
+
+import logging
+import threading
+import time
+
+from rllm.eval.proxy import EvalProxyManager
+
+
+class _ExitedProc:
+    """Stub for a proxy process that has already exited cleanly."""
+
+    def wait(self):
+        return 0
+
+
+def _manager_with_stub() -> EvalProxyManager:
+    mgr = EvalProxyManager.__new__(EvalProxyManager)  # skip real startup
+    mgr._proxy_process = _ExitedProc()
+    mgr._read_stderr_tail = lambda max_lines=60: ""
+    return mgr
+
+
+def _run_monitor(mgr) -> None:
+    mgr._start_proxy_monitor()
+    for t in threading.enumerate():
+        if t.name == "rllm-proxy-monitor":
+            t.join(timeout=10.0)
+
+
+def test_interrupt_teardown_is_not_reported_as_death(caplog):
+    """Flag set shortly AFTER the child exits — the Ctrl+C ordering."""
+    mgr = _manager_with_stub()
+
+    def late_shutdown():
+        time.sleep(0.3)
+        mgr._shutting_down = True
+
+    threading.Thread(target=late_shutdown).start()
+    with caplog.at_level(logging.ERROR, logger="rllm.eval.proxy"):
+        _run_monitor(mgr)
+    assert "PROXY DIED" not in caplog.text
+
+
+def test_genuine_death_is_still_reported(caplog):
+    """No teardown ever declared — the banner must still fire."""
+    mgr = _manager_with_stub()
+    with caplog.at_level(logging.ERROR, logger="rllm.eval.proxy"):
+        _run_monitor(mgr)
+    assert "PROXY DIED" in caplog.text


### PR DESCRIPTION
A terminal SIGINT signals the whole foreground process group, so the LiteLLM proxy child usually exits (cleanly, code 0) **before** the parent's interrupt handling reaches `shutdown_proxy()` and sets `_shutting_down`. The monitor thread checked the flag immediately after `proc.wait()` returned, so every user Ctrl+C printed:

```
🚨🚨🚨 LITELLM PROXY DIED MID-RUN (exit code 0) 🚨🚨🚨
Every subsequent LLM call now returns EMPTY and all remaining rollouts score 0. THIS is why the run is failing.
```

— alarming, and wrong about why the run ended (observed live: clean startup, 200 health check, then the banner the instant the user interrupted).

Fix: the monitor gives teardown a 3-second grace window to declare itself before alarming. A genuine mid-run death never sets the flag, so it still alarms after the window — pinned by both tests (interrupt ordering stays silent; genuine death still fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)