### PR TITLE
harbor: make served model names litellm-routable for sandboxed agents

### DIFF
--- a/rllm/integrations/harbor/trial_helper.py
+++ b/rllm/integrations/harbor/trial_helper.py
@@ -104,6 +104,29 @@ def _infer_provider_prefix(model_name: str) -> str:
     return f"openai/{model_name}"
 
 
+def _litellm_routable(model_name: str) -> str:
+    """Make *model_name* parseable by the litellm inside the Harbor agent.
+
+    litellm reads the text before the first "/" as the provider. Served model
+    names like ``nvidia/nemotron-3-ultra-550b-a55b`` carry a first segment that
+    is NOT a litellm provider, so the agent fails before making any request
+    ("LLM Provider NOT provided"). Wrapping as ``openai/<name>`` routes the
+    call to ``LLM_BASE_URL`` (rLLM's proxy/tunnel) with the FULL name on the
+    wire — which is exactly the name the proxy serves. Names whose first
+    segment is a real provider (``anthropic/``, ``openai/``, ...) keep their
+    existing routing.
+    """
+    if "/" not in model_name:
+        return _infer_provider_prefix(model_name)
+    first = model_name.split("/", 1)[0]
+    try:
+        from litellm import provider_list
+    except ImportError:  # litellm always ships with the eval extra; be safe
+        return model_name
+    known = {str(getattr(p, "value", p)) for p in provider_list}
+    return model_name if first in known else f"openai/{model_name}"
+
+
 def build_harbor_trial_config(
     task_path: str,
     agent_name: str,
@@ -150,9 +173,9 @@ def build_harbor_trial_config(
         TrialConfig,
     )
 
-    # Ensure model_name has provider/ prefix (Harbor agents require it)
-    if model_name and "/" not in model_name:
-        model_name = _infer_provider_prefix(model_name)
+    # Ensure model_name is litellm-routable (Harbor agents call through litellm)
+    if model_name:
+        model_name = _litellm_routable(model_name)
 
     env: dict[str, str] = {}
     if inference_url:

--- a/tests/integrations/test_harbor_model_prefix.py
+++ b/tests/integrations/test_harbor_model_prefix.py
@@ -1,0 +1,37 @@
+"""Model names handed to Harbor agents must be parseable by litellm.
+
+The agent inside the sandbox calls the model through litellm, which reads the
+text before the first "/" as the provider. A served name like
+``nvidia/nemotron-3-ultra-550b-a55b`` fails before any request is made:
+
+    litellm.BadRequestError: LLM Provider NOT provided. ...
+    You passed model=nvidia/nemotron-3-ultra-550b-a55b
+
+Wrapping as ``openai/<name>`` routes to LLM_BASE_URL (rLLM's proxy/tunnel)
+with the full name on the wire — the exact name the proxy serves.
+"""
+
+from rllm.integrations.harbor.trial_helper import MODEL_PLACEHOLDER, _litellm_routable
+
+
+def test_unknown_provider_prefix_is_wrapped():
+    assert _litellm_routable("nvidia/nemotron-3-ultra-550b-a55b") == "openai/nvidia/nemotron-3-ultra-550b-a55b"
+
+
+def test_known_provider_prefixes_are_untouched():
+    for name in ("anthropic/claude-sonnet-4-6", "openai/gpt-4o", "openrouter/qwen/qwen3-coder", "hosted_vllm/my-model"):
+        assert _litellm_routable(name) == name
+
+
+def test_wrapping_is_idempotent():
+    once = _litellm_routable("nvidia/nemotron-3-ultra-550b-a55b")
+    assert _litellm_routable(once) == once
+
+
+def test_bare_names_keep_the_existing_inference():
+    assert _litellm_routable("claude-sonnet-4-6") == "anthropic/claude-sonnet-4-6"
+    assert _litellm_routable("my-local-model") == "openai/my-local-model"
+
+
+def test_training_placeholder_is_untouched():
+    assert _litellm_routable(MODEL_PLACEHOLDER) == MODEL_PLACEHOLDER


### PR DESCRIPTION
## The bug

Harbor agents (OpenHands SDK et al.) call the model through **litellm inside the sandbox**, which parses the text before the first `/` as the provider. rLLM's `build_harbor_trial_config` only prefixes slash-less model names; slash-bearing names pass through verbatim. So a served name like `nvidia/nemotron-3-ultra-550b-a55b` dies before any HTTP request:

```
litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call.
You passed model=nvidia/nemotron-3-ultra-550b-a55b
```

`nvidia` is not a litellm provider (their NVIDIA adapter is `nvidia_nim`), so the agent never reaches the inference tunnel — observed live on `rllm eval harbor:swebench-verified --agent <openhands-sdk> --model nvidia/nemotron-3-ultra-550b-a55b --sandbox-backend modal`.

## The fix

Wrap names whose first segment is **not** in `litellm.provider_list` as `openai/<name>`. litellm then selects its OpenAI adapter, routes to `LLM_BASE_URL` (rLLM's proxy, via the ngrok tunnel on remote sandboxes), and sends the **full** name on the wire — exactly the name the proxy serves, so the agent-side request and the proxy's `model_list` line up with the user's single `--model` value unchanged.

Untouched by design:
- names with real provider prefixes (`anthropic/…`, `openai/…`, `openrouter/…`, `hosted_vllm/…`) keep their existing routing — `anthropic/` continues through the proxy's `/v1/messages` passthrough, `hosted_vllm/` keeps its dummy-key handling
- bare names keep the existing `_infer_provider_prefix` inference
- the training placeholder (`openai/placeholder`) — first segment is a known provider

5 unit tests: the failing name wraps, known prefixes untouched, wrapping idempotent, bare-name inference unchanged, placeholder unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)