### PR TITLE
harbor: declare llm_inside_env so remote sandboxes get the tunnel URL

### DIFF
--- a/rllm/integrations/harbor/runtime.py
+++ b/rllm/integrations/harbor/runtime.py
@@ -41,6 +41,14 @@ class HarborRuntime:
     # Used by run_dataset / Runner to cap concurrency.
     max_concurrent: int = 64
 
+    # Harbor installed agents run their LLM client INSIDE the sandbox, so the
+    # engine must hand them the publicly-reachable gateway URL (the tunnel on
+    # remote backends). Without this the default host-local URL gets the
+    # docker-only host.docker.internal rewrite, which does not resolve on
+    # modal/daytona/e2b — the agent fails its first LLM call with
+    # "OpenAIException - Connection error".
+    llm_inside_env: bool = True
+
     def __init__(
         self,
         agent_name: str = "mini-swe-agent",

--- a/tests/integrations/test_harbor_runtime_flags.py
+++ b/tests/integrations/test_harbor_runtime_flags.py
@@ -1,0 +1,15 @@
+"""HarborRuntime must ask the engine for the publicly-reachable gateway URL.
+
+Harbor installed agents run their LLM client inside the sandbox. The engine
+keys this off ``llm_inside_env`` (agentflow_engine.py); without it the agent
+env gets the host-local URL with the docker-only ``host.docker.internal``
+rewrite, which does not resolve on modal/daytona/e2b — every task fails its
+first LLM call with "OpenAIException - Connection error".
+"""
+
+from rllm.integrations.harbor.runtime import HarborRuntime
+
+
+def test_harbor_agents_declare_llm_inside_env():
+    assert HarborRuntime.llm_inside_env is True
+    assert HarborRuntime(agent_name="openhands-sdk").llm_inside_env is True


### PR DESCRIPTION
## The bug

Harbor installed agents run their LLM client **inside** the sandbox, but `HarborRuntime` never declared `llm_inside_env`. The engine keys URL selection off that attribute (`agentflow_engine.py`: `getattr(self.agent_flow, "llm_inside_env", False)`), so Harbor agents got the **host-local** gateway URL, and `trial_helper`'s docker-only rewrite turned it into:

```
LLM_BASE_URL = http://host.docker.internal:54668/sessions/...
```

`host.docker.internal` only resolves inside Docker Desktop. On `--sandbox-backend modal` DNS fails and every task dies on its first LLM call with `litellm.InternalServerError: OpenAIException - Connection error` — observed live, with the trial's recorded agent env as the smoking gun.

The eval runner had **already started an ngrok tunnel** for exactly this purpose; the URL just never reached the agent.

## The fix

One attribute, mirroring what `cli_harness.py` already declares for the same reason: `llm_inside_env = True` on `HarborRuntime`. The engine then hands over the public tunnel URL on remote backends.

Docker keeps working unchanged: when no tunnel is up, `get_session_url(public=True)` falls back to the host-local URL and the `host.docker.internal` rewrite that Docker actually resolves.

## Verified

- Live on `--sandbox-backend modal`: previously the agent env recorded `host.docker.internal` while the tunnel sat unused; the failure reproduced identically across attempts (connection error before any request reached the tunnel).
- Test pins the contract: `HarborRuntime.llm_inside_env is True`.

Part of the chain that makes `rllm eval harbor:swebench-verified --agent harbor:openhands-sdk --sandbox-backend modal` work end-to-end, with #882 (Modal sandbox names), #884 (harbor 0.21.0), #885 (litellm-routable model names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)