### PR TITLE
feat(eval): store compact graph-backed episodes by default

### DIFF
--- a/docs/datasets/running-evaluations.mdx
+++ b/docs/datasets/running-evaluations.mdx
@@ -164,7 +164,11 @@ These flags shape how the evaluation executes and what it leaves behind.
 </ParamField>
 
 <ParamField path="--save-episodes / --no-save-episodes" default="enabled">
-  Save each task's full trajectory as JSON for later inspection with `rllm view`.
+  Save each task's trajectory as JSON for later inspection with `rllm view`.
+</ParamField>
+
+<ParamField path="--compact-episodes / --full-episodes" default="compact">
+  Store cumulative messages and token IDs as a compact trajectory graph. `rllm view` materializes the graph only when you open an episode. Use `--full-episodes` for the legacy flat files.
 </ParamField>
 
 ```bash

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -20,7 +20,7 @@ from rllm.cli._pull import load_dataset_catalog, pull_dataset
 from rllm.cli._sampling import SAMPLING_PARAMS_HELP as _SAMPLING_PARAMS_HELP
 from rllm.cli._ui import console, fail, info_panel, not_found, parse_index_spec
 from rllm.eval.config import SUPPORTED_PROVIDERS
-from rllm.types import Task
+from rllm.types import Task, _materialize_trajectory_deltas
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +131,7 @@ def _run_eval(
     agent_metadata: dict | None = None,
     enable_ui: bool = False,
     save_episodes: bool = True,
+    compact_episodes: bool = False,
     episodes_dir: str | None = None,
     use_snapshot: bool = True,
     warm_queue_size: int = 0,
@@ -441,6 +442,7 @@ def _run_eval(
             "split": split,
             "timestamp": timestamp,
             "attempts": attempts,
+            "episode_format": "compact" if compact_episodes else "full",
         }
     )
     episode_store = run_store if save_episodes else None
@@ -493,7 +495,7 @@ def _run_eval(
                 except Exception:
                     logger.debug("episode_store.write failed", exc_info=True)
             if _ui_callback is not None:
-                _ui_callback(episode)
+                _ui_callback(_materialize_trajectory_deltas(episode))
 
     # Single execution path: every Task goes through ``AgentFlowEngine``
     # via ``SandboxTaskHooks``. The engine fronts every LLM call with the rLLM
@@ -519,6 +521,7 @@ def _run_eval(
             evaluator=evaluator,
             sampling_params=(sampling_config.as_dict() if sampling_config is not None else None),
             attempts=attempts,
+            compact_episodes=save_episodes and compact_episodes,
         )
     )
 
@@ -631,6 +634,7 @@ def _run_eval(
 )
 @click.option("--ui/--no-ui", "enable_ui", default=None, help="Enable/disable live UI logging. Default: auto-enabled when logged in (see 'rllm login').")
 @click.option("--save-episodes/--no-save-episodes", "save_episodes", default=True, help="Save each Episode as its own JSON file for later visualization (default: enabled).")
+@click.option("--compact-episodes", is_flag=True, help="Save graph-backed Episode JSONs without repeated cumulative messages and token IDs.")
 @click.option("--episodes-dir", "episodes_dir", default=None, help="Directory to write the episode JSONs into. Default: ~/.rllm/eval_results/<bench>_<model>_<timestamp>/.")
 @click.option("--sampling-params", "sampling_params", default=None, help=_SAMPLING_PARAMS_HELP)
 @click.option("--temperature", default=None, type=float, help="Sampling temperature (shortcut for --sampling-params temperature=...).")
@@ -667,6 +671,7 @@ def eval_cmd(
     warm_queue_size: int,
     enable_ui: bool | None,
     save_episodes: bool,
+    compact_episodes: bool,
     episodes_dir: str | None,
     sampling_params: str | None,
     temperature: float | None,
@@ -804,6 +809,7 @@ def eval_cmd(
             agent_metadata=agent_metadata,
             enable_ui=enable_ui,
             save_episodes=save_episodes,
+            compact_episodes=compact_episodes,
             episodes_dir=episodes_dir,
             use_snapshot=use_snapshot,
             warm_queue_size=warm_queue_size,

--- a/rllm/cli/eval.py
+++ b/rllm/cli/eval.py
@@ -131,7 +131,7 @@ def _run_eval(
     agent_metadata: dict | None = None,
     enable_ui: bool = False,
     save_episodes: bool = True,
-    compact_episodes: bool = False,
+    compact_episodes: bool = True,
     episodes_dir: str | None = None,
     use_snapshot: bool = True,
     warm_queue_size: int = 0,
@@ -634,7 +634,11 @@ def _run_eval(
 )
 @click.option("--ui/--no-ui", "enable_ui", default=None, help="Enable/disable live UI logging. Default: auto-enabled when logged in (see 'rllm login').")
 @click.option("--save-episodes/--no-save-episodes", "save_episodes", default=True, help="Save each Episode as its own JSON file for later visualization (default: enabled).")
-@click.option("--compact-episodes", is_flag=True, help="Save graph-backed Episode JSONs without repeated cumulative messages and token IDs.")
+@click.option(
+    "--compact-episodes/--full-episodes",
+    default=True,
+    help="Save graph-backed Episode JSONs without repeated cumulative messages and token IDs (default: compact).",
+)
 @click.option("--episodes-dir", "episodes_dir", default=None, help="Directory to write the episode JSONs into. Default: ~/.rllm/eval_results/<bench>_<model>_<timestamp>/.")
 @click.option("--sampling-params", "sampling_params", default=None, help=_SAMPLING_PARAMS_HELP)
 @click.option("--temperature", default=None, type=float, help="Sampling temperature (shortcut for --sampling-params temperature=...).")

--- a/rllm/engine/agentflow_engine.py
+++ b/rllm/engine/agentflow_engine.py
@@ -410,6 +410,7 @@ class AgentFlowEngine:
         hooks: TaskHooks | None = None,
         train_sampling_params: dict | None = None,
         val_sampling_params: dict | None = None,
+        compact_episodes: bool = False,
     ) -> None:
         if evaluator is None and hooks is None:
             raise ValueError("AgentFlowEngine requires either an `evaluator` (single evaluator for every task) or `hooks` (per-task evaluator + setup/teardown). Both cannot be None.")
@@ -432,6 +433,7 @@ class AgentFlowEngine:
         self.hooks = hooks
         self.train_sampling_params = train_sampling_params
         self.val_sampling_params = val_sampling_params
+        self.compact_episodes = compact_episodes
 
         self.n_parallel_tasks = n_parallel_tasks
         self.executor = ThreadPoolExecutor(max_workers=n_parallel_tasks)
@@ -530,7 +532,8 @@ class AgentFlowEngine:
                 # end — keeps the UI live and avoids a giant end-of-run flush.
                 if on_episode_complete is not None and episode is not None:
                     try:
-                        on_episode_complete(result_idx, _materialize_trajectory_deltas(episode))
+                        callback_episode = episode if self.compact_episodes else _materialize_trajectory_deltas(episode)
+                        on_episode_complete(result_idx, callback_episode)
                     except Exception:
                         logger.debug("on_episode_complete callback error", exc_info=True)
                 # Canary: a rollout whose LLM completions are ALL empty means the
@@ -691,7 +694,7 @@ class AgentFlowEngine:
         )
         try:
             t = time.perf_counter()
-            compact_fetch = not is_validation and getattr(self.gateway, "store", None) == "compact" and hasattr(self.gateway, "aget_trace_graph")
+            compact_fetch = (self.compact_episodes or not is_validation) and getattr(self.gateway, "store", None) == "compact" and hasattr(self.gateway, "aget_trace_graph")
             traces = await (self.gateway.aget_trace_graph(uid) if compact_fetch else self.gateway.aget_traces(uid))
             timings["time/traces_s"] = time.perf_counter() - t
 

--- a/rllm/eval/runner.py
+++ b/rllm/eval/runner.py
@@ -42,6 +42,7 @@ async def run_dataset(
     gateway: GatewayManager | None = None,
     sampling_params: dict | None = None,
     attempts: int = 1,
+    compact_episodes: bool = False,
 ) -> tuple[EvalResult, list]:
     """Run a list of :class:`rllm.types.Task` objects through :class:`AgentFlowEngine`.
 
@@ -66,6 +67,8 @@ async def run_dataset(
             into ``attempts`` adjacent copies; the engine numbers sibling rollouts
             ``task_id:0..n-1`` (training's GRPO convention) and the EvalResult
             groups them back by task to compute ``pass_at``.
+        compact_episodes: Keep graph-backed trajectories in returned episodes and
+            completion callbacks instead of materializing cumulative steps.
 
     Returns ``(EvalResult, list[Episode])``.
     """
@@ -142,6 +145,7 @@ async def run_dataset(
         raise_on_error=False,  # capture per-task errors as error Episodes
         hooks=hooks,
         val_sampling_params=sampling_params or None,  # eval is always validation
+        compact_episodes=compact_episodes,
     )
 
     warm_queue = None

--- a/rllm/eval/visualizer.py
+++ b/rllm/eval/visualizer.py
@@ -168,6 +168,18 @@ def _build_episode_index(episodes_dir: Path) -> list[dict[str, Any]]:
     return index
 
 
+def _episode_payload_for_view(data: dict[str, Any]) -> dict[str, Any]:
+    """Materialize compact trajectory graphs only when the viewer opens them."""
+    is_compact = any(isinstance(step, dict) and "prompt_ids_suffix" in step for trajectory in data.get("trajectories", []) if isinstance(trajectory, dict) for step in trajectory.get("steps", []))
+    if not is_compact:
+        return data
+
+    from rllm.types import Episode, _materialize_trajectory_deltas
+
+    episode = _materialize_trajectory_deltas(Episode.model_validate(data))
+    return {**data, **episode.model_dump(mode="json")}
+
+
 def _preview(value: Any, limit: int = 140) -> str:
     if value is None:
         return ""
@@ -902,17 +914,17 @@ def _make_handler(root_path: Path, html_factory):
             self.end_headers()
             self.wfile.write(data)
 
-        def _send_file_bytes(self, path: Path) -> None:
+        def _send_episode(self, path: Path) -> None:
             try:
-                data = path.read_bytes()
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                payload = _episode_payload_for_view(payload)
             except OSError:
                 self.send_error(404, "Not Found")
                 return
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json; charset=utf-8")
-            self.send_header("Content-Length", str(len(data)))
-            self.end_headers()
-            self.wfile.write(data)
+            except (AttributeError, json.JSONDecodeError, TypeError, ValueError):
+                self.send_error(500, "Invalid episode")
+                return
+            self._send_json(200, payload)
 
         def do_GET(self):  # noqa: N802
             path = self.path.split("?", 1)[0]
@@ -946,7 +958,7 @@ def _make_handler(root_path: Path, html_factory):
                     return self.send_error(400, "Bad path")
                 if not target.is_file():
                     return self.send_error(404, "Episode not found")
-                return self._send_file_bytes(target)
+                return self._send_episode(target)
 
             return self.send_error(404, "Not Found")
 

--- a/tests/cli/test_eval_command.py
+++ b/tests/cli/test_eval_command.py
@@ -93,6 +93,27 @@ def test_eval_base_url_requires_model(runner, tmp_rllm_home):
     assert "--model is required" in result.output
 
 
+def test_eval_compact_episodes_option_is_forwarded(runner, tmp_rllm_home):
+    with patch("rllm.cli.eval._run_eval") as mock_run:
+        result = runner.invoke(
+            cli,
+            [
+                "eval",
+                "gsm8k",
+                "--agent",
+                "math",
+                "--base-url",
+                "http://localhost:8000/v1",
+                "--model",
+                "test-model",
+                "--compact-episodes",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_run.call_args.kwargs["compact_episodes"] is True
+
+
 def test_eval_with_proxy_mode(runner, tmp_rllm_home, mock_dataset):
     """Eval without --base-url should auto-start proxy from config."""
     config = RllmConfig(provider="openai", model="gpt-5-mini", api_keys={"openai": "sk-test"})

--- a/tests/cli/test_eval_command.py
+++ b/tests/cli/test_eval_command.py
@@ -93,7 +93,8 @@ def test_eval_base_url_requires_model(runner, tmp_rllm_home):
     assert "--model is required" in result.output
 
 
-def test_eval_compact_episodes_option_is_forwarded(runner, tmp_rllm_home):
+@pytest.mark.parametrize(("episode_args", "expected"), [([], True), (["--full-episodes"], False)])
+def test_eval_episode_format_is_forwarded(runner, tmp_rllm_home, episode_args, expected):
     with patch("rllm.cli.eval._run_eval") as mock_run:
         result = runner.invoke(
             cli,
@@ -106,12 +107,12 @@ def test_eval_compact_episodes_option_is_forwarded(runner, tmp_rllm_home):
                 "http://localhost:8000/v1",
                 "--model",
                 "test-model",
-                "--compact-episodes",
+                *episode_args,
             ],
         )
 
     assert result.exit_code == 0, result.output
-    assert mock_run.call_args.kwargs["compact_episodes"] is True
+    assert mock_run.call_args.kwargs["compact_episodes"] is expected
 
 
 def test_eval_with_proxy_mode(runner, tmp_rllm_home, mock_dataset):

--- a/tests/engine/test_agentflow_engine.py
+++ b/tests/engine/test_agentflow_engine.py
@@ -75,8 +75,10 @@ def test_run_single_passes_validation_flag_and_preserves_termination_reason():
     assert episode.termination_reason == TerminationReason.ERROR
 
 
-def test_compact_gateway_is_graph_native_only_for_training():
+def test_compact_gateway_validation_graph_is_opt_in():
     from rllm_model_gateway.models import TraceGraph
+
+    from rllm.types import TrajectoryDelta
 
     class _CompactGateway(_Gateway):
         store = "compact"
@@ -87,22 +89,45 @@ def test_compact_gateway_is_graph_native_only_for_training():
 
         async def aget_traces(self, session_id):
             self.fetches.append("flat")
-            return []
+            return [_valid_token_trace(session_id)]
 
         async def aget_trace_graph(self, session_id):
             self.fetches.append("graph")
-            return TraceGraph(format="compact", version=1, deltas=[])
+            graph = TraceGraph(format="compact", version=1, deltas=[])
+            graph.add(_valid_token_trace(session_id))
+            return graph
 
     gateway = _CompactGateway()
     engine = AgentFlowEngine(agent_flow=_Agent(), evaluator=_Evaluator(), gateway=gateway, model="test-model", n_parallel_tasks=1)
+    compact_engine = AgentFlowEngine(
+        agent_flow=_Agent(),
+        evaluator=_Evaluator(),
+        gateway=gateway,
+        model="test-model",
+        n_parallel_tasks=1,
+        compact_episodes=True,
+    )
     task = task_from_row({"question": "q"}, "task")
+    completed = []
     try:
-        asyncio.run(engine._run_single(task, "task:validation", is_validation=True))
+        validation_episode = asyncio.run(engine._run_single(task, "task:validation", is_validation=True))
+        compact_validation = asyncio.run(
+            compact_engine.execute_tasks(
+                [task],
+                task_ids=["compact"],
+                is_validation=True,
+                on_episode_complete=lambda _idx, episode: completed.append(episode),
+            )
+        )[0]
         asyncio.run(engine._run_single(task, "task:training", is_validation=False))
     finally:
         engine.shutdown()
+        compact_engine.shutdown()
 
-    assert gateway.fetches == ["flat", "graph"]
+    assert gateway.fetches == ["flat", "graph", "graph"]
+    assert isinstance(validation_episode.trajectories[0], Trajectory)
+    assert isinstance(compact_validation.trajectories[0], TrajectoryDelta)
+    assert isinstance(completed[0].trajectories[0], TrajectoryDelta)
 
 
 def _empty_token_trace(session_id: str):

--- a/tests/eval/test_visualizer.py
+++ b/tests/eval/test_visualizer.py
@@ -1,0 +1,43 @@
+from rllm.eval.visualizer import _episode_payload_for_view
+from rllm.types import Episode, StepDelta, TrajectoryDelta
+
+
+def test_compact_episode_is_materialized_for_view():
+    root = StepDelta(
+        id="root",
+        parent_step_id=None,
+        prompt_ids_suffix=[1],
+        chat_completions_suffix=[
+            {"role": "user", "content": "Q0"},
+            {"role": "assistant", "content": "A0"},
+        ],
+        response_ids=[2],
+        model_response="A0",
+    )
+    child = StepDelta(
+        id="child",
+        parent_step_id="root",
+        prompt_ids_suffix=[3],
+        chat_completions_suffix=[
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+        ],
+        response_ids=[4],
+        model_response="A1",
+    )
+    payload = Episode(id="task:0", trajectories=[TrajectoryDelta(steps=[root, child])]).model_dump(mode="json")
+    payload["eval_idx"] = 7
+
+    viewed = _episode_payload_for_view(payload)
+    first, second = viewed["trajectories"][0]["steps"]
+
+    assert viewed["eval_idx"] == 7
+    assert first["prompt_ids"] == [1]
+    assert second["prompt_ids"] == [1, 2, 3]
+    assert second["chat_completions"] == [*root.chat_completions_suffix, *child.chat_completions_suffix]
+    assert "prompt_ids_suffix" not in second
+
+
+def test_full_episode_payload_is_unchanged():
+    payload = {"id": "full", "trajectories": [{"steps": [{"prompt_ids": [1]}]}]}
+    assert _episode_payload_for_view(payload) is payload


### PR DESCRIPTION
## Summary

- make compact graph-backed episode JSON the default for `rllm eval`
- request the gateway's original `TraceGraph` and preserve its `TrajectoryDelta` structure in saved `Episode` files
- materialize a temporary flat episode for evaluators and live UI consumers
- teach `rllm view` to materialize one compact episode only when it is opened
- add `--full-episodes` for the legacy flat on-disk representation
- record `episode_format` in `meta.json`

`--save-episodes` remains enabled by default. `--no-save-episodes` still disables local episode output entirely.

## Correctness boundary

This path does not rebuild a graph from an already-flattened episode or trajectory. It fetches the graph produced directly from the gateway's original trace records, then uses the existing `TraceGraph -> TrajectoryDelta` conversion used by training. That distinction matters because rebuilding from a flat trajectory would hide conversion errors and make a parity check tautological.

The saved compact file remains delta-backed on disk. `rllm view` validates and materializes it in memory for the HTTP response without rewriting the file.

## Usage

Compact storage is now automatic:

```bash
rllm eval <benchmark> ...
```

Use the compatibility flag when a downstream consumer requires cumulative flat steps:

```bash
rllm eval <benchmark> ... --full-episodes
```

## Why

A full multi-turn episode repeats cumulative chat messages and prompt token IDs in every step, and also repeats prompt data inside `model_output`. This grows roughly quadratically with turn count. Compact episodes retain task, reward, metrics, token-level outputs, logprobs, routing matrices, and graph relationships while storing cumulative prefixes once.

## Validation

- `python -m pytest tests/engine/test_agentflow_engine.py tests/eval/test_eval_engine.py tests/eval/test_visualizer.py tests/cli/test_eval_command.py -q` - 34 passed
- `pre-commit run --files ...` - ruff and ruff-format passed
- real raw-record sweep, built only from original `raw_trace_records.jsonl` inputs:
  - 97 size-stratified sessions from a 11,964-file corpus
  - 917,366,695 raw bytes and 1,672 raw records
  - 1,672 graph nodes, zero parity failures
  - exactly one root per graph
  - viewer materialization matched independent flat enrichment exactly
  - full JSON: 2,789,421,725 bytes
  - compact JSON: 702,811,500 bytes
  - reduction: 74.80%
- actual headless-browser `rllm view` test on a real 21-step trace:
  - compact file: 5,162,442 bytes; materialized form: 28,003,352 bytes
  - rendered Steps 0 through 20 and 43 cumulative chat messages
  - preserved 43,057 final prompt tokens plus all 75 response tokens, logprobs, and routing-matrix entries
  - no page, console, or request errors
  - on-disk compact file hash remained unchanged after viewing
