### PR TITLE
fix(engine): drop logprobs when OpenAIEngine retokenizes the completion text

### DIFF
--- a/rllm/engine/rollout/openai_engine.py
+++ b/rllm/engine/rollout/openai_engine.py
@@ -186,8 +186,10 @@ class OpenAIEngine(RolloutEngine):
                 try:
                     completion_ids = response.choices[0].token_ids
                     assert completion_ids is not None
+                    completion_ids_are_native = True
                 except Exception:
                     completion_ids = self.tokenizer.encode(text, add_special_tokens=False)
+                    completion_ids_are_native = False
 
                 parsed_output = self.chat_parser.parse_completion(completion_ids)
 
@@ -199,6 +201,13 @@ class OpenAIEngine(RolloutEngine):
                     assert response.choices[0].logprobs is not None
                     logprobs = response.choices[0].logprobs.token_logprobs
                 except Exception:
+                    logprobs = []
+
+                if not completion_ids_are_native:
+                    # The server's logprobs are aligned to the tokens it actually sampled,
+                    # not to completion_ids retokenized from the decoded text above
+                    # (encode(decode(ids)) == ids is not guaranteed), so pairing them here
+                    # would silently desync per-token training signal downstream.
                     logprobs = []
 
                 if sampling_params.get("echo", False) and logprobs:

--- a/tests/engine/test_openai_engine_completion.py
+++ b/tests/engine/test_openai_engine_completion.py
@@ -1,0 +1,78 @@
+"""Regression tests for OpenAIEngine.completion()'s token_ids retokenization fallback."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from rllm.engine.rollout.openai_engine import OpenAIEngine
+
+
+class _FakeTokenizer:
+    """Always returns a fixed, deliberately non-native-length token stream.
+
+    Stands in for a real tokenizer where encode(decode(ids)) != ids, which is common
+    (not a rare edge case) with BPE-style tokenizers.
+    """
+
+    def encode(self, text, add_special_tokens=False):  # noqa: ARG002
+        return [101, 102, 103]
+
+
+class _FakeChatParser:
+    def parse_completion(self, completion_ids):  # noqa: ARG002
+        return {"content": "", "reasoning": None, "tool_calls": []}
+
+
+def _make_engine():
+    engine = OpenAIEngine(
+        model="test-model",
+        tokenizer=_FakeTokenizer(),
+        chat_parser=_FakeChatParser(),
+        max_prompt_length=64,
+        max_response_length=64,
+        base_url="http://localhost:0/v1",
+        api_key="test",
+    )
+    engine.sampling_params = {}
+    return engine
+
+
+def _completions_response(*, token_ids, logprobs):
+    choice = SimpleNamespace(
+        text="some decoded completion text",
+        finish_reason="stop",
+        logprobs=SimpleNamespace(token_logprobs=logprobs),
+    )
+    if token_ids is not None:
+        choice.token_ids = token_ids
+    return SimpleNamespace(
+        choices=[choice],
+        usage=SimpleNamespace(prompt_tokens=4, completion_tokens=len(logprobs)),
+    )
+
+
+def test_logprobs_dropped_when_token_ids_fallback_fires():
+    """No native token_ids -> completion_ids is retokenized text, so the server's
+    logprobs (aligned to what it actually sampled) can no longer be trusted to line
+    up with completion_ids and must be treated as absent, not silently paired."""
+    engine = _make_engine()
+    response = _completions_response(token_ids=None, logprobs=[-0.1, -0.2])
+    engine.client = SimpleNamespace(completions=SimpleNamespace(create=AsyncMock(return_value=response)))
+
+    output = asyncio.run(engine.completion([1, 2, 3, 4]))
+
+    assert output.completion_ids == [101, 102, 103]
+    assert output.logprobs == []
+
+
+def test_logprobs_kept_when_token_ids_are_native():
+    """When the server returns native token_ids, completion_ids and logprobs come
+    from the same sampled stream and remain aligned, so logprobs must be preserved."""
+    engine = _make_engine()
+    response = _completions_response(token_ids=[10, 20, 30], logprobs=[-0.5, -0.6, -0.7])
+    engine.client = SimpleNamespace(completions=SimpleNamespace(create=AsyncMock(return_value=response)))
+
+    output = asyncio.run(engine.completion([1, 2, 3, 4]))
+
+    assert output.completion_ids == [10, 20, 30]
+    assert output.logprobs == [-0.5, -0.6, -0.7]


### PR DESCRIPTION
## Summary

`OpenAIEngine.completion()` retokenizes the decoded completion text whenever the
server does not return the vLLM-only `token_ids` field, but keeps pairing the
server's original per-token `logprobs` with those retokenized ids anyway. The two
are no longer guaranteed to correspond: `encode(decode(ids)) == ids` does not hold
in general for BPE-style tokenizers, so `completion_ids` and `logprobs` can end up
different lengths or misaligned per-index.

The existing downstream workaround in `rllm/trainer/verl/transform.py` zero-pads a
short `logprobs` list to the action length, which stops the shape crash but silently
feeds a wrong (zero) old-logprob into PPO/GRPO importance-sampling ratios for the
tail tokens instead of surfacing the mismatch.

## Root cause

`rllm/engine/rollout/openai_engine.py`, `completion()`: when
`response.choices[0].token_ids` is absent, `completion_ids` comes from
`self.tokenizer.encode(text, ...)` (a fresh retokenization), while `logprobs` still
comes from `response.choices[0].logprobs.token_logprobs` (the server's per-token
values for whatever it actually sampled). Nothing ties the two together once the
fallback fires.

## Fix

Track whether `completion_ids` came from the native `token_ids` field or the
retokenization fallback. When it's the fallback, clear `logprobs` to `[]`, matching
the "logprobs unavailable" signal the code already produces when
`response.choices[0].logprobs` itself is missing. This keeps the single place that
already interprets an empty `logprobs` list correctly, rather than adding a second
code path.

## Validation

- New regression test `tests/engine/test_openai_engine_completion.py`: fails on
  `main` (`assert [-0.1, -0.2] == []`) and passes on this branch, for both the
  fallback case (logprobs cleared) and the native-`token_ids` case (logprobs
  preserved unchanged). Ran with `pytest`, no network, in a clean
  `python:3.12-slim` container, module `__file__` printed and confirmed pointing
  at the checked-out source.
- `ruff check` and `ruff format --check` (pinned `0.11.4`, matching
  `.pre-commit-config.yaml`) clean on both changed files.
- Not run: this repo's CI only exercises `openai_engine.py` changes through
  `test-tinker.yml`, which is path-scoped to run `tests/engine/test_tinker_engine.py`
  only (verified by reading the workflow), so the new test above is not wired into
  any existing CI job; I did not add a workflow entry for it since that's a repo
  process choice. No live OpenAI-compatible endpoint was queried; the response
  shapes in the test are constructed by hand from the fields `completion()` reads.

Fixes #816
