### PR TITLE
deps: bump harbor 0.3.0 -> 0.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ code-tools = [
 ]
 
 harbor = [
-    "harbor==0.3.0 ; python_version >= '3.12'",
+    "harbor==0.21.0 ; python_version >= '3.12'",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Why

harbor 0.3.0's OpenHands-SDK agent installs itself with the **task image's own `python3`** (`python3 -m venv && pip install openhands-sdk`). SWE-bench task images pin the ancient interpreters their repos need (django tasks ship 3.6–3.8), and `openhands-sdk` requires **Python ≥3.12** — so on stock `swebench/sweb.eval.*` images the agent can never install, and every trial dies at setup with:

```
ERROR: Ignored the following versions that require a different python version: ... Requires-Python >=3.12
```

(observed live: all 500 swebench-verified tasks failing identically at agent setup)

0.21.0 installs the SDK via **uv with a managed interpreter** (`uv python install 3.12`, configurable via a new `python_version` kwarg) regardless of what the image ships — making `openhands-sdk` usable on stock SWE-bench images.

## Compatibility, verified against 0.21.0 installed

- Every harbor module rllm imports exists: `environments.base`, `models.agent.context`, `models.dataset.manifest`, `models.environment_type`, `models.task.task`, `models.trial.config`, `registry.client.factory`, `trial.trial`
- `TrialConfig` still carries `trial_name`/`task`/`agent`/`environment` and the timeout multipliers; `AgentName.OPENHANDS_SDK` registered; `EnvironmentType.MODAL` present
- Harbor registry dataset resolution works (`swebench-verified` resolves)
- rllm's harbor integration tests pass with 0.21.0 installed

(uv.lock is gitignored in this repo, so the pin is the whole diff.)

## Still needed on top

0.21.0 **still** passes the raw session id as the Modal sandbox name (`name=self.session_id` in its Modal environment), which Modal rejects when the id carries `:` — so the trial-name sanitization from #882 remains required. The two changes are complementary, not alternatives.

Not yet verified: a full task end-to-end on 0.21.0 (trajectory/ATIF format drift across 18 minor versions is the residual risk). Flagging rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)