### PR TITLE
feat(eval): add SWE-bench Pro GLM-5.2 profile

### DIFF
--- a/rllm/harnesses/openhands.py
+++ b/rllm/harnesses/openhands.py
@@ -1,0 +1,347 @@
+"""Run the OpenHands Software Agent SDK inside an rLLM sandbox.
+
+The agent and repository share the sandbox filesystem. OpenHands talks to the
+rLLM gateway through its OpenAI-compatible endpoint, so the engine captures the
+LLM trajectory while the task's normal verifier remains authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+
+from rllm.harnesses.cli_harness import BaseCliHarness
+from rllm.sandbox.protocol import Sandbox
+from rllm.types import AgentConfig, Task
+
+logger = logging.getLogger(__name__)
+
+# Pin the SDK and its tmux parser so snapshots remain reproducible. The SDK's
+# tools package allows newer libtmux versions that do not parse a few benchmark
+# images correctly, hence the explicit transitive pin.
+OPENHANDS_SDK_REVISION = "43376f1868ffd702746080714a59c16d3f69ec12"
+OPENHANDS_EXTENSIONS_REVISION = "2cfd75e2396ad5111f0e1670a5534a79bbf97a3e"
+OPENHANDS_LIBTMUX_VERSION = "0.53.0"
+OPENHANDS_LOCALE = "C.UTF-8"
+
+_VENV_DIR = "/opt/rllm/openhands"
+_DRIVER_PATH = "/tmp/rllm-openhands/driver.py"
+_PROMPT_PATH = "/tmp/rllm-openhands/prompt.txt"
+_SUMMARY_PATH = "/tmp/rllm-openhands/summary.json"
+_OUTCOME_PATH = "/tmp/rllm-openhands/outcome.json"
+_REVISION_FILE = f"{_VENV_DIR}/.sdk-revision"
+_INSTALL_REVISION = f"{OPENHANDS_SDK_REVISION}:libtmux=={OPENHANDS_LIBTMUX_VERSION}"
+_SDK_ARCHIVE = f"https://github.com/OpenHands/software-agent-sdk/archive/{OPENHANDS_SDK_REVISION}.tar.gz"
+_SDK_REQUIREMENT = f"openhands-sdk @ {_SDK_ARCHIVE}#subdirectory=openhands-sdk"
+_TOOLS_REQUIREMENT = f"openhands-tools @ {_SDK_ARCHIVE}#subdirectory=openhands-tools"
+
+_INSTALL_SCRIPT = rf"""
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+if ! command -v curl >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates git tmux
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl ca-certificates git tmux bash
+    fi
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    for attempt in 1 2 3 4 5; do
+        if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+            break
+        fi
+        if [ "$attempt" -eq 5 ]; then
+            echo "uv install failed after 5 attempts" >&2
+            exit 1
+        fi
+        sleep $((attempt * 3))
+    done
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+installed_revision="$(cat {_REVISION_FILE} 2>/dev/null || true)"
+if [ "$installed_revision" != "{_INSTALL_REVISION}" ]; then
+    uv venv --python 3.12 --clear {_VENV_DIR}
+    uv pip install --python {_VENV_DIR}/bin/python {shlex.quote(_SDK_REQUIREMENT)}
+    uv pip install --python {_VENV_DIR}/bin/python --no-deps {shlex.quote(_TOOLS_REQUIREMENT)}
+    uv pip install --python {_VENV_DIR}/bin/python binaryornot cachetools libtmux=={OPENHANDS_LIBTMUX_VERSION} func-timeout
+    printf '%s\n' "{_INSTALL_REVISION}" > {_REVISION_FILE}
+fi
+"""
+
+_DRIVER_SCRIPT = r'''"""Local-workspace OpenHands driver for rLLM."""
+
+import json
+import os
+import traceback
+
+from openhands.sdk import Agent, Conversation, LLM
+from openhands.sdk.context import AgentContext
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.event import ActionEvent, MessageEvent
+from openhands.sdk.skills import load_public_skills
+from openhands.sdk.tool.builtins.finish import FinishAction
+from openhands.tools.preset.default import get_default_tools
+
+
+def _finished(events):
+    for event in reversed(events):
+        if isinstance(event, ActionEvent):
+            return isinstance(event.action, FinishAction)
+    return False
+
+
+def _sent_message(events):
+    for event in reversed(events):
+        if isinstance(event, MessageEvent) and event.source == "agent":
+            return True
+        if isinstance(event, ActionEvent):
+            return False
+    return False
+
+
+def _fake_response(conversation):
+    user_messages = [
+        event
+        for event in conversation.state.events
+        if isinstance(event, MessageEvent) and event.source == "user"
+    ]
+    message = (
+        "Please continue working on the task on whatever approach you think is suitable.\n"
+        "When you think you have solved the question, please use the finish tool and "
+        "include your final answer in the message parameter of the finish tool.\n"
+        "IMPORTANT: YOU SHOULD NEVER ASK FOR HUMAN HELP.\n"
+    )
+    if len(user_messages) >= 2:
+        message += 'If you want to give up, use the "finish" tool to finish the interaction.\n'
+    return message
+
+
+class ConversationIncompleteError(RuntimeError):
+    pass
+
+
+def _write_json(path, data):
+    temporary = f"{path}.tmp.{os.getpid()}"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        json.dump(data, stream, indent=2, sort_keys=True)
+    os.replace(temporary, path)
+
+
+def _optional_int(name):
+    value = os.environ.get(name)
+    return int(value) if value else None
+
+
+def main():
+    conversation = None
+    failure = None
+    failure_traceback = None
+    fake_responses = 0
+    try:
+        llm_kwargs = {
+            "usage_id": "agent",
+            "model": os.environ["LLM_MODEL"],
+            "api_key": os.environ["LLM_API_KEY"],
+            "base_url": os.environ["LLM_BASE_URL"],
+            "temperature": float(os.environ["RLLM_OPENHANDS_TEMPERATURE"]),
+            "top_p": float(os.environ["RLLM_OPENHANDS_TOP_P"]),
+            "disable_vision": True,
+            "litellm_extra_body": json.loads(
+                os.environ.get("RLLM_OPENHANDS_LITELLM_EXTRA_BODY", "{}")
+            ),
+        }
+        max_input_tokens = _optional_int("RLLM_OPENHANDS_MAX_INPUT_TOKENS")
+        max_output_tokens = _optional_int("RLLM_OPENHANDS_MAX_OUTPUT_TOKENS")
+        if max_input_tokens is not None:
+            llm_kwargs["max_input_tokens"] = max_input_tokens
+        if max_output_tokens is not None:
+            llm_kwargs["max_output_tokens"] = max_output_tokens
+
+        llm = LLM(**llm_kwargs)
+        condenser_llm = llm.model_copy(deep=True, update={"usage_id": "condenser"})
+        public_skills = load_public_skills()
+        agent_context = AgentContext(skills=public_skills) if public_skills else None
+        agent = Agent(
+            llm=llm,
+            tools=get_default_tools(enable_browser=False),
+            system_prompt_kwargs={"cli_mode": True},
+            condenser=LLMSummarizingCondenser(
+                llm=condenser_llm,
+                max_size=int(os.environ["RLLM_OPENHANDS_CONDENSER_MAX_SIZE"]),
+                keep_first=int(os.environ["RLLM_OPENHANDS_CONDENSER_KEEP_FIRST"]),
+            ),
+            agent_context=agent_context,
+        )
+        conversation = Conversation(
+            agent=agent,
+            workspace=os.environ["RLLM_OPENHANDS_WORKDIR"],
+            max_iteration_per_run=int(os.environ["RLLM_OPENHANDS_MAX_ITERATIONS"]),
+            delete_on_close=True,
+        )
+        with open(os.environ["RLLM_OPENHANDS_PROMPT_PATH"], encoding="utf-8") as stream:
+            instruction = stream.read()
+        conversation.send_message(instruction)
+
+        while True:
+            conversation.run()
+            events = list(conversation.state.events)
+            if conversation.state.execution_status != ConversationExecutionStatus.FINISHED:
+                break
+            if _finished(events) or not _sent_message(events) or fake_responses >= 10:
+                break
+            conversation.send_message(_fake_response(conversation))
+            fake_responses += 1
+    except BaseException as exc:
+        # OpenHands may raise while processing a terminal FinishAction. The
+        # typed event remains authoritative, while pre-finish failures remain
+        # visible in the structured outcome and full traceback.
+        failure = exc
+        failure_traceback = traceback.format_exc()
+
+    events = list(conversation.state.events) if conversation is not None else []
+    finished = _finished(events)
+    execution_status = None
+    if conversation is not None:
+        status = conversation.state.execution_status
+        execution_status = getattr(status, "value", str(status))
+    if not finished and failure is None:
+        failure = ConversationIncompleteError(
+            f"OpenHands stopped without FinishAction (execution_status={execution_status})"
+        )
+
+    summary = {
+        "execution_status": execution_status,
+        "events": len(events),
+        "fake_responses": fake_responses,
+        "finished": finished,
+    }
+    try:
+        _write_json(os.environ["RLLM_OPENHANDS_SUMMARY_PATH"], summary)
+    except BaseException as exc:
+        if failure is None:
+            failure = exc
+            failure_traceback = traceback.format_exc()
+
+    outcome = {
+        "finished": finished,
+        "execution_status": execution_status,
+        "exception_type": None if finished else type(failure).__name__,
+        "message": "" if failure is None else str(failure),
+        "traceback": None if finished else failure_traceback,
+    }
+    _write_json(os.environ["RLLM_OPENHANDS_OUTCOME_PATH"], outcome)
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+class OpenHandsHarness(BaseCliHarness):
+    """Run OpenHands against an arbitrary sandbox task and gateway model."""
+
+    name = "openhands"
+    sandbox_backend = "docker"
+    stdout_log_path = "/tmp/openhands.log"
+
+    temperature: float = 1.0
+    top_p: float = 1.0
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    max_iterations: int = 500
+    condenser_max_size: int = 240
+    condenser_keep_first: int = 2
+    litellm_extra_body: dict | None = None
+
+    def install_script(self) -> str:
+        return _INSTALL_SCRIPT
+
+    def render_prompt(self, task: Task, workdir: str) -> str:
+        """Return the prompt written for OpenHands; profiles may override it."""
+        del workdir
+        return str(task.instruction).strip()
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        api_key = self.gateway_api_key(config, "RLLM_GATEWAY_API_KEY")
+        workdir = str(task.metadata.get("workdir") or "/app")
+        env = {
+            # Always use LiteLLM's OpenAI adapter for the sandbox-to-gateway
+            # hop. Preserve config.model verbatim after that single prefix so
+            # the gateway sees exactly the alias it registered.
+            "LLM_MODEL": f"openai/{config.model}",
+            "LLM_API_KEY": api_key,
+            "LLM_BASE_URL": config.base_url,
+            "OPENAI_API_KEY": api_key,
+            "OPENAI_API_BASE": config.base_url,
+            "OPENAI_BASE_URL": config.base_url,
+            "OPENHANDS_SUPPRESS_BANNER": "1",
+            "EXTENSIONS_REF": OPENHANDS_EXTENSIONS_REVISION,
+            "LITELLM_LOCAL_MODEL_COST_MAP": "True",
+            "LC_ALL": OPENHANDS_LOCALE,
+            "LANG": OPENHANDS_LOCALE,
+            "RLLM_OPENHANDS_WORKDIR": workdir,
+            "RLLM_OPENHANDS_PROMPT_PATH": _PROMPT_PATH,
+            "RLLM_OPENHANDS_SUMMARY_PATH": _SUMMARY_PATH,
+            "RLLM_OPENHANDS_OUTCOME_PATH": _OUTCOME_PATH,
+            "RLLM_OPENHANDS_TEMPERATURE": str(self.temperature),
+            "RLLM_OPENHANDS_TOP_P": str(self.top_p),
+            "RLLM_OPENHANDS_MAX_ITERATIONS": str(self.max_iterations),
+            "RLLM_OPENHANDS_CONDENSER_MAX_SIZE": str(self.condenser_max_size),
+            "RLLM_OPENHANDS_CONDENSER_KEEP_FIRST": str(self.condenser_keep_first),
+            "RLLM_OPENHANDS_LITELLM_EXTRA_BODY": json.dumps(self.litellm_extra_body or {}),
+        }
+        if self.max_input_tokens is not None:
+            env["RLLM_OPENHANDS_MAX_INPUT_TOKENS"] = str(self.max_input_tokens)
+        if self.max_output_tokens is not None:
+            env["RLLM_OPENHANDS_MAX_OUTPUT_TOKENS"] = str(self.max_output_tokens)
+        return env
+
+    def _read_outcome(self, sandbox: Sandbox) -> dict | None:
+        try:
+            raw = sandbox.exec(
+                f"cat {shlex.quote(_OUTCOME_PATH)} 2>/dev/null || true",
+                timeout=15,
+                user=self.agent_user,
+            ).strip()
+        except Exception as exc:
+            logger.debug("OpenHands outcome read failed: %s", exc)
+            return None
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except Exception as exc:
+            logger.debug("OpenHands outcome parse failed: %s", exc)
+            return None
+        if data.get("finished") is True:
+            return {}
+        message = data.get("message", "")
+        failure_traceback = data.get("traceback")
+        if failure_traceback:
+            message = f"{message}\n\n{failure_traceback}" if message else failure_traceback
+        return {
+            "exception_type": data.get("exception_type") or "ConversationIncompleteError",
+            "message": message,
+        }
+
+    def write_configs(
+        self,
+        sandbox: Sandbox,
+        task: Task,
+        config: AgentConfig,
+        env: dict[str, str],
+    ) -> None:
+        prompt = self.render_prompt(task, env["RLLM_OPENHANDS_WORKDIR"])
+        self._exec_agent(sandbox, self._heredoc_write(_DRIVER_PATH, _DRIVER_SCRIPT), env=env)
+        self._exec_agent(sandbox, self._heredoc_write(_PROMPT_PATH, prompt), env=env)
+
+    def build_invocation(self, instruction: str, task: Task, config: AgentConfig) -> str:
+        del instruction, task, config
+        log = shlex.quote(self.stdout_log_path)
+        return f"set -o pipefail; {_VENV_DIR}/bin/python {shlex.quote(_DRIVER_PATH)} 2>&1 | tee {log}"

--- a/rllm/harnesses/swebench_pro_openhands_glm52.py
+++ b/rllm/harnesses/swebench_pro_openhands_glm52.py
@@ -1,0 +1,159 @@
+"""GLM-5.2 reproduction profile for the llm-stats SWE-bench Pro result.
+
+llm-stats reports a 0.621 resolve rate and Z.ai discloses OpenHands, a
+tailored prompt, temperature 1, top-p 1, 32K output tokens, and a 400K context
+window. The exact private prompt and original task-level traces are unavailable,
+so this profile records the remaining provenance gap instead of claiming exact
+parity.
+"""
+
+# ruff: noqa: E501 -- keep the public OpenHands prompt readable and auditable.
+
+from __future__ import annotations
+
+from rllm.harnesses.openhands import (
+    OPENHANDS_EXTENSIONS_REVISION,
+    OPENHANDS_LIBTMUX_VERSION,
+    OPENHANDS_LOCALE,
+    OPENHANDS_SDK_REVISION,
+    OpenHandsHarness,
+)
+from rllm.types import AgentConfig, Episode, Task, TerminationReason
+
+LLM_STATS_REFERENCE_URL = "https://llm-stats.com/benchmarks/swe-bench-pro"
+LLM_STATS_TARGET_SCORE = 0.621
+TARGET_MODEL = "GLM-5.2"
+OPENROUTER_MODEL_ID = "z-ai/glm-5.2"
+FIREWORKS_MODEL_ID = "accounts/fireworks/models/glm-5p2"
+
+# Public OpenHands SWE-bench Pro baseline inspected on 2026-08-08. The generic
+# harness owns the SDK/runtime pins; this revision identifies only the public
+# benchmark prompt used as the closest available substitute for Z.ai's private
+# tailored prompt.
+OPENHANDS_BENCHMARKS_REVISION = "1411fe96666e2c00b958cd30055ad232e2a64ca1"
+
+TEMPERATURE = 1.0
+TOP_P = 1.0
+MAX_OUTPUT_TOKENS = 32_768
+CONTEXT_WINDOW_TOKENS = 400_000
+MAX_ITERATIONS = 500
+
+REPRODUCTION_PROFILE = {
+    "status": "best_effort",
+    "score_source": LLM_STATS_REFERENCE_URL,
+    "target_model": TARGET_MODEL,
+    "target_score": LLM_STATS_TARGET_SCORE,
+    "score_status": "self_reported_unverified",
+    "openhands_benchmarks_revision": OPENHANDS_BENCHMARKS_REVISION,
+    "openhands_sdk_revision": OPENHANDS_SDK_REVISION,
+    "openhands_extensions_revision": OPENHANDS_EXTENSIONS_REVISION,
+    "libtmux_version": OPENHANDS_LIBTMUX_VERSION,
+    "locale": OPENHANDS_LOCALE,
+    "temperature": TEMPERATURE,
+    "top_p": TOP_P,
+    "max_output_tokens": MAX_OUTPUT_TOKENS,
+    "context_window_tokens": CONTEXT_WINDOW_TOKENS,
+    "max_iterations": MAX_ITERATIONS,
+    "prompt_provenance": "public OpenHands SWE-bench Pro baseline; Z.ai tailored prompt undisclosed",
+    "prompt_input": "rLLM task instruction wrapped by the public OpenHands prompt",
+    "workspace": "official task image /app exposed through OpenHands local workspace",
+}
+
+
+def _render_prompt(instruction: str, workdir: str, base_commit: str) -> str:
+    """Render the pinned public OpenHands SWE-bench Pro prompt baseline."""
+    return f"""I have access to a code repository in the directory {workdir} . You can explore and modify files using the available tools. Consider the following issue description:
+
+<issue_description>
+{instruction}
+</issue_description>
+
+Can you help me implement the necessary changes to the repository so that the requirements specified in the <issue_description> are met?
+I've already taken care of all changes to any of the test files described in the <issue_description>. This means you DON'T have to modify the testing logic or any of the tests in any way.
+The benchmark image already includes the repository and its baseline dependencies, so prefer using the existing environment and only install missing dependencies when the repository clearly requires it.
+Your task is to make the minimal changes to non-test files in the {workdir} directory to ensure the <issue_description> is satisfied.
+
+Follow these phases to resolve the issue:
+
+Phase 1. READING: read the problem and reword it in clearer terms
+   1.1 If there are code or config snippets, explain any best practices or conventions they imply.
+   1.2 Highlight error messages, method names, variables, file names, stack traces, and technical details.
+   1.3 Explain the problem in clear terms.
+   1.4 Enumerate the steps to reproduce the problem.
+   1.5 Highlight any best practices to take into account when testing and fixing the issue.
+
+Phase 2. RUNNING: understand how the repository is built and tested
+   2.1 Read the repository docs and relevant config files to understand the expected workflow.
+   2.2 Identify the project language, package manager, test runner, and any required services.
+   2.3 Run the most relevant tests or reproduction steps for this issue.
+
+Phase 3. EXPLORATION: find the files that are related to the problem and possible solutions
+   3.1 Use search tools to locate relevant methods, classes, keywords, and error messages.
+   3.2 Identify all files related to the problem statement.
+   3.3 Propose the most likely files and functions to change, and explain why.
+   3.4 Select the best fix location before editing.
+
+Phase 4. TEST CREATION: before implementing any fix, create a script or command sequence to reproduce and verify the issue.
+   4.1 Look at existing tests to understand the expected style and structure.
+   4.2 Create a minimal reproduction that demonstrates the issue.
+   4.3 Run it to confirm you are reproducing the problem.
+   4.4 Refine it as needed.
+
+Phase 5. FIX ANALYSIS: state clearly the problem and how to fix it
+   5.1 State clearly what the problem is.
+   5.2 State clearly where the problem is located.
+   5.3 State clearly how the reproduction proves the issue.
+   5.4 State clearly any best practices to preserve in the fix.
+   5.5 State clearly how you will fix the problem.
+
+Phase 6. FIX IMPLEMENTATION: edit the source code to implement your chosen solution.
+   6.1 Make minimal, focused changes to fix the issue.
+
+Phase 7. VERIFICATION: test your implementation thoroughly.
+   7.1 Re-run your reproduction to verify the fix works.
+   7.2 Add edge cases when useful.
+   7.3 Run existing tests related to the modified code to ensure you have not broken anything else.
+
+Phase 8. FINAL REVIEW: carefully re-read the problem description and compare your changes with the base commit {base_commit}.
+   8.1 Ensure you've fully addressed all requirements.
+   8.2 Run any relevant tests for the issue, the files you modified, and the functions you changed.
+   8.3 If any tests fail, revise your implementation until all relevant tests pass.
+
+Be thorough in your exploration, testing, and reasoning. It is fine if your thinking process is lengthy: quality and completeness are more important than brevity.
+"""
+
+
+class SwebenchProOpenHandsGLM52Harness(OpenHandsHarness):
+    """Apply the public GLM-5.2 reproduction settings to OpenHands."""
+
+    name = "swebench-pro-openhands-glm52"
+    stdout_log_path = "/tmp/swebench-pro-openhands-glm52.log"
+
+    temperature = TEMPERATURE
+    top_p = TOP_P
+    max_input_tokens = CONTEXT_WINDOW_TOKENS
+    max_output_tokens = MAX_OUTPUT_TOKENS
+    max_iterations = MAX_ITERATIONS
+    target_score = LLM_STATS_TARGET_SCORE
+
+    def build_env(self, task: Task, config: AgentConfig) -> dict[str, str]:
+        model = config.model.lower()
+        if "glm-5.2" not in model and model != FIREWORKS_MODEL_ID:
+            raise ValueError(f"{self.name} requires a GLM-5.2 model, got {config.model!r}")
+        return super().build_env(task, config)
+
+    def render_prompt(self, task: Task, workdir: str) -> str:
+        metadata = task.metadata.get("metadata", {}) or {}
+        base_commit = str(task.metadata.get("base_commit") or metadata.get("base_commit") or "the task base commit")
+        return _render_prompt(str(task.instruction).strip(), workdir, base_commit)
+
+    def _outcome_episode(
+        self,
+        task: Task,
+        termination_reason: TerminationReason | None = None,
+        error: dict | None = None,
+    ) -> Episode:
+        episode = super()._outcome_episode(task, termination_reason, error)
+        episode.metadata = dict(episode.metadata or {})
+        episode.metadata["reproduction_profile"] = dict(REPRODUCTION_PROFILE)
+        return episode

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -31,6 +31,11 @@
       "function": "OpenHandsHarness",
       "description": "Run the OpenHands Software Agent SDK inside the sandbox."
     },
+    "swebench-pro-openhands-glm52": {
+      "module": "rllm.harnesses.swebench_pro_openhands_glm52",
+      "function": "SwebenchProOpenHandsGLM52Harness",
+      "description": "Reproduce the public GLM-5.2 SWE-bench Pro OpenHands profile."
+    },
     "terminus2": {
       "module": "rllm.harnesses.terminus2",
       "function": "Terminus2Harness",

--- a/rllm/registry/agents.json
+++ b/rllm/registry/agents.json
@@ -26,6 +26,11 @@
       "function": "MiniSweAgentHarness",
       "description": "Run mini-swe-agent inside the sandbox."
     },
+    "openhands": {
+      "module": "rllm.harnesses.openhands",
+      "function": "OpenHandsHarness",
+      "description": "Run the OpenHands Software Agent SDK inside the sandbox."
+    },
     "terminus2": {
       "module": "rllm.harnesses.terminus2",
       "function": "Terminus2Harness",

--- a/tests/harnesses/test_openhands.py
+++ b/tests/harnesses/test_openhands.py
@@ -1,0 +1,308 @@
+"""Offline tests for the generic OpenHands harness."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from types import ModuleType, SimpleNamespace
+
+from rllm.eval.agent_loader import load_agent
+from rllm.harnesses.openhands import (
+    _DRIVER_SCRIPT,
+    _OUTCOME_PATH,
+    OPENHANDS_EXTENSIONS_REVISION,
+    OPENHANDS_LIBTMUX_VERSION,
+    OPENHANDS_LOCALE,
+    OPENHANDS_SDK_REVISION,
+    OpenHandsHarness,
+)
+from rllm.sandbox.protocol import SandboxCommandTimeout
+from rllm.types import AgentConfig, Task, TerminationReason
+
+
+@dataclass
+class FakeSandbox:
+    calls: list[str] = field(default_factory=list)
+    outcome: str | None = None
+    fail_invocation: bool = False
+    timeout_invocation: bool = False
+
+    def exec(self, command: str, timeout: float | None = None, user: str | None = None) -> str:
+        del timeout, user
+        self.calls.append(command)
+        if command.startswith(f"cat {_OUTCOME_PATH}"):
+            return self.outcome or ""
+        if "/opt/rllm/openhands/bin/python /tmp/rllm-openhands/driver.py" in command:
+            if self.timeout_invocation:
+                raise SandboxCommandTimeout("agent timed out")
+            if self.fail_invocation:
+                raise RuntimeError("driver exited non-zero")
+        return "OK"
+
+    def is_alive(self) -> bool:
+        return True
+
+
+def _task() -> Task:
+    return Task(
+        id="task-1",
+        instruction="Fix the issue while keeping the API stable.",
+        metadata={"workdir": "/repo", "agent_timeout": 3600.0},
+    )
+
+
+def _config(model: str = "vendor/model-v1") -> AgentConfig:
+    return AgentConfig(
+        base_url="http://gateway/sessions/test/v1",
+        model=model,
+        session_uid="test",
+        metadata={"gateway_auth_token": "gateway-token"},
+    )
+
+
+def test_registry_loads_generic_openhands_harness():
+    assert isinstance(load_agent("openhands"), OpenHandsHarness)
+
+
+def test_install_script_pins_sdk_and_tmux_parser():
+    script = OpenHandsHarness().install_script()
+
+    assert OPENHANDS_SDK_REVISION in script
+    assert "#subdirectory=openhands-sdk" in script
+    assert "#subdirectory=openhands-tools" in script
+    assert "--no-deps" in script
+    assert f"libtmux=={OPENHANDS_LIBTMUX_VERSION}" in script
+    assert f"{OPENHANDS_SDK_REVISION}:libtmux=={OPENHANDS_LIBTMUX_VERSION}" in script
+
+
+def test_driver_is_valid_and_reads_agent_settings_from_environment():
+    compile(_DRIVER_SCRIPT, "<openhands-driver>", "exec")
+
+    assert 'os.environ["RLLM_OPENHANDS_TEMPERATURE"]' in _DRIVER_SCRIPT
+    assert 'os.environ["RLLM_OPENHANDS_TOP_P"]' in _DRIVER_SCRIPT
+    assert '_optional_int("RLLM_OPENHANDS_MAX_INPUT_TOKENS")' in _DRIVER_SCRIPT
+    assert '_optional_int("RLLM_OPENHANDS_MAX_OUTPUT_TOKENS")' in _DRIVER_SCRIPT
+    assert 'os.environ["RLLM_OPENHANDS_MAX_ITERATIONS"]' in _DRIVER_SCRIPT
+    assert "get_default_tools(enable_browser=False)" in _DRIVER_SCRIPT
+    assert "conversation.run()" in _DRIVER_SCRIPT
+    assert "traceback.format_exc()" in _DRIVER_SCRIPT
+    assert "SWE-bench" not in _DRIVER_SCRIPT
+    assert "GLM" not in _DRIVER_SCRIPT
+
+
+def test_build_env_routes_any_model_through_rllm_gateway():
+    harness = OpenHandsHarness(
+        temperature=0.2,
+        top_p=0.9,
+        max_input_tokens=123_000,
+        max_output_tokens=4_096,
+        max_iterations=17,
+    )
+    env = harness.build_env(_task(), _config("accounts/provider/models/model-v1"))
+
+    assert env["LLM_MODEL"] == "openai/accounts/provider/models/model-v1"
+    assert env["LLM_API_KEY"] == "gateway-token"
+    assert env["LLM_BASE_URL"] == "http://gateway/sessions/test/v1"
+    assert env["OPENAI_API_KEY"] == "gateway-token"
+    assert env["EXTENSIONS_REF"] == OPENHANDS_EXTENSIONS_REVISION
+    assert env["LC_ALL"] == OPENHANDS_LOCALE
+    assert env["LANG"] == OPENHANDS_LOCALE
+    assert env["RLLM_OPENHANDS_WORKDIR"] == "/repo"
+    assert env["RLLM_OPENHANDS_TEMPERATURE"] == "0.2"
+    assert env["RLLM_OPENHANDS_TOP_P"] == "0.9"
+    assert env["RLLM_OPENHANDS_MAX_INPUT_TOKENS"] == "123000"
+    assert env["RLLM_OPENHANDS_MAX_OUTPUT_TOKENS"] == "4096"
+    assert env["RLLM_OPENHANDS_MAX_ITERATIONS"] == "17"
+
+
+def test_build_env_does_not_copy_a_host_provider_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "host-provider-secret")
+    config = _config()
+    config.metadata = {}
+
+    env = OpenHandsHarness().build_env(_task(), config)
+
+    assert env["LLM_API_KEY"] == "sk-rllm-gateway"
+    assert env["OPENAI_API_KEY"] == "sk-rllm-gateway"
+
+
+def test_write_configs_uses_raw_task_instruction_by_default():
+    harness = OpenHandsHarness()
+    sandbox = FakeSandbox()
+    task = _task()
+    config = _config()
+    env = harness.build_env(task, config)
+
+    harness.write_configs(sandbox, task, config, env)
+
+    assert len(sandbox.calls) == 2
+    assert "Local-workspace OpenHands driver" in sandbox.calls[0]
+    assert task.instruction in sandbox.calls[1]
+    assert "<issue_description>" not in sandbox.calls[1]
+
+
+def _run_driver_with_fake_openhands(monkeypatch, tmp_path, *, finish_before_error: bool) -> dict:
+    class ExecutionStatus(Enum):
+        FINISHED = "finished"
+
+    class FinishAction:
+        pass
+
+    class ActionEvent:
+        def __init__(self, action):
+            self.action = action
+
+    class MessageEvent:
+        def __init__(self, source):
+            self.source = source
+
+    class LLM:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def model_copy(self, **kwargs):
+            del kwargs
+            return self
+
+    class AcceptsKeywords:
+        def __init__(self, **kwargs):
+            del kwargs
+
+    class Conversation:
+        def __init__(self, **kwargs):
+            del kwargs
+            self.state = SimpleNamespace(events=[], execution_status=ExecutionStatus.FINISHED)
+
+        def send_message(self, message):
+            del message
+
+        def run(self):
+            if finish_before_error:
+                self.state.events.append(ActionEvent(FinishAction()))
+                raise RuntimeError("cleanup failed after finish")
+            raise RuntimeError("gateway unavailable")
+
+    modules = {
+        name: ModuleType(name)
+        for name in (
+            "openhands",
+            "openhands.sdk",
+            "openhands.sdk.context",
+            "openhands.sdk.context.condenser",
+            "openhands.sdk.conversation",
+            "openhands.sdk.conversation.state",
+            "openhands.sdk.event",
+            "openhands.sdk.skills",
+            "openhands.sdk.tool",
+            "openhands.sdk.tool.builtins",
+            "openhands.sdk.tool.builtins.finish",
+            "openhands.tools",
+            "openhands.tools.preset",
+            "openhands.tools.preset.default",
+        )
+    }
+    modules["openhands.sdk"].Agent = AcceptsKeywords
+    modules["openhands.sdk"].Conversation = Conversation
+    modules["openhands.sdk"].LLM = LLM
+    modules["openhands.sdk.context"].AgentContext = AcceptsKeywords
+    modules["openhands.sdk.context.condenser"].LLMSummarizingCondenser = AcceptsKeywords
+    modules["openhands.sdk.conversation.state"].ConversationExecutionStatus = ExecutionStatus
+    modules["openhands.sdk.event"].ActionEvent = ActionEvent
+    modules["openhands.sdk.event"].MessageEvent = MessageEvent
+    modules["openhands.sdk.skills"].load_public_skills = lambda: []
+    modules["openhands.sdk.tool.builtins.finish"].FinishAction = FinishAction
+    modules["openhands.tools.preset.default"].get_default_tools = lambda **kwargs: []
+    for name, module in modules.items():
+        if name.rsplit(".", 1)[-1] not in {"condenser", "state", "event", "finish", "skills", "default"}:
+            module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    prompt_path = tmp_path / "prompt.txt"
+    summary_path = tmp_path / "summary.json"
+    outcome_path = tmp_path / "outcome.json"
+    prompt_path.write_text("Fix it")
+    env = {
+        "LLM_MODEL": "openai/model-v1",
+        "LLM_API_KEY": "test-key",
+        "LLM_BASE_URL": "http://gateway/v1",
+        "RLLM_OPENHANDS_WORKDIR": "/app",
+        "RLLM_OPENHANDS_PROMPT_PATH": str(prompt_path),
+        "RLLM_OPENHANDS_SUMMARY_PATH": str(summary_path),
+        "RLLM_OPENHANDS_OUTCOME_PATH": str(outcome_path),
+        "RLLM_OPENHANDS_TEMPERATURE": "1.0",
+        "RLLM_OPENHANDS_TOP_P": "1.0",
+        "RLLM_OPENHANDS_MAX_ITERATIONS": "500",
+        "RLLM_OPENHANDS_CONDENSER_MAX_SIZE": "240",
+        "RLLM_OPENHANDS_CONDENSER_KEEP_FIRST": "2",
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    namespace = {"__name__": "test_openhands_driver"}
+    exec(compile(_DRIVER_SCRIPT, "<openhands-driver>", "exec"), namespace)
+    namespace["main"]()
+    return json.loads(outcome_path.read_text())
+
+
+def test_driver_treats_typed_finish_as_authoritative(monkeypatch, tmp_path):
+    outcome = _run_driver_with_fake_openhands(monkeypatch, tmp_path, finish_before_error=True)
+
+    assert outcome == {
+        "execution_status": "finished",
+        "exception_type": None,
+        "finished": True,
+        "message": "cleanup failed after finish",
+        "traceback": None,
+    }
+
+
+def test_driver_records_failure_and_full_traceback_before_finish(monkeypatch, tmp_path):
+    outcome = _run_driver_with_fake_openhands(monkeypatch, tmp_path, finish_before_error=False)
+
+    assert outcome["finished"] is False
+    assert outcome["exception_type"] == "RuntimeError"
+    assert outcome["message"] == "gateway unavailable"
+    assert "RuntimeError: gateway unavailable" in outcome["traceback"]
+
+
+def test_run_maps_structured_outcomes():
+    success = FakeSandbox(outcome=json.dumps({"finished": True}))
+    failure = FakeSandbox(
+        outcome=json.dumps(
+            {
+                "finished": False,
+                "exception_type": "RuntimeError",
+                "message": "gateway unavailable",
+                "traceback": "RuntimeError: gateway unavailable",
+            }
+        )
+    )
+
+    success_episode = OpenHandsHarness().run(_task(), _config(), env=success)
+    failure_episode = OpenHandsHarness().run(_task(), _config(), env=failure)
+
+    assert success_episode.termination_reason is None
+    assert failure_episode.termination_reason == TerminationReason.ERROR
+    assert failure_episode.metadata["error"] == {
+        "error_type": "RuntimeError",
+        "message": "gateway unavailable\n\nRuntimeError: gateway unavailable",
+    }
+
+
+def test_run_maps_structured_agent_timeout():
+    sandbox = FakeSandbox(
+        outcome=json.dumps(
+            {
+                "finished": False,
+                "exception_type": "AgentTimeoutError",
+                "message": "agent timed out",
+            }
+        ),
+        timeout_invocation=True,
+    )
+
+    episode = OpenHandsHarness().run(_task(), _config(), env=sandbox)
+
+    assert episode.termination_reason == TerminationReason.TIMEOUT

--- a/tests/harnesses/test_swebench_pro_openhands_glm52.py
+++ b/tests/harnesses/test_swebench_pro_openhands_glm52.py
@@ -1,0 +1,104 @@
+"""Offline tests for the SWE-bench Pro GLM-5.2 OpenHands profile."""
+
+from __future__ import annotations
+
+import pytest
+
+from rllm.eval.agent_loader import load_agent
+from rllm.harnesses.openhands import OpenHandsHarness
+from rllm.harnesses.swebench_pro_openhands_glm52 import (
+    CONTEXT_WINDOW_TOKENS,
+    FIREWORKS_MODEL_ID,
+    LLM_STATS_TARGET_SCORE,
+    MAX_ITERATIONS,
+    MAX_OUTPUT_TOKENS,
+    OPENHANDS_BENCHMARKS_REVISION,
+    OPENROUTER_MODEL_ID,
+    REPRODUCTION_PROFILE,
+    SwebenchProOpenHandsGLM52Harness,
+    _render_prompt,
+)
+from rllm.types import AgentConfig, Task
+
+
+def _task() -> Task:
+    return Task(
+        id="task-1",
+        instruction="Fix the issue.\n\nRequirements:\nKeep the API stable.",
+        metadata={
+            "workdir": "/app",
+            "agent_timeout": 3600.0,
+            "metadata": {"base_commit": "a" * 40},
+        },
+    )
+
+
+def _config(model: str = "openai/glm-5.2") -> AgentConfig:
+    return AgentConfig(
+        base_url="http://gateway/sessions/test/v1",
+        model=model,
+        session_uid="test",
+        metadata={"gateway_auth_token": "gateway-token"},
+    )
+
+
+def test_profile_is_a_thin_openhands_specialization():
+    harness = SwebenchProOpenHandsGLM52Harness()
+
+    assert isinstance(harness, OpenHandsHarness)
+    assert harness.temperature == 1.0
+    assert harness.top_p == 1.0
+    assert harness.max_input_tokens == CONTEXT_WINDOW_TOKENS == 400_000
+    assert harness.max_output_tokens == MAX_OUTPUT_TOKENS == 32_768
+    assert harness.max_iterations == MAX_ITERATIONS == 500
+
+
+def test_profile_records_public_score_and_disclosure_gap():
+    assert LLM_STATS_TARGET_SCORE == 0.621
+    assert len(OPENHANDS_BENCHMARKS_REVISION) == 40
+    assert REPRODUCTION_PROFILE["status"] == "best_effort"
+    assert REPRODUCTION_PROFILE["score_status"] == "self_reported_unverified"
+    assert "undisclosed" in REPRODUCTION_PROFILE["prompt_provenance"]
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["openai/glm-5.2", OPENROUTER_MODEL_ID, FIREWORKS_MODEL_ID],
+)
+def test_profile_accepts_glm52_routes_and_preserves_gateway_alias(model):
+    env = SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config(model))
+
+    assert env["LLM_MODEL"] == f"openai/{model}"
+    assert env["LLM_API_KEY"] == "gateway-token"
+    assert env["LLM_BASE_URL"] == "http://gateway/sessions/test/v1"
+    assert env["RLLM_OPENHANDS_MAX_INPUT_TOKENS"] == "400000"
+    assert env["RLLM_OPENHANDS_MAX_OUTPUT_TOKENS"] == "32768"
+
+
+def test_profile_rejects_non_glm52_models():
+    with pytest.raises(ValueError, match="requires a GLM-5.2 model"):
+        SwebenchProOpenHandsGLM52Harness().build_env(_task(), _config("openai/gpt-5.4"))
+
+
+def test_public_prompt_wraps_task_and_base_commit():
+    prompt = _render_prompt("Fix it", "/app", "b" * 40)
+
+    assert "code repository in the directory /app" in prompt
+    assert "<issue_description>\nFix it\n</issue_description>" in prompt
+    assert "b" * 40 in prompt
+    assert "minimal changes to non-test files" in prompt
+
+
+def test_render_prompt_reads_builder_metadata_shape():
+    prompt = SwebenchProOpenHandsGLM52Harness().render_prompt(_task(), "/app")
+
+    assert "Keep the API stable." in prompt
+    assert "a" * 40 in prompt
+
+
+def test_registry_loads_profile_and_episode_records_provenance():
+    harness = load_agent("swebench-pro-openhands-glm52")
+    episode = harness._outcome_episode(_task())
+
+    assert isinstance(harness, SwebenchProOpenHandsGLM52Harness)
+    assert episode.metadata["reproduction_profile"] == REPRODUCTION_PROFILE


### PR DESCRIPTION
## Summary

- add a thin SWE-bench Pro GLM-5.2 profile on top of the generic OpenHands harness from #887
- apply the disclosed temperature, top-p, context-window, output-token, and iteration settings
- use the pinned public OpenHands SWE-bench Pro prompt as the closest available baseline
- validate GLM-5.2 model aliases and record the llm-stats target plus the undisclosed-prompt provenance gap
- add offline profile tests

## Dependency

Stacked on #887. The only commit unique to this PR is `feat(eval): add SWE-bench Pro GLM-5.2 profile`; once #887 lands, this PR narrows automatically to the profile, registry entry, and profile tests.

## Test plan

- `python -m pytest tests/harnesses/test_swebench_pro_openhands_glm52.py -q` (`9 passed`)
- `python -m pytest tests/harnesses/test_openhands.py tests/harnesses/test_swebench_pro_openhands_glm52.py -q` (`19 passed`)
- `python -m pytest tests/harnesses -q` (`90 passed`)
- Ruff lint and format checks
- `git diff --check`
