### PR TITLE
debug: dump raw TraceRecords and compact graphs for parity checks

### DIFF
--- a/cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
+++ b/cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
@@ -5,6 +5,8 @@
 # Source of truth:
 #   - W&B recorded program/config from commit d501e357967c45bb46807d5f6a3366cbcdfee32b
 #   - W&B run arguments are copied below field-for-field
+#   - W&B captured transformers==5.15.0; pin it because this branch's 5.5.3
+#     does not recognize model_type=deepseek_v4
 #
 # Intentional current-branch adaptations:
 #   - tb_v2_debug -> the current registry name tb-v2-debug
@@ -74,7 +76,7 @@ export RLLM_SANDBOX_TIMEOUT_S="${RLLM_SANDBOX_TIMEOUT_S:-3000}"
 export RLLM_EXPERIMENT_NAME="${RLLM_EXPERIMENT_NAME:-z6xi3xkh-dsv4-flash-lora128-trace-parity}"
 
 launch_cmd=(
-    uv run python -u cookbooks/terminal-rl/train_debug.py
+    uv run --with transformers==5.15.0 python -u cookbooks/terminal-rl/train_debug.py
     rllm/backend=fireworks
     model.name=accounts/fireworks/models/deepseek-v4-flash-0731
     model.tokenizer_model=deepseek-ai/DeepSeek-V4-Flash-0731

--- a/cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
+++ b/cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Reproduce https://wandb.ai/agentica/terminal-rl/runs/z6xi3xkh on the
+# current terminal-rl branch, with raw TraceRecord -> TraceGraph parity dumps.
+#
+# Source of truth:
+#   - W&B recorded program/config from commit d501e357967c45bb46807d5f6a3366cbcdfee32b
+#   - W&B run arguments are copied below field-for-field
+#
+# Intentional current-branch adaptations:
+#   - tb_v2_debug -> the current registry name tb-v2-debug
+#   - the old machine's fixed http://5.78.144.17:19090 route is replaced by
+#     current automatic tunnel resolution (a registered ngrok wildcard creates
+#     a unique hostname and gateway port for every run)
+#   - gateway store=compact plus a required, unique parity dump directory
+#   - nested Hydra syntax for loss_params, whose parent now exists by default
+#   - a shorter experiment name avoids the original run's >63-character
+#     Fireworks output-model-id checkpoint promotion failure
+#
+# This script deliberately keeps MiniSweAgentHarness, cumulative-token mode,
+# group/async sizing, model, optimizer, and rollout settings from the W&B run.
+# It runs the parity verifier after training exits, including failed runs.
+#
+# Required before launch:
+#   export FIREWORKS_API_KEY=...
+#   export RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR=/local/nvme/z6xi3xkh-parity-001
+#   rllm tunnel setup  # once; register an ngrok wildcard such as *.example.com
+#   rllm dataset pull tb-v2-debug
+#   rllm dataset pull harbor:terminal-bench@2.0
+#
+# With a registered wildcard, do not run `rllm tunnel up` and do not pass a
+# tunnel or port here. AgentTrainer creates both automatically. To deliberately
+# override that behavior, set the standard RLLM_GATEWAY_TUNNEL environment
+# variable before launch.
+#
+# Review without launching anything:
+#   RLLM_LAUNCH_DRY_RUN=1 \
+#     RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR=/tmp/z6xi3xkh-review \
+#     bash cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
+# Set RLLM_LAUNCH_CONFIG_ONLY=1 instead to make Hydra parse and print the fully
+# resolved static job config without entering train_debug.main or provisioning
+# infra. Tunnel and port remain null in that output because AgentTrainer resolves
+# them dynamically after loading the datasets.
+#
+# A bounded first launch can append a normal Hydra override, for example:
+#   ... bash cookbooks/terminal-rl/reproduce_z6xi3xkh.sh rllm.trainer.total_batches=1
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$repo_root"
+
+: "${RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR:?Set RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR to a unique local path with ample free space}"
+
+if [[ "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR" != /* ]]; then
+    echo "RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR must be an absolute path" >&2
+    exit 2
+fi
+
+export TERMINAL_SANDBOX_BACKEND="${TERMINAL_SANDBOX_BACKEND:-modal}"
+export TB_TRAIN_DATASET="${TB_TRAIN_DATASET:-tb-v2-debug}"
+export MINISWE_MAX_TURNS="${MINISWE_MAX_TURNS:-64}"
+export MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS="${MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS:-1}"
+export MINISWE_COMMAND_TIMEOUT="${MINISWE_COMMAND_TIMEOUT:-300}"
+export RLLM_SANDBOX_MAX_CPUS="${RLLM_SANDBOX_MAX_CPUS:-0.125}"
+export RLLM_SANDBOX_MAX_MEMORY_MB="${RLLM_SANDBOX_MAX_MEMORY_MB:-256}"
+export RLLM_MODAL_SANDBOX_CREATE_RPS="${RLLM_MODAL_SANDBOX_CREATE_RPS:-2}"
+export RLLM_HARNESS_INSTALL_TIMEOUT_S="${RLLM_HARNESS_INSTALL_TIMEOUT_S:-300}"
+export RLLM_HARNESS_RUN_TIMEOUT_S="${RLLM_HARNESS_RUN_TIMEOUT_S:-2400}"
+export RLLM_HARNESS_VERIFIER_TIMEOUT_S="${RLLM_HARNESS_VERIFIER_TIMEOUT_S:-300}"
+export RLLM_SANDBOX_TIMEOUT_S="${RLLM_SANDBOX_TIMEOUT_S:-3000}"
+export RLLM_EXPERIMENT_NAME="${RLLM_EXPERIMENT_NAME:-z6xi3xkh-dsv4-flash-lora128-trace-parity}"
+
+launch_cmd=(
+    uv run python -u cookbooks/terminal-rl/train_debug.py
+    rllm/backend=fireworks
+    model.name=accounts/fireworks/models/deepseek-v4-flash-0731
+    model.tokenizer_model=deepseek-ai/DeepSeek-V4-Flash-0731
+    model.lora_rank=128
+    fireworks_config.policy_trainer_shape_id=accounts/fireworks/trainingShapes/deepseek-v4-flash-0731-256k-lora
+    fireworks_config.policy_trainer_replica_count=2
+    fireworks_config.rollout_deployment_replica_count=4
+    training.group_size=16
+    training.learning_rate=5e-5
+    training.grad_clip_norm=0.0
+    training.beta2=0.999
+    training.eps=1e-10
+    training.max_length=67584
+    rllm.rollout.train.temperature=1.0
+    rllm.rollout.train.top_p=1.0
+    rllm.rollout.val.temperature=1.0
+    rllm.rollout.val.top_p=1.0
+    data.max_prompt_length=67584
+    data.max_response_length=16384
+    data.train_batch_size=1
+    data.val_batch_size=-1
+    rllm.data.max_prompt_length=67584
+    rllm.data.max_response_length=16384
+    rllm.data.train_batch_size=1
+    rllm.data.val_batch_size=-1
+    rllm.compact_filtering.enable=false
+    rllm.algorithm.adv_estimator=grpo
+    rllm.algorithm.norm_adv_by_std_in_grpo=false
+    rllm.algorithm.router_replay=R3
+    rllm.algorithm.loss_fn=dppo_tv
+    +rllm.algorithm.loss_params.delta=0.1
+    rllm.algorithm.loss_agg_mode=token-mean
+    rllm.algorithm.rollout_correction.bypass_mode=true
+    rllm.async_training.enable=true
+    rllm.async_training.mini_batch_size=8
+    rllm.async_training.fwd_bwd_group_size=8
+    rllm.async_training.staleness_threshold=3.0
+    rllm.async_training.trigger_parameter_sync_step=1
+    rllm.async_training.partial_rollout=true
+    rllm.workflow.n_parallel_tasks=384
+    rllm.workflow.raise_on_error=false
+    rllm.workflow.verify_only_on_env_done=true
+    rllm.rejection_sample.filter_uniform_groups=true
+    rllm.rejection_sample.refill_filtered_uniform_groups=true
+    rllm.gateway.host=127.0.0.1
+    rllm.gateway.num_workers=4
+    rllm.gateway.store=compact
+    "rllm.gateway.trace_parity_dump_dir=${RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR}"
+    rllm.gateway.cumulative_token_mode=true
+    rllm.gateway.renderer_family=auto
+    rllm.trainer.total_epochs=1000
+    rllm.episode_logging.log_episodes=true
+    "rllm.trainer.logger=[wandb]"
+    rllm.trainer.project_name=terminal-rl
+    "rllm.trainer.experiment_name=${RLLM_EXPERIMENT_NAME}"
+    rllm.trainer.val_before_train=false
+    rllm.trainer.test_freq=-1
+    rllm.trainer.save_freq=20
+    "$@"
+)
+
+if [[ "${RLLM_LAUNCH_DRY_RUN:-0}" == "1" ]]; then
+    printf 'Launch command:'
+    printf ' %q' "${launch_cmd[@]}"
+    printf '\nParity verifier: uv run python scripts/verify_trace_parity_dump.py %q\n' "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR"
+    exit 0
+fi
+
+if [[ "${RLLM_LAUNCH_CONFIG_ONLY:-0}" == "1" ]]; then
+    "${launch_cmd[@]}" --cfg job --resolve
+    exit 0
+fi
+
+export FIREWORKS_API_KEY="${FIREWORKS_API_KEY:-$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.rllm/config.json')))['api_keys']['fireworks'])" 2>/dev/null || true)}"
+if [[ -z "$FIREWORKS_API_KEY" ]]; then
+    echo "FIREWORKS_API_KEY is not set and ~/.rllm/config.json has no api_keys.fireworks (run: rllm model setup)" >&2
+    exit 2
+fi
+
+if [[ -d "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR" ]] && find "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR" -mindepth 1 -print -quit | grep -q .; then
+    echo "Trace parity dump directory must be empty: $RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR" >&2
+    exit 2
+fi
+mkdir -p "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR"
+
+printf 'Raw TraceRecord and TraceGraph dump: %s\n' "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR"
+printf 'Tunnel: automatic (registered ngrok wildcard; RLLM_GATEWAY_TUNNEL may override)\n'
+
+training_status=0
+"${launch_cmd[@]}" || training_status=$?
+
+verify_status=0
+uv run python scripts/verify_trace_parity_dump.py "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR" || verify_status=$?
+
+if ((training_status != 0)); then
+    exit "$training_status"
+fi
+exit "$verify_status"

--- a/cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
+++ b/cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
@@ -22,10 +22,13 @@
 #
 # Required before launch:
 #   export FIREWORKS_API_KEY=...
-#   export RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR=/local/nvme/z6xi3xkh-parity-001
 #   rllm tunnel setup  # once; register an ngrok wildcard such as *.example.com
 #   rllm dataset pull tb-v2-debug
 #   rllm dataset pull harbor:terminal-bench@2.0
+#
+# Raw records and graphs default to:
+#   /data/home/thw/trace-dumps/z6xi3xkh-parity-001
+# Set RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR only to override that path.
 #
 # With a registered wildcard, do not run `rllm tunnel up` and do not pass a
 # tunnel or port here. AgentTrainer creates both automatically. To deliberately
@@ -49,7 +52,7 @@ set -euo pipefail
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 cd "$repo_root"
 
-: "${RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR:?Set RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR to a unique local path with ample free space}"
+export RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR="${RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR:-/data/home/thw/trace-dumps/z6xi3xkh-parity-001}"
 
 if [[ "$RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR" != /* ]]; then
     echo "RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR must be an absolute path" >&2

--- a/cookbooks/terminal-rl/train_debug.py
+++ b/cookbooks/terminal-rl/train_debug.py
@@ -1,0 +1,85 @@
+"""Mini-SWE terminal-RL entrypoint used by W&B run z6xi3xkh.
+
+This restores the run's original ``MiniSweAgentHarness`` path on top of the
+current ``terminal-rl`` branch.  The normal cookbook now uses Terminus-2, which
+would produce a different request stream and therefore is not suitable for the
+raw-TraceRecord/TraceGraph comparison.
+"""
+
+from __future__ import annotations
+
+import os
+
+import hydra
+from omegaconf import DictConfig
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.harnesses.mini_swe_agent import MiniSweAgentHarness
+from rllm.trainer import AgentTrainer
+
+TRAIN_DATASET = os.environ.get("TB_TRAIN_DATASET", "tb-v2-debug")
+
+# Terminal-Bench eval version (Harbor registry). Must match prepare_data.py;
+# both read TB_EVAL_VERSION so the pulled and loaded dataset names agree.
+EVAL_VERSION = os.environ.get("TB_EVAL_VERSION", "2.0")
+VAL_DATASET = f"terminal-bench@{EVAL_VERSION}"
+
+# Sandbox backend for the SandboxedAgentFlow path: docker | local | modal | daytona.
+SANDBOX_BACKEND = os.environ.get("TERMINAL_SANDBOX_BACKEND", "modal")
+
+# Optional cap on the validation set size. Terminal-Bench 2.0 is 89 tasks;
+# validation runs ALL of them every time it fires, which is slow. Set
+# TB_VAL_MAX=N to validate on the first N tasks instead (0/unset = all).
+TB_VAL_MAX = int(os.environ.get("TB_VAL_MAX", "0"))
+
+# These values match the source launcher at d501e357. They are passed into
+# mini-SWE's own config, so they affect the raw request stream rather than just
+# host-side bookkeeping.
+MINISWE_MAX_TURNS = int(os.environ.get("MINISWE_MAX_TURNS", "64"))
+if MINISWE_MAX_TURNS <= 0:
+    raise ValueError(f"MINISWE_MAX_TURNS must be positive, got {MINISWE_MAX_TURNS}")
+
+MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS = int(os.environ.get("MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS", "1"))
+if MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS < 0:
+    raise ValueError(f"MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS must be non-negative, got {MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS}")
+
+MINISWE_COMMAND_TIMEOUT = int(os.environ.get("MINISWE_COMMAND_TIMEOUT", "300"))
+if MINISWE_COMMAND_TIMEOUT <= 0:
+    raise ValueError(f"MINISWE_COMMAND_TIMEOUT must be positive, got {MINISWE_COMMAND_TIMEOUT}")
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config: DictConfig) -> None:
+    train_dataset = DatasetRegistry.load_dataset(TRAIN_DATASET, "train")
+    val_dataset = DatasetRegistry.load_dataset(VAL_DATASET, "default")
+
+    if train_dataset is None:
+        raise RuntimeError(f"Dataset '{TRAIN_DATASET}' not found. Run: rllm dataset pull {TRAIN_DATASET}")
+    if val_dataset is None:
+        raise RuntimeError(f"Dataset '{VAL_DATASET}' not found. Run: rllm dataset pull harbor:{VAL_DATASET} (or: python cookbooks/terminal-rl/prepare_data.py)")
+
+    if TB_VAL_MAX > 0 and TB_VAL_MAX < len(val_dataset):
+        val_dataset = val_dataset.select(range(TB_VAL_MAX))
+
+    agent_flow = MiniSweAgentHarness(
+        sandbox_backend=SANDBOX_BACKEND,
+        max_turns=MINISWE_MAX_TURNS,
+        max_consecutive_format_errors=MINISWE_MAX_CONSECUTIVE_FORMAT_ERRORS,
+        command_timeout=MINISWE_COMMAND_TIMEOUT,
+        capture_exit_status=True,
+        cost_limit=0.0,
+    )
+
+    trainer = AgentTrainer(
+        backend=config.rllm.get("backend", "tinker"),
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        agent_flow=agent_flow,
+        sandbox_backend=SANDBOX_BACKEND,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/rllm-model-gateway/README.md
+++ b/rllm-model-gateway/README.md
@@ -111,7 +111,30 @@ workers:
 
 ### Environment Variables
 
-`RLLM_GATEWAY_HOST`, `RLLM_GATEWAY_PORT`, `RLLM_GATEWAY_DB_PATH`, `RLLM_GATEWAY_LOG_LEVEL`, `RLLM_GATEWAY_STORE`
+`RLLM_GATEWAY_HOST`, `RLLM_GATEWAY_PORT`, `RLLM_GATEWAY_DB_PATH`, `RLLM_GATEWAY_LOG_LEVEL`, `RLLM_GATEWAY_STORE`, `RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR`
+
+### Debugging compact-trace parity
+
+To check the compact graph implementation against its actual inputs, set a unique dump directory while using the compact store:
+
+```bash
+python cookbooks/terminal-rl/train.py \
+  rllm.gateway.store=compact \
+  rllm.gateway.trace_parity_dump_dir=/local/fast-disk/trace-parity-debug
+```
+
+Each session generation (retry attempts are kept separate) contains:
+
+- `raw_trace_records.jsonl`: every full `TraceRecord` serialized directly inside `store_trace()`, before `TraceGraph.add()` / `replace_leaf()` runs. It is not reconstructed from the graph, an episode, or a trajectory.
+- `trace_graph.json`: the eventual compact `TraceGraph`, written on full retrieval or session deletion.
+
+Verify exact reconstruction, including the store's same-leaf replacement semantics for retried trace IDs, with:
+
+```bash
+python scripts/verify_trace_parity_dump.py /local/fast-disk/trace-parity-debug
+```
+
+This is a debug-only path. It performs synchronous serialization on gateway workers, duplicates large prompt/token data, and may contain sensitive prompts. Prefer a small parity run on local fast storage; leave it disabled for performance measurements and normal training.
 
 ## Embedded Usage
 

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -358,6 +358,9 @@ class GatewayConfig(BaseModel):
     workers: list[WorkerConfig] = Field(default_factory=list)
     db_path: str | None = None
     store_worker: str = "memory"
+    # Diagnostic-only: write each full TraceRecord before compaction and the
+    # final TraceGraph for exact offline parity checks.
+    trace_parity_dump_dir: str | None = None
     add_logprobs: bool = True
     add_return_token_ids: bool = True
     strip_vllm_fields: bool = True

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -87,7 +87,10 @@ def create_store(config: GatewayConfig) -> TraceStore:
     if worker in ("memory", "compact"):
         from rllm_model_gateway.store.memory_store import MemoryTraceStore
 
-        return MemoryTraceStore(compact=worker == "compact")
+        return MemoryTraceStore(
+            compact=worker == "compact",
+            trace_parity_dump_dir=config.trace_parity_dump_dir,
+        )
     raise ValueError(f"Unknown store worker: {worker}")
 
 
@@ -473,6 +476,7 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         "RLLM_GATEWAY_DB_PATH": "db_path",
         "RLLM_GATEWAY_LOG_LEVEL": "log_level",
         "RLLM_GATEWAY_STORE": "store_worker",
+        "RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR": "trace_parity_dump_dir",
     }
     for env_key, config_key in env_map.items():
         val = os.environ.get(env_key)
@@ -493,6 +497,8 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["log_level"] = args.log_level
     if getattr(args, "store", None) is not None:
         data["store_worker"] = args.store
+    if getattr(args, "trace_parity_dump_dir", None) is not None:
+        data["trace_parity_dump_dir"] = args.trace_parity_dump_dir
     if getattr(args, "model", None) is not None:
         data["model"] = args.model
     if getattr(args, "cumulative_token_mode", False):
@@ -526,6 +532,12 @@ def main() -> None:
     )
     parser.add_argument("--db-path", type=str, default=None)
     parser.add_argument("--store", type=str, default=None, choices=["sqlite", "memory", "compact"])
+    parser.add_argument(
+        "--trace-parity-dump-dir",
+        type=str,
+        default=None,
+        help="Diagnostic-only directory for pre-compaction TraceRecord JSONL and final TraceGraph JSON (compact store only).",
+    )
     parser.add_argument("--log-level", type=str, default=None)
     parser.add_argument(
         "--model",

--- a/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/store/memory_store.py
@@ -1,8 +1,12 @@
 """In-memory trace store for testing and embedded usage."""
 
 import array
+import hashlib
+import json
+import os
 import time
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
 from rllm_model_gateway.models import TraceGraph, TraceRecord
@@ -57,14 +61,62 @@ def _unpack(data: dict[str, Any]) -> dict[str, Any]:
 class MemoryTraceStore:
     """Ephemeral in-memory store.  Useful for tests and short-lived processes."""
 
-    def __init__(self, compact: bool = False) -> None:
+    def __init__(self, compact: bool = False, trace_parity_dump_dir: str | None = None) -> None:
+        if trace_parity_dump_dir is not None and not compact:
+            raise ValueError("trace parity dumps require MemoryTraceStore(compact=True)")
         self._compact = compact
+        self._trace_parity_dump_root = Path(trace_parity_dump_dir).expanduser().resolve() if trace_parity_dump_dir else None
+        if self._trace_parity_dump_root is not None:
+            self._trace_parity_dump_root.mkdir(parents=True, exist_ok=True)
+        # A retry deletes and recreates the same gateway session id. Keep each
+        # deleted incarnation separate so its raw inputs are compared only with
+        # the graph built from those inputs.
+        self._trace_parity_generations: dict[str, int] = defaultdict(int)
         self._traces: dict[str, dict[str, Any]] = {}
         self._timestamps: dict[str, float] = {}
         self._session_index: dict[str, list[str]] = defaultdict(list)
         self._session_seen: dict[str, set[str]] = defaultdict(set)
         self._graphs: dict[str, TraceGraph] = defaultdict(lambda: TraceGraph(format="compact", version=1, deltas=[]))
         self._trace_session: dict[str, str] = {}
+
+    def _trace_parity_generation_dir(self, session_id: str) -> Path:
+        root = self._trace_parity_dump_root
+        if root is None:
+            raise RuntimeError("trace parity dumping is disabled")
+        session_key = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:20]
+        session_dir = root / f"session-{session_key}"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = session_dir / "session.json"
+        if not manifest_path.exists():
+            manifest_path.write_text(json.dumps({"session_id": session_id}, ensure_ascii=False) + "\n", encoding="utf-8")
+        generation = self._trace_parity_generations[session_id]
+        generation_dir = session_dir / f"generation-{generation:04d}"
+        generation_dir.mkdir(parents=True, exist_ok=True)
+        return generation_dir
+
+    def _dump_raw_trace_record(self, record: TraceRecord) -> None:
+        if self._trace_parity_dump_root is None:
+            return
+        path = self._trace_parity_generation_dir(record.session_id) / "raw_trace_records.jsonl"
+        # Deliberately synchronous: this is an opt-in diagnostic path, and a
+        # single event-loop worker must preserve store-call order exactly.
+        with path.open("a", encoding="utf-8") as f:
+            f.write(record.model_dump_json())
+            f.write("\n")
+
+    def _dump_trace_graph(self, session_id: str, graph: TraceGraph) -> None:
+        if self._trace_parity_dump_root is None:
+            return
+        path = self._trace_parity_generation_dir(session_id) / "trace_graph.json"
+        tmp_path = path.with_name(f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
+        try:
+            tmp_path.write_text(graph.model_dump_json() + "\n", encoding="utf-8")
+            os.replace(tmp_path, path)
+        finally:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
 
     async def store_trace(self, trace_id: str, session_id: str, data: dict[str, Any]) -> None:
         now = time.time()
@@ -73,6 +125,10 @@ class MemoryTraceStore:
             if missing:
                 raise ValueError(f"compact trace missing required fields: {', '.join(sorted(missing))}")
             record = TraceRecord.model_validate({**data, "trace_id": trace_id, "session_id": session_id})
+            # Capture the full, pre-compaction record. This is intentionally
+            # before graph validation so a rejected/lost input is visible to
+            # the parity checker instead of disappearing silently.
+            self._dump_raw_trace_record(record)
             existing_session = self._trace_session.get(trace_id)
             if existing_session is not None and existing_session != session_id:
                 raise ValueError(f"trace id {trace_id!r} belongs to another session")
@@ -127,7 +183,10 @@ class MemoryTraceStore:
         graph = self._graphs.get(session_id)
         if graph is None:
             graph = TraceGraph(format="compact", version=1, deltas=[])
-        return graph.slice(tids).model_dump()
+        selected = graph.slice(tids)
+        if since is None and limit is None:
+            self._dump_trace_graph(session_id, selected)
+        return selected.model_dump()
 
     async def count_session_traces(self, session_id: str) -> int:
         return len(self._session_index.get(session_id, []))
@@ -136,10 +195,17 @@ class MemoryTraceStore:
         ids = self._session_index.pop(session_id, [])
         self._session_seen.pop(session_id, None)
         if self._compact:
-            self._graphs.pop(session_id, None)
+            graph = self._graphs.get(session_id)
+            if graph is not None:
+                # Ensure failed flows and retry attempts also get an eventual
+                # graph, even when the engine never reached its trace fetch.
+                self._dump_trace_graph(session_id, graph)
+                self._graphs.pop(session_id, None)
             for tid in ids:
                 self._trace_session.pop(tid, None)
                 self._timestamps.pop(tid, None)
+            if graph is not None or ids:
+                self._trace_parity_generations[session_id] += 1
             return len(ids)
         # Collect trace_ids referenced by other sessions
         referenced: set[str] = set()

--- a/rllm-model-gateway/tests/unit/test_memory_store_compact.py
+++ b/rllm-model-gateway/tests/unit/test_memory_store_compact.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 
 import pytest
-from rllm_model_gateway.models import TraceGraph
+from rllm_model_gateway.models import TraceGraph, TraceRecord
 from rllm_model_gateway.store.memory_store import MemoryTraceStore
 
 _run = asyncio.run
@@ -144,3 +144,45 @@ def test_raw_capture_is_rejected_for_compact_store():
 
     with pytest.raises(ValueError, match="capture_raw_payloads"):
         ReverseProxy(router=None, store=MemoryTraceStore(compact=True), capture_raw_payloads=True)
+
+
+def test_trace_parity_dump_preserves_raw_inputs_and_eventual_graph(tmp_path):
+    store = MemoryTraceStore(compact=True, trace_parity_dump_dir=str(tmp_path))
+    root, child = _trajectory(2)
+    child_retry = {**child, "completion_token_ids": [999]}
+
+    _run(store.store_trace("root", "session/one", root))
+    _run(store.store_trace("child", "session/one", child))
+    _run(store.store_trace("child", "session/one", child_retry))
+    _run(store.get_session_traces_compact("session/one"))
+
+    session_dir = next(tmp_path.glob("session-*"))
+    assert json.loads((session_dir / "session.json").read_text()) == {"session_id": "session/one"}
+    generation_zero = session_dir / "generation-0000"
+    raw = [TraceRecord.model_validate_json(line) for line in (generation_zero / "raw_trace_records.jsonl").read_text().splitlines()]
+    graph = TraceGraph.model_validate_json((generation_zero / "trace_graph.json").read_text())
+
+    assert [record.trace_id for record in raw] == ["root", "child", "child"]
+    assert graph.flatten() == [raw[0], raw[2]]
+
+    # Deleting and recreating a session id is how rollout retries are isolated.
+    _run(store.delete_session("session/one"))
+    _run(store.store_trace("new-root", "session/one", root))
+    _run(store.get_session_traces_compact("session/one"))
+    assert (session_dir / "generation-0001" / "raw_trace_records.jsonl").exists()
+    assert (session_dir / "generation-0001" / "trace_graph.json").exists()
+
+
+def test_raw_trace_record_is_dumped_before_graph_conversion(tmp_path, monkeypatch):
+    store = MemoryTraceStore(compact=True, trace_parity_dump_dir=str(tmp_path))
+    record = _trajectory(1)[0]
+    original_add = TraceGraph.add
+
+    def assert_raw_dump_exists_before_add(graph, raw_record):
+        raw_path = next(tmp_path.glob("session-*/generation-0000/raw_trace_records.jsonl"))
+        dumped = TraceRecord.model_validate_json(raw_path.read_text().strip())
+        assert dumped == raw_record
+        return original_add(graph, raw_record)
+
+    monkeypatch.setattr(TraceGraph, "add", assert_raw_dump_exists_before_add)
+    _run(store.store_trace("raw", "session", record))

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -837,7 +837,7 @@ class AgentFlowEngine:
 
         t = time.perf_counter()
         evaluation_episode = _materialize_trajectory_deltas(enriched)
-        if self.verify_only_on_env_done and enriched.termination_reason != TerminationReason.ENV_DONE:
+        if getattr(self, "verify_only_on_env_done", False) and enriched.termination_reason != TerminationReason.ENV_DONE:
             eval_output = EvalOutput(
                 reward=0.0,
                 is_correct=False,

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -406,6 +406,7 @@ class AgentFlowEngine:
         n_parallel_tasks: int = 128,
         retry_limit: int = 3,
         raise_on_error: bool = True,
+        verify_only_on_env_done: bool = False,
         episode_logger: EpisodeLogger | None = None,
         hooks: TaskHooks | None = None,
         train_sampling_params: dict | None = None,
@@ -428,6 +429,7 @@ class AgentFlowEngine:
         self.n_parallel_tasks = n_parallel_tasks
         self.retry_limit = retry_limit
         self.raise_on_error = raise_on_error
+        self.verify_only_on_env_done = verify_only_on_env_done
         self.episode_logger = episode_logger
         self.hooks = hooks
         self.train_sampling_params = train_sampling_params
@@ -833,16 +835,24 @@ class AgentFlowEngine:
             strict=not is_validation,
         )
 
-        # The hook-resolved evaluator always receives the Task (legacy
-        # dict-style evaluators are adapted at hook-construction time).
         t = time.perf_counter()
         evaluation_episode = _materialize_trajectory_deltas(enriched)
-        eval_output: EvalOutput = await loop.run_in_executor(
-            self.executor,
-            ctx.evaluator.evaluate,
-            task_obj,
-            evaluation_episode,
-        )
+        if self.verify_only_on_env_done and enriched.termination_reason != TerminationReason.ENV_DONE:
+            eval_output = EvalOutput(
+                reward=0.0,
+                is_correct=False,
+                metadata={"verifier_skipped": 1.0},
+            )
+        else:
+            # The hook-resolved evaluator always receives the Task (legacy
+            # dict-style evaluators are adapted at hook-construction time).
+            eval_output = await loop.run_in_executor(
+                self.executor,
+                ctx.evaluator.evaluate,
+                task_obj,
+                evaluation_episode,
+            )
+            eval_output.metadata.setdefault("verifier_skipped", 0.0)
         if _timings is not None:
             _timings["time/evaluator_s"] = time.perf_counter() - t
             _agentflow_s = _timings.get("time/agentflow_s", 0.0)

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -198,10 +198,14 @@ class GatewayManager:
         self.port: int = int(configured_port) if configured_port is not None else (_find_free_port() if self.tunnel_backend else DEFAULT_GATEWAY_PORT)
         self.store: str = os.environ.get("RLLM_GATEWAY_STORE", gw_cfg.get("store", "compact"))
         self.db_path: str | None = gw_cfg.get("db_path", None)
+        _trace_parity_dump_dir = os.environ.get("RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR", gw_cfg.get("trace_parity_dump_dir", None))
+        self.trace_parity_dump_dir: str | None = os.path.abspath(os.path.expanduser(str(_trace_parity_dump_dir))) if _trace_parity_dump_dir else None
         if self.store not in ("memory", "compact", "sqlite"):
             raise ValueError(f"rllm.gateway.store must be 'memory', 'compact' or 'sqlite', got {self.store!r}")
         if self.store in ("memory", "compact") and self.db_path:
             raise ValueError(f"rllm.gateway.db_path is set but store={self.store!r} is in-memory; set store='sqlite' or clear db_path")
+        if self.trace_parity_dump_dir is not None and self.store != "compact":
+            raise ValueError("rllm.gateway.trace_parity_dump_dir requires rllm.gateway.store=compact")
         _model_cfg = config.get("model", {})
         self.model: str | None = _model_cfg.get("tokenizer_model") or _model_cfg.get("name", None)
 
@@ -432,6 +436,8 @@ class GatewayManager:
             for u in worker_urls or []:
                 cmd += ["--worker", u]
             return cmd
+        if self.trace_parity_dump_dir:
+            cmd += ["--trace-parity-dump-dir", self.trace_parity_dump_dir]
         if self.model:
             cmd += ["--model", self.model]
         if self.cumulative_token_mode:
@@ -532,6 +538,7 @@ class GatewayManager:
             port=self.port,
             db_path=self.db_path,
             store_worker=self.store,
+            trace_parity_dump_dir=self.trace_parity_dump_dir,
             model=self.model,
             add_logprobs=self.add_logprobs,
             add_return_token_ids=self.add_return_token_ids,

--- a/rllm/harnesses/mini_swe_agent.py
+++ b/rllm/harnesses/mini_swe_agent.py
@@ -11,11 +11,15 @@ the engine builds the trajectory.
 
 from __future__ import annotations
 
+import json
+import logging
 import shlex
 
 from rllm.harnesses.cli_harness import BaseCliHarness
 from rllm.sandbox.protocol import Sandbox
-from rllm.types import AgentConfig, Task
+from rllm.types import AgentConfig, Episode, Task, TerminationReason, termination_reason_from_error
+
+logger = logging.getLogger(__name__)
 
 # Model-name prefix → provider env-var mapping. Mirrors litellm's logic
 # without taking the dependency.
@@ -98,6 +102,12 @@ class MiniSweAgentHarness(BaseCliHarness):
     name = "mini-swe-agent"
     sandbox_backend = "docker"
     stdout_log_path = "/tmp/mini-swe-agent.log"
+    max_turns: int | None = None
+    max_consecutive_format_errors: int | None = None
+    command_timeout: int | None = None
+    capture_exit_status: bool = False
+    cost_limit: float | None = None
+    trajectory_output_path: str = "/tmp/rllm-mini-swe-trajectory.json"
 
     def install_script(self) -> str:
         return _INSTALL_SCRIPT
@@ -166,6 +176,96 @@ class MiniSweAgentHarness(BaseCliHarness):
             env=env,
         )
 
+    def _read_exit_outcome(self, sandbox: Sandbox) -> tuple[str | None, str | None, dict[str, str] | None]:
+        try:
+            raw = sandbox.exec(
+                f"cat {shlex.quote(self.trajectory_output_path)}",
+                timeout=10,
+                user=self.agent_user,
+            )
+            data = json.loads(raw)
+        except Exception as e:
+            logger.debug("Could not read mini-SWE trajectory outcome: %s", e)
+            return None, None, None
+
+        info = data.get("info", {}) if isinstance(data, dict) else {}
+        status = info.get("exit_status") if isinstance(info, dict) else None
+        status = str(status).strip() if status else None
+
+        finish_reason = None
+        error_extra = info if isinstance(info, dict) and (info.get("exception_str") or info.get("traceback")) else None
+        messages = data.get("messages", []) if isinstance(data, dict) else []
+        if isinstance(messages, list):
+            for message in reversed(messages):
+                if not isinstance(message, dict):
+                    continue
+                extra = message.get("extra")
+                if not isinstance(extra, dict):
+                    continue
+                if status is None and extra.get("exit_status"):
+                    status = str(extra["exit_status"]).strip()
+                if error_extra is None and (extra.get("exception_str") or extra.get("traceback")):
+                    error_extra = extra
+                if finish_reason is None and extra.get("interrupt_type") == "FormatError":
+                    response = extra.get("response")
+                    choices = response.get("choices") if isinstance(response, dict) else None
+                    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+                        raw_finish_reason = choices[0].get("finish_reason")
+                        finish_reason = str(raw_finish_reason).strip() if raw_finish_reason else None
+
+        error = None
+        if error_extra is not None:
+            error_type = error_extra.get("exit_status") or status or "MiniSweAgentError"
+            message = error_extra.get("exception_str") or ""
+            traceback_text = error_extra.get("traceback") or ""
+            error = {
+                "error_type": str(error_type),
+                "message": str(message),
+            }
+            if traceback_text:
+                error["traceback"] = str(traceback_text)
+
+        return status, finish_reason, error
+
+    @staticmethod
+    def _map_exit_status(
+        status: str | None,
+        finish_reason: str | None = None,
+        error: dict[str, str] | None = None,
+    ) -> TerminationReason:
+        if error:
+            error_text = "\n".join(str(error.get(key, "")) for key in ("message", "traceback"))
+            if "context_length_exceeded" in error_text:
+                return TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED
+        if status == "Submitted":
+            return TerminationReason.ENV_DONE
+        if status == "LimitsExceeded":
+            return TerminationReason.MAX_TURNS_EXCEEDED
+        if status == "TimeExceeded":
+            return TerminationReason.TIMEOUT
+        if status == "RepeatedFormatError":
+            if (finish_reason or "").lower() in {"length", "max_tokens", "max_output_tokens"}:
+                return TerminationReason.MAX_RESPONSE_LENGTH_EXCEEDED
+            return TerminationReason.FORMAT_ERROR
+        if status in (None, "", "UserInterruption"):
+            return TerminationReason.UNKNOWN
+        return termination_reason_from_error(status, default=TerminationReason.ERROR)
+
+    def run(self, task: Task, config: AgentConfig, *, env: Sandbox) -> Episode:
+        episode = super().run(task, config, env=env)
+        if not self.capture_exit_status:
+            return episode
+
+        status, finish_reason, error = self._read_exit_outcome(env)
+        episode.metadata["miniswe_exit_status"] = status or "missing"
+        if error is not None:
+            episode.metadata["error"] = error
+        if status is not None:
+            episode.termination_reason = self._map_exit_status(status, finish_reason, error)
+        elif episode.termination_reason is None:
+            episode.termination_reason = TerminationReason.UNKNOWN
+        return episode
+
     def build_invocation(
         self,
         instruction: str,
@@ -182,12 +282,49 @@ class MiniSweAgentHarness(BaseCliHarness):
         # which breaks the build with missing ``system_template`` etc.
         # The dotenv we write in :meth:`write_configs` carries the base
         # URL into the agent's environment so litellm picks it up.
+        config_overrides: list[str] = []
+        if self.cost_limit is not None:
+            cost_limit = float(self.cost_limit)
+            if cost_limit < 0:
+                raise ValueError(f"cost_limit must be non-negative, got {self.cost_limit!r}")
+            config_overrides.append(f"agent.cost_limit={cost_limit}")
+        if self.max_turns is not None:
+            max_turns = int(self.max_turns)
+            if max_turns <= 0:
+                raise ValueError(f"max_turns must be positive, got {self.max_turns!r}")
+            config_overrides.append(f"agent.step_limit={max_turns}")
+        if self.max_consecutive_format_errors is not None:
+            max_format_errors = int(self.max_consecutive_format_errors)
+            if max_format_errors < 0:
+                raise ValueError(f"max_consecutive_format_errors must be non-negative, got {self.max_consecutive_format_errors!r}")
+            config_overrides.append(f"agent.max_consecutive_format_errors={max_format_errors}")
+        if self.command_timeout is not None:
+            command_timeout = int(self.command_timeout)
+            if command_timeout <= 0:
+                raise ValueError(f"command_timeout must be positive, got {self.command_timeout!r}")
+            config_overrides.append(f"environment.timeout={command_timeout}")
+
+        config_args = ""
+        if config_overrides:
+            # Supplying any -c flag disables mini-SWE's implicit default config,
+            # so include mini.yaml explicitly before layering our overrides.
+            config_args = "--config=mini.yaml " + " ".join(f"--config={value}" for value in config_overrides) + " "
+
+        outcome_prefix = ""
+        outcome_arg = ""
+        if self.capture_exit_status:
+            output_path = shlex.quote(self.trajectory_output_path)
+            outcome_prefix = f"rm -f {output_path}; "
+            outcome_arg = f"--output={output_path} "
         return (
             f"{self._cd_prefix(task)}"
             f'export PATH="$HOME/.local/bin:$PATH"; '
+            f"{outcome_prefix}"
             f"mini-swe-agent --yolo "
+            f"{config_args}"
             f"--model={shlex.quote(qualified)} "
             f"--task={shlex.quote(instruction)} "
+            f"{outcome_arg}"
             f"--exit-immediately "
             f"2>&1 | tee {shlex.quote(self.stdout_log_path)}"
         )

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -177,6 +177,10 @@ gateway:
                       # `rllm tunnel setup` can reserve a wildcard for isolated per-run ngrok URLs.
   store: compact      # "compact" (default) | "memory" (legacy) | "sqlite" (persistent)
   db_path: null       # Only used when store=sqlite; null → auto-resolved path (logged at startup)
+  # Diagnostic only. With store=compact, writes full pre-compaction TraceRecord JSONL plus
+  # the eventual TraceGraph JSON for offline exact-parity verification. Use a unique local
+  # directory per run; this is intentionally expensive and may contain sensitive prompts.
+  trace_parity_dump_dir: null
   # Sampling params attached to a session overwrite those keys on every LLM call;
   # keys not set pass through untouched.
   cumulative_token_mode: false   # Drift-free multi-turn token forwarding: rewrites turn 2+ to

--- a/rllm/trainer/config/rllm/base.yaml
+++ b/rllm/trainer/config/rllm/base.yaml
@@ -36,6 +36,8 @@ workflow:
   n_parallel_tasks: 256
   retry_limit: 3
   raise_on_error: true
+  # Skip grading unless the agent explicitly completed its environment protocol.
+  verify_only_on_env_done: false
   # Sandbox warm-pool prefetch for training (mirrors eval): 0 disables,
   # negative matches the sandbox-creation frontier, positive = literal cap.
   warm_queue_size: -1

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -252,6 +252,7 @@ class UnifiedTrainer:
                 n_parallel_tasks=self.rllm_config.workflow.n_parallel_tasks,
                 retry_limit=self.rllm_config.workflow.retry_limit,
                 raise_on_error=self.rllm_config.workflow.get("raise_on_error", True),
+                verify_only_on_env_done=self.rllm_config.workflow.get("verify_only_on_env_done", False),
                 episode_logger=self.episode_logger,
                 train_sampling_params=training_sampling_params,
                 val_sampling_params=val_sampling_params,

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 class TerminationReason(Enum):
     MAX_PROMPT_LENGTH_EXCEEDED = "max_prompt_length_exceeded"
     MAX_RESPONSE_LENGTH_EXCEEDED = "max_response_length_exceeded"
+    FORMAT_ERROR = "format_error"
     ENV_DONE = "env_done"
     MAX_TURNS_EXCEEDED = "max_turns_exceeded"
     TIMEOUT = "timeout"  # agent execution wall-clock budget — reward is still graded on partial state
@@ -84,6 +85,7 @@ _ERROR_TYPE_TO_REASON: dict[str, TerminationReason] = {
     "VerifierTimeoutError": TerminationReason.VERIFIER_TIMEOUT,
     # Model/context (harbor.llms.base)
     "ContextLengthExceededError": TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED,
+    "ContextWindowExceededError": TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED,
     "OutputLengthExceededError": TerminationReason.MAX_RESPONSE_LENGTH_EXCEEDED,
     # Agent process (harbor.agents.installed.base)
     "NonZeroAgentExitCodeError": TerminationReason.ERROR,

--- a/scripts/verify_trace_parity_dump.py
+++ b/scripts/verify_trace_parity_dump.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Verify that dumped compact gateway graphs exactly reproduce raw records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+
+from rllm_model_gateway.models import TraceGraph, TraceRecord
+
+
+def _session_id(generation_dir: Path) -> str:
+    manifest = generation_dir.parent / "session.json"
+    if not manifest.exists():
+        return generation_dir.parent.name
+    return str(json.loads(manifest.read_text(encoding="utf-8"))["session_id"])
+
+
+def _read_raw_records(path: Path) -> list[TraceRecord]:
+    if not path.exists():
+        return []
+    records: list[TraceRecord] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            records.append(TraceRecord.model_validate_json(line))
+        except Exception as exc:
+            raise ValueError(f"{path}:{line_number}: invalid TraceRecord: {exc}") from exc
+    return records
+
+
+def _final_raw_records(records: list[TraceRecord]) -> list[TraceRecord]:
+    # Compact-store retries replace the same leaf in place. Assignment to an
+    # existing OrderedDict key retains that trace's original graph position.
+    final: OrderedDict[str, TraceRecord] = OrderedDict()
+    for record in records:
+        final[record.trace_id] = record
+    return list(final.values())
+
+
+@dataclass
+class _ExpectedTrace:
+    record: TraceRecord
+    parent_trace_id: str | None
+
+
+def _message_key(message: dict) -> str:
+    """Compare chat blocks byte-semantically, including dict key order."""
+    return json.dumps(message, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _messages_start_with(values: list[dict], prefix: list[dict]) -> bool:
+    return len(prefix) <= len(values) and all(_message_key(value) == _message_key(expected) for value, expected in zip(values[: len(prefix)], prefix, strict=True))
+
+
+def _completed_messages(record: TraceRecord) -> list[dict]:
+    return [*record.messages, record.response_message]
+
+
+def _completed_token_ids(record: TraceRecord) -> list[int]:
+    return [*record.prompt_token_ids, *record.completion_token_ids]
+
+
+def _valid_parent_prefix(parent: TraceRecord, record: TraceRecord, *, require_same_model: bool) -> bool:
+    return (
+        parent.session_id == record.session_id
+        and parent.lineage_id == record.lineage_id
+        and (not require_same_model or parent.model == record.model)
+        and _messages_start_with(record.messages, _completed_messages(parent))
+        and record.prompt_token_ids[: len(_completed_token_ids(parent))] == _completed_token_ids(parent)
+    )
+
+
+def _find_expected_parent(record: TraceRecord, states: OrderedDict[str, _ExpectedTrace]) -> str | None:
+    """Independently derive the deepest prior completed-message parent.
+
+    Parent discovery is message-first. If the deepest matching completed state
+    has a token-tape mismatch, compaction must safely make the record a root;
+    it must not silently attach to a shallower state.
+    """
+    best: TraceRecord | None = None
+    best_depth = -1
+    for state in states.values():
+        candidate = state.record
+        completed_messages = _completed_messages(candidate)
+        if (
+            candidate.session_id == record.session_id
+            and candidate.lineage_id == record.lineage_id
+            and candidate.model == record.model
+            and _messages_start_with(record.messages, completed_messages)
+            and len(completed_messages) > best_depth
+        ):
+            # Strictly greater keeps the first inserted representative when
+            # two records complete the same message path.
+            best = candidate
+            best_depth = len(completed_messages)
+    if best is None:
+        return None
+    return best.trace_id if record.prompt_token_ids[: len(_completed_token_ids(best))] == _completed_token_ids(best) else None
+
+
+def _expected_structure(records: list[TraceRecord]) -> list[_ExpectedTrace]:
+    """Model add/leaf-replacement semantics from raw records, without a graph."""
+    states: OrderedDict[str, _ExpectedTrace] = OrderedDict()
+    for record in records:
+        current = states.get(record.trace_id)
+        if current is None:
+            states[record.trace_id] = _ExpectedTrace(record=record, parent_trace_id=_find_expected_parent(record, states))
+            continue
+
+        if any(state.parent_trace_id == record.trace_id for state in states.values()):
+            raise ValueError(f"raw input tries to replace non-leaf trace {record.trace_id!r}")
+        if current.record.session_id != record.session_id or current.record.lineage_id != record.lineage_id:
+            raise ValueError(f"raw input moves trace {record.trace_id!r} to another session or lineage")
+
+        parent = states.get(current.parent_trace_id) if current.parent_trace_id is not None else None
+        parent_trace_id = current.parent_trace_id if parent is not None and _valid_parent_prefix(parent.record, record, require_same_model=False) else None
+        states[record.trace_id] = _ExpectedTrace(record=record, parent_trace_id=parent_trace_id)
+    return list(states.values())
+
+
+def _different_fields(expected: TraceRecord, actual: TraceRecord) -> list[str]:
+    expected_data = expected.model_dump(mode="json")
+    actual_data = actual.model_dump(mode="json")
+    return sorted(key for key in expected_data.keys() | actual_data.keys() if expected_data.get(key) != actual_data.get(key))
+
+
+def verify_generation(generation_dir: Path) -> tuple[bool, str, int, int, int]:
+    session_id = _session_id(generation_dir)
+    raw_path = generation_dir / "raw_trace_records.jsonl"
+    graph_path = generation_dir / "trace_graph.json"
+    raw_records = _read_raw_records(raw_path)
+    try:
+        expected_states = _expected_structure(raw_records)
+    except Exception as exc:
+        return False, f"{session_id} {generation_dir.name}: invalid raw store sequence: {exc}", len(_final_raw_records(raw_records)), raw_path.stat().st_size if raw_path.exists() else 0, 0
+    expected = [state.record for state in expected_states]
+    duplicates = len(raw_records) - len(expected)
+
+    if not graph_path.exists():
+        return False, f"{session_id} {generation_dir.name}: missing trace_graph.json", len(expected), raw_path.stat().st_size if raw_path.exists() else 0, 0
+
+    try:
+        graph = TraceGraph.model_validate_json(graph_path.read_text(encoding="utf-8"))
+        actual = graph.flatten()
+    except Exception as exc:
+        return False, f"{session_id} {generation_dir.name}: invalid/unresolvable graph: {exc}", len(expected), raw_path.stat().st_size if raw_path.exists() else 0, graph_path.stat().st_size
+
+    expected_ids = [record.trace_id for record in expected]
+    actual_ids = [record.trace_id for record in actual]
+    if expected_ids != actual_ids:
+        return (
+            False,
+            f"{session_id} {generation_dir.name}: trace id/order mismatch raw={expected_ids} graph={actual_ids}",
+            len(expected),
+            raw_path.stat().st_size if raw_path.exists() else 0,
+            graph_path.stat().st_size,
+        )
+
+    for expected_state, delta in zip(expected_states, graph.deltas, strict=True):
+        parent = next((state.record for state in expected_states if state.record.trace_id == expected_state.parent_trace_id), None)
+        expected_messages_suffix = expected_state.record.messages if parent is None else expected_state.record.messages[len(_completed_messages(parent)) :]
+        expected_prompt_ids_suffix = expected_state.record.prompt_token_ids if parent is None else expected_state.record.prompt_token_ids[len(_completed_token_ids(parent)) :]
+        if delta.parent_trace_id != expected_state.parent_trace_id:
+            return (
+                False,
+                f"{session_id} {generation_dir.name}: trace {expected_state.record.trace_id!r} parent_trace_id raw-derived={expected_state.parent_trace_id!r} graph={delta.parent_trace_id!r}",
+                len(expected),
+                raw_path.stat().st_size if raw_path.exists() else 0,
+                graph_path.stat().st_size,
+            )
+        if delta.messages_suffix != expected_messages_suffix:
+            return (
+                False,
+                f"{session_id} {generation_dir.name}: trace {expected_state.record.trace_id!r} has incorrect messages_suffix",
+                len(expected),
+                raw_path.stat().st_size if raw_path.exists() else 0,
+                graph_path.stat().st_size,
+            )
+        if delta.prompt_ids_suffix != expected_prompt_ids_suffix:
+            return (
+                False,
+                f"{session_id} {generation_dir.name}: trace {expected_state.record.trace_id!r} has incorrect prompt_ids_suffix",
+                len(expected),
+                raw_path.stat().st_size if raw_path.exists() else 0,
+                graph_path.stat().st_size,
+            )
+
+    for expected_record, actual_record in zip(expected, actual, strict=True):
+        fields = _different_fields(expected_record, actual_record)
+        if fields:
+            return (
+                False,
+                f"{session_id} {generation_dir.name}: trace {expected_record.trace_id!r} differs in fields: {', '.join(fields)}",
+                len(expected),
+                raw_path.stat().st_size if raw_path.exists() else 0,
+                graph_path.stat().st_size,
+            )
+
+    detail = f"{session_id} {generation_dir.name}: {len(expected)} records ({duplicates} replacement inputs)"
+    return True, detail, len(expected), raw_path.stat().st_size if raw_path.exists() else 0, graph_path.stat().st_size
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump_dir", type=Path, help="Directory configured as rllm.gateway.trace_parity_dump_dir")
+    parser.add_argument("--verbose", action="store_true", help="Print each passing session generation")
+    args = parser.parse_args()
+
+    generation_dirs = sorted(path for path in args.dump_dir.glob("session-*/generation-*") if path.is_dir())
+    if not generation_dirs:
+        print(f"No trace parity generations found under {args.dump_dir}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    total_records = 0
+    raw_bytes = 0
+    graph_bytes = 0
+    for generation_dir in generation_dirs:
+        try:
+            passed, detail, records, generation_raw_bytes, generation_graph_bytes = verify_generation(generation_dir)
+        except Exception as exc:
+            passed, detail, records, generation_raw_bytes, generation_graph_bytes = False, f"{generation_dir}: {exc}", 0, 0, 0
+        total_records += records
+        raw_bytes += generation_raw_bytes
+        graph_bytes += generation_graph_bytes
+        if not passed:
+            failures.append(detail)
+            print(f"FAIL {detail}")
+        elif args.verbose:
+            print(f"PASS {detail}")
+
+    ratio = raw_bytes / graph_bytes if graph_bytes else float("inf")
+    print(f"Checked {len(generation_dirs)} session generations and {total_records} final records: {len(failures)} failures; raw={raw_bytes} bytes graph={graph_bytes} bytes compression={ratio:.2f}x")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -156,6 +156,75 @@ def _valid_token_trace(session_id: str):
     )
 
 
+def test_verify_only_on_env_done_skips_nonterminal_rollout_grading():
+    class _CountingEvaluator:
+        calls = 0
+
+        def evaluate(self, task, episode):
+            self.calls += 1
+            return EvalOutput(reward=1.0, is_correct=True)
+
+    evaluator = _CountingEvaluator()
+    gateway = _Gateway(traces=[_valid_token_trace("task:0")])
+    engine = AgentFlowEngine(
+        agent_flow=_Agent(),
+        evaluator=evaluator,
+        gateway=gateway,
+        model="test-model",
+        n_parallel_tasks=1,
+        verify_only_on_env_done=True,
+    )
+    task = task_from_row({"question": "q"}, "task")
+
+    try:
+        episode = asyncio.run(engine._run_single(task, "task:0"))
+    finally:
+        engine.shutdown()
+
+    assert evaluator.calls == 0
+    assert episode.metrics["verifier_skipped"] == 1.0
+    assert episode.is_correct is False
+    assert episode.termination_reason == TerminationReason.ERROR
+
+
+def test_verify_only_on_env_done_still_grades_completed_rollout():
+    class _DoneAgent:
+        async def arun(self, task, config):
+            return Episode(
+                id=task.id,
+                termination_reason=TerminationReason.ENV_DONE,
+                trajectories=[Trajectory(name="solver")],
+            )
+
+    class _CountingEvaluator:
+        calls = 0
+
+        def evaluate(self, task, episode):
+            self.calls += 1
+            return EvalOutput(reward=1.0, is_correct=True)
+
+    evaluator = _CountingEvaluator()
+    gateway = _Gateway(traces=[_valid_token_trace("task:0")])
+    engine = AgentFlowEngine(
+        agent_flow=_DoneAgent(),
+        evaluator=evaluator,
+        gateway=gateway,
+        model="test-model",
+        n_parallel_tasks=1,
+        verify_only_on_env_done=True,
+    )
+    task = task_from_row({"question": "q"}, "task")
+
+    try:
+        episode = asyncio.run(engine._run_single(task, "task:0"))
+    finally:
+        engine.shutdown()
+
+    assert evaluator.calls == 1
+    assert episode.metrics["verifier_skipped"] == 0.0
+    assert episode.is_correct is True
+
+
 def test_empty_response_retries_are_filtered_before_strict_enrichment():
     """Transient API attempts have no response envelope and must not poison
     the successful same-turn retry that follows them."""

--- a/tests/engine/test_gateway_manager.py
+++ b/tests/engine/test_gateway_manager.py
@@ -18,6 +18,7 @@ def _make_config(**gateway_overrides):
 def _unset_store_env(monkeypatch):
     # Store selection reads RLLM_GATEWAY_STORE; keep the ambient value out.
     monkeypatch.delenv("RLLM_GATEWAY_STORE", raising=False)
+    monkeypatch.delenv("RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR", raising=False)
 
 
 class TestGatewayStoreSelection:
@@ -55,6 +56,10 @@ class TestGatewayStoreValidation:
         with pytest.raises(ValueError, match="db_path is set but store='memory'"):
             GatewayManager(_make_config(store="memory", db_path="/tmp/x.db"), mode="thread")
 
+    def test_trace_parity_dump_requires_compact_store(self, tmp_path):
+        with pytest.raises(ValueError, match="trace_parity_dump_dir requires"):
+            GatewayManager(_make_config(store="memory", trace_parity_dump_dir=str(tmp_path)), mode="thread")
+
 
 class TestCompactStoreDefault:
     @pytest.mark.parametrize(
@@ -82,6 +87,12 @@ class TestCompactStoreDefault:
     def test_compact_with_db_path_raises(self):
         with pytest.raises(ValueError, match="db_path is set but store='compact'"):
             GatewayManager(_make_config(store="compact", db_path="/tmp/x.db"), mode="thread")
+
+    def test_trace_parity_dump_is_passed_only_to_gateway_workers(self, tmp_path):
+        gw = GatewayManager(_make_config(store="compact", trace_parity_dump_dir=str(tmp_path)), mode="thread")
+        assert gw.trace_parity_dump_dir == str(tmp_path.resolve())
+        assert gw._gateway_cmd(9091)[-2:] == ["--trace-parity-dump-dir", str(tmp_path.resolve())]
+        assert "--trace-parity-dump-dir" not in gw._gateway_cmd(9091, front=True, worker_urls=["http://127.0.0.1:9092"])
 
 
 class TestContainerReachableUrl:

--- a/tests/engine/test_trace_parity_dump.py
+++ b/tests/engine/test_trace_parity_dump.py
@@ -1,0 +1,65 @@
+import json
+
+from rllm_model_gateway.models import TraceDelta, TraceGraph, TraceRecord
+
+from scripts.verify_trace_parity_dump import verify_generation
+
+
+def _records() -> list[TraceRecord]:
+    root = TraceRecord(
+        trace_id="root",
+        session_id="session",
+        model="model",
+        messages=[{"role": "user", "content": "one"}],
+        prompt_token_ids=[1],
+        response_message={"role": "assistant", "content": "two"},
+        completion_token_ids=[2],
+    )
+    child = TraceRecord(
+        trace_id="child",
+        session_id="session",
+        model="model",
+        messages=[*root.messages, root.response_message, {"role": "user", "content": "three"}],
+        prompt_token_ids=[*root.prompt_token_ids, *root.completion_token_ids, 3],
+        response_message={"role": "assistant", "content": "four"},
+        completion_token_ids=[4],
+    )
+    return [root, child]
+
+
+def _write_dump(generation_dir, records: list[TraceRecord], graph: TraceGraph) -> None:
+    generation_dir.mkdir(parents=True)
+    (generation_dir.parent / "session.json").write_text(json.dumps({"session_id": "session"}))
+    (generation_dir / "raw_trace_records.jsonl").write_text("".join(record.model_dump_json() + "\n" for record in records))
+    (generation_dir / "trace_graph.json").write_text(graph.model_dump_json())
+
+
+def test_verifier_rejects_lossless_but_structurally_wrong_all_root_graph(tmp_path):
+    records = _records()
+    graph = TraceGraph(
+        format="compact",
+        version=1,
+        deltas=[TraceDelta.against(record, None) for record in records],
+    )
+    # This proves flatten-only parity would be a false positive.
+    assert graph.flatten() == records
+
+    generation_dir = tmp_path / "session-test" / "generation-0000"
+    _write_dump(generation_dir, records, graph)
+    passed, detail, *_ = verify_generation(generation_dir)
+
+    assert not passed
+    assert "parent_trace_id" in detail
+
+
+def test_verifier_accepts_raw_derived_parent_and_suffixes(tmp_path):
+    records = _records()
+    graph = TraceGraph(format="compact", version=1, deltas=[])
+    for record in records:
+        graph.add(record)
+
+    generation_dir = tmp_path / "session-test" / "generation-0000"
+    _write_dump(generation_dir, records, graph)
+    passed, detail, *_ = verify_generation(generation_dir)
+
+    assert passed, detail

--- a/tests/harnesses/test_cli_harness.py
+++ b/tests/harnesses/test_cli_harness.py
@@ -443,6 +443,40 @@ def test_mini_swe_agent_invocation_uses_qualified_model():
     assert "--exit-immediately" in cmd
 
 
+def test_mini_swe_agent_reproduction_options_reach_cli():
+    h = MiniSweAgentHarness(
+        max_turns=64,
+        max_consecutive_format_errors=1,
+        command_timeout=300,
+        capture_exit_status=True,
+        cost_limit=0.0,
+    )
+
+    cmd = h.build_invocation("hi", _make_task(), _make_config(model="gpt-4o"))
+
+    assert "--config=mini.yaml" in cmd
+    assert "--config=agent.cost_limit=0.0" in cmd
+    assert "--config=agent.step_limit=64" in cmd
+    assert "--config=agent.max_consecutive_format_errors=1" in cmd
+    assert "--config=environment.timeout=300" in cmd
+    assert "--output=/tmp/rllm-mini-swe-trajectory.json" in cmd
+
+
+@pytest.mark.parametrize(
+    ("status", "finish_reason", "expected"),
+    [
+        ("Submitted", None, TerminationReason.ENV_DONE),
+        ("LimitsExceeded", None, TerminationReason.MAX_TURNS_EXCEEDED),
+        ("TimeExceeded", None, TerminationReason.TIMEOUT),
+        ("RepeatedFormatError", "length", TerminationReason.MAX_RESPONSE_LENGTH_EXCEEDED),
+        ("RepeatedFormatError", None, TerminationReason.FORMAT_ERROR),
+        ("UserInterruption", None, TerminationReason.UNKNOWN),
+    ],
+)
+def test_mini_swe_agent_maps_recorded_exit_status(status, finish_reason, expected):
+    assert MiniSweAgentHarness._map_exit_status(status, finish_reason) == expected
+
+
 # ---------------------------------------------------------------------------
 # ClaudeCodeHarness — bypassPermissions sandbox mode
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

This is debug-only instrumentation for validating the compact gateway trace pipeline against real training traffic, including the workload from [W&B run z6xi3xkh](https://wandb.ai/agentica/terminal-rl/runs/z6xi3xkh).

The two artifacts are intentionally independent:

- `raw_trace_records.jsonl` is serialized directly from the full `TraceRecord` inside `MemoryTraceStore.store_trace()`, before `TraceGraph.add()` or `replace_leaf()` runs.
- `trace_graph.json` is the eventual compact graph emitted later on full retrieval or session deletion.

The raw file is **not** produced from `TraceGraph.flatten()`, an `Episode`, a `Step`, or a `Trajectory`. Deriving both sides from the graph would make parity tautological and hide conversion bugs.

## What changed

- Add opt-in `rllm.gateway.trace_parity_dump_dir` / `RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR` plumbing for thread and multi-worker gateway modes.
- Dump full pre-compaction records and the eventual graph into per-session, per-generation directories.
- Keep retry incarnations of the same session separate and preserve every raw replacement input.
- Add `scripts/verify_trace_parity_dump.py`.
  - Independently derive the expected completed-message parent from raw records.
  - Check `parent_trace_id`, `messages_suffix`, and `prompt_ids_suffix`.
  - Then check exact full-record reconstruction.
  - Handle same-leaf replacement semantics for retried trace IDs.
- Add a regression test proving that a lossless all-root graph passes `flatten()` equality but is still rejected as structurally wrong.

## z6xi3xkh reproduction

The W&B run points to commit `d501e357967c45bb46807d5f6a3366cbcdfee32b` on `kyle/terminal-rl-fireworks`. I checked out that exact commit and compared it with the current `terminal-rl` base. The current cookbook uses Terminus-2, so this PR restores the run's `MiniSweAgentHarness` entrypoint and the run-required MiniSwe exit-status/config behavior instead of silently changing its request stream. The captured W&B environment used `transformers==5.15.0`, which the launcher pins explicitly because this branch's installed 5.5.3 does not recognize `model_type=deepseek_v4`.

`cookbooks/terminal-rl/reproduce_z6xi3xkh.sh` carries over the W&B-recorded model, LoRA rank, Fireworks shapes/replicas, group and async sizes, optimizer, rollout limits, DPPO-TV settings, and MiniSwe limits. Intentional current-machine/current-branch differences are documented at the top of the script:

- current dataset registry name `tb-v2-debug`
- compact store plus independent raw-record/graph dumps
- automatic tunnel resolution instead of the old machine's fixed gateway route
- shorter experiment name to avoid the original run's Fireworks output-model-id length failure

The current machine has an ngrok wildcard registered. Leave `rllm.gateway.tunnel` and `rllm.gateway.port` unset: `AgentTrainer` creates a unique wildcard hostname and free gateway port for the run. `RLLM_GATEWAY_TUNNEL` remains an optional explicit override.

Review the launch without provisioning or training:

```bash
RLLM_LAUNCH_DRY_RUN=1 bash cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
```

Parse and print the resolved static Hydra config:

```bash
RLLM_LAUNCH_CONFIG_ONLY=1 bash cookbooks/terminal-rl/reproduce_z6xi3xkh.sh
```

The launcher defaults the dump directory to `/data/home/thw/trace-dumps/z6xi3xkh-parity-001`, so it can be run directly. `RLLM_GATEWAY_TRACE_PARITY_DUMP_DIR` remains available as an override for a later run. For a bounded first real launch, append `rllm.trainer.total_batches=1`. The launcher automatically runs the parity verifier after training exits, including failed runs.

## Operational warning

The dump feature is off by default outside this reproduction launcher. It is compact-store-only, synchronous, disk-heavy, and may contain sensitive prompts/token data. It is intended for small debugging runs on fast local storage, not normal training or performance measurements.

A first manual launch exposed the Transformers version mismatch after Fireworks provisioning but before any rollout or trace generation; Fireworks deleted that trainer job cleanly. The pinned 5.15.0 environment now loads the exact DeepSeek V4 config and tokenizer locally before another launch.

## Validation

- `rllm-model-gateway/.venv/bin/python -m pytest rllm-model-gateway/tests/unit -q` — 308 passed
- `PYTHONPATH=. uv run pytest -q tests/harnesses/test_cli_harness.py tests/engine/test_agentflow_engine.py tests/engine/test_gateway_manager.py tests/engine/test_trace_parity_dump.py` — 122 passed
- launcher dry run — passed without requiring a per-run tunnel
- Hydra config-only parse — passed
- exact `deepseek-ai/DeepSeek-V4-Flash-0731` config/tokenizer load under pinned Transformers 5.15.0 — passed (`DeepseekV4Config`, max positions 1048576, vocabulary 128000)
- focused synthetic raw-record -> graph -> verifier smoke test — passed
- repository pre-commit hooks (`ruff`, `ruff-format`) — passed
- `git diff --check` — passed
