### PR TITLE
feat(harness): add generic OpenHands agent

### DIFF
--- a/rllm/harnesses/openhands.py
+++ b/rllm/harnesses/openhands.py
@@ -1,0 +1,347 @@
+"""Run the OpenHands Software Agent SDK inside an rLLM sandbox.
+
+The agent and repository share the sandbox filesystem. OpenHands talks to the
+rLLM gateway through its OpenAI-compatible endpoint, so the engine captures the
+LLM trajectory while the task's normal verifier remains authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+
+from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
+from rllm.types import AgentConfig, Task
+
+logger = logging.getLogger(__name__)
+
+# Pin the SDK and its tmux parser so snapshots remain reproducible. The SDK's
+# tools package allows newer libtmux versions that do not parse a few benchmark
+# images correctly, hence the explicit transitive pin.
+OPENHANDS_SDK_REVISION = "43376f1868ffd702746080714a59c16d3f69ec12"
+OPENHANDS_EXTENSIONS_REVISION = "2cfd75e2396ad5111f0e1670a5534a79bbf97a3e"
+OPENHANDS_LIBTMUX_VERSION = "0.53.0"
+OPENHANDS_LOCALE = "C.UTF-8"
+
+_VENV_DIR = "/opt/rllm/openhands"
+_DRIVER_PATH = "/tmp/rllm-openhands/driver.py"
+_PROMPT_PATH = "/tmp/rllm-openhands/prompt.txt"
+_SUMMARY_PATH = "/tmp/rllm-openhands/summary.json"
+_OUTCOME_PATH = "/tmp/rllm-openhands/outcome.json"
+_REVISION_FILE = f"{_VENV_DIR}/.sdk-revision"
+_INSTALL_REVISION = f"{OPENHANDS_SDK_REVISION}:libtmux=={OPENHANDS_LIBTMUX_VERSION}"
+_SDK_ARCHIVE = f"https://github.com/OpenHands/software-agent-sdk/archive/{OPENHANDS_SDK_REVISION}.tar.gz"
+_SDK_REQUIREMENT = f"openhands-sdk @ {_SDK_ARCHIVE}#subdirectory=openhands-sdk"
+_TOOLS_REQUIREMENT = f"openhands-tools @ {_SDK_ARCHIVE}#subdirectory=openhands-tools"
+
+_INSTALL_SCRIPT = rf"""
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+if ! command -v curl >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates git tmux
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl ca-certificates git tmux bash
+    fi
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    for attempt in 1 2 3 4 5; do
+        if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+            break
+        fi
+        if [ "$attempt" -eq 5 ]; then
+            echo "uv install failed after 5 attempts" >&2
+            exit 1
+        fi
+        sleep $((attempt * 3))
+    done
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+installed_revision="$(cat {_REVISION_FILE} 2>/dev/null || true)"
+if [ "$installed_revision" != "{_INSTALL_REVISION}" ]; then
+    uv venv --python 3.12 --clear {_VENV_DIR}
+    uv pip install --python {_VENV_DIR}/bin/python {shlex.quote(_SDK_REQUIREMENT)}
+    uv pip install --python {_VENV_DIR}/bin/python --no-deps {shlex.quote(_TOOLS_REQUIREMENT)}
+    uv pip install --python {_VENV_DIR}/bin/python binaryornot cachetools libtmux=={OPENHANDS_LIBTMUX_VERSION} func-timeout
+    printf '%s\n' "{_INSTALL_REVISION}" > {_REVISION_FILE}
+fi
+"""
+
+_DRIVER_SCRIPT = r'''"""Local-workspace OpenHands driver for rLLM."""
+
+import json
+import os
+import traceback
+
+from openhands.sdk import Agent, Conversation, LLM
+from openhands.sdk.context import AgentContext
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.event import ActionEvent, MessageEvent
+from openhands.sdk.skills import load_public_skills
+from openhands.sdk.tool.builtins.finish import FinishAction
+from openhands.tools.preset.default import get_default_tools
+
+
+def _finished(events):
+    for event in reversed(events):
+        if isinstance(event, ActionEvent):
+            return isinstance(event.action, FinishAction)
+    return False
+
+
+def _sent_message(events):
+    for event in reversed(events):
+        if isinstance(event, MessageEvent) and event.source == "agent":
+            return True
+        if isinstance(event, ActionEvent):
+            return False
+    return False
+
+
+def _fake_response(conversation):
+    user_messages = [
+        event
+        for event in conversation.state.events
+        if isinstance(event, MessageEvent) and event.source == "user"
+    ]
+    message = (
+        "Please continue working on the task on whatever approach you think is suitable.\n"
+        "When you think you have solved the question, please use the finish tool and "
+        "include your final answer in the message parameter of the finish tool.\n"
+        "IMPORTANT: YOU SHOULD NEVER ASK FOR HUMAN HELP.\n"
+    )
+    if len(user_messages) >= 2:
+        message += 'If you want to give up, use the "finish" tool to finish the interaction.\n'
+    return message
+
+
+class ConversationIncompleteError(RuntimeError):
+    pass
+
+
+def _write_json(path, data):
+    temporary = f"{path}.tmp.{os.getpid()}"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        json.dump(data, stream, indent=2, sort_keys=True)
+    os.replace(temporary, path)
+
+
+def _optional_int(name):
+    value = os.environ.get(name)
+    return int(value) if value else None
+
+
+def main():
+    conversation = None
+    failure = None
+    failure_traceback = None
+    fake_responses = 0
+    try:
+        llm_kwargs = {
+            "usage_id": "agent",
+            "model": os.environ["LLM_MODEL"],
+            "api_key": os.environ["LLM_API_KEY"],
+            "base_url": os.environ["LLM_BASE_URL"],
+            "temperature": float(os.environ["RLLM_OPENHANDS_TEMPERATURE"]),
+            "top_p": float(os.environ["RLLM_OPENHANDS_TOP_P"]),
+            "disable_vision": True,
+            "litellm_extra_body": json.loads(
+                os.environ.get("RLLM_OPENHANDS_LITELLM_EXTRA_BODY", "{}")
+            ),
+        }
+        max_input_tokens = _optional_int("RLLM_OPENHANDS_MAX_INPUT_TOKENS")
+        max_output_tokens = _optional_int("RLLM_OPENHANDS_MAX_OUTPUT_TOKENS")
+        if max_input_tokens is not None:
+            llm_kwargs["max_input_tokens"] = max_input_tokens
+        if max_output_tokens is not None:
+            llm_kwargs["max_output_tokens"] = max_output_tokens
+
+        llm = LLM(**llm_kwargs)
+        condenser_llm = llm.model_copy(deep=True, update={"usage_id": "condenser"})
+        public_skills = load_public_skills()
+        agent_context = AgentContext(skills=public_skills) if public_skills else None
+        agent = Agent(
+            llm=llm,
+            tools=get_default_tools(enable_browser=False),
+            system_prompt_kwargs={"cli_mode": True},
+            condenser=LLMSummarizingCondenser(
+                llm=condenser_llm,
+                max_size=int(os.environ["RLLM_OPENHANDS_CONDENSER_MAX_SIZE"]),
+                keep_first=int(os.environ["RLLM_OPENHANDS_CONDENSER_KEEP_FIRST"]),
+            ),
+            agent_context=agent_context,
+        )
+        conversation = Conversation(
+            agent=agent,
+            workspace=os.environ["RLLM_OPENHANDS_WORKDIR"],
+            max_iteration_per_run=int(os.environ["RLLM_OPENHANDS_MAX_ITERATIONS"]),
+            delete_on_close=True,
+        )
+        with open(os.environ["RLLM_OPENHANDS_PROMPT_PATH"], encoding="utf-8") as stream:
+            instruction = stream.read()
+        conversation.send_message(instruction)
+
+        while True:
+            conversation.run()
+            events = list(conversation.state.events)
+            if conversation.state.execution_status != ConversationExecutionStatus.FINISHED:
+                break
+            if _finished(events) or not _sent_message(events) or fake_responses >= 10:
+                break
+            conversation.send_message(_fake_response(conversation))
+            fake_responses += 1
+    except BaseException as exc:
+        # OpenHands may raise while processing a terminal FinishAction. The
+        # typed event remains authoritative, while pre-finish failures remain
+        # visible in the structured outcome and full traceback.
+        failure = exc
+        failure_traceback = traceback.format_exc()
+
+    events = list(conversation.state.events) if conversation is not None else []
+    finished = _finished(events)
+    execution_status = None
+    if conversation is not None:
+        status = conversation.state.execution_status
+        execution_status = getattr(status, "value", str(status))
+    if not finished and failure is None:
+        failure = ConversationIncompleteError(
+            f"OpenHands stopped without FinishAction (execution_status={execution_status})"
+        )
+
+    summary = {
+        "execution_status": execution_status,
+        "events": len(events),
+        "fake_responses": fake_responses,
+        "finished": finished,
+    }
+    try:
+        _write_json(os.environ["RLLM_OPENHANDS_SUMMARY_PATH"], summary)
+    except BaseException as exc:
+        if failure is None:
+            failure = exc
+            failure_traceback = traceback.format_exc()
+
+    outcome = {
+        "finished": finished,
+        "execution_status": execution_status,
+        "exception_type": None if finished else type(failure).__name__,
+        "message": "" if failure is None else str(failure),
+        "traceback": None if finished else failure_traceback,
+    }
+    _write_json(os.environ["RLLM_OPENHANDS_OUTCOME_PATH"], outcome)
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+class OpenHandsHarness(BaseCliHarness):
+    """Run OpenHands against an arbitrary sandbox task and gateway model."""
+
+    name = "openhands"
+    sandbox_backend = "docker"
+    stdout_log_path = "/tmp/openhands.log"
+
+    temperature: float = 1.0
+    top_p: float = 1.0
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    max_iterations: int = 500
+    condenser_max_size: int = 240
+    condenser_keep_first: int = 2
+    litellm_extra_body: dict | None = None
+
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
+
+    def render_prompt(self, task: Task, workdir: str) -> str:
+        """Return the prompt written for OpenHands; profiles may override it."""
+        del workdir
+        return str(task.instruction).strip()
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        api_key = self.gateway_api_key(config, "RLLM_GATEWAY_API_KEY")
+        workdir = str(task.metadata.get("workdir") or "/app")
+        env = {
+            # Always use LiteLLM's OpenAI adapter for the sandbox-to-gateway
+            # hop. Preserve config.model verbatim after that single prefix so
+            # the gateway sees exactly the alias it registered.
+            "LLM_MODEL": f"openai/{config.model}",
+            "LLM_API_KEY": api_key,
+            "LLM_BASE_URL": config.base_url,
+            "OPENAI_API_KEY": api_key,
+            "OPENAI_API_BASE": config.base_url,
+            "OPENAI_BASE_URL": config.base_url,
+            "OPENHANDS_SUPPRESS_BANNER": "1",
+            "EXTENSIONS_REF": OPENHANDS_EXTENSIONS_REVISION,
+            "LITELLM_LOCAL_MODEL_COST_MAP": "True",
+            "LC_ALL": OPENHANDS_LOCALE,
+            "LANG": OPENHANDS_LOCALE,
+            "RLLM_OPENHANDS_WORKDIR": workdir,
+            "RLLM_OPENHANDS_PROMPT_PATH": _PROMPT_PATH,
+            "RLLM_OPENHANDS_SUMMARY_PATH": _SUMMARY_PATH,
+            "RLLM_OPENHANDS_OUTCOME_PATH": _OUTCOME_PATH,
+            "RLLM_OPENHANDS_TEMPERATURE": str(self.temperature),
+            "RLLM_OPENHANDS_TOP_P": str(self.top_p),
+            "RLLM_OPENHANDS_MAX_ITERATIONS": str(self.max_iterations),
+            "RLLM_OPENHANDS_CONDENSER_MAX_SIZE": str(self.condenser_max_size),
+            "RLLM_OPENHANDS_CONDENSER_KEEP_FIRST": str(self.condenser_keep_first),
+            "RLLM_OPENHANDS_LITELLM_EXTRA_BODY": json.dumps(self.litellm_extra_body or {}),
+        }
+        if self.max_input_tokens is not None:
+            env["RLLM_OPENHANDS_MAX_INPUT_TOKENS"] = str(self.max_input_tokens)
+        if self.max_output_tokens is not None:
+            env["RLLM_OPENHANDS_MAX_OUTPUT_TOKENS"] = str(self.max_output_tokens)
+        return env
+
+    def _read_outcome(self, sandbox: Sandbox) -> dict | None:
+        try:
+            raw = sandbox.exec(
+                f"cat {shlex.quote(_OUTCOME_PATH)} 2>/dev/null || true",
+                timeout=15,
+                user=self.agent_user,
+            ).strip()
+        except Exception as exc:
+            logger.debug("OpenHands outcome read failed: %s", exc)
+            return None
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except Exception as exc:
+            logger.debug("OpenHands outcome parse failed: %s", exc)
+            return None
+        if data.get("finished") is True:
+            return {}
+        message = data.get("message", "")
+        failure_traceback = data.get("traceback")
+        if failure_traceback:
+            message = f"{message}\n\n{failure_traceback}" if message else failure_traceback
+        return {
+            "exception_type": data.get("exception_type") or "ConversationIncompleteError",
+            "message": message,
+        }
+
+    def write_configs(
+        self,
+        sandbox: Sandbox,
+        task: Task,
+        config: AgentConfig,
+        env: dict[str, str],
+    ) -> None:
+        prompt = self.render_prompt(task, env["RLLM_OPENHANDS_WORKDIR"])
+        self._exec_agent(sandbox, self._heredoc_write(_DRIVER_PATH, _DRIVER_SCRIPT), env=env)
+        self._exec_agent(sandbox, self._heredoc_write(_PROMPT_PATH, prompt), env=env)
+
+    def build_invocation(self, instruction: str, task: Task, config: AgentConfig) -> str:
+        del instruction, task, config
+        log = shlex.quote(self.stdout_log_path)
+        return f"set -o pipefail; {_VENV_DIR}/bin/python {shlex.quote(_DRIVER_PATH)} 2>&1 | tee {log}"

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -26,6 +26,11 @@
       "function": "MiniSweAgentHarness",
       "description": "Run mini-swe-agent inside the sandbox."
     },
+    "openhands": {
+      "module": "rllm.harnesses.openhands",
+      "function": "OpenHandsHarness",
+      "description": "Run the OpenHands Software Agent SDK inside the sandbox."
+    },
     "terminus2": {
       "module": "rllm.harnesses.terminus2",
       "function": "Terminus2Harness",

--- a/tests/harnesses/test_openhands.py
+++ b/tests/harnesses/test_openhands.py
@@ -1,0 +1,308 @@
+"""Offline tests for the generic OpenHands harness."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from types import ModuleType, SimpleNamespace
+
+from rllm.eval.agent_loader import load_agent
+from rllm.harnesses.openhands import (
+    _DRIVER_SCRIPT,
+    _OUTCOME_PATH,
+    OPENHANDS_EXTENSIONS_REVISION,
+    OPENHANDS_LIBTMUX_VERSION,
+    OPENHANDS_LOCALE,
+    OPENHANDS_SDK_REVISION,
+    OpenHandsHarness,
+)
+from rllm.sandbox.protocol import SandboxCommandTimeout
+from rllm.types import AgentConfig, Task, TerminationReason
+
+
+@dataclass
+class FakeSandbox:
+    calls: list[str] = field(default_factory=list)
+    outcome: str | None = None
+    fail_invocation: bool = False
+    timeout_invocation: bool = False
+
+    def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
+        del timeout, user
+        self.calls.append(command)
+        if command.startswith(f"cat {_OUTCOME_PATH}"):
+            return self.outcome or ""
+        if "/opt/rllm/openhands/bin/python /tmp/rllm-openhands/driver.py" in command:
+            if self.timeout_invocation:
+                raise SandboxCommandTimeout("agent timed out")
+            if self.fail_invocation:
+                raise RuntimeError("driver exited non-zero")
+        return "OK"
+
+    def is_alive(self) -> bool:
+        return True
+
+
+def _task() -> Task:
+    return Task(
+        id="task-1",
+        instruction="Fix the issue while keeping the API stable.",
+        metadata={"workdir": "/repo", "agent_timeout": 3600.0},
+    )
+
+
+def _config(model: str = "vendor/model-v1") -> AgentConfig:
+    return AgentConfig(
+        base_url="http://gateway/sessions/test/v1",
+        model=model,
+        session_uid="test",
+        metadata={"gateway_auth_token": "gateway-token"},
+    )
+
+
+def test_registry_loads_generic_openhands_harness():
+    assert isinstance(load_agent("openhands"), OpenHandsHarness)
+
+
+def test_install_script_pins_sdk_and_tmux_parser():
+    script = OpenHandsHarness().install_script()
+
+    assert OPENHANDS_SDK_REVISION in script
+    assert "#subdirectory=openhands-sdk" in script
+    assert "#subdirectory=openhands-tools" in script
+    assert "--no-deps" in script
+    assert f"libtmux=={OPENHANDS_LIBTMUX_VERSION}" in script
+    assert f"{OPENHANDS_SDK_REVISION}:libtmux=={OPENHANDS_LIBTMUX_VERSION}" in script
+
+
+def test_driver_is_valid_and_reads_agent_settings_from_environment():
+    compile(_DRIVER_SCRIPT, "<openhands-driver>", "exec")
+
+    assert 'os.environ["RLLM_OPENHANDS_TEMPERATURE"]' in _DRIVER_SCRIPT
+    assert 'os.environ["RLLM_OPENHANDS_TOP_P"]' in _DRIVER_SCRIPT
+    assert '_optional_int("RLLM_OPENHANDS_MAX_INPUT_TOKENS")' in _DRIVER_SCRIPT
+    assert '_optional_int("RLLM_OPENHANDS_MAX_OUTPUT_TOKENS")' in _DRIVER_SCRIPT
+    assert 'os.environ["RLLM_OPENHANDS_MAX_ITERATIONS"]' in _DRIVER_SCRIPT
+    assert "get_default_tools(enable_browser=False)" in _DRIVER_SCRIPT
+    assert "conversation.run()" in _DRIVER_SCRIPT
+    assert "traceback.format_exc()" in _DRIVER_SCRIPT
+    assert "SWE-bench" not in _DRIVER_SCRIPT
+    assert "GLM" not in _DRIVER_SCRIPT
+
+
+def test_build_env_routes_any_model_through_rllm_gateway():
+    harness = OpenHandsHarness(
+        temperature=0.2,
+        top_p=0.9,
+        max_input_tokens=123_000,
+        max_output_tokens=4_096,
+        max_iterations=17,
+    )
+    env = harness.build_env(_task(), _config("accounts/provider/models/model-v1"))
+
+    assert env["LLM_MODEL"] == "openai/accounts/provider/models/model-v1"
+    assert env["LLM_API_KEY"] == "gateway-token"
+    assert env["LLM_BASE_URL"] == "http://gateway/sessions/test/v1"
+    assert env["OPENAI_API_KEY"] == "gateway-token"
+    assert env["EXTENSIONS_REF"] == OPENHANDS_EXTENSIONS_REVISION
+    assert env["LC_ALL"] == OPENHANDS_LOCALE
+    assert env["LANG"] == OPENHANDS_LOCALE
+    assert env["RLLM_OPENHANDS_WORKDIR"] == "/repo"
+    assert env["RLLM_OPENHANDS_TEMPERATURE"] == "0.2"
+    assert env["RLLM_OPENHANDS_TOP_P"] == "0.9"
+    assert env["RLLM_OPENHANDS_MAX_INPUT_TOKENS"] == "123000"
+    assert env["RLLM_OPENHANDS_MAX_OUTPUT_TOKENS"] == "4096"
+    assert env["RLLM_OPENHANDS_MAX_ITERATIONS"] == "17"
+
+
+def test_build_env_does_not_copy_a_host_provider_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "host-provider-secret")
+    config = _config()
+    config.metadata = {}
+
+    env = OpenHandsHarness().build_env(_task(), config)
+
+    assert env["LLM_API_KEY"] == "sk-rllm-gateway"
+    assert env["OPENAI_API_KEY"] == "sk-rllm-gateway"
+
+
+def test_write_configs_uses_raw_task_instruction_by_default():
+    harness = OpenHandsHarness()
+    sandbox = FakeSandbox()
+    task = _task()
+    config = _config()
+    env = harness.build_env(task, config)
+
+    harness.write_configs(sandbox, task, config, env)
+
+    assert len(sandbox.calls) == 2
+    assert "Local-workspace OpenHands driver" in sandbox.calls[0]
+    assert task.instruction in sandbox.calls[1]
+    assert "<issue_description>" not in sandbox.calls[1]
+
+
+def _run_driver_with_fake_openhands(monkeypatch, tmp_path, *, finish_before_error: bool) -> dict:
+    class ExecutionStatus(Enum):
+        FINISHED = "finished"
+
+    class FinishAction:
+        pass
+
+    class ActionEvent:
+        def __init__(self, action):
+            self.action = action
+
+    class MessageEvent:
+        def __init__(self, source):
+            self.source = source
+
+    class LLM:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def model_copy(self, **kwargs):
+            del kwargs
+            return self
+
+    class AcceptsKeywords:
+        def __init__(self, **kwargs):
+            del kwargs
+
+    class Conversation:
+        def __init__(self, **kwargs):
+            del kwargs
+            self.state = SimpleNamespace(events=[], execution_status=ExecutionStatus.FINISHED)
+
+        def send_message(self, message):
+            del message
+
+        def run(self):
+            if finish_before_error:
+                self.state.events.append(ActionEvent(FinishAction()))
+                raise RuntimeError("cleanup failed after finish")
+            raise RuntimeError("gateway unavailable")
+
+    modules = {
+        name: ModuleType(name)
+        for name in (
+            "openhands",
+            "openhands.sdk",
+            "openhands.sdk.context",
+            "openhands.sdk.context.condenser",
+            "openhands.sdk.conversation",
+            "openhands.sdk.conversation.state",
+            "openhands.sdk.event",
+            "openhands.sdk.skills",
+            "openhands.sdk.tool",
+            "openhands.sdk.tool.builtins",
+            "openhands.sdk.tool.builtins.finish",
+            "openhands.tools",
+            "openhands.tools.preset",
+            "openhands.tools.preset.default",
+        )
+    }
+    modules["openhands.sdk"].Agent = AcceptsKeywords
+    modules["openhands.sdk"].Conversation = Conversation
+    modules["openhands.sdk"].LLM = LLM
+    modules["openhands.sdk.context"].AgentContext = AcceptsKeywords
+    modules["openhands.sdk.context.condenser"].LLMSummarizingCondenser = AcceptsKeywords
+    modules["openhands.sdk.conversation.state"].ConversationExecutionStatus = ExecutionStatus
+    modules["openhands.sdk.event"].ActionEvent = ActionEvent
+    modules["openhands.sdk.event"].MessageEvent = MessageEvent
+    modules["openhands.sdk.skills"].load_public_skills = lambda: []
+    modules["openhands.sdk.tool.builtins.finish"].FinishAction = FinishAction
+    modules["openhands.tools.preset.default"].get_default_tools = lambda **kwargs: []
+    for name, module in modules.items():
+        if name.rsplit(".", 1)[-1] not in {"condenser", "state", "event", "finish", "skills", "default"}:
+            module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    prompt_path = tmp_path / "prompt.txt"
+    summary_path = tmp_path / "summary.json"
+    outcome_path = tmp_path / "outcome.json"
+    prompt_path.write_text("Fix it")
+    env = {
+        "LLM_MODEL": "openai/model-v1",
+        "LLM_API_KEY": "test-key",
+        "LLM_BASE_URL": "http://gateway/v1",
+        "RLLM_OPENHANDS_WORKDIR": "/app",
+        "RLLM_OPENHANDS_PROMPT_PATH": str(prompt_path),
+        "RLLM_OPENHANDS_SUMMARY_PATH": str(summary_path),
+        "RLLM_OPENHANDS_OUTCOME_PATH": str(outcome_path),
+        "RLLM_OPENHANDS_TEMPERATURE": "1.0",
+        "RLLM_OPENHANDS_TOP_P": "1.0",
+        "RLLM_OPENHANDS_MAX_ITERATIONS": "500",
+        "RLLM_OPENHANDS_CONDENSER_MAX_SIZE": "240",
+        "RLLM_OPENHANDS_CONDENSER_KEEP_FIRST": "2",
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    namespace = {"__name__": "test_openhands_driver"}
+    exec(compile(_DRIVER_SCRIPT, "<openhands-driver>", "exec"), namespace)
+    namespace["main"]()
+    return json.loads(outcome_path.read_text())
+
+
+def test_driver_treats_typed_finish_as_authoritative(monkeypatch, tmp_path):
+    outcome = _run_driver_with_fake_openhands(monkeypatch, tmp_path, finish_before_error=True)
+
+    assert outcome == {
+        "execution_status": "finished",
+        "exception_type": None,
+        "finished": True,
+        "message": "cleanup failed after finish",
+        "traceback": None,
+    }
+
+
+def test_driver_records_failure_and_full_traceback_before_finish(monkeypatch, tmp_path):
+    outcome = _run_driver_with_fake_openhands(monkeypatch, tmp_path, finish_before_error=False)
+
+    assert outcome["finished"] is False
+    assert outcome["exception_type"] == "RuntimeError"
+    assert outcome["message"] == "gateway unavailable"
+    assert "RuntimeError: gateway unavailable" in outcome["traceback"]
+
+
+def test_run_maps_structured_outcomes():
+    success = FakeSandbox(outcome=json.dumps({"finished": True}))
+    failure = FakeSandbox(
+        outcome=json.dumps(
+            {
+                "finished": False,
+                "exception_type": "RuntimeError",
+                "message": "gateway unavailable",
+                "traceback": "RuntimeError: gateway unavailable",
+            }
+        )
+    )
+
+    success_episode = OpenHandsHarness().run(_task(), _config(), env=success)
+    failure_episode = OpenHandsHarness().run(_task(), _config(), env=failure)
+
+    assert success_episode.termination_reason is None
+    assert failure_episode.termination_reason == TerminationReason.ERROR
+    assert failure_episode.metadata["error"] == {
+        "error_type": "RuntimeError",
+        "message": "gateway unavailable\n\nRuntimeError: gateway unavailable",
+    }
+
+
+def test_run_maps_structured_agent_timeout():
+    sandbox = FakeSandbox(
+        outcome=json.dumps(
+            {
+                "finished": False,
+                "exception_type": "AgentTimeoutError",
+                "message": "agent timed out",
+            }
+        ),
+        timeout_invocation=True,
+    )
+
+    episode = OpenHandsHarness().run(_task(), _config(), env=sandbox)
+
+    assert episode.termination_reason == TerminationReason.TIMEOUT


### PR DESCRIPTION
## Summary

- add a model- and benchmark-agnostic OpenHands Software Agent SDK harness
- route OpenHands calls through the existing rLLM gateway while preserving the configured model alias
- pin the SDK and compatible libtmux revision for reproducible sandbox snapshots
- record typed OpenHands completion, failures, and full tracebacks through the standard CLI harness lifecycle
- add offline registry, configuration, driver, and outcome tests

This PR intentionally contains no SWE-bench Pro prompt, GLM settings, score target, cookbook, or new rLLM runtime feature.

## Test plan

- `python -m pytest tests/harnesses/test_openhands.py -q` (`10 passed`)
- `python -m pytest tests/harnesses -q` (`90 passed` on the stacked validation branch)
- Ruff lint and format checks
- `git diff --check`
