### PR TITLE
fix(modal): output decoding

### DIFF
--- a/rllm/sandbox/backends/modal_backend.py
+++ b/rllm/sandbox/backends/modal_backend.py
@@ -322,10 +322,11 @@ class ModalSandbox:
 
         run = _build_exec_command(command, self._persistent_env, user)
         start = time.monotonic()
-        process = self._sandbox.exec("bash", "-c", run, **exec_kwargs)
+        # Decode raw terminal output lossily because it may not be valid UTF-8.
+        process = self._sandbox.exec("bash", "-c", run, text=False, **exec_kwargs)
 
-        stdout = process.stdout.read()
-        stderr = process.stderr.read()
+        stdout = process.stdout.read().decode("utf-8", errors="replace")
+        stderr = process.stderr.read().decode("utf-8", errors="replace")
 
         # Wait for the process to complete and get exit code
         process.wait()


### PR DESCRIPTION
## Summary

rLLM's Modal sandbox currently decodes sandbox process output as strict UTF-8, which can raise `UnicodeDecodeError` when terminal programs emit invalid bytes. This occured on several ocassions during Terminal Bennch 2.1 evaluation, ending the rollout with a terminaion reason of Error. The fix is to request raw output streams from Modal and decode them with UTF-8 replacement before returning them through the sandbox interface. This aligns with Daytona's SDK.