### PR TITLE
fix: canonicalize traces and update Fireworks dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,8 @@ tinker = [
 ]
 
 fireworks = [
-    "fireworks-ai[training]==1.2.1 ; python_version >= '3.11'",
-    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@6b1232504fdacd1149895acf63b388ae792cb062#subdirectory=training ; python_version >= '3.11'",
+    "fireworks-ai[training]==1.2.9 ; python_version >= '3.11'",
+    "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@76821fa1ded720d903029381b37d3c3ea7ce9ddd#subdirectory=training ; python_version >= '3.11'",
 ]
 
 opentelemetry = [

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -45,8 +45,57 @@ def _message_key(message: dict[str, Any]) -> str:
     return key
 
 
-def _messages_start_with(values: list[dict[str, Any]], prefix: list[dict[str, Any]]) -> bool:
-    return len(prefix) <= len(values) and all(_message_key(a) == _message_key(b) for a, b in zip(values[: len(prefix)], prefix, strict=True))
+def canonicalize_message(message: dict[str, Any]) -> dict[str, Any]:
+    """Convert equivalent chat-message wire shapes to one stable form.
+
+    The gateway response uses ``reasoning`` while LiteLLM resends that same
+    assistant turn as ``reasoning_content`` and duplicates it under
+    ``provider_specific_fields.reasoning``. A null refusal is another
+    transport-added default. Normalize only those known aliases; retain every
+    other provider-specific field so materially different messages stay
+    different.
+
+    TraceRecord remains the untouched capture format. TraceDelta calls this at
+    the raw-record-to-graph boundary, so the graph has one stable message shape.
+    """
+    normalized = json.loads(_message_key(message))
+    provider_fields = normalized.get("provider_specific_fields")
+    if provider_fields is None:
+        normalized.pop("provider_specific_fields", None)
+        provider_fields = None
+
+    reasoning_values = [value for value in (normalized.get("reasoning"), normalized.get("reasoning_content")) if value is not None]
+    if reasoning_values and all(value == reasoning_values[0] for value in reasoning_values[1:]):
+        normalized.pop("reasoning", None)
+        normalized.pop("reasoning_content", None)
+        normalized["reasoning_content"] = reasoning_values[0]
+        if isinstance(provider_fields, dict) and provider_fields.get("reasoning") == reasoning_values[0]:
+            provider_fields.pop("reasoning", None)
+    elif not reasoning_values:
+        if normalized.get("reasoning") is None:
+            normalized.pop("reasoning", None)
+        if normalized.get("reasoning_content") is None:
+            normalized.pop("reasoning_content", None)
+        if isinstance(provider_fields, dict) and provider_fields.get("reasoning") is None:
+            provider_fields.pop("reasoning", None)
+
+    if normalized.get("refusal") is None:
+        normalized.pop("refusal", None)
+    if isinstance(provider_fields, dict):
+        if provider_fields.get("refusal") is None:
+            provider_fields.pop("refusal", None)
+        if not provider_fields:
+            normalized.pop("provider_specific_fields", None)
+    return json.loads(json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False))
+
+
+def _canonical_message_key(message: dict[str, Any]) -> str:
+    """Stable identity for parent discovery, independent of wire aliases."""
+    return _message_key(canonicalize_message(message))
+
+
+def _canonical_messages_start_with(values: list[dict[str, Any]], prefix: list[dict[str, Any]]) -> bool:
+    return len(prefix) <= len(values) and all(_canonical_message_key(value) == _canonical_message_key(expected) for value, expected in zip(values[: len(prefix)], prefix, strict=True))
 
 
 class TraceDelta(BaseModel):
@@ -71,9 +120,9 @@ class TraceDelta(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
-    def _validate_messages(self) -> "TraceDelta":
-        for message in [*self.messages_suffix, self.response_message]:
-            _message_key(message)
+    def _canonicalize_messages(self) -> "TraceDelta":
+        self.messages_suffix = [canonicalize_message(message) for message in self.messages_suffix]
+        self.response_message = canonicalize_message(self.response_message)
         return self
 
     @classmethod
@@ -94,7 +143,7 @@ class TraceDelta(BaseModel):
             parent is not None
             and parent.session_id == record.session_id
             and parent.lineage_id == record.lineage_id
-            and (_prefix_verified or _messages_start_with(record.messages, messages))
+            and (_prefix_verified or _canonical_messages_start_with(record.messages, messages))
             and (_prefix_verified or record.prompt_token_ids[: len(prompt_ids)] == prompt_ids)
         ):
             parent = None
@@ -167,7 +216,7 @@ class TraceGraph(BaseModel):
         node = 0
         completed_trace_id = None
         for message in record.messages:
-            next_node = self._message_children.get((node, _message_key(message)))
+            next_node = self._message_children.get((node, _canonical_message_key(message)))
             if next_node is None:
                 break
             node = next_node

--- a/rllm-model-gateway/tests/unit/test_trace_graph.py
+++ b/rllm-model-gateway/tests/unit/test_trace_graph.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 from pydantic import ValidationError
-from rllm_model_gateway.models import TraceDelta, TraceGraph, TraceRecord
+from rllm_model_gateway.models import TraceDelta, TraceGraph, TraceRecord, canonicalize_message
 
 
 def _record(
@@ -125,15 +125,87 @@ def test_root_and_child_deltas_resolve_exactly():
     _assert_exact(graph.resolve(continuation.trace_id), continuation)
 
 
-def test_message_identity_preserves_key_order_for_byte_parity():
+def test_message_identity_canonicalizes_key_order_without_mutating_raw_input():
     parent = _record(0, [{"role": "user", "content": {"a": 1, "b": 2}}], [1])
-    same_message = {"content": {"b": 2, "a": 1}, "role": "user"}
-    child = _record(1, [same_message, {"role": "user", "content": "next"}], [1, 2])
+    child = _record(
+        1,
+        [
+            {"content": {"b": 2, "a": 1}, "role": "user"},
+            {"content": "a0", "role": "assistant"},
+            {"role": "user", "content": "next"},
+        ],
+        [1, *parent.completion_token_ids, 2],
+    )
+    raw_child = child.model_dump_json()
 
     graph = _graph([parent, child])
 
-    assert graph.deltas[1].parent_trace_id is None
-    _assert_exact(graph.resolve(child.trace_id), child)
+    assert graph.deltas[1].parent_trace_id == parent.trace_id
+    assert child.model_dump_json() == raw_child
+    assert graph.resolve(child.trace_id).messages == [canonicalize_message(message) for message in child.messages]
+
+
+def test_canonical_message_normalizes_litellm_reasoning_transport_aliases():
+    response = {
+        "role": "assistant",
+        "content": "",
+        "reasoning": "inspect the repository",
+        "tool_calls": [],
+    }
+    resent = {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "inspect the repository",
+        "tool_calls": [],
+        "provider_specific_fields": {
+            "refusal": None,
+            "reasoning": "inspect the repository",
+        },
+    }
+
+    assert canonicalize_message(response) == canonicalize_message(resent)
+    assert response["reasoning"] == "inspect the repository"
+    assert resent["provider_specific_fields"]["reasoning"] == "inspect the repository"
+
+
+def test_graph_stores_canonical_messages_without_mutating_raw_records():
+    parent = _record(0, [{"role": "user", "content": "question"}], [1, 2])
+    parent.response_message = {
+        "role": "assistant",
+        "content": "",
+        "reasoning": "inspect the repository",
+        "tool_calls": [],
+    }
+    resent_response = {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "inspect the repository",
+        "tool_calls": [],
+        "provider_specific_fields": {
+            "refusal": None,
+            "reasoning": "inspect the repository",
+        },
+    }
+    child = _record(
+        1,
+        [*parent.messages, resent_response, {"role": "tool", "tool_call_id": "call-0", "content": "result"}],
+        [*parent.prompt_token_ids, *parent.completion_token_ids, 3],
+    )
+    raw_parent = parent.model_dump_json()
+    raw_child = child.model_dump_json()
+
+    graph = _graph([parent, child])
+    delta = graph.deltas[1]
+
+    assert delta.parent_trace_id == parent.trace_id
+    assert delta.messages_suffix == [canonicalize_message(child.messages[-1])]
+    assert delta.response_message == canonicalize_message(child.response_message)
+    assert graph.resolve(child.trace_id).messages == [canonicalize_message(message) for message in child.messages]
+    assert parent.model_dump_json() == raw_parent
+    assert child.model_dump_json() == raw_child
+
+    restored = TraceGraph.model_validate_json(graph.model_dump_json())
+    assert restored.resolve(child.trace_id).messages == [canonicalize_message(message) for message in child.messages]
 
 
 @pytest.mark.parametrize("facet", ["messages", "tokens"])

--- a/rllm/trainer/metrics_aggregator.py
+++ b/rllm/trainer/metrics_aggregator.py
@@ -37,7 +37,8 @@ def _infer_rule(key: str) -> str:
     Resolution order:
     1. Explicit sum keys
     2. Prefix-based rules (last or mean)
-    3. Keyword-based rules (/max, /min, /mean, /avg, /std, /fraction)
+    3. Keyword-based rules in the final metric component
+       (max, min, mean, avg, std, fraction)
     4. Default: mean
     """
     if key in _SUM_KEYS:
@@ -51,14 +52,17 @@ def _infer_rule(key: str) -> str:
         if key.startswith(prefix):
             return "mean"
 
-    # Keyword inference from the key name
-    if "/max" in key:
+    # Infer from the metric name, not arbitrary path components. A role such as
+    # ``mini-swe-agent`` must not make every reward metric use the ``min``
+    # reducer. Splitting on ``_`` preserves names such as ``max_group_size``.
+    metric_tokens = set(key.rsplit("/", 1)[-1].replace(":", "_").split("_"))
+    if "max" in metric_tokens:
         return "max"
-    if "/min" in key:
+    if "min" in metric_tokens:
         return "min"
-    if "/mean" in key or "/avg" in key:
+    if "mean" in metric_tokens or "avg" in metric_tokens:
         return "mean"
-    if "/std" in key or "/fraction" in key:
+    if "std" in metric_tokens or "fraction" in metric_tokens:
         return "mean"
 
     return "mean"

--- a/tests/unified_trainer/test_buffer_reward_metrics.py
+++ b/tests/unified_trainer/test_buffer_reward_metrics.py
@@ -39,6 +39,32 @@ def test_record_reward_stats_values():
     assert m["reward/opencode/all/std"] > 0.0
 
 
+def test_reward_role_name_does_not_select_metric_reducer():
+    aggregator = MetricsAggregator()
+    for value in (0.75, 0.9375, 0.5, 0.0625):
+        aggregator.record("reward/mini-swe-agent/all/mean", value)
+        aggregator.record("reward/mini-swe-agent/all/max", value)
+        aggregator.record("reward/mini-swe-agent/all/min", value)
+    m = aggregator.flush()
+
+    assert m["reward/mini-swe-agent/all/mean"] == 0.5625
+    assert m["reward/mini-swe-agent/all/max"] == 0.9375
+    assert m["reward/mini-swe-agent/all/min"] == 0.0625
+
+
+def test_compound_metric_name_still_selects_reducer():
+    aggregator = MetricsAggregator()
+    for value in (4.0, 16.0, 8.0):
+        aggregator.record("groups/max_group_size", value)
+        aggregator.record("groups/min_group_size", value)
+        aggregator.record("groups/avg_group_size", value)
+    m = aggregator.flush()
+
+    assert m["groups/max_group_size"] == 16.0
+    assert m["groups/min_group_size"] == 4.0
+    assert m["groups/avg_group_size"] == 28.0 / 3.0
+
+
 def test_reward_by_role_reports_each_role_separately():
     # Multi-agent: solver + judge each get their own reward/<role>/all/*.
     buf = _buffer_with_aggregator()


### PR DESCRIPTION
## Why

This draft is used to debug raw `TraceRecord` to compact `TraceGraph` parity in terminal-rl training.

The diagnostic run exposed three independent compatibility and observability issues:

- Semantically equivalent assistant messages arrived in different shapes (`reasoning`, `reasoning_content`, provider-specific aliases, and nullable fields). Compact parent lookup compared their raw dict representation, so prior turns were not recognized and each delta could become a root.
- The older Fireworks package/cookbook pins used an incompatible tokenizer/config API for DeepSeek V4 Flash.
- Reward aggregation inferred reducers from arbitrary path substrings. The role name `mini-swe-agent` contains `/min`, so its W&B mean/std metrics were incorrectly reduced with `min`. This only affected reported metrics; trajectories already carried their computed advantages into training.

The raw `TraceRecord` is deliberately left untouched so parity checks compare the actual gateway input against the eventual graph. Only the message representation stored and compared inside `TraceGraph` is canonicalized.

## What changed

- Pin `fireworks-ai` to 1.2.9 and the Fireworks cookbook to `76821fa1`.
- Canonicalize compact-graph messages at the raw-record-to-graph boundary:
  - unify equivalent reasoning aliases as `reasoning_content`;
  - remove null refusal/provider-only fields;
  - use stable key ordering for stored messages and parent lookup.
- Add regression coverage for alias normalization, canonical graph storage, stable key order, correct parent linking, and preservation of the original raw record.
- Infer metric reducers from the final metric-name component rather than role/path substrings, with regression coverage for `mini-swe-agent` and compound metric names such as `max_group_size`.

## Validation

- `rllm-model-gateway` full unit suite: 308 passed.
- Focused trace-graph suite: 29 passed.
- Compact memory-store suite: 11 passed.
- Reward-metric regression suite: 9 passed.
- Pre-commit checks pass on all changed files.
- Live DeepSeek V4 Flash terminal-rl debug run completed three consecutive optimizer updates and weight syncs without trainer, gateway, sequence, or OOM failures.
- Independent parity snapshot: 1,098 finalized graphs / 21,078 final records, 0 parity failures.
- Root histogram: 1,097 graphs with one root; one graph with two independently valid roots because its raw session contains an unrelated unlineaged legacy completion alongside the chat lineage.
- For the verified snapshot, compact graph JSON was 33.41% smaller than the corresponding raw TraceRecord JSONL.

This remains a draft for review and debugging.
