### PR TITLE
Miles training backend (draft)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,6 @@ gcp-key.json
 
 # IDE
 .vscode/
+
+# Miles backend venv (see scripts/setup_miles_env.sh)
+miles-venv/

--- a/cookbooks/countdown/train_miles.sh
+++ b/cookbooks/countdown/train_miles.sh
@@ -65,6 +65,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
     miles.rollout_num_gpus_per_engine=1 \
     miles.global_batch_size=128 \
     miles.max_tokens_per_gpu=8192 \
+    miles.sglang_log_level_http=warning \
+    miles.sglang_decode_log_interval=1000 \
     miles.lr=2e-6 \
     rllm.data.train_batch_size=16 \
     rllm.data.max_prompt_length=512 \

--- a/cookbooks/countdown/train_miles.sh
+++ b/cookbooks/countdown/train_miles.sh
@@ -65,8 +65,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
     miles.rollout_num_gpus_per_engine=1 \
     miles.global_batch_size=128 \
     miles.max_tokens_per_gpu=8192 \
-    miles.sglang_log_level_http=warning \
-    miles.sglang_decode_log_interval=1000 \
     miles.lr=2e-6 \
     rllm.data.train_batch_size=16 \
     rllm.data.max_prompt_length=512 \

--- a/cookbooks/countdown/train_miles.sh
+++ b/cookbooks/countdown/train_miles.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Countdown via the AgentFlow protocol (@rllm.rollout + @rllm.evaluator) on the Miles
+# backend: SGLang rollout + FSDP2 training, 4 train GPUs + 4 rollout GPUs on one 8-GPU node.
+#
+# This is the AgentFlow counterpart to
+# examples/countdown/unified_trainer/train_countdown_unified_miles.sh (SimpleWorkflow).
+# The difference matters: AgentFlow agents talk OpenAI over rLLM's *gateway*, which
+# registers Miles' SGLang router as an inference worker and reconstructs tokens from the
+# captured traces. SimpleWorkflow instead goes straight through MilesEngine's
+# token-in/token-out path. Same trainer, different rollout plumbing.
+#
+# Prerequisites:
+#   1. bash scripts/setup_miles_env.sh          (or an existing miles venv)
+#   2. python cookbooks/countdown/prepare_data.py
+#   3. uv pip install --no-deps -e cookbooks/countdown
+#
+# Usage:
+#   PYTHON=/path/to/miles-venv/bin/python bash cookbooks/countdown/train_miles.sh [overrides...]
+#
+# Any trailing argument is a Hydra override, e.g.
+#   ... bash cookbooks/countdown/train_miles.sh rllm.trainer.total_batches=60
+set -x
+set -euo pipefail
+
+PY="${PYTHON:-python}"
+PYBIN="$(cd "$(dirname "$(command -v "$PY")")" && pwd)"
+
+# SGLang JIT-compiles kernels at engine start, so ninja and nvcc must be on PATH in the
+# Ray workers (they inherit the launching shell's PATH).
+export PATH="${PYBIN}:/usr/local/cuda/bin:${PATH}"
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+
+# Triton's cache must be a FRESH dir on tmpfs: a stale ~/.triton/cache, or one on an
+# overlay fs, makes concurrent ranks race during the first kernel compile and surfaces as
+# "__triton_launcher...so: cannot open shared object file".
+export TRITON_CACHE_DIR="$(mktemp -d /dev/shm/triton.XXXXXX)"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+trap 'rm -rf "$TRITON_CACHE_DIR"' EXIT
+
+# The model is already cached, and a run fires ~8 concurrent Hub lookups (4 train actors
+# + 4 SGLang engines) which reliably trips HF rate limiting. Set HF_TOKEN instead if you
+# need to pull a new model.
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+"$PY" -u train.py \
+    rllm/backend=miles \
+    model.name=Qwen/Qwen3-1.7B \
+    miles.train_backend=fsdp \
+    miles.actor_num_nodes=1 \
+    miles.actor_num_gpus_per_node=4 \
+    miles.rollout_num_gpus=4 \
+    miles.rollout_num_gpus_per_engine=1 \
+    miles.global_batch_size=128 \
+    miles.max_tokens_per_gpu=8192 \
+    miles.lr=2e-6 \
+    rllm.data.train_batch_size=16 \
+    rllm.data.max_prompt_length=512 \
+    rllm.data.max_response_length=1024 \
+    rllm.rollout.n=8 \
+    rllm.rollout.n_val=1 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.disable_thinking=true \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.workflow.n_parallel_tasks=64 \
+    rllm.trainer.logger=['console'] \
+    rllm.trainer.project_name='rllm-countdown-miles' \
+    rllm.trainer.experiment_name='countdown-agentflow-miles' \
+    rllm.trainer.total_batches=20 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=10 \
+    rllm.trainer.save_freq=1000 \
+    "$@"
+
+# Sanity checks on the output, in order of what has actually bitten this backend:
+#   train/tis_abs        ~0.01   - trainer and SGLang agree. Anything larger and the
+#                                 forward passes diverge; nothing downstream is valid.
+#   batch/miles_samples  > 0     - the transform produced trainable sequences
+#   train/loss, grad_norm        - present at all means Miles' optimizer metrics arrived

--- a/cookbooks/countdown/train_miles.sh
+++ b/cookbooks/countdown/train_miles.sh
@@ -43,6 +43,17 @@ trap 'rm -rf "$TRITON_CACHE_DIR"' EXIT
 export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
+# NOTE on thinking mode: rllm.disable_thinking is deliberately NOT set here. It only
+# affects rLLM's own ChatTemplateParser, i.e. the SimpleWorkflow / direct-engine path.
+# On the AgentFlow path the *server* applies the chat template, so Qwen3 defaults to
+# thinking ON and responses are long -- hence max_response_length=2048 rather than the
+# 1024 the SimpleWorkflow script uses. Passing disable_thinking here would look like it
+# worked and change nothing.
+#
+# To actually disable it, the agent has to ask the server:
+#   client.chat.completions.create(..., extra_body={"chat_template_kwargs": {"enable_thinking": False}})
+# which is per-agent and not portable across backends, so it is left to the caller.
+
 
 "$PY" -u train.py \
     rllm/backend=miles \
@@ -57,12 +68,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
     miles.lr=2e-6 \
     rllm.data.train_batch_size=16 \
     rllm.data.max_prompt_length=512 \
-    rllm.data.max_response_length=1024 \
+    rllm.data.max_response_length=2048 \
     rllm.rollout.n=8 \
     rllm.rollout.n_val=1 \
     rllm.rollout.train.temperature=1.0 \
     rllm.rollout.train.top_p=1.0 \
-    rllm.disable_thinking=true \
     rllm.algorithm.adv_estimator=grpo \
     rllm.workflow.n_parallel_tasks=64 \
     rllm.trainer.logger=['console'] \

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -76,17 +76,16 @@ Two caveats:
 Qwen3-1.7B, 4 train GPUs (FSDP) + 4 rollout GPUs, thinking disabled. ~18s/step at 128
 samples/step, so a 60-step run is ~20 minutes.
 
-**Reward climbs, on held-out data.** 60 steps, 16 prompts x 8 rollouts, lr 2e-6:
+**Reward climbs, on held-out data.** 60 steps, 16 prompts x 8 rollouts, lr 2e-6, with
+`flash_attention_2` (see §0.4 -- the earlier sdpa numbers were measured with a corrupted
+forward pass and are kept here only for contrast):
 
-| | train reward | truncation | adv_zero |
+| `val/countdown/pass@1` | @20 | @40 | @60 |
 |---|---|---|---|
-| steps 1–15 | 0.432 | 0.148 | 0.633 |
-| steps 16–30 | 0.579 | 0.258 | 0.704 |
-| steps 31–45 | 0.602 | 0.358 | 0.679 |
-| steps 46–60 | 0.612 | 0.351 | 0.721 |
+| **sync, flash_attention_2** | **0.554** | **0.661** | **0.676** |
+| sync, sdpa (corrupted) | 0.537 | 0.620 | 0.630 |
 
-`val/countdown/pass@1` on 1024 held-out tasks: **0.537 → 0.620 → 0.630** at steps
-20/40/60 (SE ≈ 0.015, so +0.093 is ~6σ), against 0.444 for the earlier 8-step run.
+Train reward by third, FA2 vs sdpa: 0.445/0.593/0.612 against 0.432/0.579/0.602.
 
 Two things to read from that. Truncation *rises* as reward rises — the policy first
 learns the `<answer>` format and stops rambling, then spends the recovered budget on
@@ -400,7 +399,7 @@ rLLM at all.
 
 Ordered by what would bite a real run first. Everything in §0 is verified.
 
-### Resolved: the train/inference divergence was `attn_implementation`
+### 0.4 Resolved: the train/inference divergence was `attn_implementation`
 
 Miles' FSDP path calls the model with `attention_mask=None` and packed `position_ids`
 that reset at each document start, deriving `cu_seqlens` from them
@@ -422,17 +421,26 @@ stayed correlated with the right direction — which is why it hid for so long. 
 hit far harder: TIS computes its correction from precisely the logprobs that were wrong,
 so the correction was noise and made the slope *worse* than no correction.
 
-With it fixed, async matches sync's learning rate:
+With it fixed, both modes improve, and async becomes competitive with sync:
 
-| val pass@1 | @8 | @16 | @24 | slope |
-|---|---|---|---|---|
-| async + TIS, sdpa | 0.423 | 0.459 | 0.475 | +0.0032/step |
-| **async + TIS, FA2** | **0.455** | **0.504** | **0.552** | **+0.0061/step** |
-| sync, sdpa (@8→@20) | 0.444 | — | 0.537 @20 | +0.0078/step |
+| `val/countdown/pass@1` | @8 | @16 | @20 | @24 | @40 | @60 |
+|---|---|---|---|---|---|---|
+| sync, FA2 | — | — | 0.554 | — | 0.661 | 0.676 |
+| sync, sdpa | 0.444 | — | 0.537 | — | 0.620 | 0.630 |
+| async + TIS, FA2 | 0.455 | 0.504 | — | 0.552 | — | — |
+| async + TIS, sdpa | 0.423 | 0.459 | — | 0.475 | — | — |
 
-Async on FA2 at step 24 (0.552) already exceeds the old sync baseline at step 20 (0.537),
-and that baseline was itself measured with the broken attention path — so **the sync
-numbers in §0.2 understate what the backend does and need re-measuring on FA2.**
+The blast radius differed sharply by code path, which is why it hid for so long:
+
+- **async** lost ~0.08 pass@1, because TIS computes its correction *from* the corrupted
+  logprobs, so the correction was noise and made the slope worse than no correction.
+- **sync** lost ~0.05, and only visibly with training: +0.017 at step 20 growing to
+  +0.046 by step 60. It never reads `rollout_log_probs`, so it only suffered a partially
+  wrong gradient — still correlated with the right direction, which is exactly what made
+  a 60-step run look healthy.
+
+`tis_abs` is the diagnostic: it should be ~0.01. At 0.83 nothing downstream is
+trustworthy.
 
 `validate_attention` now rejects any non-varlen attention implementation under
 `qkv_format=thd`, and `scripts/setup_miles_env.sh` installs flash-attn. Do not "optimise"

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -400,30 +400,43 @@ rLLM at all.
 
 Ordered by what would bite a real run first. Everything in §0 is verified.
 
-### The one blocking async
+### Resolved: the train/inference divergence was `attn_implementation`
 
-**Train/inference logprob divergence.** `tis_abs` ~0.83 -- the same weights on the same
-tokens give very different logprobs between Miles' trainer and the SGLang engines. Ruled
-out: our extraction (SGLang rescores its own generation to within 0.0155 nats) and weight
-sync (`--check-weight-update-equal` passes, 14 calls, zero failures). What is left is the
-forward pass: the trainer runs `attn_implementation=sdpa` because flash-attn is not
-installed, while SGLang runs flashinfer.
+Miles' FSDP path calls the model with `attention_mask=None` and packed `position_ids`
+that reset at each document start, deriving `cu_seqlens` from them
+(`fsdp_utils/adaptations/packing/boundaries.py`). `qkv_format` defaults to `thd`, so
+several samples share one row. **SDPA cannot consume `cu_seqlens`**, so it applies one
+causal mask across the whole packed row and samples attend across each other — the wrong
+computation, not merely lower precision. Miles defaults to `flash_attention_2` for
+exactly this reason and does not validate the combination, so overriding it failed
+silently.
 
-This is why async underperforms and why TIS makes it *worse* -- a correction computed
-from a badly mismatched ratio is worse than none:
-
-| val pass@1 | @8 | @16 | @24 |
+| training attn | inference attn | `tis` | `tis_abs` |
 |---|---|---|---|
-| async, no correction | 0.380 | 0.400 | 0.438 |
-| async + TIS | 0.423 | 0.459 | 0.475 |
-| *sync* | *0.444* | — | *0.537 @20* |
+| sdpa | flashinfer | 0.303 | 0.830 |
+| sdpa | torch_native (sdpa) | 0.403 | 0.712 |
+| **flash_attention_2 (varlen)** | flashinfer | **1.000** | **0.012** |
 
-Sync is unaffected because it never reads `rollout_log_probs`.
+It corrupted the forward pass in *every* run. Sync still learned, because the gradient
+stayed correlated with the right direction — which is why it hid for so long. Async was
+hit far harder: TIS computes its correction from precisely the logprobs that were wrong,
+so the correction was noise and made the slope *worse* than no correction.
 
-*Next:* confirm by scoring one fixed token sequence on the **base** checkpoint (no
-training, so no weight drift) through a bare SGLang server and through HF with `sdpa`,
-then install flash-attn (prebuilt cu128 wheel from Miles' wheels release) so training
-and inference share an attention path.
+With it fixed, async matches sync's learning rate:
+
+| val pass@1 | @8 | @16 | @24 | slope |
+|---|---|---|---|---|
+| async + TIS, sdpa | 0.423 | 0.459 | 0.475 | +0.0032/step |
+| **async + TIS, FA2** | **0.455** | **0.504** | **0.552** | **+0.0061/step** |
+| sync, sdpa (@8→@20) | 0.444 | — | 0.537 @20 | +0.0078/step |
+
+Async on FA2 at step 24 (0.552) already exceeds the old sync baseline at step 20 (0.537),
+and that baseline was itself measured with the broken attention path — so **the sync
+numbers in §0.2 understate what the backend does and need re-measuring on FA2.**
+
+`validate_attention` now rejects any non-varlen attention implementation under
+`qkv_format=thd`, and `scripts/setup_miles_env.sh` installs flash-attn. Do not "optimise"
+that install away.
 
 ### Would bite the first serious run
 

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -23,7 +23,12 @@ Branch `feat/miles-backend`. Landed and tested off-GPU:
 | `rllm/trainer/miles/transform.py` (episodes → Samples) | done, 19 tests |
 | `rllm/trainer/miles/_flag_audit.py` (offline flag-drift guard) | done |
 | `rllm/trainer/config/rllm/backend/miles.yaml` | done |
-| `miles_engine.py`, `miles_backend.py`, `miles_launcher.py`, `custom_loss.py`, `patch.py` | **not started** — all import miles, so they need the image |
+| `miles_engine.py` (SGLang /generate, TITO) | done |
+| `miles_backend.py` (BackendProtocol) | done, 12 tests |
+| `miles_launcher.py` (Ray init + bring-up) | done |
+| `patch.py` (advantages CP-slice) | done, contract asserted against installed miles |
+| `custom_loss.py` | **not needed until Phase 3** — stock `policy_loss_function` reads `batch["advantages"]` |
+| End-to-end bring-up (`create_training_models`, a train step) | **blocked on GPUs**: cu130 torch vs this box's CUDA 12.8 driver |
 
 Zero regressions: the failing-test set is byte-identical before and after
 (91 pre-existing failures in a venv without ray/verl/vllm, including two float32

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -359,3 +359,59 @@ Roughly 3–4 weeks to Phase 4 for one engineer.
 `backend=miles` does **not** also support Miles' own rollout path (rLLM as trainer only). It
 would double the config surface for no gain — rLLM's agent/workflow layer is the reason to use
 rLLM at all.
+
+## 7. Remaining work
+
+Ordered by what would bite a real run first. Everything in §0 is verified; nothing below is
+known-broken, but nothing below has been executed either.
+
+### Would bite the first serious run
+
+1. **Checkpointing has never executed.** Every run so far used `save_freq=1000`, so
+   `actor_model.save_model()`, `rollout_manager.save()` and resume via `start_rollout_id`
+   are all unexercised. The first run that actually tries to checkpoint is the test.
+2. **Miles' training metrics don't reach rLLM.** `loss`, `grad_norm`, `entropy`, `ppo_kl`,
+   `pg_clipfrac` are computed by Miles and logged to its own tracking, but nothing lands in
+   `trainer_state.metrics` — so from rLLM's side you cannot see whether the optimizer is
+   healthy. `RayTrainGroup.train` returns a `train_step_outcome`; wire it through.
+3. **The sglang fork is unpinned.** Installed from `sglang-miles` branch HEAD (`cb05a44`).
+   A fork commit can change weight-update or generation behavior with no signal. Pin it,
+   next to the Miles commit pin.
+
+### Untested paths, not known-broken
+
+4. **CP > 1.** At CP=1 `slice_log_prob_with_cp` is the identity, so the advantages patch has
+   never done real work. This is the highest-value correctness test left.
+5. **Multi-turn merged samples.** The transform's merge walk is unit-tested but has only run
+   live on single-turn countdown.
+6. **Megatron backend.** Needs the offline HF→`torch_dist` conversion for `ref_load`. Also
+   the only path with TP/PP/EP, and the one all of Miles' recipes are tuned for.
+7. **R3 routing replay.** `routing_matrices` is plumbed through `MilesEngine` end to end but
+   never exercised; needs an MoE model plus `use_rollout_routing_replay`.
+
+### Efficiency and quality
+
+8. **`adv_zero` ≈ 0.7.** Two thirds of every batch is uniform-reward groups contributing no
+   gradient. `rllm.rejection_sample.filter_uniform_groups` is the intended fix, untried.
+9. **The curve flattens after ~step 40.** Unexplored: lr schedule, larger batch, more steps.
+
+### Hygiene
+
+10. `MilesEngine.close()` is never called — the httpx client leaks at shutdown.
+    `MilesBackend.shutdown()` should await it.
+11. `_num_rollout_per_epoch` is assigned and never read.
+12. `on_policy_updated` is an empty stub (correct until async lands).
+13. **Upstream the three patches** so `patch.py` can be deleted: the CP-slice key tuple, the
+    `_package_shards` allowlist, and gating the FSDP actor's `compute_advantages_and_returns`
+    the way the Megatron actor already does.
+14. `rllm[train]` is named in five error messages and by the `all` extra but does not exist
+    in `pyproject.toml`. Pre-existing, but making tinker optional turned it into a path users
+    can actually reach.
+15. The environment recipe in §0.1/§0.2 is prose. It wants to be a script.
+16. **Fault tolerance is unavailable**, not just untested: `nvidia-resiliency-ext` cannot
+    install on glibc < 2.39, so `--use-fault-tolerance` has no chance of working on this box.
+
+### Deliberately out of scope
+
+Async (Phase 5), a critic / PPO, multimodal rollouts and `--colocate` are all rejected in
+`validate_config` or the transform, with an explanatory error rather than a silent failure.

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -107,6 +107,42 @@ Environment fixes this needed on a CUDA-12.8 box, in order:
 | `404 /begin_weight_update` | stock PyPI sglang serves generation fine but has no weight-update endpoint; install the fork: `git clone -b sglang-miles`, `pip install --no-deps --no-build-isolation -e python` |
 | `ModuleNotFoundError: megatron` inside `compute_log_probs` | `pip install megatron-core`. The FSDP path *does* need it -- Miles' shared log-prob kernel uses Megatron's fused cross-entropy (there is a `TODO` there for a fallback) |
 
+### 0.3 Async training (validated 2026-08-22)
+
+Async needs `fwd_bwd_group_size == mini_batch_size` (Miles takes its optimizer step
+inside `RayTrainGroup.train()`, so it cannot accumulate across passes) and
+`rllm.workflow.raise_on_error=false`. Weight sync moves to `on_policy_updated`; Miles'
+own update pauses, flushes, loads and resumes every engine, and the default
+`--pause-generation-mode retract` requeues in-flight requests instead of killing them,
+so `partial_rollout=true` is safe.
+
+**Off-policy correction is not optional.** `rllm.algorithm.rollout_correction.*` was
+initially unmapped, so `tis_mode` / `tis_cap` / `bypass_mode` were accepted by Hydra and
+discarded. A/B on countdown, Qwen3-1.7B, `mini_batch_size=32`, `staleness_threshold=0.5`,
+identical apart from correction:
+
+| `val/countdown/pass@1` | step 8 | step 16 | step 24 |
+|---|---|---|---|
+| no correction | 0.380 | 0.400 | 0.438 |
+| **+ TIS** (`tis_mode=token`, `tis_cap=2.0`) | **0.445** | **0.471** | **0.475** |
+| *sync reference* | *0.444* | — | *0.537 @20* |
+
+Train reward by 5-step window, control vs TIS: 0.380/0.388, 0.381/0.443, 0.359/0.445,
+0.397/0.454, 0.436/0.468 — TIS ahead everywhere past the first window, where staleness
+is still 0–1. Miles reports `ois'` (uncorrected) = 1.0 against `tis'` ≈ 0.21–0.31, so
+stale samples were being overweighted 3–5x. Uncorrected reward *falls* over steps 11–15,
+which is what a biased gradient looks like once the policy has drifted from the
+behaviour policy.
+
+Corrected async matches sync at step 8 (0.445 vs 0.444) but stays behind by step 20–24
+(0.475 vs 0.537): the residual cost of off-policy learning, plus the ~40% of groups
+still lost to uniform-reward filtering. `filter_uniform_groups` is the next lever and
+now has a baseline to beat.
+
+Sizing matters as much as correction: every working async config in the repo uses
+`mini_batch_size` 32–64. The first attempt used 4, giving ~21 samples/step after
+filtering, and learned nothing.
+
 ## 1. Target architecture
 
 One Ray cluster, one driver process (rLLM), inside Miles' docker image.
@@ -413,5 +449,6 @@ known-broken, but nothing below has been executed either.
 
 ### Deliberately out of scope
 
-Async (Phase 5), a critic / PPO, multimodal rollouts and `--colocate` are all rejected in
-`validate_config` or the transform, with an explanatory error rather than a silent failure.
+A critic / PPO, multimodal rollouts and `--colocate` are rejected in `validate_config` or
+the transform, with an explanatory error rather than a silent failure. Async is supported
+(§0.3).

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -1,0 +1,305 @@
+# Miles as an rLLM training backend
+
+Plan for adding `backend="miles"` alongside `verl` / `tinker` / `fireworks`, with
+rLLM's `UnifiedTrainer` owning the loop and Miles owning the GPUs.
+
+Miles: https://github.com/radixark/miles (slime fork; SGLang rollout + Megatron-LM/FSDP2 training).
+References below are to a local checkout at `~/miles`.
+
+## 0. Status (2026-08-21)
+
+Branch `feat/miles-backend`. Landed and tested off-GPU:
+
+| Piece | State |
+|---|---|
+| Phase 0 dependency analysis | done — see below |
+| Miles importable without its container image | **done** — recipe in §0.1 |
+| Config bridge validated against Miles' real `parse_args` | **done** — 7 live tests |
+| Transform validated against real `convert_samples_to_train_data` | **done** — 5 live tests |
+| `pyproject.toml`: tinker optional, `miles` extra | done |
+| Table-driven launcher dispatch + install hints | done |
+| `rllm/trainer/algorithms/step_merge.py` (shared merge helpers) | done, tinker rewired to it |
+| `rllm/trainer/miles/miles_config.py` (config bridge) | done, 34 tests |
+| `rllm/trainer/miles/transform.py` (episodes → Samples) | done, 19 tests |
+| `rllm/trainer/miles/_flag_audit.py` (offline flag-drift guard) | done |
+| `rllm/trainer/config/rllm/backend/miles.yaml` | done |
+| `miles_engine.py`, `miles_backend.py`, `miles_launcher.py`, `custom_loss.py`, `patch.py` | **not started** — all import miles, so they need the image |
+
+Zero regressions: the failing-test set is byte-identical before and after
+(91 pre-existing failures in a venv without ray/verl/vllm, including two float32
+round-trip failures in `tests/unified_trainer/test_tinker_transform.py` that
+predate this branch).
+
+### 0.1 Miles without the container image
+
+The image is **not** required for Phases 0–3. Miles installs from source; what its
+`requirements.txt` omits (torch, sglang, megatron-core, transformer_engine) comes
+from the image base, and only `sglang` is needed for the modules this backend touches.
+
+```bash
+# a separate venv: miles pins transformers==5.12.1, which breaks tinker in the rLLM venv
+uv venv --python 3.12 /path/to/mvenv
+cd ~/miles
+# nvidia-resiliency-ext 0.6.0 ships only manylinux_2_39 wheels (glibc 2.39 / Ubuntu 24.04).
+# On glibc 2.35 there is no sdist to fall back on. Fault-tolerance only -> drop it.
+grep -v '^nvidia-resiliency-ext' requirements.txt > /tmp/reqs.txt
+uv pip install --python /path/to/mvenv --prerelease=allow -r /tmp/reqs.txt   # ~36s
+uv pip install --python /path/to/mvenv --no-deps -e .
+uv pip install --python /path/to/mvenv --prerelease=allow "sglang==0.5.16"   # ~48s
+uv pip install --python /path/to/mvenv -e /path/to/rllm
+```
+
+That makes all five modules the backend touches importable — `miles.utils.types`,
+`miles.utils.arguments`, `miles.ray.rollout.train_data_conversion`,
+`miles.backends.training_utils.data`, `miles.ray.placement_group` — with **no
+Megatron and no TransformerEngine**, because the FSDP path imports neither.
+
+Two caveats:
+
+- Stock `sglang==0.5.16` downgrades torch 2.13 → 2.11. Fine for argument parsing and
+  the CPU-side seams; the image's forked SGLang is authoritative for anything
+  behavioral.
+- **This box cannot run GPU work in either venv.** The driver is CUDA 12.8
+  (570.195.03) while both venvs carry cu130-built torch, so
+  `torch.cuda.is_available()` is False — true of the pre-existing rLLM venv too.
+  Phase 1 onward needs cu12 wheels, or Miles' `cu12-x86` image variant
+  (`ENABLE_CUDA_13=0`).
+
+## 1. Target architecture
+
+One Ray cluster, one driver process (rLLM), inside Miles' docker image.
+
+```
+rllm train backend=miles
+  └─ MilesTrainerLauncher
+       ├─ build Miles argparse Namespace from OmegaConf          (config bridge)
+       ├─ ray.init(runtime_env=...)  +  create_placement_groups(args)
+       ├─ create_rollout_manager(args, pgs["rollout"])           # SGLang fleet + router
+       │     rollout fn = sleep_rollout  → never called
+       ├─ create_training_models(args, pgs, rollout_manager)     # actor_model: RayTrainGroup
+       └─ UnifiedTrainer(backend_cls=MilesBackend)
+            ├─ init_rollout_engine        → MilesEngine → SGLang router /generate (TITO)
+            ├─ generate_episodes          → rLLM workflow engine (unchanged)
+            ├─ transform_to_backend_batch → Episodes → list[Sample] → train_data → data_ref
+            ├─ process_backend_batch      → no-op (Miles' actor does its own fwd passes)
+            ├─ compute_advantages         → rLLM native, per-token, rides in the batch
+            ├─ update_policy              → actor_model.train(rollout_id, {"data_ref": ...})
+            └─ on_batch_end               → save_model() ; update_weights()
+```
+
+Miles' `train.py` / `train_async.py` are not used. `RolloutManager` is kept purely as the
+engine-fleet + router + weight-update broker — `update_weights` routes through it
+(`miles/ray/actor_group.py:119` → `rollout_manager.get_updatable_engines_and_lock`), which is
+why we keep it rather than launching SGLang ourselves.
+
+## 2. Deliverables
+
+```
+rllm/trainer/miles/
+  __init__.py
+  miles_launcher.py     # MilesTrainerLauncher: config bridge + Ray/PG/actor bring-up
+  miles_config.py       # OmegaConf -> miles argparse Namespace
+  miles_backend.py      # MilesBackend(BackendProtocol[Iterable, MilesBatch])
+  transform.py          # Episodes/TrajectoryGroups -> list[Sample] -> train_data dict
+  custom_loss.py        # rLLM loss -> miles loss-fn signature shim (trainer ranks)
+  patch.py              # worker-side monkey patches applied to miles
+  utils.py              # sync_config shared-keys table
+rllm/engine/rollout/miles_engine.py
+rllm/trainer/config/rllm/backend/miles.yaml
+```
+
+Touched: `rllm/trainer/unified_trainer.py` — one `elif backend == "miles"` branch (~10 lines,
+mirroring the tinker branch at :1163).
+
+## 3. The four hard problems, and the decisions
+
+### P1 — Config bridge (the biggest chunk)
+
+Miles args are one flat `argparse.Namespace` built on top of **Megatron's own** `parse_args`
+(`miles/utils/arguments.py:2664`), so the whole Megatron flag surface shares one CLI and
+`PYTHONPATH=/root/Megatron-LM` must be set before import.
+
+**Decision:** `miles_config.build_miles_args(cfg) -> Namespace` renders an argv list and calls
+Miles' own `parse_args()` under a temporarily swapped `sys.argv`. Do *not* hand-construct a
+Namespace — `miles_validate_args` + `megatron_validate_args` + `set_default_megatron_args` do
+substantial derivation we want to run.
+
+Two config layers, matching how tinker/verl already work:
+
+- `rllm/trainer/config/rllm/backend/miles.yaml` holds a `miles:` block that mirrors Miles flags
+  near-verbatim (`actor_num_nodes`, `rollout_num_gpus`, `train_backend`, `megatron_model_type`,
+  `hf_checkpoint`, `ref_load`, …), rendered to `--kebab-case` argv.
+- A `_SHARED_KEYS` table in `rllm/trainer/miles/utils.py` fed to the existing
+  `sync_shared_keys` (see `rllm/trainer/tinker/utils.py`) mirrors `rllm.data.*` /
+  `rllm.algorithm.*` onto Miles names so users set them once.
+
+Escape hatch: `miles.extra_args: ["--foo", "bar"]` appended verbatim, so an unmirrored Miles
+flag is never a blocker.
+
+Pinned by us, not user-settable (assert in `validate_config`):
+
+| flag | value | why |
+|---|---|---|
+| `--rollout-function-path` | `miles.rollout.sleep_rollout.sleep` | rLLM owns generation; RolloutManager must never generate |
+| `--rollout-global-dataset` | `false` | rLLM owns the dataset; skips Miles' Dataset/tokenizer load |
+| `--disable-compute-advantages-and-returns` | set | advantages come from rLLM |
+| `--loss-type` | `custom_loss` (phase 3+) | with `--custom-loss-function-path rllm.trainer.miles.custom_loss:loss_fn` |
+| `--colocate` | forbidden (phase 1) | disaggregated only, so generation and training don't fight over GPUs |
+
+### P2 — Per-token advantages into the trainer
+
+Miles computes advantages **inside the train step** from scalar rewards
+(`miles/backends/megatron_utils/actor.py:558` → `miles/backends/training_utils/loss.py:28`),
+gated on `args.compute_advantages_and_returns`. rLLM computes its own per-token advantages on
+the driver.
+
+`--disable-compute-advantages-and-returns` (`miles/utils/arguments.py:1437`) turns Miles'
+computation off — its help text says "useful for sft or custom loss function". So the only
+missing piece is transport for a driver-supplied, response-aligned float array.
+
+That transport already exists for `rollout_log_probs`: `get_rollout_data`
+(`miles/backends/training_utils/data.py:93`) CP-slices exactly three keys through
+`slice_log_prob_with_cp`, which asserts `len(x) == response_length` — the same shape our
+advantages have.
+
+**Decision:** patch that key tuple worker-side from rLLM to include `"advantages"`. Same
+mechanism rLLM already uses for verl (`rllm/trainer/verl/patch.py`, applied via
+`runtime_env.worker_process_setup_hook` in `ray_runtime_env.py`). ~5 lines.
+
+Consequence worth noting: with advantages arriving CP-correct, **stock Miles
+`policy_loss_function` works unmodified** — it reads `batch["advantages"]` at
+`miles/backends/training_utils/loss_hub/losses.py:91`. So phases 1–2 need no custom loss at
+all; `custom_loss.py` is only for rLLM-specific losses (DPPO etc.).
+
+Test CP=1 first (`C_i == R_i`, slicing is identity), then CP>1.
+
+Upstream as a small PR (`for key in (..., "advantages")` plus a `ROLLOUT_DATA_VALUE_SPEC`
+entry) so the patch can be dropped.
+
+### P3 — Rollout engine
+
+`MilesEngine(RolloutEngine)` modelled directly on `VerlEngine`
+(`rllm/engine/rollout/verl_engine.py`): `supports_token_in_token_out = True`,
+`get_token_output_from_token_input` POSTs to SGLang's raw `/generate` on Miles' router
+(`args.sglang_router_ip` / `sglang_router_port`) with `input_ids` and `return_logprob=True`.
+
+Raw `/generate` rather than Miles' TITO session server, because rLLM already owns
+tokenization, prompt assembly and loss masks end to end (`ChatTemplateParser` + the transform).
+Routing through the session server would install a second tokenizer authority and duplicate the
+merge logic. Miles documents this path explicitly (`docs/user-guide/generate-endpoint.md`:
+"owning prompt construction, tokens, and loss masks").
+
+Field mapping is already 1:1:
+
+| rLLM `ModelOutput` | Miles `Sample` |
+|---|---|
+| `prompt_ids` + `completion_ids` | `tokens` |
+| merged completion length | `response_length` |
+| `logprobs` | `rollout_log_probs` |
+| `routing_matrices` | `rollout_routed_experts` (R3) |
+| `weight_version` | `weight_versions` |
+
+### P4 — Transform
+
+`transform.py` ports `trajectory_to_datums` (`rllm/trainer/tinker/transform.py:78`) — the
+prefix-extension merge, lineage partitioning and per-token advantage broadcast are reusable
+verbatim. It is *simpler* than the tinker version: Miles takes raw `tokens` and does its own
+shift internally, so drop `create_rightshifted_model_input_and_leftshifted_targets`.
+
+One `Sample` per merged sequence:
+
+- `tokens` = `[O1, A1, O2, A2, …]`
+- `response_length` = `len(tokens) - len(O1)`
+- `loss_mask` = 0 on observation tokens, 1 on action tokens (length `response_length`)
+- `rollout_log_probs`, `advantages` = same length, 0-filled over observation tokens
+- `status` from `Episode.termination_reason` → `COMPLETED` / `TRUNCATED` / `ABORTED`
+- `index` / `group_index` from `TrajectoryGroup.group_id`
+
+Then `convert_samples_to_train_data(args, samples, metadata, None, None)` +
+`split_train_data_by_dp(...)` (`miles/ray/rollout/train_data_conversion.py`) produce the
+`{"sample_indices": …, "data_ref": …}` pack `RayTrainGroup.train` expects
+(`miles/ray/actor_group.py:77`).
+
+Ray's object store ignores `value_spec` (`miles/utils/object_store.py:117` is just
+`ray.put(value)`), so the extra `advantages` key needs no spec entry — *unless* someone enables
+the Mooncake store, where it does. Covered by the same upstream PR.
+
+## 4. Phases
+
+**Phase 0 — env feasibility. Dependency half done; image half still open.**
+
+Measured, not guessed. The blocker is exact: `tinker-cookbook 0.5.2` requires
+`transformers!=5.4.*,!=5.5.0,!=5.5.1,!=5.5.2,!=5.5.3,<=5.5.4,>=4.57.6`, while Miles
+requires `transformers==5.12.1`. rLLM listed `tinker` / `tinker-cookbook` in **core**
+`dependencies` *and* in the `tinker` extra, so every install inherited that cap.
+
+Resolved by dropping the redundant core copy. Proven end-to-end: `uv pip install -e .`
+into a `transformers==5.12.1` venv now leaves it at 5.12.1, whereas adding
+`tinker-cookbook` back downgrades it to 5.5.4. Also verified by blocking `tinker` and
+`tinker_cookbook` at the import hook: `rllm`, `rllm.cli.main`,
+`rllm.trainer.unified_trainer`, `rllm.data`, `rllm.hooks`, `rllm.gateway.manager` and
+the algorithm modules all import clean — the only gap was `ray` (the verl extra).
+`rllm/trainer/fireworks/fireworks_policy_trainer.py` imports tinker at module scope,
+so the `fireworks` extra now declares it explicitly.
+
+Still open, and it needs a GPU box with docker (this dev box has neither): Miles'
+image is mandatory regardless of the pin. It builds off `lmsysorg/sglang:v0.5.16`
+with a forked SGLang (`sglang-miles`), a forked Megatron-LM
+(`radixark/Megatron-LM@miles-main`) and prebuilt cu130 wheels — none of it
+assemblable from PyPI. So `backend=miles` means "runs in the Miles image", and
+`validate_config` should say so.
+
+*Exit:* `import rllm`, `import miles`, `import megatron` in one interpreter, inside
+the image.
+
+**Phase 1 — train-only loop, no rLLM generation (2–3 days).**
+Bring up placement groups + `RolloutManager(sleep)` + actor from the rLLM launcher. Feed a
+hand-built `list[Sample]` fixture straight into `actor_model.train()`.
+*Exit:* loss decreases on a memorized batch; `update_weights()` completes.
+
+**Phase 2 — MilesEngine + transform (3–5 days).**
+Point rLLM's workflow engine at the Miles router. Single-turn GRPO on a small dense model
+(Qwen3-4B, `--train-backend fsdp` to skip Megatron checkpoint conversion).
+*Exit:* reward curve on a math task matches the verl backend within noise.
+
+**Phase 3 — advantages passthrough + custom loss (2–3 days).**
+Apply the `data.py` patch and `--disable-compute-advantages-and-returns`.
+*Exit:* identical loss/grad-norm to Phase 2 when rLLM is configured to reproduce Miles' GRPO;
+then a non-native rLLM loss runs through `custom_loss.py`.
+
+**Phase 4 — multi-turn + Megatron + scale (1–2 weeks).**
+Merged multi-turn samples, CP>1 slicing, `--train-backend megatron` with TP/PP/EP, checkpoint
+save/resume via `save_model` + `start_rollout_id`, R3 routing replay.
+*Exit:* an agentic run (terminal-bench / SWE) on a ≥30B MoE.
+
+**Phase 5 — async (deferred).**
+Map `rllm.async_training` onto `on_policy_updated` + `update_weights_interval`, with
+`pause_generation` / `continue_generation` (`miles/backends/sglang_utils/sglang_engine.py:623`)
+around weight updates. Do not start until 1–4 are stable.
+
+Roughly 3–4 weeks to Phase 4 for one engineer.
+
+## 5. Things that will bite
+
+1. **Ray ownership.** Both frameworks call `ray.init` and build placement groups. rLLM inits
+   Ray first with Miles' runtime env (`MEGATRON_` / `SGLANG_` prefixes are already in rLLM's
+   `FORWARD_PREFIXES`), then hands `pgs` to Miles' `create_*`. Also: Miles' `execute_train`
+   normally runs a `pkill -9 sglang; ray stop --force` preamble
+   (`miles/utils/external_utils/command_utils.py:166`); we bypass it, so stale SGLang processes
+   become our problem.
+2. **We use Miles against its grain.** It ships as a driver (`ray job submit train.py`), not a
+   library. `create_placement_groups` / `create_rollout_manager` / `create_training_models` are
+   plain importable functions, but carry no API-stability promise. Pin a Miles commit; expect
+   breakage on bumps. Budget for upstreaming 2–3 small patches (advantages key, value spec,
+   maybe an args-from-dict entry point) to shrink the surface we depend on.
+3. **Megatron checkpoint conversion.** `--train-backend megatron` needs an offline
+   HF→`torch_dist` conversion for `ref_load`. Phase 2 sidesteps it with FSDP; Phase 4 owns it.
+4. **`sample.index` / `group_index`.** `convert_samples_to_train_data` still uses these for
+   grouping and metrics even when we supply advantages. Set them from `TrajectoryGroup.group_id`
+   or reward normalization will silently misbehave.
+
+## 6. Decided
+
+`backend=miles` does **not** also support Miles' own rollout path (rLLM as trainer only). It
+would double the config surface for no gain — rLLM's agent/workflow layer is the reason to use
+rLLM at all.

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -398,57 +398,75 @@ rLLM at all.
 
 ## 7. Remaining work
 
-Ordered by what would bite a real run first. Everything in §0 is verified; nothing below is
-known-broken, but nothing below has been executed either.
+Ordered by what would bite a real run first. Everything in §0 is verified.
+
+### The one blocking async
+
+**Train/inference logprob divergence.** `tis_abs` ~0.83 -- the same weights on the same
+tokens give very different logprobs between Miles' trainer and the SGLang engines. Ruled
+out: our extraction (SGLang rescores its own generation to within 0.0155 nats) and weight
+sync (`--check-weight-update-equal` passes, 14 calls, zero failures). What is left is the
+forward pass: the trainer runs `attn_implementation=sdpa` because flash-attn is not
+installed, while SGLang runs flashinfer.
+
+This is why async underperforms and why TIS makes it *worse* -- a correction computed
+from a badly mismatched ratio is worse than none:
+
+| val pass@1 | @8 | @16 | @24 |
+|---|---|---|---|
+| async, no correction | 0.380 | 0.400 | 0.438 |
+| async + TIS | 0.423 | 0.459 | 0.475 |
+| *sync* | *0.444* | — | *0.537 @20* |
+
+Sync is unaffected because it never reads `rollout_log_probs`.
+
+*Next:* confirm by scoring one fixed token sequence on the **base** checkpoint (no
+training, so no weight drift) through a bare SGLang server and through HF with `sdpa`,
+then install flash-attn (prebuilt cu128 wheel from Miles' wheels release) so training
+and inference share an attention path.
 
 ### Would bite the first serious run
 
-1. **Checkpointing has never executed.** Every run so far used `save_freq=1000`, so
-   `actor_model.save_model()`, `rollout_manager.save()` and resume via `start_rollout_id`
-   are all unexercised. The first run that actually tries to checkpoint is the test.
-2. **Miles' training metrics don't reach rLLM.** `loss`, `grad_norm`, `entropy`, `ppo_kl`,
-   `pg_clipfrac` are computed by Miles and logged to its own tracking, but nothing lands in
-   `trainer_state.metrics` — so from rLLM's side you cannot see whether the optimizer is
-   healthy. `RayTrainGroup.train` returns a `train_step_outcome`; wire it through.
-3. **The sglang fork is unpinned.** Installed from `sglang-miles` branch HEAD (`cb05a44`).
-   A fork commit can change weight-update or generation behavior with no signal. Pin it,
-   next to the Miles commit pin.
+1. **Checkpointing has never executed.** Every run used `save_freq=1000`, so
+   `save_model()`, `rollout_manager.save()` and resume via `start_rollout_id` are
+   unexercised.
+2. **Miles' training metrics don't reach rLLM.** `loss`, `grad_norm`, `entropy`,
+   `ppo_kl`, `pg_clipfrac` are computed and logged by Miles but never land in
+   `trainer_state.metrics`, so the optimizer's health is invisible from rLLM's side.
+   Reading `tis`/`tis_abs` required grepping Miles' raw log.
+3. **Pin the sglang fork.** `scripts/setup_miles_env.sh` clones `sglang-miles` at branch
+   HEAD; a fork commit can change weight-update or generation behaviour with no signal.
+   Same for the Miles checkout.
 
 ### Untested paths, not known-broken
 
-4. **CP > 1.** At CP=1 `slice_log_prob_with_cp` is the identity, so the advantages patch has
-   never done real work. This is the highest-value correctness test left.
-5. **Multi-turn merged samples.** The transform's merge walk is unit-tested but has only run
-   live on single-turn countdown.
-6. **Megatron backend.** Needs the offline HF→`torch_dist` conversion for `ref_load`. Also
-   the only path with TP/PP/EP, and the one all of Miles' recipes are tuned for.
-7. **R3 routing replay.** `routing_matrices` is plumbed through `MilesEngine` end to end but
-   never exercised; needs an MoE model plus `use_rollout_routing_replay`.
+4. **CP > 1** — at CP=1 `slice_log_prob_with_cp` is the identity, so the advantages
+   patch has never done real work. Highest-value correctness test left.
+5. **Multi-turn merged samples** — unit-tested, only ever run on single-turn countdown.
+6. **Megatron backend** — needs the offline HF -> `torch_dist` conversion for `ref_load`;
+   the only path with TP/PP/EP and the one Miles' own recipes target.
+7. **R3 routing replay** — plumbed end to end, never exercised (needs MoE +
+   `use_rollout_routing_replay`).
 
-### Efficiency and quality
+### Efficiency
 
-8. **`adv_zero` ≈ 0.7.** Two thirds of every batch is uniform-reward groups contributing no
-   gradient. `rllm.rejection_sample.filter_uniform_groups` is the intended fix, untried.
-9. **The curve flattens after ~step 40.** Unexplored: lr schedule, larger batch, more steps.
+8. **`adv_zero` ~0.7 / ~40% of groups filtered.** Uniform-reward groups contribute no
+   gradient; `rllm.rejection_sample.filter_uniform_groups` is the intended fix, untried.
+9. **Async needs `mini_batch_size` 32-64.** 4 gives ~21 samples/step after filtering and
+   learns nothing. Sizing matters as much as correctness here.
 
 ### Hygiene
 
-10. `MilesEngine.close()` is never called — the httpx client leaks at shutdown.
-    `MilesBackend.shutdown()` should await it.
+10. **Upstream the patches** so `patch.py` can be deleted: the CP-slice key tuple, the
+    `_package_shards` allowlist, and gating the FSDP actor's
+    `compute_advantages_and_returns` the way the Megatron actor already does.
 11. `_num_rollout_per_epoch` is assigned and never read.
-12. `on_policy_updated` is an empty stub (correct until async lands).
-13. **Upstream the three patches** so `patch.py` can be deleted: the CP-slice key tuple, the
-    `_package_shards` allowlist, and gating the FSDP actor's `compute_advantages_and_returns`
-    the way the Megatron actor already does.
-14. `rllm[train]` is named in five error messages and by the `all` extra but does not exist
-    in `pyproject.toml`. Pre-existing, but making tinker optional turned it into a path users
-    can actually reach.
-15. The environment recipe in §0.1/§0.2 is prose. It wants to be a script.
-16. **Fault tolerance is unavailable**, not just untested: `nvidia-resiliency-ext` cannot
-    install on glibc < 2.39, so `--use-fault-tolerance` has no chance of working on this box.
+12. `rllm[train]` is named in five error messages and by the `all` extra but does not
+    exist in `pyproject.toml` (pre-existing; making tinker optional made it reachable).
+13. **Fault tolerance is unavailable**, not merely untested: `nvidia-resiliency-ext`
+    cannot install on glibc < 2.39.
 
 ### Deliberately out of scope
 
 A critic / PPO, multimodal rollouts and `--colocate` are rejected in `validate_config` or
-the transform, with an explanatory error rather than a silent failure. Async is supported
-(§0.3).
+the transform, with an explanatory error rather than a silent failure.

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -28,7 +28,7 @@ Branch `feat/miles-backend`. Landed and tested off-GPU:
 | `miles_launcher.py` (Ray init + bring-up) | done |
 | `patch.py` (advantages CP-slice) | done, contract asserted against installed miles |
 | `custom_loss.py` | **not needed** — stock `policy_loss_function` reads `batch["advantages"]`, verified live |
-| End-to-end training run | **done** — 8 GRPO steps on countdown, Qwen3-1.7B, 8xH100, val pass@1 0.444 |
+| End-to-end training run | **done** — 60 GRPO steps, val pass@1 0.537→0.630 (~6σ) |
 
 Zero regressions: the failing-test set is byte-identical before and after
 (91 pre-existing failures in a venv without ray/verl/vllm, including two float32
@@ -73,10 +73,27 @@ Two caveats:
 ### 0.2 End-to-end run (validated 2026-08-21)
 
 `examples/countdown/unified_trainer/train_countdown_unified_miles.sh` — countdown,
-Qwen3-1.7B, 4 train GPUs (FSDP) + 4 rollout GPUs, thinking disabled, 8 GRPO steps.
-Completes in a few minutes; final `val/countdown/pass@1` 0.444 with 8 `actor_train`
-passes. Reward is noisy across 8 steps (0.22-0.53) and does not visibly climb -- this
-validates the **mechanism**, not learning.
+Qwen3-1.7B, 4 train GPUs (FSDP) + 4 rollout GPUs, thinking disabled. ~18s/step at 128
+samples/step, so a 60-step run is ~20 minutes.
+
+**Reward climbs, on held-out data.** 60 steps, 16 prompts x 8 rollouts, lr 2e-6:
+
+| | train reward | truncation | adv_zero |
+|---|---|---|---|
+| steps 1–15 | 0.432 | 0.148 | 0.633 |
+| steps 16–30 | 0.579 | 0.258 | 0.704 |
+| steps 31–45 | 0.602 | 0.358 | 0.679 |
+| steps 46–60 | 0.612 | 0.351 | 0.721 |
+
+`val/countdown/pass@1` on 1024 held-out tasks: **0.537 → 0.620 → 0.630** at steps
+20/40/60 (SE ≈ 0.015, so +0.093 is ~6σ), against 0.444 for the earlier 8-step run.
+
+Two things to read from that. Truncation *rises* as reward rises — the policy first
+learns the `<answer>` format and stops rambling, then spends the recovered budget on
+reasoning. And the curve flattens after ~step 40 while `adv_zero` stays near 0.7: two
+thirds of every batch is uniform-reward groups contributing no gradient, which is what
+`rllm.rejection_sample.filter_uniform_groups` exists to fix. An 8-step run cannot see
+any of this — it sits entirely inside the noise band.
 
 Environment fixes this needed on a CUDA-12.8 box, in order:
 

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -27,8 +27,8 @@ Branch `feat/miles-backend`. Landed and tested off-GPU:
 | `miles_backend.py` (BackendProtocol) | done, 12 tests |
 | `miles_launcher.py` (Ray init + bring-up) | done |
 | `patch.py` (advantages CP-slice) | done, contract asserted against installed miles |
-| `custom_loss.py` | **not needed until Phase 3** — stock `policy_loss_function` reads `batch["advantages"]` |
-| End-to-end bring-up (`create_training_models`, a train step) | **blocked on GPUs**: cu130 torch vs this box's CUDA 12.8 driver |
+| `custom_loss.py` | **not needed** — stock `policy_loss_function` reads `batch["advantages"]`, verified live |
+| End-to-end training run | **done** — 8 GRPO steps on countdown, Qwen3-1.7B, 8xH100, val pass@1 0.444 |
 
 Zero regressions: the failing-test set is byte-identical before and after
 (91 pre-existing failures in a venv without ray/verl/vllm, including two float32
@@ -69,6 +69,26 @@ Two caveats:
   `torch.cuda.is_available()` is False — true of the pre-existing rLLM venv too.
   Phase 1 onward needs cu12 wheels, or Miles' `cu12-x86` image variant
   (`ENABLE_CUDA_13=0`).
+
+### 0.2 End-to-end run (validated 2026-08-21)
+
+`examples/countdown/unified_trainer/train_countdown_unified_miles.sh` — countdown,
+Qwen3-1.7B, 4 train GPUs (FSDP) + 4 rollout GPUs, thinking disabled, 8 GRPO steps.
+Completes in a few minutes; final `val/countdown/pass@1` 0.444 with 8 `actor_train`
+passes. Reward is noisy across 8 steps (0.22-0.53) and does not visibly climb -- this
+validates the **mechanism**, not learning.
+
+Environment fixes this needed on a CUDA-12.8 box, in order:
+
+| Symptom | Fix |
+|---|---|
+| `torch.cuda.is_available()` false | `torch==2.11.0+cu128` (+ matching torchvision/torchaudio) from the pytorch cu128 index; sglang pins the torch *version*, not its CUDA build |
+| `libnvrtc.so.13` / `libcudart.so.13` missing | `sglang-kernel` from `docs.sglang.ai/whl/cu129/`; uninstall `sgl-deep-gemm` (cu13-only, and DeepGEMM needs SM100+ anyway) |
+| `FileNotFoundError: 'ninja'` | `pip install ninja`; put the venv bin and `/usr/local/cuda/bin` on PATH so Ray workers inherit them |
+| `__triton_launcher...so: cannot open shared object file` | `TRITON_CACHE_DIR=$(mktemp -d /dev/shm/triton.XXXXXX)` -- and `TRITON_` had to be added to rLLM's forwarded env prefixes or workers never see it |
+| `FlashAttention2 ... doesn't seem to be installed` | `miles.attn_implementation=sdpa` (FA2 ships in Miles' image wheels) |
+| `404 /begin_weight_update` | stock PyPI sglang serves generation fine but has no weight-update endpoint; install the fork: `git clone -b sglang-miles`, `pip install --no-deps --no-build-isolation -e python` |
+| `ModuleNotFoundError: megatron` inside `compute_log_probs` | `pip install megatron-core`. The FSDP path *does* need it -- Miles' shared log-prob kernel uses Megatron's fused cross-entropy (there is a `TODO` there for a fallback) |
 
 ## 1. Target architecture
 
@@ -177,6 +197,20 @@ Consequence worth noting: with advantages arriving CP-correct, **stock Miles
 all; `custom_loss.py` is only for rLLM-specific losses (DPPO etc.).
 
 Test CP=1 first (`C_i == R_i`, slicing is identity), then CP>1.
+
+**Two further sites, found only by running end to end.** With either one unpatched the
+run completes and looks healthy while the loss quietly uses Miles' own advantages:
+
+1. `_package_shards` (`train_data_conversion.py:357`) copies a **hardcoded allowlist**
+   of keys into each DP shard, so any extra key the driver attaches is dropped.
+2. The Megatron actor gates `compute_advantages_and_returns` on the flag; the **FSDP
+   actor calls it unconditionally** (`fsdp_utils/actor.py:496`), recomputing from the
+   scalar rewards and overwriting what rLLM shipped. Patching this needs the *actor
+   module's* binding repointed, not just the source module's -- both actors import the
+   function by value.
+
+Verified live: the worker receives 16 advantage rows per DP rank (64 total) and the
+short-circuit keeps rLLM's GRPO z-scores (-1.732 = -sqrt(3), 0.5773 = 1/sqrt(3)).
 
 Upstream as a small PR (`for key in (..., "advantages")` plus a `ROLLOUT_DATA_VALUE_SPEC`
 entry) so the patch can be dropped.

--- a/design/miles-training-backend.md
+++ b/design/miles-training-backend.md
@@ -397,6 +397,16 @@ rLLM at all.
 
 ## 7. Remaining work
 
+**Streaming agents are not yet supported on the gateway path.** SGLang rejects
+`return_meta_info` together with `stream=true` (`serving_chat.py`), and trace capture
+needs `return_meta_info` to get completion token IDs at all. A streaming agent therefore
+fails outright rather than silently losing tokens. The fix is fake streaming in the
+gateway -- strip `stream` before forwarding, synthesize the SSE frames back to the
+client -- which is exactly what `miles.rollout.session.core` does and would also let
+`extract_delta_*` be deleted. Non-streaming agents (including `cookbooks/countdown`) are
+unaffected.
+
+
 Ordered by what would bite a real run first. Everything in §0 is verified.
 
 ### 0.4 Resolved: the train/inference divergence was `attn_implementation`

--- a/examples/countdown/unified_trainer/train_countdown_unified_miles.py
+++ b/examples/countdown/unified_trainer/train_countdown_unified_miles.py
@@ -1,0 +1,28 @@
+import hydra
+
+from rllm.data.dataset import DatasetRegistry
+from rllm.rewards.countdown_reward import countdown_reward_fn
+from rllm.trainer import AgentTrainer
+from rllm.workflows.simple_workflow import SimpleWorkflow
+
+
+@hydra.main(config_path="pkg://rllm.trainer.config", config_name="unified", version_base=None)
+def main(config):
+    train_dataset = DatasetRegistry.load_dataset("countdown", "train")
+    test_dataset = DatasetRegistry.load_dataset("countdown", "test")
+
+    trainer = AgentTrainer(
+        workflow_class=SimpleWorkflow,
+        workflow_args={
+            "reward_function": countdown_reward_fn,
+        },
+        config=config,
+        train_dataset=train_dataset,
+        val_dataset=test_dataset,
+        backend="miles",
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/countdown/unified_trainer/train_countdown_unified_miles.sh
+++ b/examples/countdown/unified_trainer/train_countdown_unified_miles.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Countdown on the Miles backend (SGLang rollout + FSDP2 training), 8 GPUs.
+#
+# Smoke-test shape: Qwen3-1.7B, 4 train GPUs + 4 rollout GPUs, thinking disabled so
+# responses stay short, 8 steps. Meant to exercise the whole loop quickly, not to reach a
+# good score. Raise rllm.trainer.total_batches and the model size for real runs.
+#
+# Prerequisites:
+#   1. miles installed (see design/miles-training-backend.md §0.1)
+#   2. python examples/countdown/prepare_countdown_data.py
+set -x
+
+# SGLang JIT-compiles some kernels at engine start, so `ninja` and `nvcc` must be on
+# PATH in the Ray workers (they inherit the launching shell's PATH). ninja comes from
+# the venv; nvcc from the system CUDA toolkit, which must match the torch CUDA build.
+PYBIN="$(cd "$(dirname "$(command -v "${PYTHON:-python}")")" && pwd)"
+export PATH="${PYBIN}:/usr/local/cuda/bin:${PATH}"
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+nvcc --version | tail -1
+ninja --version
+
+# Triton's cache must be a FRESH dir on tmpfs: a stale ~/.triton/cache, or one on
+# an overlay fs, makes concurrent ranks race during the first kernel compile and
+# surfaces as "__triton_launcher...so: cannot open shared object file".
+export TRITON_CACHE_DIR="$(mktemp -d /dev/shm/triton.XXXXXX)"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+trap 'rm -rf "$TRITON_CACHE_DIR"' EXIT
+
+/home/sijuntan/.claude/jobs/9cad83b2/tmp/mvenv/bin/python -m examples.countdown.unified_trainer.train_countdown_unified_miles \
+    rllm/backend=miles \
+    model.name=Qwen/Qwen3-1.7B \
+    miles.train_backend=fsdp \
+    miles.actor_num_nodes=1 \
+    miles.actor_num_gpus_per_node=4 \
+    miles.rollout_num_gpus=4 \
+    miles.rollout_num_gpus_per_engine=1 \
+    miles.global_batch_size=64 \
+    miles.max_tokens_per_gpu=16384 \
+    miles.lr=1e-6 \
+    rllm.data.train_batch_size=8 \
+    rllm.data.max_prompt_length=512 \
+    rllm.data.max_response_length=1024 \
+    rllm.rollout.n=8 \
+    rllm.rollout.n_val=1 \
+    rllm.rollout.train.temperature=1.0 \
+    rllm.rollout.train.top_p=1.0 \
+    rllm.algorithm.adv_estimator=grpo \
+    rllm.disable_thinking=true \
+    rllm.trainer.logger=['console'] \
+    rllm.trainer.project_name='rllm-countdown-miles' \
+    rllm.trainer.experiment_name='smoke-qwen3-0.6b' \
+    rllm.trainer.total_batches=8 \
+    rllm.trainer.total_epochs=1 \
+    rllm.trainer.val_before_train=false \
+    rllm.trainer.test_freq=1000 \
+    rllm.trainer.save_freq=1000

--- a/examples/countdown/unified_trainer/train_countdown_unified_miles.sh
+++ b/examples/countdown/unified_trainer/train_countdown_unified_miles.sh
@@ -53,4 +53,5 @@ trap 'rm -rf "$TRITON_CACHE_DIR"' EXIT
     rllm.trainer.total_epochs=1 \
     rllm.trainer.val_before_train=false \
     rllm.trainer.test_freq=1000 \
-    rllm.trainer.save_freq=1000
+    rllm.trainer.save_freq=1000 \
+    "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ dependencies = [
     "aiosqlite",
     "hydra-core",
     "codetiming",
-    "tinker>=0.22.2 ; python_version >= '3.11'",
-    "tinker-cookbook>=0.4.1 ; python_version >= '3.11'",
 ]
 
 [project.scripts]
@@ -87,12 +85,23 @@ verl = [
     "qwen-vl-utils",
 ]
 
+miles = [
+    # miles itself, plus megatron-core / sglang / transformers, come from the
+    # Miles container image (docker/Dockerfile in the miles repo). Installing
+    # them from PyPI is not supported: miles pins a forked SGLang and Megatron-LM.
+    "ray",
+    "numpy",
+]
+
 tinker = [
     "tinker>=0.22.2 ; python_version >= '3.11'",
     "tinker-cookbook>=0.4.1 ; python_version >= '3.11'",
 ]
 
 fireworks = [
+    # fireworks_policy_trainer imports tinker directly (shared forward_backward_custom)
+    "tinker>=0.22.2 ; python_version >= '3.11'",
+    "tinker-cookbook>=0.4.1 ; python_version >= '3.11'",
     "fireworks-ai[training]==1.2.1 ; python_version >= '3.11'",
     "fireworks-training-cookbook @ git+https://github.com/fw-ai/cookbook.git@6b1232504fdacd1149895acf63b388ae792cb062#subdirectory=training ; python_version >= '3.11'",
 ]

--- a/rllm-model-gateway/src/rllm_model_gateway/client.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/client.py
@@ -7,6 +7,30 @@ import httpx
 from rllm_model_gateway.models import TraceRecord, WorkerInfo
 
 
+# Connection tuning shared by both clients.
+#
+# Keepalive stays disabled (max_keepalive_connections=0) so every request opens a fresh
+# TCP connection. That avoids the race where the client and uvicorn both expire an idle
+# connection at ~5s and the next request lands on a half-closed socket (httpx.ReadError).
+#
+# What is bounded here is *connect*. The trace API is called with timeout=600s, and a
+# scalar httpx timeout applies to connect and pool acquisition too -- so a connect that
+# stalls used to hang the rollout for ten minutes with the gateway completely idle, which
+# reads as "the run is stuck on its last few trajectories". A connect to the gateway is
+# local or one hop away, so cap it and let the caller's retry handle a real failure.
+_CONNECT_TIMEOUT_S = 10.0
+_POOL_TIMEOUT_S = 60.0
+
+
+def _limits() -> "httpx.Limits":
+    return httpx.Limits(max_keepalive_connections=0)
+
+
+def _timeout(timeout: float) -> "httpx.Timeout":
+    """Caller's value governs read/write; connect and pool are bounded separately."""
+    return httpx.Timeout(timeout, connect=_CONNECT_TIMEOUT_S, pool=_POOL_TIMEOUT_S)
+
+
 class GatewayClient:
     """Synchronous client for the rllm-model-gateway REST API.
 
@@ -20,13 +44,7 @@ class GatewayClient:
         timeout: float = 30.0,
     ) -> None:
         self.gateway_url = gateway_url.rstrip("/")
-        # max_keepalive_connections=0 disables idle connection reuse so every
-        # request opens a fresh TCP connection. Avoids the keepalive race where
-        # client and uvicorn both expire idle connections at ~5s and the next
-        # request hits a half-closed socket → httpx.ReadError. Per-request
-        # handshake cost is negligible for the control-plane JSON calls this
-        # client makes.
-        self._http = httpx.Client(timeout=timeout, limits=httpx.Limits(max_keepalive_connections=0))
+        self._http = httpx.Client(timeout=_timeout(timeout), limits=_limits())
 
     def close(self) -> None:
         self._http.close()
@@ -164,8 +182,7 @@ class AsyncGatewayClient:
         timeout: float = 30.0,
     ) -> None:
         self.gateway_url = gateway_url.rstrip("/")
-        # See GatewayClient.__init__ for why keepalive is disabled.
-        self._http = httpx.AsyncClient(timeout=timeout, limits=httpx.Limits(max_keepalive_connections=0))
+        self._http = httpx.AsyncClient(timeout=_timeout(timeout), limits=_limits())
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/rllm-model-gateway/src/rllm_model_gateway/client.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/client.py
@@ -13,12 +13,25 @@ from rllm_model_gateway.models import TraceRecord, WorkerInfo
 # TCP connection. That avoids the race where the client and uvicorn both expire an idle
 # connection at ~5s and the next request lands on a half-closed socket (httpx.ReadError).
 #
-# What is bounded here is *connect*. The trace API is called with timeout=600s, and a
-# scalar httpx timeout applies to connect and pool acquisition too -- so a connect that
-# stalls used to hang the rollout for ten minutes with the gateway completely idle, which
-# reads as "the run is stuck on its last few trajectories". A connect to the gateway is
-# local or one hop away, so cap it and let the caller's retry handle a real failure.
-_CONNECT_TIMEOUT_S = 10.0
+# What is bounded here is *connect*. httpx's four phases are independent, and a scalar
+# timeout sets all of them: the trace API passes 600s, so a stalled connect hung the
+# rollout for ten minutes with the gateway completely idle -- which reads as "the run is
+# stuck on its last few trajectories" rather than as a connection problem.
+#
+# Only connect is capped. `read` keeps the caller's full budget, so a slow *response* is
+# unaffected; and generations never come through here anyway -- they use Proxy's own
+# client, which deliberately runs with no timeout at all.
+#
+# 30s, not something tighter: a connect to the gateway is same-node, so under a
+# millisecond, and the pathological case stalled indefinitely -- any finite bound
+# separates them. The cost of being wrong is real, because a ConnectTimeout propagates
+# out of aget_traces and makes process_task_with_retry re-run the whole rollout
+# (generation included), up to retry_limit; with the default raise_on_error=True a
+# persistent failure then takes the run down. So leave headroom for a transient stall and
+# still turn a 30-minute hang into a ~90s diagnosable failure.
+_CONNECT_TIMEOUT_S = 30.0
+# Inert as things stand: _limits() leaves max_connections unbounded, so httpx never waits
+# for a pool slot. Kept as a guard in case that cap is ever introduced.
 _POOL_TIMEOUT_S = 60.0
 
 
@@ -163,7 +176,11 @@ class GatewayClient:
     # -- Lifecycle ---------------------------------------------------------
 
     def flush(self, timeout: float = 30.0) -> bool:
-        resp = self._http.post(f"{self.gateway_url}/admin/flush", timeout=timeout)
+        # _timeout(), not the bare float: a per-request *scalar* replaces the client
+        # default outright, so passing `timeout` here would restore connect=timeout and
+        # undo the cap set above. flush is on the per-rollout path, so that matters:
+        # aget_traces calls it before reading traces, once per rollout.
+        resp = self._http.post(f"{self.gateway_url}/admin/flush", timeout=_timeout(timeout))
         resp.raise_for_status()
         return resp.json().get("status") == "flushed"
 
@@ -309,7 +326,8 @@ class AsyncGatewayClient:
     # -- Lifecycle ---------------------------------------------------------
 
     async def flush(self, timeout: float = 30.0) -> bool:
-        resp = await self._http.post(f"{self.gateway_url}/admin/flush", timeout=timeout)
+        # See GatewayClient.flush: a scalar here would undo the connect bound.
+        resp = await self._http.post(f"{self.gateway_url}/admin/flush", timeout=_timeout(timeout))
         resp.raise_for_status()
         return resp.json().get("status") == "flushed"
 

--- a/rllm-model-gateway/src/rllm_model_gateway/data_process.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/data_process.py
@@ -20,6 +20,21 @@ logger = logging.getLogger(__name__)
 # ------------------------------------------------------------------
 
 
+def _sglang_output_token_logprobs(response: dict[str, Any]) -> list:
+    """SGLang's ``meta_info.output_token_logprobs``: ``[logprob, token_id, ...]`` per position.
+
+    Attached to the choice when the request set ``return_meta_info`` (which is why the
+    middleware hardcodes it for sglang workers). SGLang has no vLLM-style
+    ``choices[0].token_ids``, so this is the only place completion ids appear.
+    """
+    choices = response.get("choices")
+    if not choices:
+        return []
+    meta = choices[0].get("meta_info") or response.get("meta_info") or {}
+    pairs = meta.get("output_token_logprobs")
+    return pairs if isinstance(pairs, list) else []
+
+
 def extract_prompt_token_ids(response: dict[str, Any]) -> list[int]:
     """Extract ``prompt_token_ids`` from a vLLM response.
 
@@ -40,9 +55,10 @@ def extract_completion_token_ids(response: dict[str, Any]) -> list[int]:
     if not choices:
         return []
     ids = choices[0].get("token_ids")
-    if ids is None:
-        return []
-    return list(ids)
+    if ids is not None:
+        return list(ids)
+    # SGLang: ids live at index 1 of each meta_info.output_token_logprobs entry.
+    return [p[1] for p in _sglang_output_token_logprobs(response) if isinstance(p, (list, tuple)) and len(p) > 1]
 
 
 def extract_logprobs(response: dict[str, Any]) -> list[float]:
@@ -55,6 +71,14 @@ def extract_logprobs(response: dict[str, Any]) -> list[float]:
     choices = response.get("choices")
     if not choices:
         return []
+
+    # Prefer SGLang's meta_info when present: completion ids come from there too, so
+    # taking both from one source keeps them index-aligned. logprobs.content is a
+    # post-processed view (special tokens trimmed) and can differ in length, which would
+    # misalign ids against logprobs without any error.
+    pairs = _sglang_output_token_logprobs(response)
+    if pairs:
+        return [float(p[0]) for p in pairs if isinstance(p, (list, tuple)) and p and p[0] is not None]
 
     lp_obj = choices[0].get("logprobs")
     if lp_obj is None:

--- a/rllm-model-gateway/src/rllm_model_gateway/middleware.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/middleware.py
@@ -43,12 +43,14 @@ class SessionRoutingMiddleware:
         add_return_token_ids: bool = True,
         sessions: Any | None = None,
         model: str | None = None,
+        worker_flavor: str = "vllm",
     ) -> None:
         self.app = app
         self.add_logprobs = add_logprobs
         self.add_return_token_ids = add_return_token_ids
         self.sessions = sessions  # SessionManager — for per-session sampling params
         self.model = model
+        self.worker_flavor = worker_flavor
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -137,8 +139,18 @@ class SessionRoutingMiddleware:
         # is left alone.
         if self.add_logprobs and not payload.get("logprobs"):
             payload["logprobs"] = True
-        if self.add_return_token_ids and not payload.get("return_token_ids"):
-            payload["return_token_ids"] = True
+        if self.add_return_token_ids:
+            if self.worker_flavor == "sglang":
+                # SGLang has no return_token_ids. Completion ids ride in
+                # meta_info.output_token_logprobs ([logprob, token_id] pairs), which
+                # return_meta_info attaches to the choice; prompt ids come from
+                # return_prompt_token_ids. skip_special_tokens must stay False so stop
+                # tokens are trimmed from the text while their ids survive.
+                payload["return_meta_info"] = True
+                payload["return_prompt_token_ids"] = True
+                payload["skip_special_tokens"] = False
+            elif not payload.get("return_token_ids"):
+                payload["return_token_ids"] = True
         # Pin the model the gateway forwards to (overrides whatever the client sets)
         if self.model:
             payload["model"] = self.model

--- a/rllm-model-gateway/src/rllm_model_gateway/middleware.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/middleware.py
@@ -129,9 +129,15 @@ class SessionRoutingMiddleware:
         Keys in the session config overwrite whatever the client sent; keys absent
         from it pass through untouched.
         """
-        if self.add_logprobs and "logprobs" not in payload:
+        # Overwrite a falsy value, do not merely fill an absent key: an agent that sends
+        # `logprobs: false` would otherwise silently destroy its own training data --
+        # trace capture needs per-token logprobs, and the client's original intent is
+        # already recorded in `originally_requested_logprobs` so the proxy can strip them
+        # from the response. A client asking for *more* (completions-style `logprobs: 5`)
+        # is left alone.
+        if self.add_logprobs and not payload.get("logprobs"):
             payload["logprobs"] = True
-        if self.add_return_token_ids and "return_token_ids" not in payload:
+        if self.add_return_token_ids and not payload.get("return_token_ids"):
             payload["return_token_ids"] = True
         # Pin the model the gateway forwards to (overrides whatever the client sets)
         if self.model:

--- a/rllm-model-gateway/src/rllm_model_gateway/middleware.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/middleware.py
@@ -144,11 +144,12 @@ class SessionRoutingMiddleware:
                 # SGLang has no return_token_ids. Completion ids ride in
                 # meta_info.output_token_logprobs ([logprob, token_id] pairs), which
                 # return_meta_info attaches to the choice; prompt ids come from
-                # return_prompt_token_ids. skip_special_tokens must stay False so stop
-                # tokens are trimmed from the text while their ids survive.
+                # return_prompt_token_ids. no_stop_trim=False keeps the stop token out of
+                # the assistant text while its id survives in meta_info -- this mirrors
+                # miles.rollout.session.core, which is the reference for these flags.
                 payload["return_meta_info"] = True
                 payload["return_prompt_token_ids"] = True
-                payload["skip_special_tokens"] = False
+                payload["no_stop_trim"] = False
             elif not payload.get("return_token_ids"):
                 payload["return_token_ids"] = True
         # Pin the model the gateway forwards to (overrides whatever the client sets)

--- a/rllm-model-gateway/src/rllm_model_gateway/models.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/models.py
@@ -121,6 +121,12 @@ class GatewayConfig(BaseModel):
     store_worker: str = "memory"
     add_logprobs: bool = True
     add_return_token_ids: bool = True
+    # Which inference server the workers are: decides how trace capture is requested.
+    # "vllm" uses return_token_ids; "sglang" uses return_meta_info +
+    # return_prompt_token_ids, because SGLang has no return_token_ids and carries
+    # completion ids in meta_info.output_token_logprobs instead. Set explicitly --
+    # guessing wrong yields empty response_ids, which looks like a healthy run.
+    worker_flavor: str = "vllm"
     strip_vllm_fields: bool = True
     routing_policy: str | None = None
     health_check_interval: float = 10.0

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -493,6 +493,8 @@ def _load_config(args: argparse.Namespace) -> GatewayConfig:
         data["store_worker"] = args.store
     if getattr(args, "model", None) is not None:
         data["model"] = args.model
+    if getattr(args, "worker_flavor", None) is not None:
+        data["worker_flavor"] = args.worker_flavor
     if getattr(args, "cumulative_token_mode", False):
         data["cumulative_token_mode"] = True
     if getattr(args, "renderer_family", None) is not None:
@@ -530,6 +532,15 @@ def main() -> None:
         type=str,
         default=None,
         help="If set, the gateway rewrites every request body's 'model' field to this value before forwarding.",
+    )
+    parser.add_argument(
+        "--worker-flavor",
+        type=str,
+        default=None,
+        choices=["vllm", "sglang"],
+        help="Inference server family behind this gateway. Decides which per-request fields the "
+        "middleware injects to capture training tokens: vLLM exposes return_token_ids, SGLang "
+        "instead needs return_meta_info. Getting this wrong loses token IDs silently.",
     )
     parser.add_argument(
         "--cumulative-token-mode",

--- a/rllm-model-gateway/src/rllm_model_gateway/server.py
+++ b/rllm-model-gateway/src/rllm_model_gateway/server.py
@@ -223,6 +223,7 @@ def create_app(
         add_return_token_ids=config.add_return_token_ids,
         sessions=sessions,
         model=config.model,
+        worker_flavor=config.worker_flavor,
     )
 
     # -- Health endpoints --------------------------------------------------

--- a/rllm-model-gateway/tests/test_client.py
+++ b/rllm-model-gateway/tests/test_client.py
@@ -1,0 +1,16 @@
+
+
+class TestConnectIsBounded:
+    """The trace API is called with timeout=600s. A scalar httpx timeout also governs
+    connect and pool acquisition, so a stalled connect hung the rollout for ten minutes
+    with the gateway idle -- observed as a run stuck on its last few trajectories.
+    """
+
+    def test_connect_and_pool_do_not_inherit_the_read_timeout(self):
+        from rllm_model_gateway.client import AsyncGatewayClient, GatewayClient
+
+        for cls in (GatewayClient, AsyncGatewayClient):
+            t = cls("http://127.0.0.1:1", timeout=600.0)._http._timeout
+            assert t.read == 600.0, cls.__name__
+            assert t.connect == 10.0, f"{cls.__name__}: connect must not inherit 600s"
+            assert t.pool == 60.0, f"{cls.__name__}: pool must not inherit 600s"

--- a/rllm-model-gateway/tests/test_client.py
+++ b/rllm-model-gateway/tests/test_client.py
@@ -12,5 +12,23 @@ class TestConnectIsBounded:
         for cls in (GatewayClient, AsyncGatewayClient):
             t = cls("http://127.0.0.1:1", timeout=600.0)._http._timeout
             assert t.read == 600.0, cls.__name__
-            assert t.connect == 10.0, f"{cls.__name__}: connect must not inherit 600s"
+            assert t.connect == 30.0, f"{cls.__name__}: connect must not inherit 600s"
             assert t.pool == 60.0, f"{cls.__name__}: pool must not inherit 600s"
+
+
+    def test_flush_does_not_undo_the_bound_with_a_scalar(self):
+        """flush() takes its own timeout arg. httpx replaces the client default outright
+        when a request passes a *scalar*, so `timeout=600.0` there restored connect=600s
+        and silently reopened the hang on the flush leg -- which is on the per-rollout
+        path (aget_traces calls flush first).
+        """
+        from rllm_model_gateway.client import GatewayClient, _timeout
+
+        http = GatewayClient("http://127.0.0.1:1", timeout=600.0)._http
+        eff = http.build_request("POST", "http://x/admin/flush", timeout=_timeout(600.0)).extensions["timeout"]
+        assert eff["connect"] == 30.0
+        assert eff["pool"] == 60.0
+        assert eff["read"] == 600.0, "the long read budget must survive"
+
+        bare = http.build_request("POST", "http://x/admin/flush", timeout=600.0).extensions["timeout"]
+        assert bare["connect"] == 600.0, "guard premise: a scalar really does override connect"

--- a/rllm/engine/rollout/miles_engine.py
+++ b/rllm/engine/rollout/miles_engine.py
@@ -58,17 +58,30 @@ class MilesEngine(RolloutEngine):
         # get_token_output_from_token_input, not here.
         rollout_cfg = rllm_cfg.get("rollout", {}) or {}
         self.train_sampling_params = self._sampling_from(rollout_cfg.get("train", {}))
-        self.val_sampling_params = self._sampling_from(rollout_cfg.get("val", {})) or self.train_sampling_params.copy()
+        self.val_sampling_params = self._sampling_from(rollout_cfg.get("val", None) or rollout_cfg.get("train", {}))
 
         self._client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_S)
 
-    @staticmethod
-    def _sampling_from(block) -> dict:
-        """Pass through what SGLang accepts, dropping keys it does not."""
-        if not block:
-            return {}
+    # Sent on every request so no server-side default can leak in. SGLang otherwise
+    # falls back to the model's generation_config -- for Qwen3 that is top_k=20, which
+    # samples from a truncated distribution and returns logprobs renormalised over those
+    # 20 tokens. Those logprobs are systematically too high, so
+    # exp(train_log_probs - rollout_log_probs) lands far below 1 and any importance
+    # correction built on them (TIS) scales the gradient by a bogus factor. Invisible
+    # without TIS, because then rollout_log_probs are never read by the loss.
+    # Miles' own rollout does the same thing (rollout_top_k defaults to -1).
+    _SAMPLING_DEFAULTS = {"temperature": 1.0, "top_p": 1.0, "top_k": -1}
+
+    @classmethod
+    def _sampling_from(cls, block) -> dict:
+        """Pass through what SGLang accepts, over explicit defaults."""
         allowed = ("temperature", "top_p", "top_k", "min_p", "repetition_penalty", "frequency_penalty", "presence_penalty", "stop", "stop_token_ids")
-        return {k: v for k in allowed if (v := block.get(k)) is not None}
+        params = dict(cls._SAMPLING_DEFAULTS)
+        for key in allowed:
+            value = (block or {}).get(key)
+            if value is not None:
+                params[key] = value
+        return params
 
     @property
     def supports_token_in_token_out(self) -> bool:

--- a/rllm/engine/rollout/miles_engine.py
+++ b/rllm/engine/rollout/miles_engine.py
@@ -53,12 +53,22 @@ class MilesEngine(RolloutEngine):
         self._return_routed_experts = bool(getattr(miles_args, "use_rollout_routing_replay", False))
         self._return_indexer_topk = bool(getattr(miles_args, "use_rollout_indexer_replay", False))
 
-        sampling = rllm_cfg.get("sampling", {}) or {}
-        val_sampling = rllm_cfg.get("val_sampling", {}) or sampling
-        self.train_sampling_params = {"temperature": sampling.get("temperature", 1.0), "top_p": sampling.get("top_p", 1.0)}
-        self.val_sampling_params = {"temperature": val_sampling.get("temperature", 1.0), "top_p": val_sampling.get("top_p", 1.0)}
+        # rllm.rollout.train / .val are the canonical sampling blocks (see
+        # rllm/trainer/config/rllm/base.yaml); max_tokens is applied per request in
+        # get_token_output_from_token_input, not here.
+        rollout_cfg = rllm_cfg.get("rollout", {}) or {}
+        self.train_sampling_params = self._sampling_from(rollout_cfg.get("train", {}))
+        self.val_sampling_params = self._sampling_from(rollout_cfg.get("val", {})) or self.train_sampling_params.copy()
 
         self._client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_S)
+
+    @staticmethod
+    def _sampling_from(block) -> dict:
+        """Pass through what SGLang accepts, dropping keys it does not."""
+        if not block:
+            return {}
+        allowed = ("temperature", "top_p", "top_k", "min_p", "repetition_penalty", "frequency_penalty", "presence_penalty", "stop", "stop_token_ids")
+        return {k: v for k in allowed if (v := block.get(k)) is not None}
 
     @property
     def supports_token_in_token_out(self) -> bool:

--- a/rllm/engine/rollout/miles_engine.py
+++ b/rllm/engine/rollout/miles_engine.py
@@ -1,0 +1,178 @@
+"""Rollout engine for the Miles backend: token-in, token-out against Miles' SGLang router.
+
+rLLM already owns tokenization, prompt assembly and loss masks end to end, so this
+talks to SGLang's stateless ``/generate`` endpoint with ``input_ids`` rather than
+going through Miles' TITO session server -- routing through the session server
+would install a second tokenizer authority and duplicate the merge logic that
+``rllm/trainer/miles/transform.py`` already performs.
+
+Request/response shape mirrors ``miles/rollout/generate_utils/generate_endpoint_utils.py``
+so the two stay interchangeable against the same router.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import cast
+
+import httpx
+import numpy as np
+from omegaconf import DictConfig
+from typing_extensions import override
+
+from rllm.engine.rollout.rollout_engine import ModelOutput, RolloutEngine
+from rllm.engine.rollout.types import MilesTokenOutput, TokenInput, Tokenizer, TokenOutput
+from rllm.parser import ChatTemplateParser
+from rllm.types import TerminationEvent, TerminationReason
+
+logger = logging.getLogger(__name__)
+
+# Agentic turns legitimately take minutes; the trainer bounds the episode, not this.
+_REQUEST_TIMEOUT_S = 3600
+
+
+class MilesEngine(RolloutEngine):
+    def __init__(self, config: DictConfig, router_url: str, tokenizer: Tokenizer, miles_args=None, **kwargs):
+        super().__init__()
+        self.config = config
+        self.router_url = router_url.rstrip("/")
+        self.tokenizer = tokenizer
+        self.miles_args = miles_args
+
+        rllm_cfg = config.get("rllm", {})
+        self.chat_parser = ChatTemplateParser.get_parser(tokenizer, disable_thinking=rllm_cfg.get("disable_thinking", False))
+        self.max_prompt_length = rllm_cfg.data.max_prompt_length
+        self.max_response_length = rllm_cfg.data.max_response_length
+        self.accumulate_reasoning = rllm_cfg.get("accumulate_reasoning", False)
+        self.router_replay_mode = rllm_cfg.get("algorithm", {}).get("router_replay", "disabled")
+
+        # Miles gates the extra return fields on its own args; mirror them so a run
+        # that did not enable routing replay never asks the engine for it.
+        self._return_routed_experts = bool(getattr(miles_args, "use_rollout_routing_replay", False))
+        self._return_indexer_topk = bool(getattr(miles_args, "use_rollout_indexer_replay", False))
+
+        sampling = rllm_cfg.get("sampling", {}) or {}
+        val_sampling = rllm_cfg.get("val_sampling", {}) or sampling
+        self.train_sampling_params = {"temperature": sampling.get("temperature", 1.0), "top_p": sampling.get("top_p", 1.0)}
+        self.val_sampling_params = {"temperature": val_sampling.get("temperature", 1.0), "top_p": val_sampling.get("top_p", 1.0)}
+
+        self._client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_S)
+
+    @property
+    def supports_token_in_token_out(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    @override
+    async def get_token_output_from_token_input(self, token_input: TokenInput, **kwargs) -> MilesTokenOutput:
+        input_ids = cast(list[int], token_input)
+        enforce_max_prompt_length = kwargs.pop("enforce_max_prompt_length", True)
+        if enforce_max_prompt_length and len(input_ids) > self.max_prompt_length:
+            raise TerminationEvent(TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED)
+
+        sampling_params = (self.val_sampling_params if self.is_validation else self.train_sampling_params).copy()
+        sampling_params.update(kwargs)
+        max_new_tokens = sampling_params.pop("max_tokens", None) or sampling_params.pop("max_new_tokens", None) or self.max_response_length
+        # The context window bounds the whole sequence, not just the completion.
+        max_new_tokens = min(max_new_tokens, max(self.max_prompt_length + self.max_response_length - len(input_ids), 0))
+        if max_new_tokens <= 0:
+            raise TerminationEvent(TerminationReason.MAX_PROMPT_LENGTH_EXCEEDED)
+
+        payload = {
+            "input_ids": input_ids,
+            "sampling_params": {**sampling_params, "max_new_tokens": max_new_tokens},
+            "return_logprob": True,
+            "return_routed_experts": self._return_routed_experts,
+            "return_indexer_topk": self._return_indexer_topk,
+        }
+
+        response = await self._client.post(f"{self.router_url}/generate", json=payload)
+        response.raise_for_status()
+        output = response.json()
+
+        meta = output.get("meta_info", {})
+        # SGLang returns [logprob, token_id, ...] per position.
+        pairs = meta.get("output_token_logprobs") or []
+        token_ids = [item[1] for item in pairs]
+        log_probs = [item[0] for item in pairs]
+
+        finish_reason = meta.get("finish_reason")
+        if isinstance(finish_reason, dict):
+            finish_reason = finish_reason.get("type")
+        if finish_reason in ("abort", "aborted"):
+            raise RuntimeError("Rollout aborted by the Miles router (weight update or oversampling abort)")
+
+        return MilesTokenOutput(
+            token_ids=token_ids,
+            log_probs=log_probs,
+            stop_reason="length" if len(token_ids) >= max_new_tokens else (finish_reason or "stop"),
+            routed_experts=self._decode_routed_experts(meta),
+        )
+
+    @staticmethod
+    def _decode_routed_experts(meta: dict):
+        """R3: SGLang ships routed experts as a base64 blob plus a shape header."""
+        blob = meta.get("output_routed_experts")
+        if not blob:
+            return None
+        try:
+            header, data = blob if isinstance(blob, list) else (None, blob)
+            arr = np.frombuffer(base64.b64decode(data), dtype=np.int32)
+            if header:
+                shape = json.loads(header)["shape"]
+                arr = arr.reshape(-1, *shape)
+            return arr
+        except Exception as e:  # a malformed blob must not kill the rollout
+            logger.warning("Could not decode routed experts from the router response: %s", e)
+            return None
+
+    @override
+    async def _get_model_response(self, messages: list[dict], **kwargs) -> ModelOutput:
+        tools = kwargs.pop("tools", [])
+        accumulate_reasoning = kwargs.pop("accumulate_reasoning", self.accumulate_reasoning)
+        reasoning_effort = kwargs.pop("reasoning_effort", "medium")
+
+        prompt = self.chat_parser.parse(
+            messages,
+            add_generation_prompt=True,
+            is_first_msg=True,
+            tools=tools,
+            accumulate_reasoning=accumulate_reasoning,
+            reasoning_effort=reasoning_effort,
+        )
+        prompt_ids = self.tokenizer.encode(prompt, add_special_tokens=False)
+        token_output = await self.get_token_output_from_token_input(token_input=prompt_ids, **kwargs)
+        return self.assemble_model_output(token_input=prompt_ids, token_output=token_output, prompt_ids=prompt_ids)
+
+    @override
+    def assemble_model_output(self, token_input: TokenInput, token_output: TokenOutput, **kwargs) -> ModelOutput:
+        prompt_ids = kwargs.pop("prompt_ids", None) or cast(list[int], token_input)
+        token_output = cast(MilesTokenOutput, token_output)
+        completion_ids = token_output.token_ids
+
+        completion_text = self.tokenizer.decode(completion_ids, skip_special_tokens=True)
+        parsed = self.chat_parser.parse_completion(completion_ids)
+
+        routing_matrices = None
+        if self.router_replay_mode == "R3" and token_output.routed_experts is not None:
+            arr = token_output.routed_experts
+            header = json.dumps({"shape": list(arr.shape[1:]), "dtype": str(arr.dtype)})
+            routing_matrices = [header, base64.b64encode(arr.tobytes()).decode("ascii")]
+
+        return ModelOutput(
+            text=completion_text,
+            content=parsed["content"],
+            reasoning=parsed["reasoning"],
+            tool_calls=parsed["tool_calls"],
+            prompt_ids=prompt_ids,
+            completion_ids=completion_ids,
+            logprobs=token_output.log_probs,
+            prompt_length=len(prompt_ids),
+            completion_length=len(completion_ids),
+            finish_reason=token_output.stop_reason,
+            routing_matrices=routing_matrices,
+        )

--- a/rllm/engine/rollout/miles_engine.py
+++ b/rllm/engine/rollout/miles_engine.py
@@ -60,6 +60,11 @@ class MilesEngine(RolloutEngine):
         self.train_sampling_params = self._sampling_from(rollout_cfg.get("train", {}))
         self.val_sampling_params = self._sampling_from(rollout_cfg.get("val", None) or rollout_cfg.get("train", {}))
 
+        # The gateway registers these as inference workers for the AgentFlow path.
+        # SGLang's router is OpenAI-compatible and already load-balances across the
+        # engines behind it, so one address is enough (verl registers one per worker).
+        self.server_addresses = [self.router_url]
+
         self._client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_S)
 
     # Sent on every request so no server-side default can leak in. SGLang otherwise

--- a/rllm/engine/rollout/types.py
+++ b/rllm/engine/rollout/types.py
@@ -2,6 +2,7 @@
 Type alias for TokenOutput and TokenInput -- need to take different backends into account.
 """
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 if TYPE_CHECKING:
@@ -40,6 +41,26 @@ try:
 except ImportError:  # avoid cases when the verl backend is not used
     VerlTokenOutput: TypeAlias = Any
 
+# Miles types. Miles' rollout side has no token-output class of its own -- its
+# generate functions write straight onto a Sample -- so rLLM defines one.
+MilesTokenInput: TypeAlias = list[int]
+
+
+@dataclass
+class MilesTokenOutput:
+    """One SGLang ``/generate`` completion, as Miles' router returns it.
+
+    ``meta_info.output_token_logprobs`` arrives as ``[logprob, token_id, ...]``
+    triples; this is that split apart.
+    """
+
+    token_ids: list[int]
+    log_probs: list[float]
+    stop_reason: str | None = None
+    # (completion_len, num_layers, topk) int32, only when R3 routing replay is on
+    routed_experts: Any = None
+
+
 # Union everything together
-TokenInput: TypeAlias = TinkerTokenInput | VerlTokenInput
-TokenOutput: TypeAlias = TinkerTokenOutput | VerlTokenOutput
+TokenInput: TypeAlias = TinkerTokenInput | VerlTokenInput | MilesTokenInput
+TokenOutput: TypeAlias = TinkerTokenOutput | VerlTokenOutput | MilesTokenOutput

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -435,6 +435,10 @@ class GatewayManager:
             return cmd
         if self.model:
             cmd += ["--model", self.model]
+        # Must cross the process boundary: the subprocess gateway defaults to "vllm",
+        # so omitting this made an SGLang run inject vLLM's return_token_ids, capture no
+        # token IDs at all, and fail only later in Step validation.
+        cmd += ["--worker-flavor", self.worker_flavor]
         if self.cumulative_token_mode:
             cmd.append("--cumulative-token-mode")
             if self.renderer_family != "auto":

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -174,6 +174,22 @@ def _get_routable_ip() -> str:
     return "127.0.0.1"
 
 
+def _quiet_httpx() -> None:
+    """Drop httpx's per-request INFO line in the trainer process.
+
+    httpx logs one line per request. On the AgentFlow path that is one per agent turn
+    across n_parallel_tasks, which buries rLLM's own progress and metrics. The gateway
+    already does this inside its own process; the trainer never did. Set
+    RLLM_LOG_HTTPX=1 to keep them when debugging gateway traffic.
+    """
+    if os.environ.get("RLLM_LOG_HTTPX") == "1":
+        return
+    for name in ("httpx", "httpcore"):
+        logger_ = logging.getLogger(name)
+        if logger_.level in (logging.NOTSET, logging.INFO, logging.DEBUG):
+            logger_.setLevel(logging.WARNING)
+
+
 class GatewayManager:
     """Manages model gateway lifecycle for training.
 
@@ -263,6 +279,7 @@ class GatewayManager:
         For TinkerEngine / FireworksEngine: creates an in-process handler (no sidecar needed).
         """
         engine_cls = type(rollout_engine).__name__
+        _quiet_httpx()
 
         if engine_cls in ("TinkerEngine", "FireworksEngine"):
             if self.num_workers >= 1:

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -47,7 +47,7 @@ from rllm.env import env_float
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
-    from rllm.engine.rollout import RolloutEngine, VerlEngine
+    from rllm.engine.rollout import RolloutEngine
 
 logger = logging.getLogger(__name__)
 
@@ -257,7 +257,7 @@ class GatewayManager:
     def start(self, rollout_engine: RolloutEngine) -> None:
         """Start the gateway and register inference workers.
 
-        For VerlEngine: registers the existing vLLM server addresses.
+        For VerlEngine / MilesEngine: registers the existing HTTP server addresses.
         For TinkerEngine / FireworksEngine: creates an in-process handler (no sidecar needed).
         """
         engine_cls = type(rollout_engine).__name__
@@ -273,13 +273,13 @@ class GatewayManager:
 
                 self._local_handler = create_tinker_handler(rollout_engine)
                 self._start_thread(local_handler=self._local_handler)
-        elif engine_cls == "VerlEngine":
+        elif engine_cls in ("VerlEngine", "MilesEngine"):
             if self.mode == "process":
                 self._start_process()
             else:
                 self._start_thread()
 
-            worker_urls = self._ensure_verl_engine_workers(rollout_engine)
+            worker_urls = self._http_worker_urls(rollout_engine)
             for url in worker_urls:
                 worker_id = self.client.add_worker(url=url)
                 logger.info("Registered worker %s -> %s", worker_id, url)
@@ -399,8 +399,12 @@ class GatewayManager:
 
     # -- Worker setup --------------------------------------------------------
 
-    def _ensure_verl_engine_workers(self, rollout_engine: VerlEngine) -> list[str]:
-        """Get or create worker URLs for the VerlEngine."""
+    def _http_worker_urls(self, rollout_engine) -> list[str]:
+        """Worker URLs for an engine that fronts its own OpenAI-compatible HTTP servers.
+
+        VerlEngine exposes one address per vLLM worker; MilesEngine exposes its SGLang
+        router, which already load-balances across the engines behind it.
+        """
         addresses = rollout_engine.server_addresses
         return [f"http://{addr}" if not addr.startswith("http") else addr for addr in addresses]
 

--- a/rllm/gateway/manager.py
+++ b/rllm/gateway/manager.py
@@ -186,6 +186,8 @@ class GatewayManager:
     # off when the upstream isn't vLLM (e.g. OpenAI/Anthropic via LiteLLM).
     add_logprobs: bool = True
     add_return_token_ids: bool = True
+    # Set from the rollout engine in start(); see GatewayConfig.worker_flavor.
+    worker_flavor: str = "vllm"
 
     def __init__(self, config: DictConfig, mode: str = "thread") -> None:
         gw_cfg = config.rllm.get("gateway", {})
@@ -274,6 +276,9 @@ class GatewayManager:
                 self._local_handler = create_tinker_handler(rollout_engine)
                 self._start_thread(local_handler=self._local_handler)
         elif engine_cls in ("VerlEngine", "MilesEngine"):
+            # Must be set before the gateway starts: the middleware reads it when
+            # injecting trace-capture flags on every request.
+            self.worker_flavor = "sglang" if engine_cls == "MilesEngine" else "vllm"
             if self.mode == "process":
                 self._start_process()
             else:
@@ -531,6 +536,7 @@ class GatewayManager:
             model=self.model,
             add_logprobs=self.add_logprobs,
             add_return_token_ids=self.add_return_token_ids,
+            worker_flavor=self.worker_flavor,
             cumulative_token_mode=self.cumulative_token_mode,
             renderer_family=self.renderer_family,
         )

--- a/rllm/trainer/algorithms/step_merge.py
+++ b/rllm/trainer/algorithms/step_merge.py
@@ -1,0 +1,40 @@
+"""Step-sequence helpers shared by the token-level backend transforms.
+
+A multi-turn trajectory is merged into as few training sequences as possible: when
+each step's prompt extends the previous step's prompt+response, the whole turn
+chain is one sequence. These two helpers decide where those chains start and stop.
+Kept free of any backend SDK so every transform can use them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["is_prefix", "partition_steps_by_lineage"]
+
+
+def is_prefix(seq1: list[Any], seq2: list[Any]) -> bool:
+    """Whether ``seq1`` is a prefix of ``seq2``."""
+    return len(seq1) <= len(seq2) and seq2[: len(seq1)] == seq1
+
+
+def partition_steps_by_lineage(steps: list[Any]) -> list[list[Any]]:
+    """Group steps by gateway ``lineage_id`` (from ``step.metadata``), in first-appearance order.
+
+    A subagent runs under the same session with its own system prompt, so its turns
+    are not prefix-extensions of the parent's. Partitioning first means each lineage
+    merges independently instead of fragmenting into one sequence per turn, even when
+    parent and subagent turns interleave in time.
+
+    Untagged steps (cumulative mode off, or eval) share the ``None`` key and so form a
+    single partition — the un-partitioned behavior.
+    """
+    groups: dict[Any, list[Any]] = {}
+    order: list[Any] = []
+    for step in steps:
+        lid = (step.metadata or {}).get("lineage_id")
+        if lid not in groups:
+            groups[lid] = []
+            order.append(lid)
+        groups[lid].append(step)
+    return [groups[lid] for lid in order]

--- a/rllm/trainer/config/rllm/backend/miles.yaml
+++ b/rllm/trainer/config/rllm/backend/miles.yaml
@@ -1,0 +1,72 @@
+# @package _global_
+
+# Miles backend: rLLM's UnifiedTrainer drives the loop, Miles (SGLang rollout +
+# Megatron-LM / FSDP2 training) owns the GPUs. See design/miles-training-backend.md.
+#
+# This backend only runs inside the Miles container image (docker/Dockerfile in the
+# miles repo): it pins a forked SGLang and Megatron-LM plus transformers==5.12.1,
+# which cannot be assembled from PyPI.
+
+model:
+  name: "Qwen/Qwen3-4B"
+
+training:
+  group_size: ???      # rollouts per prompt (GRPO group size)
+  learning_rate: 1e-6
+
+validation:
+  group_size: 1
+
+workflow:
+  n_parallel_tasks: 64
+
+# Everything under `miles:` is passed through to Miles' CLI verbatim. Keys are
+# *flag names* in snake_case, not argparse dests -- so a negated flag is written
+# the way Miles spells it (e.g. `disable_rollout_global_dataset`, not
+# `rollout_global_dataset`). null means "leave Miles' own default alone".
+#
+# Flags rLLM owns (rollout_function_path, eval_function_path,
+# disable_rollout_global_dataset, disable_compute_advantages_and_returns,
+# num_rollout) are set by the backend and rejected here -- see
+# rllm/trainer/miles/miles_config.py:PINNED_FLAGS.
+miles:
+  # --- training backend ---------------------------------------------------
+  # `fsdp` trains the HF implementation as-is (no checkpoint conversion, the fast
+  # path for bring-up). `megatron` needs an offline HF -> torch_dist conversion
+  # into `ref_load`, and is the only backend with TP/PP/CP/EP.
+  train_backend: fsdp
+
+  # --- GPU layout ---------------------------------------------------------
+  # Disaggregated only: rLLM generates while Miles trains, so the two must not
+  # share GPUs. `colocate` is rejected by the config bridge.
+  actor_num_nodes: 1
+  actor_num_gpus_per_node: 4
+  rollout_num_gpus: 4
+  rollout_num_gpus_per_engine: 1
+
+  # --- checkpointing ------------------------------------------------------
+  # Miles owns the weights, so Miles writes the checkpoints. miles_validate_args
+  # requires --save whenever --save-interval is set.
+  save: 'checkpoints/${rllm.trainer.project_name}/${rllm.trainer.experiment_name}'
+
+  # --- optimization -------------------------------------------------------
+  global_batch_size: 32
+  advantage_estimator: grpo   # still selects Miles' loss kernel (GRPO/GSPO clip),
+                              # even though the advantages themselves come from rLLM
+  max_tokens_per_gpu: 16384
+
+  # --- megatron-only (ignored when train_backend=fsdp) --------------------
+  ref_load: null              # torch_dist checkpoint dir, required for megatron
+  tensor_model_parallel_size: null
+  pipeline_model_parallel_size: null
+
+  # --- escape hatch -------------------------------------------------------
+  # Appended to argv verbatim. Use for any Miles or Megatron flag not mirrored
+  # above, so an unmodelled flag never blocks a run.
+  extra_args: []
+
+rllm:
+  backend: miles
+  rollout:
+    n: ${oc.select:training.group_size, 8}
+    n_val: ${oc.select:validation.group_size, 1}

--- a/rllm/trainer/config/rllm/backend/miles.yaml
+++ b/rllm/trainer/config/rllm/backend/miles.yaml
@@ -69,9 +69,13 @@ miles:
   max_tokens_per_gpu: 16384
 
   # --- fsdp-only (ignored when train_backend=megatron) --------------------
-  # Miles defaults this to flash_attention_2, which ships in its container image's
-  # wheels release. `sdpa` is built into torch and needs nothing extra.
-  attn_implementation: sdpa
+  # Left unset on purpose: Miles defaults to flash_attention_2, and that default is
+  # load-bearing. The FSDP path packs several samples into one row and passes
+  # attention_mask=None, deriving cu_seqlens from packed position_ids -- so an attention
+  # implementation that ignores cu_seqlens (sdpa, eager) attends across document
+  # boundaries. Silently: no error, just corrupted logprobs. Install flash-attn
+  # (scripts/setup_miles_env.sh does) rather than overriding this.
+  attn_implementation: null
 
   # --- megatron-only (ignored when train_backend=fsdp) --------------------
   ref_load: null              # torch_dist checkpoint dir, required for megatron

--- a/rllm/trainer/config/rllm/backend/miles.yaml
+++ b/rllm/trainer/config/rllm/backend/miles.yaml
@@ -7,6 +7,15 @@
 # miles repo): it pins a forked SGLang and Megatron-LM plus transformers==5.12.1,
 # which cannot be assembled from PyPI.
 
+# Mirrored from rllm.data.* by rllm/trainer/miles/utils.py:sync_config. Nothing on
+# the miles path reads these, but shared code (and the verl-flavoured transforms)
+# expect the top-level namespace to exist.
+data:
+  train_batch_size: ${rllm.data.train_batch_size}
+  val_batch_size: ${rllm.data.val_batch_size}
+  max_prompt_length: ${rllm.data.max_prompt_length}
+  max_response_length: ${rllm.data.max_response_length}
+
 model:
   name: "Qwen/Qwen3-4B"
 
@@ -50,10 +59,19 @@ miles:
   save: 'checkpoints/${rllm.trainer.project_name}/${rllm.trainer.experiment_name}'
 
   # --- optimization -------------------------------------------------------
+  lr: 1e-6
+  # Megatron-only knobs (weight_decay, lr_decay_style, ...) are not in Miles'
+  # own parser and do not exist on the FSDP path; pass them via extra_args.
+  clip_grad: 1.0
   global_batch_size: 32
   advantage_estimator: grpo   # still selects Miles' loss kernel (GRPO/GSPO clip),
                               # even though the advantages themselves come from rLLM
   max_tokens_per_gpu: 16384
+
+  # --- fsdp-only (ignored when train_backend=megatron) --------------------
+  # Miles defaults this to flash_attention_2, which ships in its container image's
+  # wheels release. `sdpa` is built into torch and needs nothing extra.
+  attn_implementation: sdpa
 
   # --- megatron-only (ignored when train_backend=fsdp) --------------------
   ref_load: null              # torch_dist checkpoint dir, required for megatron

--- a/rllm/trainer/config/rllm/backend/miles.yaml
+++ b/rllm/trainer/config/rllm/backend/miles.yaml
@@ -66,7 +66,12 @@ miles:
   global_batch_size: 32
   advantage_estimator: grpo   # still selects Miles' loss kernel (GRPO/GSPO clip),
                               # even though the advantages themselves come from rLLM
-  max_tokens_per_gpu: 16384
+  # Sizes the micro-batches, and therefore peak training memory: the backend pins
+  # use_dynamic_batch_size (a static global_batch_size cannot work once filtering makes
+  # the surviving sample count vary), so this replaces micro_batch_size as the memory
+  # knob. 16384 OOMs a 1.7B model on an 80GB card that is sharing the GPU with another
+  # tenant; raise it when you have the card to yourself.
+  max_tokens_per_gpu: 8192
 
   # --- fsdp-only (ignored when train_backend=megatron) --------------------
   # Left unset on purpose: Miles defaults to flash_attention_2, and that default is

--- a/rllm/trainer/config/rllm/backend/miles.yaml
+++ b/rllm/trainer/config/rllm/backend/miles.yaml
@@ -73,6 +73,15 @@ miles:
   # tenant; raise it when you have the card to yourself.
   max_tokens_per_gpu: 8192
 
+  # --- router --------------------------------------------------------------
+  # Must stay true. The Rust sglang_router re-serializes chat requests through its own
+  # struct, dropping the sglang-miles-only return_meta_info / return_prompt_token_ids --
+  # which is where rLLM reads completion token IDs from on the AgentFlow path. logprobs
+  # survives the round-trip, so the loss is silent until Step validation reports
+  # "length mismatch between response_ids and logprobs, got 0, N". Miles' own router
+  # proxies raw bytes, so nothing is dropped; miles_config.py:validate_router enforces it.
+  use_miles_router: true
+
   # --- rollout-server logging ---------------------------------------------
   # SGLang is very chatty at its own defaults and drowns rLLM's metrics: one
   # "Decode batch, ..." line every `decode_log_interval` steps (default 40) per engine,

--- a/rllm/trainer/config/rllm/backend/miles.yaml
+++ b/rllm/trainer/config/rllm/backend/miles.yaml
@@ -73,6 +73,16 @@ miles:
   # tenant; raise it when you have the card to yourself.
   max_tokens_per_gpu: 8192
 
+  # --- rollout-server logging ---------------------------------------------
+  # SGLang is very chatty at its own defaults and drowns rLLM's metrics: one
+  # "Decode batch, ..." line every `decode_log_interval` steps (default 40) per engine,
+  # plus a uvicorn access line per request -- and the AgentFlow path issues one request
+  # per agent turn, so that scales with n_parallel_tasks. Quiet by default; raise either
+  # when actually debugging the rollout servers (e.g. miles.sglang_log_level_http=info).
+  # Note these keep the `sglang_` prefix as attributes on Miles' namespace.
+  sglang_log_level_http: warning
+  sglang_decode_log_interval: 1000
+
   # --- fsdp-only (ignored when train_backend=megatron) --------------------
   # Left unset on purpose: Miles defaults to flash_attention_2, and that default is
   # load-bearing. The FSDP path packs several samples into one row and passes

--- a/rllm/trainer/miles/__init__.py
+++ b/rllm/trainer/miles/__init__.py
@@ -1,0 +1,33 @@
+"""Trainer miles package exports.
+
+Provides the RL ``MilesBackend``: rLLM's UnifiedTrainer drives the loop, Miles
+(SGLang rollout + Megatron-LM / FSDP2 training) owns the GPUs. See
+``design/miles-training-backend.md``.
+
+Lazy attribute access keeps ``import rllm.trainer.miles`` cheap: the backend and
+launcher import miles (and therefore megatron), which only exist inside the Miles
+container image. The transform and config bridge stay importable anywhere.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["MilesBackend", "MilesTrainerLauncher"]
+
+if TYPE_CHECKING:
+    from rllm.trainer.miles.miles_backend import MilesBackend
+    from rllm.trainer.miles.miles_launcher import MilesTrainerLauncher
+
+_LAZY = {
+    "MilesBackend": ("rllm.trainer.miles.miles_backend", "MilesBackend"),
+    "MilesTrainerLauncher": ("rllm.trainer.miles.miles_launcher", "MilesTrainerLauncher"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY:
+        module_path, attr = _LAZY[name]
+        return getattr(import_module(module_path), attr)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/rllm/trainer/miles/_flag_audit.py
+++ b/rllm/trainer/miles/_flag_audit.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from rllm.trainer.miles.miles_config import BOOL_OPTIONAL
+
 # Miles registers flags two ways: plain add_argument, and reset_arg(parser, "--flag", ...)
 # which overrides a Megatron default and falls back to add_argument when the flag
 # does not exist yet (as on the FSDP path, where Megatron never ran).
@@ -38,10 +40,36 @@ def _call_name(node: ast.Call) -> str | None:
     return None
 
 
+def _fsdp_dataclass_flags(root: Path) -> dict[str, int | str]:
+    """Flags Miles' FSDP parser derives from the ``FSDPArgs`` dataclass.
+
+    ``build_fsdp_parser`` walks ``dataclasses.fields(FSDPArgs)`` and registers one
+    flag per field -- bools via ``BooleanOptionalAction`` -- so none of them appear
+    as an ``add_argument`` call and a source scan misses them entirely.
+    """
+    path = root / "miles" / "backends" / "fsdp_utils" / "arguments.py"
+    if not path.exists():
+        return {}
+
+    out: dict[str, int | str] = {}
+    for node in ast.walk(ast.parse(path.read_text())):
+        if not (isinstance(node, ast.ClassDef) and node.name == "FSDPArgs"):
+            continue
+        for stmt in node.body:
+            if not isinstance(stmt, ast.AnnAssign) or not isinstance(stmt.target, ast.Name):
+                continue
+            name = stmt.target.id
+            if name == "config":
+                continue  # build_fsdp_parser skips it
+            is_bool = isinstance(stmt.annotation, ast.Name) and stmt.annotation.id == "bool"
+            out[name] = BOOL_OPTIONAL if is_bool else 1
+    return out
+
+
 def flag_arity_from_source(miles_root: str | Path) -> dict[str, int | str]:
     """Map flag name (snake_case, no leading --) to value count: 0, 1, or "+"."""
     root = Path(miles_root)
-    arity: dict[str, int | str] = {}
+    arity: dict[str, int | str] = _fsdp_dataclass_flags(root)
 
     for relpath in SOURCE_RELPATHS:
         path = root / relpath

--- a/rllm/trainer/miles/_flag_audit.py
+++ b/rllm/trainer/miles/_flag_audit.py
@@ -1,0 +1,69 @@
+"""Extract Miles' flag surface from source, without importing miles.
+
+Importing ``miles.utils.arguments`` pulls in sglang (and, on the megatron path,
+Megatron-LM), so it only works inside the Miles container image. Parsing the
+source with ``ast`` lets the config bridge be audited from any checkout, which is
+what ``tests/test_miles_flags.py`` uses to catch flag-name drift.
+
+This is an auditing aid, not a parser: ``miles_arity()`` in ``miles_config`` is
+still the authority at runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# Miles registers flags two ways: plain add_argument, and reset_arg(parser, "--flag", ...)
+# which overrides a Megatron default and falls back to add_argument when the flag
+# does not exist yet (as on the FSDP path, where Megatron never ran).
+_REGISTRARS = {"add_argument", "reset_arg"}
+
+# Files holding Miles' own (statically declared) flags. The --sglang-* family is
+# generated at runtime from ServerArgs.add_cli_args and is deliberately not covered.
+SOURCE_RELPATHS = (
+    "miles/utils/arguments.py",
+    "miles/backends/fsdp_utils/arguments.py",
+    "miles/backends/sglang_utils/arguments.py",
+    "miles/dashboard/args.py",
+)
+
+
+def _call_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def flag_arity_from_source(miles_root: str | Path) -> dict[str, int | str]:
+    """Map flag name (snake_case, no leading --) to value count: 0, 1, or "+"."""
+    root = Path(miles_root)
+    arity: dict[str, int | str] = {}
+
+    for relpath in SOURCE_RELPATHS:
+        path = root / relpath
+        if not path.exists():
+            continue
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not (isinstance(node, ast.Call) and _call_name(node) in _REGISTRARS):
+                continue
+            names = [a.value for a in node.args if isinstance(a, ast.Constant) and isinstance(a.value, str) and a.value.startswith("--")]
+            if not names:
+                continue
+            kwargs = {k.arg: k.value for k in node.keywords}
+
+            n: int | str = 1
+            action = kwargs.get("action")
+            if isinstance(action, ast.Constant) and action.value in ("store_true", "store_false"):
+                n = 0
+            nargs = kwargs.get("nargs")
+            if isinstance(nargs, ast.Constant) and nargs.value in ("+", "*"):
+                n = "+"
+
+            for name in names:
+                arity[name[2:].replace("-", "_")] = n
+
+    return arity

--- a/rllm/trainer/miles/miles_backend.py
+++ b/rllm/trainer/miles/miles_backend.py
@@ -47,6 +47,18 @@ class MilesBatch:
     num_samples: int = 0
     metrics: dict = field(default_factory=dict)
 
+    def __len__(self) -> int:
+        """Trainable sequences in this batch.
+
+        The async training loop sums ``len(backend_batch)`` across forward-backward
+        passes and skips the optimizer step when the total is zero.
+        """
+        return self.num_samples
+
+    @property
+    def is_empty(self) -> bool:
+        return self.num_samples == 0
+
 
 class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
     """Backend that trains through Miles' Ray actors."""
@@ -62,6 +74,9 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         self.rollout_engine = None
         self.tokenizer = None
         self.algorithm_config: AlgorithmConfig | None = None
+        # Async training moves weight sync from on_batch_end to on_policy_updated,
+        # which the trainer calls inside its own pause/drain window.
+        self.is_async = bool((config.rllm.get("async_training", {}) or {}).get("enable", False))
         # Miles indexes everything by rollout_id; rLLM's global_step is the same clock.
         self._num_rollout_per_epoch = None
         # Advantages are computed during transform (stage 4), but the trainer's
@@ -88,11 +103,36 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
 
         node = self.full_config.get("miles", None)
         raw = OmegaConf.to_container(node, resolve=True) if node is not None else {}
-        validate_pinned(raw if isinstance(raw, dict) else {})
+        raw = raw if isinstance(raw, dict) else {}
+        validate_pinned(raw)
 
         async_cfg = self.full_config.rllm.get("async_training", {}) or {}
         if async_cfg.get("enable", False):
-            raise ValueError("Async training is not wired up for the miles backend yet (Phase 5). Set rllm.async_training.enable=false.")
+            # The trainer's async loop accumulates gradient across `num_fwd_bwd_passes`
+            # calls to process_backend_batch, then takes one optimizer step in
+            # update_policy. Miles' RayTrainGroup.train() is monolithic -- log-probs, loss
+            # and the optimizer steps happen in one call -- so it cannot accumulate across
+            # passes. Constrain the loop to one pass per step, the same restriction verl's
+            # separated mode carries.
+            mini_batch = async_cfg.get("mini_batch_size", 1)
+            fwd_bwd = async_cfg.get("fwd_bwd_group_size") or mini_batch
+            if fwd_bwd != mini_batch:
+                raise ValueError(
+                    f"The miles backend needs rllm.async_training.fwd_bwd_group_size ({fwd_bwd}) "
+                    f"== mini_batch_size ({mini_batch}): Miles takes its optimizer step inside "
+                    "RayTrainGroup.train(), so it cannot accumulate gradient across passes."
+                )
+            # The trainer asserts this too, but only once _fit_fully_async starts --
+            # after Ray, the SGLang engines and the model are all up, which is minutes of
+            # setup to reach a config error. validate_config runs before any of that.
+            if self.full_config.rllm.get("workflow", {}).get("raise_on_error", True):
+                raise ValueError("Async training needs rllm.workflow.raise_on_error=false so a failed task still yields an (error) episode instead of killing the generation loop.")
+            if raw.get("pause_generation_mode") == "abort":
+                raise ValueError(
+                    "miles.pause_generation_mode=abort kills in-flight generation on every "
+                    "weight update, which async training does continuously. Use 'retract' "
+                    "(Miles' default): it requeues those requests and resumes them after."
+                )
 
     def init_rollout_engine(self, **kwargs) -> RolloutEngine:
         """Build Miles' args, bring up its Ray actors, and return the rollout engine.
@@ -159,6 +199,14 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         return MilesEngine(config=self.full_config, router_url=router_url, tokenizer=self.tokenizer, miles_args=self.miles_args)
 
     def shutdown(self) -> None:
+        engine = self.rollout_engine
+        if engine is not None and hasattr(engine, "close"):
+            try:
+                from miles.utils.async_utils import run as miles_run
+
+                miles_run(engine.close())
+            except Exception:
+                logger.exception("MilesEngine HTTP client did not close cleanly")
         try:
             if self.rollout_manager is not None:
                 import ray
@@ -208,12 +256,18 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         grouped = trajectory_groups_to_payloads(groups)
         samples, advantages = payloads_to_samples(grouped)
         if not samples:
-            raise ValueError("No trainable samples in this batch; every trajectory group was empty.")
+            # Every group was dropped (e.g. all responses empty). The async loop treats a
+            # zero-length batch as "this pass contributes no gradient" and carries on, so
+            # returning empty is more useful than raising -- update_policy skips it.
+            logger.warning("No trainable samples in this batch; %d trajectory groups produced nothing.", len(groups))
+            return MilesBatch(data_ref=None, num_samples=0, metrics={"batch/miles_samples": 0, "batch/miles_groups": 0})
+
+        samples, advantages, dynamic_gbs = self._fit_to_dp(samples, advantages)
 
         train_data = convert_samples_to_train_data(
             self.miles_args,
             samples,
-            metadata={},
+            metadata={"dynamic_global_batch_size": dynamic_gbs},
             custom_convert_samples_to_train_data_func=None,
             custom_reward_post_process_func=None,
         )
@@ -233,6 +287,39 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
             num_samples=len(samples),
             metrics={"batch/miles_samples": len(samples), "batch/miles_groups": len(grouped)},
         )
+
+    def _fit_to_dp(self, samples: list, advantages: list[list[float]]) -> tuple[list, list[list[float]], int]:
+        """Trim the batch to a multiple of the DP size and return that as the batch size.
+
+        Miles computes ``num_steps_per_rollout = num_local_samples // num_local_gbs`` with
+        integer division, so a static ``--global-batch-size`` would either drop the
+        remainder silently or take several optimizer steps inside one rLLM step. Reusing
+        Miles' own ``_compute_dynamic_global_batch_size`` (rounded down to ``dp_size``)
+        pins it to exactly one step over exactly the samples we keep, whatever survived
+        rejection sampling and compact filtering.
+        """
+        from miles.ray.rollout.rollout_data_conversion import _compute_dynamic_global_batch_size
+
+        parallel_config = self._train_parallel_config()
+        dynamic_gbs = _compute_dynamic_global_batch_size(self.miles_args, parallel_config, len(samples))
+
+        if dynamic_gbs > len(samples):
+            # Fewer samples than dp_size: Miles pads the batch size up and would index
+            # past the end. Nothing trainable here.
+            raise ValueError(
+                f"Only {len(samples)} trainable samples for dp_size={parallel_config['dp_size']}; "
+                "raise rllm.async_training.mini_batch_size (or rllm.data.train_batch_size) "
+                "or rllm.rollout.n so every DP rank gets at least one sample."
+            )
+        if dynamic_gbs < len(samples):
+            logger.info(
+                "Trimming batch from %d to %d samples (a multiple of dp_size=%d) so Miles takes exactly one optimizer step.",
+                len(samples),
+                dynamic_gbs,
+                parallel_config["dp_size"],
+            )
+            samples, advantages = samples[:dynamic_gbs], advantages[:dynamic_gbs]
+        return samples, advantages, dynamic_gbs
 
     def _train_parallel_config(self):
         """Read the DP layout the train actor pushed into the RolloutManager.
@@ -271,6 +358,9 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
 
     async def update_policy(self, trainer_state: TrainerState, **kwargs) -> None:
         batch: MilesBatch = trainer_state.backend_batch  # type: ignore[assignment]
+        if batch is None or batch.is_empty:
+            logger.warning("Skipping the optimizer step: no trainable sequences in this batch.")
+            return
         rollout_id = trainer_state.global_step
         with simple_timer("update_actor", trainer_state.timing_dict):
             await self.actor_model.train(rollout_id, {"data_ref": batch.data_ref, "sample_indices": batch.sample_indices})
@@ -291,12 +381,27 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
                 await self.actor_model.save_model(rollout_id)
                 await self.rollout_manager.save.remote(rollout_id)
 
-        # Colocated runs would need offload here; phase 1 is disaggregated only.
-        with simple_timer("update_weights", trainer_state.timing_dict):
-            await self.actor_model.update_weights(rollout_id=rollout_id)
+        # Sync mode publishes weights at the end of the step; async mode syncs in
+        # on_policy_updated instead, inside the trainer's pause/drain window. Doing both
+        # would push the same weights twice per step.
+        if not self.is_async:
+            with simple_timer("update_weights", trainer_state.timing_dict):
+                await self.actor_model.update_weights(rollout_id=rollout_id)
 
     async def on_policy_updated(self, trainer_state: TrainerState) -> None:
-        """Async path syncs here instead of on_batch_end. Not wired up yet (Phase 5)."""
+        """Publish new weights to the SGLang engines (async path).
+
+        Called from the trainer's ``_perform_weight_sync``. With ``partial_rollout=True``
+        the trainer does *not* drain generation first, which is safe because Miles' own
+        update pauses every engine, flushes, loads and resumes
+        (``update_weight_utils.update_weights``). Under the default
+        ``--pause-generation-mode retract`` in-flight requests are requeued rather than
+        killed, so a rollout crossing a sync boundary survives it.
+        """
+        if not self.is_async:
+            return
+        with simple_timer("weight_sync", trainer_state.timing_dict):
+            await self.actor_model.update_weights(rollout_id=trainer_state.global_step)
 
     async def on_validation_start(self, trainer_state: TrainerState) -> bool:
         trainer_state.is_training = False

--- a/rllm/trainer/miles/miles_backend.py
+++ b/rllm/trainer/miles/miles_backend.py
@@ -180,6 +180,25 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         # generation starts on-policy. Mirrors miles' train.py.
         miles_run(self.actor_model.update_weights())
 
+        # Diagnostic, mirroring miles' train.py: assert the engines actually hold the
+        # trainer's weights. A silent divergence here shows up much later as a large
+        # train/inference logprob gap, which wrecks any importance correction (TIS)
+        # without ever failing a run. create_rollout_manager already took the snapshot
+        # and reset the engine tensors when this flag is set.
+        if getattr(self.miles_args, "check_weight_update_equal", False):
+            import ray
+
+            logger.info("Comparing engine weights against the trainer (--check-weight-update-equal)")
+            result = ray.get(
+                self.rollout_manager.check_weights.remote(
+                    action="compare",
+                    allow_quant_error=self.miles_args.check_weight_update_allow_quant_error,
+                    selector=self.miles_args.check_weight_update_selector,
+                    skip_list=self.miles_args.check_weight_update_skip_list,
+                )
+            )
+            logger.info("Weight comparison result: %s", result)
+
         self.tokenizer = self._load_tokenizer()
         self.rollout_engine = self._build_engine()
         return self.rollout_engine

--- a/rllm/trainer/miles/miles_backend.py
+++ b/rllm/trainer/miles/miles_backend.py
@@ -1,0 +1,284 @@
+"""Miles backend for the UnifiedTrainer.
+
+rLLM drives the loop; Miles owns the GPUs. Miles' own ``train.py`` is never used --
+this reproduces its spine (generate, train, update_weights) with rLLM's workflow
+engine standing in for the generate half. See ``design/miles-training-backend.md``.
+
+Miles' ``RolloutManager`` is still created, because it owns the SGLang engine fleet,
+the router, and the weight-update broker that ``RayTrainGroup.update_weights`` goes
+through. Its rollout function is pinned to ``sleep_rollout`` and never invoked.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from omegaconf import DictConfig
+
+from rllm.data.utils import interleave_tasks
+from rllm.engine.rollout import RolloutEngine
+from rllm.trainer.algorithms.advantage import AlgorithmConfig, collect_reward_and_advantage_from_trajectory_groups
+from rllm.trainer.algorithms.performance import simple_timer
+from rllm.trainer.backend_protocol import BackendProtocol
+from rllm.trainer.miles.miles_config import build_miles_args, validate_pinned
+from rllm.trainer.miles.transform import payloads_to_samples, trajectory_groups_to_payloads
+from rllm.types import Episode
+
+if TYPE_CHECKING:
+    from rllm.engine.unified_workflow_engine import UnifiedWorkflowEngine
+    from rllm.trainer.unified_trainer import TrainerState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MilesBatch:
+    """What ``RayTrainGroup.train`` consumes, plus what we need for metrics.
+
+    ``data_ref`` is the object-store handle Miles' train workers pull from;
+    ``sample_indices`` mirrors what its own rollout path returns alongside it.
+    """
+
+    data_ref: Any
+    sample_indices: Any = None
+    num_samples: int = 0
+    metrics: dict = field(default_factory=dict)
+
+
+class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
+    """Backend that trains through Miles' Ray actors."""
+
+    name: str = "miles"
+
+    def __init__(self, config: DictConfig, **kwargs):
+        BackendProtocol.__init__(self, config, **kwargs)
+        self.full_config = config
+        self.miles_args = None
+        self.rollout_manager = None
+        self.actor_model = None
+        self.rollout_engine = None
+        self.tokenizer = None
+        self.algorithm_config: AlgorithmConfig | None = None
+        # Miles indexes everything by rollout_id; rLLM's global_step is the same clock.
+        self._num_rollout_per_epoch = None
+
+    # =====================================================================
+    # setup
+    # =====================================================================
+
+    def validate_config(self) -> None:
+        """Fail before any GPU is claimed."""
+        try:
+            import miles  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                f"The miles backend needs the `miles` package ({e}). Install it from source:\n"
+                "  git clone https://github.com/radixark/miles && cd miles\n"
+                "  pip install -r requirements.txt && pip install -e . --no-deps\n"
+                "See design/miles-training-backend.md for the full recipe."
+            ) from e
+
+        from omegaconf import OmegaConf
+
+        node = self.full_config.get("miles", None)
+        raw = OmegaConf.to_container(node, resolve=True) if node is not None else {}
+        validate_pinned(raw if isinstance(raw, dict) else {})
+
+        async_cfg = self.full_config.rllm.get("async_training", {}) or {}
+        if async_cfg.get("enable", False):
+            raise ValueError("Async training is not wired up for the miles backend yet (Phase 5). Set rllm.async_training.enable=false.")
+
+    def init_rollout_engine(self, **kwargs) -> RolloutEngine:
+        """Build Miles' args, bring up its Ray actors, and return the rollout engine.
+
+        Called from ``UnifiedTrainer.__init__`` after the dataloaders exist, which is
+        the first point ``total_training_steps`` is known -- and Miles needs it as
+        ``--num-rollout``, because ``--num-epoch`` asserts the global dataset we disable.
+        """
+        from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
+        from miles.utils import object_store
+        from miles.utils.async_utils import run as miles_run
+        from miles.utils.tracking_utils.tracking import init_tracking
+
+        from rllm.trainer.miles.patch import apply_all_miles_patches
+
+        # Worker processes get these through runtime_env.worker_process_setup_hook
+        # (see MilesTrainerLauncher); the driver needs them applied here.
+        apply_all_miles_patches()
+
+        self.algorithm_config = kwargs.get("algorithm_config")
+        total_steps = kwargs.get("total_training_steps")
+
+        self.miles_args = build_miles_args(self.full_config, total_steps=total_steps)
+        logger.info("Miles args built: train_backend=%s num_rollout=%s", self.miles_args.train_backend, self.miles_args.num_rollout)
+
+        pgs = create_placement_groups(self.miles_args)
+        object_store.init_instance(self.miles_args, contribute_segment=False)
+        init_tracking(self.miles_args)
+
+        self.rollout_manager, self._num_rollout_per_epoch = create_rollout_manager(self.miles_args, pgs["rollout"])
+        # create_training_models is async and we are in sync __init__; miles' own
+        # helper runs it on a background loop, which is safe either way.
+        self.actor_model, critic_model = miles_run(create_training_models(self.miles_args, pgs, self.rollout_manager))
+        if critic_model is not None:
+            raise ValueError("The miles backend does not support a critic yet (advantage_estimator=ppo).")
+
+        # Publish the freshly loaded training weights before the first rollout, so
+        # generation starts on-policy. Mirrors miles' train.py.
+        miles_run(self.actor_model.update_weights())
+
+        self.tokenizer = self._load_tokenizer()
+        self.rollout_engine = self._build_engine()
+        return self.rollout_engine
+
+    def _load_tokenizer(self):
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained(self.miles_args.hf_checkpoint, trust_remote_code=True)
+
+    def _build_engine(self) -> RolloutEngine:
+        import ray
+
+        from rllm.engine.rollout.miles_engine import MilesEngine
+
+        host, port = ray.get(self.rollout_manager.get_router_address.remote())
+        router_url = f"http://{host}:{port}"
+        logger.info("Miles SGLang router at %s", router_url)
+        return MilesEngine(config=self.full_config, router_url=router_url, tokenizer=self.tokenizer, miles_args=self.miles_args)
+
+    def shutdown(self) -> None:
+        try:
+            if self.rollout_manager is not None:
+                import ray
+
+                ray.get(self.rollout_manager.dispose.remote())
+        except Exception:
+            logger.exception("Miles rollout manager did not dispose cleanly")
+        try:
+            from miles.utils.tracking_utils.tracking import finish_tracking
+
+            finish_tracking()
+        except Exception:
+            logger.exception("Miles tracking did not finish cleanly")
+
+    # =====================================================================
+    # training loop
+    # =====================================================================
+
+    async def generate_episodes(self, batch: Any, agent_workflow_engine: UnifiedWorkflowEngine, is_validation: bool = False, **kwargs) -> list[Episode]:
+        """rLLM generates; Miles is not involved beyond serving the engines."""
+        repeat_times = self.full_config.rllm.rollout.n_val if is_validation else self.full_config.rllm.rollout.n
+        tasks, task_ids = interleave_tasks(batch, repeat_times)
+        episodes = await agent_workflow_engine.execute_tasks(tasks, task_ids, is_validation=is_validation, **kwargs)
+        for episode, task in zip(episodes, tasks, strict=True):
+            data_source = task.get("data_source") if isinstance(task, dict) else None
+            if data_source is not None:
+                episode.info["data_source"] = data_source
+        return episodes
+
+    def transform_to_backend_batch(self, trainer_state: TrainerState, **kwargs) -> MilesBatch:
+        """Trajectory groups -> Miles Samples -> the train-data pack its workers pull."""
+        from miles.ray.rollout.train_data_conversion import ROLLOUT_DATA_VALUE_SPEC, convert_samples_to_train_data, split_train_data_by_dp
+        from miles.utils import object_store
+
+        groups = trainer_state.trajectory_groups
+        assert groups is not None, "trajectory_groups must be set before transform_to_backend_batch"
+
+        grouped = trajectory_groups_to_payloads(groups)
+        samples, advantages = payloads_to_samples(grouped)
+        if not samples:
+            raise ValueError("No trainable samples in this batch; every trajectory group was empty.")
+
+        train_data = convert_samples_to_train_data(
+            self.miles_args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+        # rLLM owns advantage computation, so they ride along as a top-level key.
+        # Miles CP-slices it beside rollout_log_probs; see rllm/trainer/miles/patch.py.
+        train_data["advantages"] = advantages
+
+        sample_indices = train_data.get("sample_indices")
+        if self.miles_args.delay_split_train_data_by_dp:
+            data_ref = object_store.get_instance().put(value=train_data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
+        else:
+            data_ref = split_train_data_by_dp(self.miles_args, train_data, self._train_parallel_config())
+
+        return MilesBatch(
+            data_ref=data_ref,
+            sample_indices=sample_indices,
+            num_samples=len(samples),
+            metrics={"batch/miles_samples": len(samples), "batch/miles_groups": len(grouped)},
+        )
+
+    def _train_parallel_config(self):
+        """Read the DP layout the train actor pushed into the RolloutManager.
+
+        ``train_actor.set_rollout_manager`` calls
+        ``rollout_manager.set_train_parallel_config(...)`` during init, so the value
+        exists by the time ``create_training_models`` returns -- but RolloutManager
+        exposes only the setter. It is derived from live torch.distributed state
+        (``get_parallel_state().intra_dp.size``), so the driver cannot recompute it;
+        ``__ray_call__`` reads the attribute off the actor instead of patching Miles.
+        """
+        import ray
+
+        return ray.get(self.rollout_manager.__ray_call__.remote(lambda mgr: mgr.train_parallel_config))
+
+    async def process_backend_batch(self, trainer_state: TrainerState, **kwargs) -> None:
+        """No-op: Miles' train actor runs its own log-prob and reference forward passes."""
+        batch = trainer_state.backend_batch
+        if isinstance(batch, MilesBatch) and batch.metrics:
+            trainer_state.metrics.update(batch.metrics)
+
+    async def compute_advantages(self, trainer_state: TrainerState, algorithm_config: AlgorithmConfig, **kwargs) -> None:
+        """rLLM-native, per token. Miles' own estimator is off via
+        ``--disable-compute-advantages-and-returns``."""
+        assert trainer_state.trajectory_groups is not None, "Trajectory groups are not set"
+        adv_metrics = collect_reward_and_advantage_from_trajectory_groups(trainer_state.trajectory_groups, algorithm_config)
+        trainer_state.metrics.update(adv_metrics)
+
+    async def update_policy(self, trainer_state: TrainerState, **kwargs) -> None:
+        batch: MilesBatch = trainer_state.backend_batch  # type: ignore[assignment]
+        rollout_id = trainer_state.global_step
+        with simple_timer("update_actor", trainer_state.timing_dict):
+            await self.actor_model.train(rollout_id, {"data_ref": batch.data_ref, "sample_indices": batch.sample_indices})
+
+        from miles.utils.data import remove_rollout_data_refs
+
+        remove_rollout_data_refs(self.miles_args, {"data_ref": batch.data_ref, "sample_indices": batch.sample_indices})
+
+    # =====================================================================
+    # hooks
+    # =====================================================================
+
+    async def on_batch_end(self, trainer_state: TrainerState) -> None:
+        rollout_id = trainer_state.global_step
+        save_interval = self.miles_args.save_interval
+        if save_interval and rollout_id % save_interval == 0:
+            with simple_timer("save_checkpoint", trainer_state.timing_dict):
+                await self.actor_model.save_model(rollout_id)
+                await self.rollout_manager.save.remote(rollout_id)
+
+        # Colocated runs would need offload here; phase 1 is disaggregated only.
+        with simple_timer("update_weights", trainer_state.timing_dict):
+            await self.actor_model.update_weights(rollout_id=rollout_id)
+
+    async def on_policy_updated(self, trainer_state: TrainerState) -> None:
+        """Async path syncs here instead of on_batch_end. Not wired up yet (Phase 5)."""
+
+    async def on_validation_start(self, trainer_state: TrainerState) -> bool:
+        trainer_state.is_training = False
+        if self.rollout_engine is not None:
+            self.rollout_engine.is_validation = True
+        return True
+
+    async def on_validation_end(self, trainer_state: TrainerState) -> None:
+        trainer_state.is_training = True
+        if self.rollout_engine is not None:
+            self.rollout_engine.is_validation = False

--- a/rllm/trainer/miles/miles_backend.py
+++ b/rllm/trainer/miles/miles_backend.py
@@ -76,6 +76,7 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         self.algorithm_config: AlgorithmConfig | None = None
         # Async training moves weight sync from on_batch_end to on_policy_updated,
         # which the trainer calls inside its own pause/drain window.
+        self._engine_closed = False
         self.is_async = bool((config.rllm.get("async_training", {}) or {}).get("enable", False))
         # Miles indexes everything by rollout_id; rLLM's global_step is the same clock.
         self._num_rollout_per_epoch = None
@@ -198,15 +199,32 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         logger.info("Miles SGLang router at %s", router_url)
         return MilesEngine(config=self.full_config, router_url=router_url, tokenizer=self.tokenizer, miles_args=self.miles_args)
 
-    def shutdown(self) -> None:
-        engine = self.rollout_engine
-        if engine is not None and hasattr(engine, "close"):
-            try:
-                from miles.utils.async_utils import run as miles_run
+    async def on_train_end(self, trainer_state: TrainerState) -> None:
+        """Close the engine's HTTP client on the loop that opened it.
 
-                miles_run(engine.close())
-            except Exception:
-                logger.exception("MilesEngine HTTP client did not close cleanly")
+        httpx binds its connections to the running loop, so closing them anywhere else
+        (Miles' background loop, or after ``fit()``'s loop has been torn down) raises
+        "Event loop is closed". This hook is awaited on the trainer's own loop, which is
+        the only safe place.
+        """
+        await self._close_engine()
+
+    async def _close_engine(self) -> None:
+        engine = self.rollout_engine
+        if engine is None or self._engine_closed or not hasattr(engine, "close"):
+            return
+        self._engine_closed = True
+        try:
+            await engine.close()
+        except Exception:
+            logger.warning("MilesEngine HTTP client did not close cleanly", exc_info=True)
+
+    def shutdown(self) -> None:
+        # on_train_end already closed the engine on the right loop. Reaching here with it
+        # still open means fit() never ran (a bring-up failure), and there is no live loop
+        # to close it on -- the process is exiting anyway, so leave it.
+        if self.rollout_engine is not None and not self._engine_closed:
+            logger.debug("MilesEngine HTTP client left open; no event loop available at shutdown.")
         try:
             if self.rollout_manager is not None:
                 import ray

--- a/rllm/trainer/miles/miles_backend.py
+++ b/rllm/trainer/miles/miles_backend.py
@@ -64,6 +64,9 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         self.algorithm_config: AlgorithmConfig | None = None
         # Miles indexes everything by rollout_id; rLLM's global_step is the same clock.
         self._num_rollout_per_epoch = None
+        # Advantages are computed during transform (stage 4), but the trainer's
+        # compute_advantages hook runs at stage 6; carry the metrics across.
+        self._pending_adv_metrics: dict | None = None
 
     # =====================================================================
     # setup
@@ -113,7 +116,13 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         total_steps = kwargs.get("total_training_steps")
 
         self.miles_args = build_miles_args(self.full_config, total_steps=total_steps)
-        logger.info("Miles args built: train_backend=%s num_rollout=%s", self.miles_args.train_backend, self.miles_args.num_rollout)
+        logger.info(
+            "Miles args: train_backend=%s num_rollout=%s compute_advantages=%s global_dataset=%s",
+            self.miles_args.train_backend,
+            self.miles_args.num_rollout,
+            self.miles_args.compute_advantages_and_returns,
+            self.miles_args.rollout_global_dataset,
+        )
 
         pgs = create_placement_groups(self.miles_args)
         object_store.init_instance(self.miles_args, contribute_segment=False)
@@ -187,6 +196,15 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
         groups = trainer_state.trajectory_groups
         assert groups is not None, "trajectory_groups must be set before transform_to_backend_batch"
 
+        # The trainer calls this at stage 4 but compute_advantages only at stage 6, so
+        # the per-token advantages the transform needs do not exist yet. Compute them
+        # here when absent -- the same thing the tinker transform does -- and hand the
+        # metrics to compute_advantages rather than computing twice.
+        needs_advantages = any(step.advantage is None for group in groups for traj in group.trajectories for step in traj.steps)
+        if needs_advantages:
+            assert self.algorithm_config is not None, "algorithm_config was not provided to init_rollout_engine"
+            self._pending_adv_metrics = collect_reward_and_advantage_from_trajectory_groups(groups, self.algorithm_config)
+
         grouped = trajectory_groups_to_payloads(groups)
         samples, advantages = payloads_to_samples(grouped)
         if not samples:
@@ -237,11 +255,19 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
             trainer_state.metrics.update(batch.metrics)
 
     async def compute_advantages(self, trainer_state: TrainerState, algorithm_config: AlgorithmConfig, **kwargs) -> None:
-        """rLLM-native, per token. Miles' own estimator is off via
-        ``--disable-compute-advantages-and-returns``."""
+        """Publish the advantage metrics. Miles' own estimator is off via
+        ``--disable-compute-advantages-and-returns``.
+
+        The advantages themselves were computed in transform_to_backend_batch, which
+        the trainer runs earlier; this only reports. Recomputing here would be
+        wasteful and would double-count the reward metrics.
+        """
         assert trainer_state.trajectory_groups is not None, "Trajectory groups are not set"
-        adv_metrics = collect_reward_and_advantage_from_trajectory_groups(trainer_state.trajectory_groups, algorithm_config)
-        trainer_state.metrics.update(adv_metrics)
+        metrics = self._pending_adv_metrics
+        self._pending_adv_metrics = None
+        if metrics is None:
+            metrics = collect_reward_and_advantage_from_trajectory_groups(trainer_state.trajectory_groups, algorithm_config)
+        trainer_state.metrics.update(metrics)
 
     async def update_policy(self, trainer_state: TrainerState, **kwargs) -> None:
         batch: MilesBatch = trainer_state.backend_batch  # type: ignore[assignment]

--- a/rllm/trainer/miles/miles_backend.py
+++ b/rllm/trainer/miles/miles_backend.py
@@ -325,6 +325,37 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
             metrics={"batch/miles_samples": len(samples), "batch/miles_groups": len(grouped)},
         )
 
+    @staticmethod
+    def _optimizer_metrics(results: Any) -> dict:
+        """Pull Miles' per-step optimizer metrics out of the train return value.
+
+        ``RayTrainGroup.train`` gathers one entry per train worker; only rank 0 logs, so
+        exactly one entry normally carries metrics (see
+        ``rllm/trainer/miles/patch.py:patch_capture_train_metrics``). A rollout can contain
+        several optimizer steps, so numeric values are averaged across them; ``train/step``
+        is dropped as it is a counter, not a measurement.
+
+        Returns an empty dict when the patch is not applied, so this stays safe against a
+        Miles version whose actors return something else.
+        """
+        if not isinstance(results, list):
+            results = [results]
+
+        steps: list[dict] = []
+        for entry in results:
+            if isinstance(entry, dict):
+                steps.extend(d for d in entry.get("miles_train_metrics", []) or [] if isinstance(d, dict))
+        if not steps:
+            return {}
+
+        totals: dict[str, list[float]] = {}
+        for step in steps:
+            for key, value in step.items():
+                if key == "train/step" or not isinstance(value, (int, float)) or isinstance(value, bool):
+                    continue
+                totals.setdefault(key, []).append(float(value))
+        return {key: sum(vals) / len(vals) for key, vals in totals.items()}
+
     def _fit_to_dp(self, samples: list, advantages: list[list[float]]) -> tuple[list, list[list[float]], int]:
         """Trim the batch to a multiple of the DP size and return that as the batch size.
 
@@ -400,7 +431,9 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
             return
         rollout_id = trainer_state.global_step
         with simple_timer("update_actor", trainer_state.timing_dict):
-            await self.actor_model.train(rollout_id, {"data_ref": batch.data_ref, "sample_indices": batch.sample_indices})
+            results = await self.actor_model.train(rollout_id, {"data_ref": batch.data_ref, "sample_indices": batch.sample_indices})
+
+        trainer_state.metrics.update(self._optimizer_metrics(results))
 
         from miles.utils.data import remove_rollout_data_refs
 

--- a/rllm/trainer/miles/miles_backend.py
+++ b/rllm/trainer/miles/miles_backend.py
@@ -325,33 +325,40 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
             metrics={"batch/miles_samples": len(samples), "batch/miles_groups": len(grouped)},
         )
 
-    @staticmethod
-    def _optimizer_metrics(results: Any) -> dict:
-        """Pull Miles' per-step optimizer metrics out of the train return value.
+    def _optimizer_metrics(self) -> dict:
+        """Pull Miles' per-step optimizer metrics off the train workers.
 
-        ``RayTrainGroup.train`` gathers one entry per train worker; only rank 0 logs, so
-        exactly one entry normally carries metrics (see
-        ``rllm/trainer/miles/patch.py:patch_capture_train_metrics``). A rollout can contain
-        several optimizer steps, so numeric values are averaged across them; ``train/step``
-        is dropped as it is a counter, not a measurement.
+        The actors return ``None`` on the FSDP path, so there is nothing to read from
+        ``train()``. Instead each worker buffers what ``log_train_step`` produced (see
+        ``rllm/trainer/miles/patch.py``) and the driver drains it with ``__ray_call__`` --
+        no dependence on the actor class having been patched in the worker.
 
-        Returns an empty dict when the patch is not applied, so this stays safe against a
-        Miles version whose actors return something else.
+        Only rank 0 logs, so normally one worker has entries. A rollout can contain
+        several optimizer steps, so numeric values are averaged; ``train/step`` is dropped
+        as a counter rather than a measurement. Returns ``{}`` on any failure -- missing
+        metrics must never take down a training step.
         """
-        if not isinstance(results, list):
-            results = [results]
+        import ray
 
-        steps: list[dict] = []
-        for entry in results:
-            if isinstance(entry, dict):
-                steps.extend(d for d in entry.get("miles_train_metrics", []) or [] if isinstance(d, dict))
+        from rllm.trainer.miles.patch import drain_train_metrics
+
+        handles = getattr(self.actor_model, "_actor_handles", None)
+        if not handles:
+            return {}
+        try:
+            per_worker = ray.get([h.__ray_call__.remote(lambda _self: drain_train_metrics()) for h in handles])
+        except Exception:
+            logger.warning("Could not read Miles' optimizer metrics off the train workers", exc_info=True)
+            return {}
+
+        steps = [d for worker in per_worker if worker for d in worker if isinstance(d, dict)]
         if not steps:
             return {}
 
         totals: dict[str, list[float]] = {}
         for step in steps:
             for key, value in step.items():
-                if key == "train/step" or not isinstance(value, (int, float)) or isinstance(value, bool):
+                if key == "train/step" or isinstance(value, bool) or not isinstance(value, (int, float)):
                     continue
                 totals.setdefault(key, []).append(float(value))
         return {key: sum(vals) / len(vals) for key, vals in totals.items()}
@@ -431,9 +438,9 @@ class MilesBackend(BackendProtocol[Iterable, MilesBatch]):
             return
         rollout_id = trainer_state.global_step
         with simple_timer("update_actor", trainer_state.timing_dict):
-            results = await self.actor_model.train(rollout_id, {"data_ref": batch.data_ref, "sample_indices": batch.sample_indices})
+            await self.actor_model.train(rollout_id, {"data_ref": batch.data_ref, "sample_indices": batch.sample_indices})
 
-        trainer_state.metrics.update(self._optimizer_metrics(results))
+        trainer_state.metrics.update(self._optimizer_metrics())
 
         from miles.utils.data import remove_rollout_data_refs
 

--- a/rllm/trainer/miles/miles_config.py
+++ b/rllm/trainer/miles/miles_config.py
@@ -1,0 +1,221 @@
+"""OmegaConf -> Miles ``argparse.Namespace``.
+
+Miles builds one flat Namespace on top of Megatron's own ``parse_args``
+(``miles/utils/arguments.py``), so every Megatron flag shares the Miles CLI. We
+render an argv list and let Miles parse it, rather than hand-building a
+Namespace: ``miles_validate_args`` / ``megatron_validate_args`` /
+``set_default_megatron_args`` do real derivation we want to run.
+
+Config keys are **flag names** in snake_case, not argparse dests. That matters
+for negated flags: Miles spells "don't load a dataset" as
+``--disable-rollout-global-dataset`` (``action="store_false"``,
+``dest="rollout_global_dataset"``), so keying on the flag avoids having to model
+the dest/flag inversion.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+from omegaconf import DictConfig, OmegaConf
+
+logger = logging.getLogger(__name__)
+
+# Flags rLLM owns. The user cannot set these; validate_pinned() rejects attempts.
+PINNED_FLAGS: dict[str, Any] = {
+    # rLLM drives generation. The RolloutManager stays up only to own the SGLang
+    # fleet, the router, and the weight-update broker -- it must never generate.
+    "rollout_function_path": "miles.rollout.sleep_rollout.sleep",
+    "eval_function_path": "miles.rollout.sleep_rollout.sleep",
+    # rLLM owns the dataset; skips Miles' Dataset + tokenizer load.
+    "disable_rollout_global_dataset": True,
+    # Advantages arrive per-token from rLLM inside the batch.
+    "disable_compute_advantages_and_returns": True,
+}
+
+# Flags that configure *Miles'* generation path, which rLLM bypasses entirely.
+# Several of them also select a rollout function and would silently override -- or
+# assert against -- our sleep_rollout pin (see resolve_rollout_function_paths and
+# _resolve_rollout_functions in miles/utils/arguments.py), so reject them with an
+# explanation instead of letting Miles emit a confusing conflict.
+REJECTED_GENERATION_FLAGS: dict[str, str] = {
+    "fully_async": "overrides rollout_function_path with FullyAsyncRolloutFn, and asserts when both are set",
+    "multi_lora": "selects a rollout function of its own",
+    "partial_rollout": "resumes Miles-side generation, which never runs here",
+    "custom_generate_function_path": "configures Miles' generate path",
+    "custom_agent_function_path": "configures Miles' TITO agent path",
+    "use_session_server": "the TITO session server serves Miles-side agents; rLLM owns tokenization",
+    "rollout_global_dataset": "spelled --disable-rollout-global-dataset; the dataset lives on the rLLM side",
+    # miles_validate_args: "Evaluation datasets must be configured when eval_interval is set."
+    # rLLM runs validation through its own workflow engine, so Miles never evaluates.
+    "eval_interval": "rLLM runs validation itself; Miles' eval path is pinned to sleep_rollout",
+    "eval_prompt_data": "eval datasets live on the rLLM side",
+    "eval_config": "eval datasets live on the rLLM side",
+}
+
+
+# (miles_flag, rllm_config_path) -- mirrored so users set these once on the rllm.* side.
+SHARED_KEYS: list[tuple[str, str]] = [
+    ("hf_checkpoint", "model.name"),
+    ("rollout_batch_size", "rllm.data.train_batch_size"),
+    ("rollout_max_prompt_len", "rllm.data.max_prompt_length"),
+    ("save_interval", "rllm.trainer.save_freq"),
+]
+
+
+def _flag(key: str) -> str:
+    return "--" + key.replace("_", "-")
+
+
+def miles_arity(argv: list[str] | None = None) -> dict[str, int | str]:
+    """Value count per Miles flag, introspected from Miles' own parser.
+
+    0 for store_true/store_false, 1 for a scalar, "+" for nargs.
+
+    Parts of Miles' argument provider partial-parse ``sys.argv`` while registering
+    flags, so pass ``argv`` (without the program name) to install a valid one for
+    the duration. Otherwise the host process's argv leaks in and argparse prints a
+    spurious "the following arguments are required" usage error to stderr.
+    """
+    import argparse
+
+    from miles.utils.arguments import get_miles_extra_args_provider
+
+    saved = sys.argv
+    try:
+        if argv is not None:
+            sys.argv = ["rllm-miles", *argv]
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+    finally:
+        sys.argv = saved
+
+    arity: dict[str, int | str] = {}
+    for action in parser._actions:
+        n = 0 if action.nargs == 0 or isinstance(action.const, bool) else (action.nargs or 1)
+        if action.nargs in ("+", "*"):
+            n = "+"
+        elif not isinstance(action.nargs, int) and action.nargs is not None:
+            n = 1
+        for opt in action.option_strings:
+            if opt.startswith("--"):
+                arity[opt[2:].replace("-", "_")] = n
+    return arity
+
+
+def _infer_arity(value: Any) -> int | str:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (list, tuple)):
+        return "+"
+    return 1
+
+
+def render_argv(block: dict[str, Any], arity: dict[str, int | str] | None = None) -> list[str]:
+    """Render a ``{flag_name: value}`` mapping to argv.
+
+    ``None`` values are omitted (let Miles' own default stand). A zero-arity flag
+    is emitted bare when truthy and omitted when falsy. Flags absent from
+    ``arity`` fall back to inferring it from the Python type, which is why the
+    Megatron half of the CLI works without introspecting Megatron.
+    """
+    arity = arity or {}
+    argv: list[str] = []
+    for key, value in block.items():
+        if value is None:
+            continue
+        n = arity.get(key, _infer_arity(value))
+        if n == 0:
+            if value:
+                argv.append(_flag(key))
+            continue
+        if n == "+":
+            if not isinstance(value, (list, tuple)):
+                raise TypeError(f"miles.{key} takes a list, got {type(value).__name__}: {value!r}")
+            if not value:
+                continue
+            argv.append(_flag(key))
+            argv.extend(str(v) for v in value)
+            continue
+        if isinstance(value, (list, tuple)):
+            raise TypeError(f"miles.{key} takes a single value, got a list: {value!r}")
+        argv.extend([_flag(key), str(value)])
+    return argv
+
+
+def validate_pinned(block: dict[str, Any]) -> None:
+    """Reject user-set flags that rLLM owns."""
+    clashes = sorted(set(block) & set(PINNED_FLAGS))
+    if clashes:
+        raise ValueError("These Miles flags are set by the rLLM backend and cannot be overridden: " + ", ".join(f"miles.{c}" for c in clashes))
+    for flag, why in REJECTED_GENERATION_FLAGS.items():
+        if block.get(flag):
+            raise ValueError(f"miles.{flag} is not supported by the rLLM backend: {why}. rLLM drives generation, so Miles' rollout path is pinned to sleep_rollout.")
+
+    if block.get("colocate"):
+        raise ValueError("miles.colocate is not supported yet: rLLM generates while Miles trains, so the two must not share GPUs.")
+    if block.get("num_epoch") is not None:
+        # Miles asserts num_epoch requires rollout_global_dataset, which we disable.
+        raise ValueError("Set epochs on the rLLM side (rllm.trainer.total_epochs); miles.num_epoch needs Miles' own dataset.")
+
+
+def build_block(config: DictConfig, total_steps: int | None = None) -> tuple[dict[str, Any], list[Any]]:
+    """Assemble the flag mapping: user's ``miles:`` block + shared keys + pinned."""
+    node = config.get("miles", None)
+    # An empty DictConfig is falsy, so `or {}` here would hand to_container a plain dict.
+    raw = OmegaConf.to_container(node, resolve=True) if node is not None else {}
+    if not isinstance(raw, dict):
+        raise TypeError(f"`miles:` must be a mapping of flag names to values, got {type(raw).__name__}")
+    extra_args = raw.pop("extra_args", None) or []
+    validate_pinned(raw)
+
+    block: dict[str, Any] = dict(raw)
+    for miles_flag, rllm_path in SHARED_KEYS:
+        if block.get(miles_flag) is not None:
+            continue  # explicit miles.* wins
+        value = OmegaConf.select(config, rllm_path)
+        if value is not None:
+            block[miles_flag] = value
+
+    # rLLM owns the schedule. num_rollout is required because --num-epoch asserts
+    # Miles' global dataset, which we disable.
+    if total_steps is not None:
+        block["num_rollout"] = total_steps
+    block.update(PINNED_FLAGS)
+    return block, extra_args
+
+
+def build_miles_args(config: DictConfig, total_steps: int | None = None):
+    """Build the Miles ``Namespace``. Imports miles, so needs the Miles image."""
+    from miles.utils.arguments import parse_args
+
+    block, extra_args = build_block(config, total_steps=total_steps)
+    tail = [str(a) for a in extra_args]
+
+    # Two passes, because building argv needs the arity map and introspecting the
+    # arity map needs a valid argv: parts of Miles' argument provider partial-parse
+    # sys.argv while registering flags, and against the host process's argv that
+    # fails on Miles' required flags (printing a bogus usage error to stderr).
+    # Pass 1 infers arity from config value types -- enough to render a valid argv.
+    saved = sys.argv
+    try:
+        pass1 = render_argv(block) + tail
+        sys.argv = ["rllm-miles", *pass1]
+        try:
+            arity = miles_arity(pass1)
+        except Exception as e:  # pragma: no cover - introspection is best-effort
+            logger.warning("Could not introspect Miles' parser (%s); inferring flag arity from config types.", e)
+            arity = {}
+
+        # Pass 2 re-renders against Miles' declared arity, which is authoritative.
+        argv = render_argv(block, arity) + tail
+        if arity and argv != pass1:
+            logger.warning("Inferred flag arity disagreed with Miles' parser; using Miles'. Check miles.* value types.")
+        logger.info("miles argv: %s", " ".join(argv))
+
+        sys.argv = ["rllm-miles", *argv]
+        return parse_args()
+    finally:
+        sys.argv = saved

--- a/rllm/trainer/miles/miles_config.py
+++ b/rllm/trainer/miles/miles_config.py
@@ -37,6 +37,15 @@ PINNED_FLAGS: dict[str, Any] = {
     "disable_rollout_global_dataset": True,
     # Advantages arrive per-token from rLLM inside the batch.
     "disable_compute_advantages_and_returns": True,
+    # rLLM's loop assumes exactly one optimizer step per update_policy call, but Miles
+    # takes `num_samples // global_batch_size` of them -- so a static global_batch_size
+    # both desyncs the step accounting and breaks whenever filtering makes the surviving
+    # sample count vary. The dynamic size is computed per batch in the transform.
+    "use_dynamic_global_batch_size": True,
+    # Miles asserts these two together: static micro-batching cannot keep
+    # dp_size * mb_group alignment when the physical sample count is data-dependent.
+    # Pairs with miles.max_tokens_per_gpu, which sizes the micro-batches.
+    "use_dynamic_batch_size": True,
 }
 
 # Flags that configure *Miles'* generation path, which rLLM bypasses entirely.
@@ -64,6 +73,11 @@ REJECTED_GENERATION_FLAGS: dict[str, str] = {
 SHARED_KEYS: list[tuple[str, str]] = [
     ("hf_checkpoint", "model.name"),
     ("rollout_batch_size", "rllm.data.train_batch_size"),
+    # Feeds Miles' train_iters (and its legacy reward-grouping fallback):
+    #   train_iters = num_rollout * rollout_batch_size * n_samples_per_prompt // global_batch_size
+    # Left at Miles' default of 1 this silently understates the schedule length; harmless
+    # only while lr_decay_style is "constant".
+    ("n_samples_per_prompt", "rllm.rollout.n"),
     ("rollout_max_prompt_len", "rllm.data.max_prompt_length"),
     ("save_interval", "rllm.trainer.save_freq"),
 ]
@@ -192,6 +206,15 @@ def build_block(config: DictConfig, total_steps: int | None = None) -> tuple[dic
         value = OmegaConf.select(config, rllm_path)
         if value is not None:
             block[miles_flag] = value
+
+    # Async training pins rllm.data.train_batch_size to 1 (the trainer streams one task
+    # batch at a time), so the prompts-per-optimizer-step Miles needs is the async
+    # mini_batch_size instead. Getting this wrong makes train_iters 0 and the FSDP LR
+    # scheduler asserts on `lr_decay_steps > 0`.
+    async_cfg = OmegaConf.select(config, "rllm.async_training") or {}
+    if async_cfg.get("enable", False):
+        mini_batch = async_cfg.get("mini_batch_size", 1)
+        block["rollout_batch_size"] = mini_batch
 
     # rLLM owns the schedule. num_rollout is required because --num-epoch asserts
     # Miles' global dataset, which we disable.

--- a/rllm/trainer/miles/miles_config.py
+++ b/rllm/trainer/miles/miles_config.py
@@ -189,6 +189,44 @@ def validate_pinned(block: dict[str, Any]) -> None:
         raise ValueError("Set epochs on the rLLM side (rllm.trainer.total_epochs); miles.num_epoch needs Miles' own dataset.")
 
 
+def _apply_rollout_correction(config: DictConfig, block: dict[str, Any]) -> None:
+    """Map rllm.algorithm.rollout_correction onto Miles' TIS flags.
+
+    Async training consumes trajectories generated one or more weight versions ago.
+    Without truncated importance sampling the ratio is taken against a freshly computed
+    pi_old, which ignores that the data came from an older behaviour policy -- the update
+    is biased and the policy can degrade. Every reference async config sets tis_mode.
+
+    rLLM -> Miles:
+      tis_mode "token"  -> --use-tis (Miles' TIS is token-level)
+      tis_cap           -> --tis-clip
+      bypass_mode true  -> --use-rollout-logprobs   (pi_old = pi_rollout)
+    """
+    correction = OmegaConf.select(config, "rllm.algorithm.rollout_correction") or {}
+    tis_mode = correction.get("tis_mode")
+    bypass = correction.get("bypass_mode")
+
+    if tis_mode == "sequence":
+        raise ValueError("rllm.algorithm.rollout_correction.tis_mode=sequence has no equivalent on the miles backend: Miles' --use-tis is token-level. Use tis_mode=token.")
+    if tis_mode == "token":
+        block.setdefault("use_tis", True)
+        cap = correction.get("tis_cap")
+        if cap is not None:
+            block.setdefault("tis_clip", cap)
+    if bypass is True:
+        block.setdefault("use_rollout_logprobs", True)
+
+    staleness = OmegaConf.select(config, "rllm.async_training.staleness_threshold") or 0
+    async_on = bool(OmegaConf.select(config, "rllm.async_training.enable"))
+    if async_on and staleness > 0 and not tis_mode:
+        logger.warning(
+            "Async training with staleness_threshold=%s but no rollout correction: set "
+            "rllm.algorithm.rollout_correction.tis_mode=token (and tis_cap) or the update is "
+            "biased by the policy lag and the run can get worse, not better.",
+            staleness,
+        )
+
+
 def build_block(config: DictConfig, total_steps: int | None = None) -> tuple[dict[str, Any], list[Any]]:
     """Assemble the flag mapping: user's ``miles:`` block + shared keys + pinned."""
     node = config.get("miles", None)
@@ -215,6 +253,8 @@ def build_block(config: DictConfig, total_steps: int | None = None) -> tuple[dic
     if async_cfg.get("enable", False):
         mini_batch = async_cfg.get("mini_batch_size", 1)
         block["rollout_batch_size"] = mini_batch
+
+    _apply_rollout_correction(config, block)
 
     # rLLM owns the schedule. num_rollout is required because --num-epoch asserts
     # Miles' global dataset, which we disable.

--- a/rllm/trainer/miles/miles_config.py
+++ b/rllm/trainer/miles/miles_config.py
@@ -189,6 +189,32 @@ def validate_pinned(block: dict[str, Any]) -> None:
         raise ValueError("Set epochs on the rLLM side (rllm.trainer.total_epochs); miles.num_epoch needs Miles' own dataset.")
 
 
+# Attention implementations that consume `cu_seqlens`, i.e. that honour packed-sequence
+# boundaries. Miles' FSDP path passes `attention_mask=None` with packed `position_ids`
+# (see fsdp_utils/adaptations/packing/boundaries.py), so with `qkv_format=thd` -- the
+# default -- anything else silently attends across document boundaries: samples in the
+# same microbatch see each other. No error, just wrong logprobs, which shows up as a huge
+# train/inference gap and wrecks any importance correction.
+_VARLEN_ATTENTION = {"flash_attention_2", "flash_attention_3", "fa3", "triton"}
+
+
+def validate_attention(block: dict[str, Any]) -> None:
+    """Reject an attention implementation that cannot honour packed-sequence boundaries."""
+    attn = block.get("attn_implementation")
+    if attn is None or attn in _VARLEN_ATTENTION:
+        return
+    # bshd pads one sequence per row, so there is nothing to cross-contaminate.
+    if block.get("qkv_format", "thd") == "bshd":
+        return
+    raise ValueError(
+        f"miles.attn_implementation={attn!r} cannot honour packed-sequence boundaries: Miles' FSDP "
+        "path passes attention_mask=None with packed position_ids, so with qkv_format=thd (the "
+        "default) samples in a microbatch attend to each other. Use flash_attention_2 (Miles' own "
+        f"default; install flash-attn), one of {sorted(_VARLEN_ATTENTION)}, or set "
+        "miles.qkv_format=bshd to pad instead of pack."
+    )
+
+
 def _apply_rollout_correction(config: DictConfig, block: dict[str, Any]) -> None:
     """Map rllm.algorithm.rollout_correction onto Miles' TIS flags.
 
@@ -236,6 +262,7 @@ def build_block(config: DictConfig, total_steps: int | None = None) -> tuple[dic
         raise TypeError(f"`miles:` must be a mapping of flag names to values, got {type(raw).__name__}")
     extra_args = raw.pop("extra_args", None) or []
     validate_pinned(raw)
+    validate_attention(raw)
 
     block: dict[str, Any] = dict(raw)
     for miles_flag, rllm_path in SHARED_KEYS:

--- a/rllm/trainer/miles/miles_config.py
+++ b/rllm/trainer/miles/miles_config.py
@@ -23,6 +23,10 @@ from omegaconf import DictConfig, OmegaConf
 
 logger = logging.getLogger(__name__)
 
+# Arity sentinel for argparse.BooleanOptionalAction flags (--flag / --no-flag),
+# as distinct from store_true/store_false (0), a scalar (1), or nargs ("+").
+BOOL_OPTIONAL = "bool"
+
 # Flags rLLM owns. The user cannot set these; validate_pinned() rejects attempts.
 PINNED_FLAGS: dict[str, Any] = {
     # rLLM drives generation. The RolloutManager stays up only to own the SGLang
@@ -94,13 +98,16 @@ def miles_arity(argv: list[str] | None = None) -> dict[str, int | str]:
 
     arity: dict[str, int | str] = {}
     for action in parser._actions:
-        n = 0 if action.nargs == 0 or isinstance(action.const, bool) else (action.nargs or 1)
-        if action.nargs in ("+", "*"):
-            n = "+"
-        elif not isinstance(action.nargs, int) and action.nargs is not None:
-            n = 1
+        if isinstance(action, argparse.BooleanOptionalAction):
+            n: int | str = BOOL_OPTIONAL
+        else:
+            n = 0 if action.nargs == 0 or isinstance(action.const, bool) else (action.nargs or 1)
+            if action.nargs in ("+", "*"):
+                n = "+"
+            elif not isinstance(action.nargs, int) and action.nargs is not None:
+                n = 1
         for opt in action.option_strings:
-            if opt.startswith("--"):
+            if opt.startswith("--") and not opt.startswith("--no-"):
                 arity[opt[2:].replace("-", "_")] = n
     return arity
 
@@ -127,6 +134,13 @@ def render_argv(block: dict[str, Any], arity: dict[str, int | str] | None = None
         if value is None:
             continue
         n = arity.get(key, _infer_arity(value))
+        if n == BOOL_OPTIONAL:
+            # argparse.BooleanOptionalAction: omitting the flag keeps the declared
+            # default, so a False override has to be spelled --no-<flag>. Miles' FSDP
+            # args are all dataclass-derived and use this, and three of them default
+            # to True -- omitting would silently ignore the user.
+            argv.append(_flag(key) if value else _flag(key).replace("--", "--no-", 1))
+            continue
         if n == 0:
             if value:
                 argv.append(_flag(key))

--- a/rllm/trainer/miles/miles_config.py
+++ b/rllm/trainer/miles/miles_config.py
@@ -215,6 +215,29 @@ def validate_attention(block: dict[str, Any]) -> None:
     )
 
 
+def validate_router(block: dict[str, Any]) -> None:
+    """Reject the Rust router: it silently drops the fork-only trace-capture fields.
+
+    ``sglang_router`` (0.3.2 measured) deserializes a chat request into its own struct and
+    re-serializes it, so fields it does not know are dropped -- including
+    ``return_meta_info`` and ``return_prompt_token_ids``, the sglang-miles additions that
+    make completion token IDs available. ``logprobs`` survives, because it is a field the
+    router knows. The result is a response with logprobs and no token IDs, which surfaces
+    far downstream as "length mismatch between response_ids and logprobs, got 0, N".
+
+    Miles' own session server never hits this: it proxies raw bytes straight to an engine.
+    ``use_miles_router`` selects that same transparent Python router, so rLLM requires it.
+    """
+    if block.get("use_miles_router") is False:
+        raise ValueError(
+            "miles.use_miles_router=false drops trace-capture fields. rLLM reads completion "
+            "token IDs out of SGLang's meta_info, which needs return_meta_info on the request; "
+            "the Rust sglang_router re-serializes the body through its own struct and drops "
+            "that field, leaving logprobs with no matching token IDs. Leave use_miles_router "
+            "at rLLM's default (true), which selects Miles' transparent proxy."
+        )
+
+
 def _apply_rollout_correction(config: DictConfig, block: dict[str, Any]) -> None:
     """Map rllm.algorithm.rollout_correction onto Miles' TIS flags.
 
@@ -263,6 +286,7 @@ def build_block(config: DictConfig, total_steps: int | None = None) -> tuple[dic
     extra_args = raw.pop("extra_args", None) or []
     validate_pinned(raw)
     validate_attention(raw)
+    validate_router(raw)
 
     block: dict[str, Any] = dict(raw)
     for miles_flag, rllm_path in SHARED_KEYS:

--- a/rllm/trainer/miles/miles_launcher.py
+++ b/rllm/trainer/miles/miles_launcher.py
@@ -1,0 +1,92 @@
+"""Launcher for the Miles backend.
+
+Miles ships as a Ray driver (``ray job submit train.py``), not a library, so rLLM
+has to own Ray init before handing placement groups to Miles' ``create_*`` helpers.
+Miles' own launcher additionally runs a ``pkill -9 sglang; ray stop --force``
+preamble that we bypass -- stale SGLang processes from a crashed run are therefore
+this process's problem, not Miles'.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from omegaconf import DictConfig, OmegaConf
+
+from rllm.data import Dataset
+from rllm.trainer.miles.miles_backend import MilesBackend
+from rllm.trainer.miles.utils import sync_config
+from rllm.trainer.unified_trainer import TrainerLauncher, UnifiedTrainer
+from rllm.workflows.workflow import Workflow
+
+logger = logging.getLogger(__name__)
+
+
+class MilesTrainerLauncher(TrainerLauncher):
+    """Scaffolds Ray, then hands off to the UnifiedTrainer."""
+
+    def __init__(
+        self,
+        config: DictConfig,
+        workflow_class: type[Workflow] | None = None,
+        train_dataset: Dataset | None = None,
+        val_dataset: Dataset | None = None,
+        workflow_args: dict | None = None,
+        **kwargs,
+    ):
+        super().__init__(config, workflow_class, train_dataset, val_dataset, workflow_args, **kwargs)
+
+    def _hydra_overrides(self) -> list[str]:
+        try:
+            from hydra.core.hydra_config import HydraConfig
+
+            return list(HydraConfig.get().overrides.task)
+        except (ValueError, AttributeError, ImportError):
+            return []
+
+    def _init_ray(self) -> None:
+        import ray
+
+        if ray.is_initialized():
+            logger.info("Ray already initialized; reusing the existing cluster.")
+            return
+
+        from rllm.trainer.ray_init_utils import get_forwarded_env_vars, get_ray_init_settings
+
+        # Not verl's get_ppo_ray_runtime_env(): that sets VLLM_* defaults, which are
+        # meaningless for Miles (SGLang). The env forwarding is the part worth reusing --
+        # MEGATRON_ / SGLANG_ / NCCL_ / CUDA_ prefixes are exactly what Miles' actors need.
+        env_vars = {"TOKENIZERS_PARALLELISM": "true", "NCCL_CUMEM_ENABLE": "0", **get_forwarded_env_vars()}
+        ray.init(
+            runtime_env={
+                "env_vars": env_vars,
+                # Driver-side monkey-patches do not reach worker processes, and the
+                # advantages CP-slice patch has to run inside Miles' train workers.
+                "worker_process_setup_hook": "rllm.trainer.miles.patch.apply_all_miles_patches",
+            },
+            **get_ray_init_settings(self.config),
+        )
+
+    def train(self):
+        sync_config(self.config, self._hydra_overrides())
+        OmegaConf.resolve(self.config)
+        self._init_ray()
+
+        trainer = None
+        try:
+            trainer = UnifiedTrainer(
+                backend_cls=MilesBackend,
+                config=self.config,
+                workflow_class=self.workflow_class,
+                train_dataset=self.train_dataset,
+                val_dataset=self.val_dataset,
+                workflow_args=self.workflow_args,
+                store=self.store,
+                **self.kwargs,
+            )
+            trainer.fit()
+        except KeyboardInterrupt:
+            logger.warning("Training interrupted by user.")
+        finally:
+            if trainer is not None:
+                trainer.shutdown()

--- a/rllm/trainer/miles/patch.py
+++ b/rllm/trainer/miles/patch.py
@@ -1,0 +1,96 @@
+"""Monkey-patches applied to Miles from the rLLM backend.
+
+Same mechanism rLLM already uses for verl (``rllm/trainer/verl/patch.py``): applied
+lazily, idempotent, and applied on the train workers as well as the driver.
+
+Each patch here should end up upstream in Miles; the docstrings say what the
+upstream change would be so they can be dropped as it lands.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_ADVANTAGES_CP_SLICE_PATCHED = False
+
+# The key tuple in miles/backends/training_utils/data.py:get_rollout_data that gets
+# CP-sliced per sample. Asserted so a Miles upgrade that renames or reorders these
+# fails loudly here instead of silently skipping our advantages.
+_EXPECTED_CP_SLICED_KEYS = ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl")
+
+
+def patch_advantages_cp_slice() -> None:
+    """Let driver-supplied per-token advantages ride the ``rollout_log_probs`` path.
+
+    rLLM computes advantages itself and ships them as a top-level
+    ``rollout_data["advantages"]``. Miles' own estimator is off (via
+    ``--disable-compute-advantages-and-returns``), and its
+    ``policy_loss_function`` reads ``batch["advantages"]`` directly -- so the only
+    thing missing is the per-sample context-parallel slice that every other
+    response-aligned float array gets.
+
+    ``get_rollout_data`` applies ``slice_log_prob_with_cp`` to a hardcoded tuple of
+    keys. This wraps it so ``advantages`` is sliced the same way. At CP size 1 the
+    slice is the identity, so this is a no-op there and only matters for CP > 1.
+
+    Upstream equivalent: add ``"advantages"`` to that tuple, plus a
+    ``ROLLOUT_DATA_VALUE_SPEC`` entry (needed only for the Mooncake object store;
+    the Ray store ignores the spec).
+    """
+    global _ADVANTAGES_CP_SLICE_PATCHED
+    if _ADVANTAGES_CP_SLICE_PATCHED:
+        return
+
+    import torch
+    from miles.backends.training_utils import data as miles_data
+
+    original = miles_data.get_rollout_data
+
+    def get_rollout_data(args, rollout_data_ref, witness_info=None):
+        rollout_data, store_get_result = original(args, rollout_data_ref, witness_info=witness_info)
+
+        advantages = rollout_data.get("advantages")
+        if advantages is not None and not isinstance(advantages[0], torch.Tensor):
+            rollout_data["advantages"] = [
+                torch.as_tensor(
+                    miles_data.slice_log_prob_with_cp(
+                        value,
+                        total_length,
+                        response_length,
+                        args.qkv_format,
+                        rollout_data["max_seq_lens"][i] if args.qkv_format == "bshd" else None,
+                    ),
+                    device=torch.cuda.current_device(),
+                    dtype=torch.float32,
+                )
+                for i, (value, total_length, response_length) in enumerate(zip(advantages, rollout_data["total_lengths"], rollout_data["response_lengths"], strict=True))
+            ]
+        return rollout_data, store_get_result
+
+    miles_data.get_rollout_data = get_rollout_data
+    _ADVANTAGES_CP_SLICE_PATCHED = True
+    logger.info("Patched miles get_rollout_data to CP-slice rLLM's per-token advantages")
+
+
+def assert_cp_slice_contract() -> None:
+    """Fail loudly if Miles moved the ground this patch stands on."""
+    import inspect
+
+    from miles.backends.training_utils import data as miles_data
+
+    source = inspect.getsource(miles_data)
+    expected = 'for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):'
+    if expected not in source:
+        raise RuntimeError(
+            "miles get_rollout_data no longer CP-slices the expected key tuple "
+            f"{_EXPECTED_CP_SLICED_KEYS}. rllm/trainer/miles/patch.py assumes that shape "
+            "for per-token advantages; re-check it against the installed miles version."
+        )
+
+
+def apply_all_miles_patches() -> None:
+    """Entry point for both the driver and the train workers."""
+    assert_cp_slice_contract()
+    patch_advantages_cp_slice()

--- a/rllm/trainer/miles/patch.py
+++ b/rllm/trainer/miles/patch.py
@@ -152,25 +152,46 @@ def patch_respect_disable_compute_advantages() -> None:
     logger.info("Patched miles compute_advantages_and_returns to respect --disable-compute-advantages-and-returns")
 
 
-def assert_cp_slice_contract() -> None:
-    """Fail loudly if Miles moved the ground this patch stands on."""
+def assert_patch_contracts() -> None:
+    """Fail loudly if Miles moved the ground any of these patches stands on.
+
+    Every one of them is load-bearing for rLLM's advantages reaching the loss, and
+    every one fails *silently* if it stops applying -- the run completes and the loss
+    quietly uses Miles' own advantages. So the structural assumptions are asserted
+    rather than assumed, and an upstream fix is reported so the patch can be dropped.
+    """
     import inspect
 
+    from miles.backends.fsdp_utils import actor as fsdp_actor
     from miles.backends.training_utils import data as miles_data
+    from miles.ray.rollout import train_data_conversion as tdc
 
-    source = inspect.getsource(miles_data)
+    # 1. the CP-slice key tuple get_rollout_data walks
     expected = 'for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):'
-    if expected not in source:
+    if expected not in inspect.getsource(miles_data):
         raise RuntimeError(
             "miles get_rollout_data no longer CP-slices the expected key tuple "
             f"{_EXPECTED_CP_SLICED_KEYS}. rllm/trainer/miles/patch.py assumes that shape "
             "for per-token advantages; re-check it against the installed miles version."
         )
 
+    # 2. the DP-shard allowlist we append to
+    if not hasattr(tdc, "_package_shards"):
+        raise RuntimeError("miles train_data_conversion._package_shards is gone; the DP-shard advantages patch cannot apply.")
+    if '"advantages"' in inspect.getsource(tdc._package_shards):
+        logger.info("miles _package_shards now forwards advantages itself; the rLLM patch is redundant.")
+
+    # 3. the ungated FSDP call site the wrapper compensates for
+    fsdp_source = inspect.getsource(fsdp_actor)
+    if "compute_advantages_and_returns(" not in fsdp_source:
+        raise RuntimeError("the miles FSDP actor no longer calls compute_advantages_and_returns; re-check whether rLLM's advantages still survive to the loss.")
+    if "if self.args.compute_advantages_and_returns" in fsdp_source:
+        logger.info("miles' FSDP actor now honours --disable-compute-advantages-and-returns; the rLLM wrapper is redundant.")
+
 
 def apply_all_miles_patches() -> None:
     """Entry point for both the driver and the train workers."""
-    assert_cp_slice_contract()
+    assert_patch_contracts()
     patch_advantages_cp_slice()
     patch_package_shards_forwards_advantages()
     patch_respect_disable_compute_advantages()

--- a/rllm/trainer/miles/patch.py
+++ b/rllm/trainer/miles/patch.py
@@ -150,8 +150,24 @@ def patch_respect_disable_compute_advantages() -> None:
     original = miles_loss.compute_advantages_and_returns
 
     def compute_advantages_and_returns(args, rollout_data):
-        if not getattr(args, "compute_advantages_and_returns", True) and rollout_data.get("advantages") is not None:
-            rollout_data.setdefault("returns", rollout_data["advantages"])
+        disabled = not getattr(args, "compute_advantages_and_returns", True)
+        advantages = rollout_data.get("advantages")
+
+        if disabled and advantages is None:
+            # Falling through here would have Miles recompute advantages from the scalar
+            # rewards and train on those instead of rLLM's -- the run would look healthy
+            # while quietly ignoring the estimator, which is the exact failure this
+            # backend has hit twice. Refuse rather than train on the wrong signal.
+            raise RuntimeError(
+                "rLLM's per-token advantages did not reach the train worker "
+                f"(keys present: {sorted(rollout_data)}). Miles' own advantage computation is "
+                "disabled, so there is nothing correct to train on. This means one of the "
+                "patches in rllm/trainer/miles/patch.py stopped applying -- check "
+                "assert_patch_contracts and that _package_shards still forwards 'advantages'."
+            )
+
+        if disabled:
+            rollout_data.setdefault("returns", advantages)
             return
         return original(args, rollout_data)
 

--- a/rllm/trainer/miles/patch.py
+++ b/rllm/trainer/miles/patch.py
@@ -24,6 +24,23 @@ _RESPECT_DISABLE_ADV_PATCHED = False
 _EXPECTED_CP_SLICED_KEYS = ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl")
 
 
+# Both actors do `from ...module import name`, which binds the function *by value* at
+# import time. Rebinding the source module therefore only reaches an actor that has not
+# been imported yet -- and anything that imports an actor early (assert_patch_contracts
+# did) silently defeats the patch. Always repoint the holders too.
+_FUNCTION_HOLDERS = ("miles.backends.fsdp_utils.actor", "miles.backends.megatron_utils.actor")
+
+
+def _rebind_everywhere(name: str, replacement) -> None:
+    for module_path in _FUNCTION_HOLDERS:
+        try:
+            module = importlib.import_module(module_path)
+        except Exception:  # the megatron actor needs megatron installed
+            continue
+        if hasattr(module, name):
+            setattr(module, name, replacement)
+
+
 def patch_advantages_cp_slice() -> None:
     """Let driver-supplied per-token advantages ride the ``rollout_log_probs`` path.
 
@@ -73,6 +90,7 @@ def patch_advantages_cp_slice() -> None:
         return rollout_data, store_get_result
 
     miles_data.get_rollout_data = get_rollout_data
+    _rebind_everywhere("get_rollout_data", get_rollout_data)
     _ADVANTAGES_CP_SLICE_PATCHED = True
     logger.info("Patched miles get_rollout_data to CP-slice rLLM's per-token advantages")
 
@@ -138,15 +156,7 @@ def patch_respect_disable_compute_advantages() -> None:
         return original(args, rollout_data)
 
     miles_loss.compute_advantages_and_returns = compute_advantages_and_returns
-    # Both actors do `from ...loss import compute_advantages_and_returns`, binding the
-    # function by value, so rebinding the source module is not enough.
-    for module_path in ("miles.backends.fsdp_utils.actor", "miles.backends.megatron_utils.actor"):
-        try:
-            module = importlib.import_module(module_path)
-        except Exception:  # megatron actor needs megatron installed
-            continue
-        if hasattr(module, "compute_advantages_and_returns"):
-            module.compute_advantages_and_returns = compute_advantages_and_returns
+    _rebind_everywhere("compute_advantages_and_returns", compute_advantages_and_returns)
 
     _RESPECT_DISABLE_ADV_PATCHED = True
     logger.info("Patched miles compute_advantages_and_returns to respect --disable-compute-advantages-and-returns")

--- a/rllm/trainer/miles/patch.py
+++ b/rllm/trainer/miles/patch.py
@@ -9,11 +9,14 @@ upstream change would be so they can be dropped as it lands.
 
 from __future__ import annotations
 
+import importlib
 import logging
 
 logger = logging.getLogger(__name__)
 
 _ADVANTAGES_CP_SLICE_PATCHED = False
+_PACKAGE_SHARDS_PATCHED = False
+_RESPECT_DISABLE_ADV_PATCHED = False
 
 # The key tuple in miles/backends/training_utils/data.py:get_rollout_data that gets
 # CP-sliced per sample. Asserted so a Miles upgrade that renames or reorders these
@@ -74,6 +77,81 @@ def patch_advantages_cp_slice() -> None:
     logger.info("Patched miles get_rollout_data to CP-slice rLLM's per-token advantages")
 
 
+def patch_package_shards_forwards_advantages() -> None:
+    """Stop the DP split from dropping rLLM's per-token advantages.
+
+    ``_package_shards`` copies a **hardcoded allowlist** of keys into each DP rank's
+    shard (``miles/ray/rollout/train_data_conversion.py``), so any extra key the
+    driver attaches -- ours included -- is silently discarded on the way to the train
+    workers. Silently: the loss then falls back to whatever Miles computed itself, and
+    the run looks healthy while ignoring rLLM's advantages entirely.
+
+    Upstream equivalent: add ``"advantages"`` to that per-sample list.
+    """
+    global _PACKAGE_SHARDS_PATCHED
+    if _PACKAGE_SHARDS_PATCHED:
+        return
+
+    from miles.ray.rollout import train_data_conversion as tdc
+
+    original = tdc._package_shards
+
+    def _package_shards(args, data, partitions):
+        shards = original(args, data, partitions)
+        advantages = data.get("advantages")
+        if advantages is not None:
+            for shard, partition in zip(shards, partitions, strict=True):
+                shard["advantages"] = [advantages[j] for j in partition]
+        return shards
+
+    tdc._package_shards = _package_shards
+    # split_train_data_by_dp_raw closed over the module-level name at def time only
+    # if it had been imported by value; it calls it through the module, so this is enough.
+    _PACKAGE_SHARDS_PATCHED = True
+    logger.info("Patched miles _package_shards to forward rLLM's advantages to the DP shards")
+
+
+def patch_respect_disable_compute_advantages() -> None:
+    """Make ``--disable-compute-advantages-and-returns`` actually hold on the FSDP path.
+
+    The Megatron actor gates its ``compute_advantages_and_returns`` call on that flag;
+    the FSDP actor (``miles/backends/fsdp_utils/actor.py``) calls it unconditionally, so
+    Miles recomputes advantages from the scalar rewards and overwrites the per-token
+    values rLLM shipped. This wraps the function to no-op when the flag is off and
+    advantages are already present, leaving ``returns`` aliased to them (GRPO's
+    identity, and the only estimator this backend supports today).
+
+    Upstream equivalent: wrap the FSDP call site in the same ``if`` the Megatron one uses.
+    """
+    global _RESPECT_DISABLE_ADV_PATCHED
+    if _RESPECT_DISABLE_ADV_PATCHED:
+        return
+
+    from miles.backends.training_utils import loss as miles_loss
+
+    original = miles_loss.compute_advantages_and_returns
+
+    def compute_advantages_and_returns(args, rollout_data):
+        if not getattr(args, "compute_advantages_and_returns", True) and rollout_data.get("advantages") is not None:
+            rollout_data.setdefault("returns", rollout_data["advantages"])
+            return
+        return original(args, rollout_data)
+
+    miles_loss.compute_advantages_and_returns = compute_advantages_and_returns
+    # Both actors do `from ...loss import compute_advantages_and_returns`, binding the
+    # function by value, so rebinding the source module is not enough.
+    for module_path in ("miles.backends.fsdp_utils.actor", "miles.backends.megatron_utils.actor"):
+        try:
+            module = importlib.import_module(module_path)
+        except Exception:  # megatron actor needs megatron installed
+            continue
+        if hasattr(module, "compute_advantages_and_returns"):
+            module.compute_advantages_and_returns = compute_advantages_and_returns
+
+    _RESPECT_DISABLE_ADV_PATCHED = True
+    logger.info("Patched miles compute_advantages_and_returns to respect --disable-compute-advantages-and-returns")
+
+
 def assert_cp_slice_contract() -> None:
     """Fail loudly if Miles moved the ground this patch stands on."""
     import inspect
@@ -94,3 +172,5 @@ def apply_all_miles_patches() -> None:
     """Entry point for both the driver and the train workers."""
     assert_cp_slice_contract()
     patch_advantages_cp_slice()
+    patch_package_shards_forwards_advantages()
+    patch_respect_disable_compute_advantages()

--- a/rllm/trainer/miles/patch.py
+++ b/rllm/trainer/miles/patch.py
@@ -183,17 +183,30 @@ def patch_respect_disable_compute_advantages() -> None:
     logger.info("Patched miles compute_advantages_and_returns to respect --disable-compute-advantages-and-returns")
 
 
+def drain_train_metrics() -> list[dict]:
+    """Return and clear this process's captured optimizer metrics.
+
+    Called on the train workers through ``actor.__ray_call__``, so the driver never has
+    to depend on the actor class being patched.
+    """
+    captured = [dict(d) for d in _TRAIN_METRICS]
+    del _TRAIN_METRICS[:]
+    return captured
+
+
 def patch_capture_train_metrics() -> None:
-    """Return Miles' optimizer metrics to the driver instead of only logging them.
+    """Make Miles' optimizer metrics readable from the driver.
 
     ``log_train_step`` builds ``train/loss``, ``train/grad_norm``, ``train/tis``, the
     learning rates and so on, returns the dict, and ``tracking.log``s it on rank 0 only.
     Nothing hands it back, so from rLLM's side the optimizer is invisible -- diagnosing
-    the attention bug meant grepping Miles' raw worker log for ``tis_abs``.
+    the attention bug meant grepping a worker log for ``tis_abs``.
 
-    ``RayTrainGroup.train`` already gathers a per-rank return list; on the FSDP path every
-    entry is ``None``. So: stash what ``log_train_step`` produced in the worker, and have
-    the actor's ``train`` drain it into its return value.
+    This only rebinds a module attribute (both callers import ``log_train_step`` by
+    value, so the holders are repointed too). It deliberately does *not* wrap the actor's
+    ``train``: that would mean patching a Ray actor class in the worker and depending on
+    patch-vs-import ordering. The driver instead pulls the buffer with ``__ray_call__``,
+    the same escape hatch used for ``train_parallel_config``.
 
     Upstream equivalent: have the actors return the accumulated log dict.
     """
@@ -203,47 +216,24 @@ def patch_capture_train_metrics() -> None:
 
     from miles.backends.training_utils import log_utils
 
-    original_log = log_utils.log_train_step
+    original = log_utils.log_train_step
 
     def log_train_step(*args, **kwargs):
-        out = original_log(*args, **kwargs)
+        out = original(*args, **kwargs)
         if isinstance(out, dict):
             _TRAIN_METRICS.append(dict(out))
         return out
 
     log_utils.log_train_step = log_train_step
     _rebind_everywhere("log_train_step", log_train_step)
-
-    for module_path, cls_name in (
-        ("miles.backends.fsdp_utils.actor", "FSDPTrainRayActor"),
-        ("miles.backends.megatron_utils.actor", "MegatronTrainRayActor"),
-    ):
-        try:
-            cls = getattr(importlib.import_module(module_path), cls_name)
-        except Exception:  # the megatron actor needs megatron installed
-            continue
-        if getattr(cls.train, "_rllm_wrapped", False):
-            continue
-        original_train = cls.train
-
-        def train(self, *args, _original=original_train, **kwargs):
-            del _TRAIN_METRICS[:]
-            result = _original(self, *args, **kwargs)
-            captured = [dict(d) for d in _TRAIN_METRICS]
-            del _TRAIN_METRICS[:]
-            # Only widen shapes we understand: None (FSDP) or a dict (megatron, which
-            # carries train_step_outcome and possibly critic values).
-            if result is None:
-                return {"miles_train_metrics": captured}
-            if isinstance(result, dict):
-                return {**result, "miles_train_metrics": captured}
-            return result
-
-        train._rllm_wrapped = True
-        cls.train = train
+    # megatron calls it from model.py, not actor.py
+    try:
+        importlib.import_module("miles.backends.megatron_utils.model").log_train_step = log_train_step
+    except Exception:
+        pass
 
     _TRAIN_METRICS_PATCHED = True
-    logger.info("Patched miles log_train_step + actor.train to return optimizer metrics")
+    logger.info("Patched miles log_train_step to capture optimizer metrics")
 
 
 def assert_patch_contracts() -> None:

--- a/rllm/trainer/miles/patch.py
+++ b/rllm/trainer/miles/patch.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 _ADVANTAGES_CP_SLICE_PATCHED = False
 _PACKAGE_SHARDS_PATCHED = False
 _RESPECT_DISABLE_ADV_PATCHED = False
+_TRAIN_METRICS_PATCHED = False
+
+# Filled in the *worker* by the patched log_train_step, drained by the patched
+# actor train() so the values ride the return channel back to the driver.
+_TRAIN_METRICS: list[dict] = []
 
 # The key tuple in miles/backends/training_utils/data.py:get_rollout_data that gets
 # CP-sliced per sample. Asserted so a Miles upgrade that renames or reorders these
@@ -178,6 +183,69 @@ def patch_respect_disable_compute_advantages() -> None:
     logger.info("Patched miles compute_advantages_and_returns to respect --disable-compute-advantages-and-returns")
 
 
+def patch_capture_train_metrics() -> None:
+    """Return Miles' optimizer metrics to the driver instead of only logging them.
+
+    ``log_train_step`` builds ``train/loss``, ``train/grad_norm``, ``train/tis``, the
+    learning rates and so on, returns the dict, and ``tracking.log``s it on rank 0 only.
+    Nothing hands it back, so from rLLM's side the optimizer is invisible -- diagnosing
+    the attention bug meant grepping Miles' raw worker log for ``tis_abs``.
+
+    ``RayTrainGroup.train`` already gathers a per-rank return list; on the FSDP path every
+    entry is ``None``. So: stash what ``log_train_step`` produced in the worker, and have
+    the actor's ``train`` drain it into its return value.
+
+    Upstream equivalent: have the actors return the accumulated log dict.
+    """
+    global _TRAIN_METRICS_PATCHED
+    if _TRAIN_METRICS_PATCHED:
+        return
+
+    from miles.backends.training_utils import log_utils
+
+    original_log = log_utils.log_train_step
+
+    def log_train_step(*args, **kwargs):
+        out = original_log(*args, **kwargs)
+        if isinstance(out, dict):
+            _TRAIN_METRICS.append(dict(out))
+        return out
+
+    log_utils.log_train_step = log_train_step
+    _rebind_everywhere("log_train_step", log_train_step)
+
+    for module_path, cls_name in (
+        ("miles.backends.fsdp_utils.actor", "FSDPTrainRayActor"),
+        ("miles.backends.megatron_utils.actor", "MegatronTrainRayActor"),
+    ):
+        try:
+            cls = getattr(importlib.import_module(module_path), cls_name)
+        except Exception:  # the megatron actor needs megatron installed
+            continue
+        if getattr(cls.train, "_rllm_wrapped", False):
+            continue
+        original_train = cls.train
+
+        def train(self, *args, _original=original_train, **kwargs):
+            del _TRAIN_METRICS[:]
+            result = _original(self, *args, **kwargs)
+            captured = [dict(d) for d in _TRAIN_METRICS]
+            del _TRAIN_METRICS[:]
+            # Only widen shapes we understand: None (FSDP) or a dict (megatron, which
+            # carries train_step_outcome and possibly critic values).
+            if result is None:
+                return {"miles_train_metrics": captured}
+            if isinstance(result, dict):
+                return {**result, "miles_train_metrics": captured}
+            return result
+
+        train._rllm_wrapped = True
+        cls.train = train
+
+    _TRAIN_METRICS_PATCHED = True
+    logger.info("Patched miles log_train_step + actor.train to return optimizer metrics")
+
+
 def assert_patch_contracts() -> None:
     """Fail loudly if Miles moved the ground any of these patches stands on.
 
@@ -221,3 +289,4 @@ def apply_all_miles_patches() -> None:
     patch_advantages_cp_slice()
     patch_package_shards_forwards_advantages()
     patch_respect_disable_compute_advantages()
+    patch_capture_train_metrics()

--- a/rllm/trainer/miles/transform.py
+++ b/rllm/trainer/miles/transform.py
@@ -1,0 +1,208 @@
+"""rLLM episodes -> Miles training samples.
+
+Ported from ``rllm/trainer/tinker/transform.py``, minus the right-shift: Miles
+consumes the raw ``tokens`` sequence and applies its own logits/token offset
+internally, so we hand it flat tokens plus three response-aligned arrays.
+
+A merged multi-turn sequence looks like ``[O1, A1, O2, A2, ...]``. Miles models a
+sample as prompt + response with ``loss_mask`` over the response only, so the
+prompt is ``O1`` and the response is everything after it, with the mask zeroed on
+the intermediate observations.
+
+The three response arrays must each be exactly ``response_length`` long:
+``convert_samples_to_train_data`` asserts it for ``loss_mask``, and
+``slice_log_prob_with_cp`` asserts it for the per-token float arrays.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from rllm.trainer.algorithms.step_merge import is_prefix, partition_steps_by_lineage
+from rllm.types import Trajectory, TrajectoryGroup
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SamplePayload:
+    """One Miles ``Sample`` worth of data, without importing miles.
+
+    Keeping this backend-SDK-free is what lets the token math be unit-tested off
+    the Miles image.
+    """
+
+    tokens: list[int]
+    prompt_length: int
+    loss_mask: list[int]
+    rollout_log_probs: list[float]
+    advantages: list[float]
+    reward: float = 0.0
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def response_length(self) -> int:
+        return len(self.tokens) - self.prompt_length
+
+    def validate(self) -> None:
+        n = self.response_length
+        if n < 0:
+            raise ValueError(f"prompt_length {self.prompt_length} exceeds token count {len(self.tokens)}")
+        for name, arr in (
+            ("loss_mask", self.loss_mask),
+            ("rollout_log_probs", self.rollout_log_probs),
+            ("advantages", self.advantages),
+        ):
+            if len(arr) != n:
+                raise ValueError(f"{name} has length {len(arr)}, expected response_length {n}")
+
+
+def _step_tokens(step, which: str) -> list[int]:
+    ids = getattr(step, which) or []
+    if not all(isinstance(t, int) for t in ids):
+        raise TypeError(f"Miles backend needs flat integer {which}; got a chunked/multimodal token input. Multimodal rollouts are not supported on this backend yet.")
+    return list(ids)
+
+
+def _step_advantages(step, n_response: int) -> list[float]:
+    if step.advantage is None:
+        raise ValueError("step.advantage is None — compute advantages before transforming.")
+    if isinstance(step.advantage, list):
+        if len(step.advantage) != n_response:
+            raise ValueError(f"per-token advantage has length {len(step.advantage)}, expected {n_response}")
+        return [float(a) for a in step.advantage]
+    return [float(step.advantage)] * n_response
+
+
+@dataclass
+class _Chain:
+    """One merge chain being accumulated: a prompt, then interleaved action/observation tokens."""
+
+    tokens: list[int] = field(default_factory=list)
+    mask: list[int] = field(default_factory=list)
+    logprobs: list[float] = field(default_factory=list)
+    advantages: list[float] = field(default_factory=list)
+    prompt_length: int = 0
+
+    @property
+    def trainable(self) -> bool:
+        """False for a chain that never produced a response token (nothing to learn from)."""
+        return self.prompt_length < len(self.tokens)
+
+    def add_turn(self, delta: list[int], response: list[int], logprobs: list[float], advantages: list[float]) -> None:
+        """Append an observation delta (masked out) followed by an action (masked in)."""
+        pad = [0] * len(delta)
+        self.tokens.extend(delta + response)
+        self.mask.extend(pad + [1] * len(response))
+        self.logprobs.extend([0.0] * len(delta) + logprobs)
+        self.advantages.extend([0.0] * len(delta) + advantages)
+
+    def to_payload(self, reward: float, metadata: dict) -> SamplePayload:
+        cut = self.prompt_length
+        payload = SamplePayload(
+            tokens=list(self.tokens),
+            prompt_length=cut,
+            loss_mask=self.mask[cut:],
+            rollout_log_probs=self.logprobs[cut:],
+            advantages=self.advantages[cut:],
+            reward=reward,
+            metadata=metadata,
+        )
+        payload.validate()
+        return payload
+
+
+def trajectory_to_payloads(traj: Trajectory) -> list[SamplePayload]:
+    """Merge a trajectory's steps into as few sequences as possible.
+
+    Steps are partitioned by gateway lineage first, then each lineage is walked: a
+    step whose prompt extends the accumulated sequence continues the chain, anything
+    else closes it and starts a new one.
+    """
+    payloads: list[SamplePayload] = []
+    reward = traj.reward or 0.0
+    metadata = dict(traj.metadata or {})
+
+    for lineage_steps in partition_steps_by_lineage(traj.steps):
+        chain = _Chain()
+
+        for step in lineage_steps:
+            prompt = _step_tokens(step, "prompt_ids")
+            response = _step_tokens(step, "response_ids")
+            step_logprobs = [float(x) for x in (step.logprobs or [])]
+            if len(step_logprobs) != len(response):
+                raise ValueError(f"step has {len(response)} response tokens but {len(step_logprobs)} logprobs")
+            step_advantages = _step_advantages(step, len(response))
+
+            if not chain.tokens:
+                delta = prompt
+                chain.prompt_length = len(prompt)
+            elif is_prefix(chain.tokens, prompt):
+                delta = prompt[len(chain.tokens) :]
+            else:
+                if chain.trainable:
+                    payloads.append(chain.to_payload(reward, metadata))
+                chain = _Chain(prompt_length=len(prompt))
+                delta = prompt
+
+            chain.add_turn(delta, response, step_logprobs, step_advantages)
+
+        if chain.trainable:
+            payloads.append(chain.to_payload(reward, metadata))
+
+    return payloads
+
+
+def trajectory_groups_to_payloads(groups: list[TrajectoryGroup]) -> list[list[SamplePayload]]:
+    """One inner list per group, so GRPO grouping survives into ``Sample.group_index``."""
+    out: list[list[SamplePayload]] = []
+    for group in groups:
+        group_payloads: list[SamplePayload] = []
+        for traj in group.trajectories:
+            group_payloads.extend(trajectory_to_payloads(traj))
+        if group_payloads:
+            out.append(group_payloads)
+        else:
+            logger.warning("trajectory group %s produced no trainable samples; dropping", group.group_id)
+    return out
+
+
+def payloads_to_samples(grouped: list[list[SamplePayload]]) -> tuple[list, list[list[float]]]:
+    """Build Miles ``Sample`` objects plus the parallel per-token advantage arrays.
+
+    Advantages are returned separately rather than stuffed into ``Sample.metadata``:
+    they have to land as a top-level ``rollout_data["advantages"]`` key so Miles'
+    ``get_rollout_data`` CP-slices them alongside ``rollout_log_probs``. The two
+    lists are index-aligned, and ``convert_samples_to_train_data`` preserves sample
+    order, so the caller can attach them after conversion.
+
+    ``index`` / ``group_index`` are set because ``convert_samples_to_train_data``
+    still uses them for grouping and metrics even though we supply advantages.
+
+    Imports miles, so this needs the Miles image.
+    """
+    from miles.utils.types import Sample
+
+    samples: list[Sample] = []
+    advantages: list[list[float]] = []
+    index = 0
+    for group_index, group in enumerate(grouped):
+        for payload in group:
+            payload.validate()
+            samples.append(
+                Sample(
+                    group_index=group_index,
+                    index=index,
+                    tokens=payload.tokens,
+                    response_length=payload.response_length,
+                    loss_mask=payload.loss_mask,
+                    rollout_log_probs=payload.rollout_log_probs,
+                    reward=payload.reward,
+                    status=Sample.Status.COMPLETED,
+                    metadata=dict(payload.metadata),
+                )
+            )
+            advantages.append(payload.advantages)
+            index += 1
+    return samples, advantages

--- a/rllm/trainer/miles/utils.py
+++ b/rllm/trainer/miles/utils.py
@@ -1,0 +1,24 @@
+"""Helpers for the MilesBackend, mirroring verl's and tinker's config-sync structure."""
+
+from __future__ import annotations
+
+from omegaconf import DictConfig
+
+from rllm.trainer.algorithms.config import sync_shared_keys
+
+# (miles_native_path, rllm_path) -- kept in parity by sync_config.
+#
+# Note this is the *top-level mirror* table, not the Miles CLI mapping: flags that
+# reach Miles' argv live in miles_config.SHARED_KEYS. These are the keys the rest of
+# rLLM reads off the top level for the miles backend, the same way tinker does.
+_SHARED_KEYS: list[tuple[str, str]] = [
+    ("data.train_batch_size", "rllm.data.train_batch_size"),
+    ("data.val_batch_size", "rllm.data.val_batch_size"),
+    ("data.max_prompt_length", "rllm.data.max_prompt_length"),
+    ("data.max_response_length", "rllm.data.max_response_length"),
+]
+
+
+def sync_config(config: DictConfig, hydra_overrides: list[str] | None = None) -> None:
+    """Mirror rllm.* into the top-level namespace over the shared-keys table."""
+    sync_shared_keys(config, _SHARED_KEYS, hydra_overrides=hydra_overrides)

--- a/rllm/trainer/ray_init_utils.py
+++ b/rllm/trainer/ray_init_utils.py
@@ -14,6 +14,63 @@ import os
 from pathlib import Path
 from typing import Any
 
+FORWARD_PREFIXES = [
+    "VLLM_",
+    "SGL_",
+    "SGLANG_",
+    "HF_",
+    "TOKENIZERS_",
+    "DATASETS_",
+    "TORCH_",
+    "PYTORCH_",
+    "DEEPSPEED_",
+    "MEGATRON_",
+    "NCCL_",
+    "CUDA_",
+    "CUBLAS_",
+    "CUDNN_",
+    "NV_",
+    "NVIDIA_",
+    "RLLM_",
+]
+
+
+def get_forwarded_env_vars():
+    """
+    Get the forwarded environment variables. The `RLLM_EXCLUDE` environment variable can be used to
+    exclude specific environment variables or all variables with a specific prefix.
+
+    Example:
+    ```
+    RLLM_EXCLUDE=VLLM*,CUDA*,NCCL_IB_DISABLE
+    ```
+    will exclude all variables with prefix `VLLM_`, `CUDA_`, and `NCCL_IB_DISABLE`.
+
+    By default, all environment variables with prefix in `FORWARD_PREFIXES` are forwarded.
+    """
+    if os.environ.get("RLLM_EXCLUDE", None) is not None:
+        rllm_exclude = str(os.environ.get("RLLM_EXCLUDE")).split(",")
+    else:
+        rllm_exclude = []
+
+    forward_prefix = FORWARD_PREFIXES.copy()
+
+    # RLLM_EXCLUDE is a control var read on the launching node; it matches the
+    # RLLM_ prefix but must never be forwarded into workers.
+    exclude_vars = {"RLLM_EXCLUDE"}
+    for name in rllm_exclude:
+        if "*" in name:  # denote a prefix match, e.g. "VLLM*"
+            prefix = name.replace("*", "_")
+            try:
+                forward_prefix.remove(prefix)
+            except ValueError:
+                pass
+        else:
+            exclude_vars.add(name)
+
+    forwarded = {k: v for k, v in os.environ.items() if any(k.startswith(p) for p in forward_prefix) and k not in exclude_vars}
+    return forwarded
+
 
 def _ray_current_cluster_path() -> Path:
     # Default location Ray uses to store the current cluster address.

--- a/rllm/trainer/ray_init_utils.py
+++ b/rllm/trainer/ray_init_utils.py
@@ -23,6 +23,9 @@ FORWARD_PREFIXES = [
     "DATASETS_",
     "TORCH_",
     "PYTORCH_",
+    # Triton's compile cache must be a fresh tmpfs dir per run or concurrent
+    # ranks race on it; TRITON_CACHE_DIR only helps if workers actually see it.
+    "TRITON_",
     "DEEPSPEED_",
     "MEGATRON_",
     "NCCL_",

--- a/rllm/trainer/tinker/transform.py
+++ b/rllm/trainer/tinker/transform.py
@@ -14,16 +14,11 @@ from tinker_cookbook.supervised.common import create_rightshifted_model_input_an
 from rllm.engine.rollout.tinker_engine import _flat_token_input_length, _flat_token_input_to_model_input
 from rllm.engine.rollout.types import TinkerTokenInput
 from rllm.trainer.algorithms import AlgorithmConfig, collect_reward_and_advantage_from_trajectory_groups
+from rllm.trainer.algorithms.step_merge import is_prefix as _is_prefix
+from rllm.trainer.algorithms.step_merge import partition_steps_by_lineage as _partition_steps_by_lineage
 from rllm.types import Trajectory, TrajectoryGroup
 
 logger = logging.getLogger(__name__)
-
-
-def _is_prefix(seq1: TinkerTokenInput, seq2: TinkerTokenInput) -> bool:
-    """
-    Check if seq1 is a prefix of seq2.
-    """
-    return len(seq1) <= len(seq2) and seq2[: len(seq1)] == seq1
 
 
 def _flatten_token_input(token_input: TinkerTokenInput) -> TinkerTokenInput:
@@ -56,23 +51,6 @@ def _trajectory_oov_token(traj: Trajectory, vocab_size: int) -> int | None:
             if isinstance(elem, int) and elem >= vocab_size:
                 return elem
     return None
-
-
-def _partition_steps_by_lineage(steps: list) -> list[list]:
-    """Group steps by gateway ``lineage_id`` (``step.metadata``), first-appearance
-    order. Steps of one lineage stay together even when interleaved in time with
-    other lineages. Untagged steps (no ``lineage_id`` — cumulative mode off, or
-    eval) share the ``None`` key → a single partition, i.e. the original behavior.
-    """
-    groups: dict = {}
-    order: list = []
-    for step in steps:
-        lid = (step.metadata or {}).get("lineage_id")
-        if lid not in groups:
-            groups[lid] = []
-            order.append(lid)
-        groups[lid].append(step)
-    return [groups[lid] for lid in order]
 
 
 def trajectory_to_datums(traj: Trajectory, router_replay: bool = False) -> list[tinker.Datum]:

--- a/rllm/trainer/unified_trainer.py
+++ b/rllm/trainer/unified_trainer.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import logging
 import time
 import uuid
@@ -1054,6 +1055,27 @@ class TrainerLauncher(ABC):
         raise NotImplementedError("Train method of the trainer launcher is not implemented")
 
 
+# backend -> (launcher module, launcher class, pip extra that provides it).
+# Every launcher takes the same constructor signature, so dispatch is a table lookup.
+_BACKEND_LAUNCHERS: dict[str, tuple[str, str, str]] = {
+    "verl": ("rllm.trainer.verl.verl_launcher", "VerlTrainerLauncher", "verl"),
+    "tinker": ("rllm.trainer.tinker.tinker_launcher", "TinkerTrainerLauncher", "tinker"),
+    "fireworks": ("rllm.trainer.fireworks.fireworks_launcher", "FireworksTrainerLauncher", "fireworks"),
+    "miles": ("rllm.trainer.miles.miles_launcher", "MilesTrainerLauncher", "miles"),
+}
+
+
+def _resolve_launcher_cls(backend: str) -> type:
+    """Import a backend's launcher, turning a missing backend dep into an install hint."""
+    if backend not in _BACKEND_LAUNCHERS:
+        raise ValueError(f"Unsupported backend: {backend!r}; expected one of {', '.join(_BACKEND_LAUNCHERS)}")
+    module_path, cls_name, extra = _BACKEND_LAUNCHERS[backend]
+    try:
+        return getattr(importlib.import_module(module_path), cls_name)
+    except ImportError as e:
+        raise ImportError(f"Backend {backend!r} is missing dependencies ({e}).\n  Install with: pip install 'rllm[{extra}]'") from e
+
+
 class AgentTrainer:
     """
     A unified agent trainer launcher that directly interfaces with the user script to launch training jobs.
@@ -1084,7 +1106,7 @@ class AgentTrainer:
         train_dataset: Dataset | None = None,
         val_dataset: Dataset | None = None,
         workflow_args: dict | None = None,
-        backend: Literal["verl", "tinker", "fireworks"] = "verl",
+        backend: Literal["verl", "tinker", "fireworks", "miles"] = "verl",
         agent_flow: Any = None,
         evaluator: Any = None,
         hooks: Any = None,
@@ -1146,44 +1168,16 @@ class AgentTrainer:
             kwargs["hooks"] = hooks
         kwargs["backend_name"] = backend
 
-        if backend == "verl":
-            from rllm.trainer.verl.verl_launcher import VerlTrainerLauncher
-
-            self.launcher = VerlTrainerLauncher(
-                config=config,
-                workflow_class=workflow_class,
-                train_dataset=train_dataset,
-                val_dataset=val_dataset,
-                workflow_args=workflow_args,
-                store=store,
-                **kwargs,
-            )
-        elif backend == "tinker":
-            from rllm.trainer.tinker.tinker_launcher import TinkerTrainerLauncher
-
-            self.launcher = TinkerTrainerLauncher(
-                config=config,
-                workflow_class=workflow_class,
-                train_dataset=train_dataset,
-                val_dataset=val_dataset,
-                workflow_args=workflow_args,
-                store=store,
-                **kwargs,
-            )
-        elif backend == "fireworks":
-            from rllm.trainer.fireworks.fireworks_launcher import FireworksTrainerLauncher
-
-            self.launcher = FireworksTrainerLauncher(
-                config=config,
-                workflow_class=workflow_class,
-                train_dataset=train_dataset,
-                val_dataset=val_dataset,
-                workflow_args=workflow_args,
-                store=store,
-                **kwargs,
-            )
-        else:
-            raise ValueError(f"Unsupported backend: {backend}")
+        launcher_cls = _resolve_launcher_cls(backend)
+        self.launcher = launcher_cls(
+            config=config,
+            workflow_class=workflow_class,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            workflow_args=workflow_args,
+            store=store,
+            **kwargs,
+        )
 
     def train(self):
         self.launcher.train()

--- a/rllm/trainer/verl/ray_runtime_env.py
+++ b/rllm/trainer/verl/ray_runtime_env.py
@@ -3,6 +3,8 @@ import os
 
 from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
 
+from rllm.trainer.ray_init_utils import FORWARD_PREFIXES, get_forwarded_env_vars  # noqa: F401  (re-exported)
+
 PPO_RAY_RUNTIME_ENV = {
     "env_vars": {
         "TOKENIZERS_PARALLELISM": "true",
@@ -21,63 +23,6 @@ PPO_RAY_RUNTIME_ENV = {
     },
 }
 
-FORWARD_PREFIXES = [
-    "VLLM_",
-    "SGL_",
-    "SGLANG_",
-    "HF_",
-    "TOKENIZERS_",
-    "DATASETS_",
-    "TORCH_",
-    "PYTORCH_",
-    "DEEPSPEED_",
-    "MEGATRON_",
-    "NCCL_",
-    "CUDA_",
-    "CUBLAS_",
-    "CUDNN_",
-    "NV_",
-    "NVIDIA_",
-    "RLLM_",
-]
-
-
-def _get_forwarded_env_vars():
-    """
-    Get the forwarded environment variables. The `RLLM_EXCLUDE` environment variable can be used to
-    exclude specific environment variables or all variables with a specific prefix.
-
-    Example:
-    ```
-    RLLM_EXCLUDE=VLLM*,CUDA*,NCCL_IB_DISABLE
-    ```
-    will exclude all variables with prefix `VLLM_`, `CUDA_`, and `NCCL_IB_DISABLE`.
-
-    By default, all environment variables with prefix in `FORWARD_PREFIXES` are forwarded.
-    """
-    if os.environ.get("RLLM_EXCLUDE", None) is not None:
-        rllm_exclude = str(os.environ.get("RLLM_EXCLUDE")).split(",")
-    else:
-        rllm_exclude = []
-
-    forward_prefix = FORWARD_PREFIXES.copy()
-
-    # RLLM_EXCLUDE is a control var read on the launching node; it matches the
-    # RLLM_ prefix but must never be forwarded into workers.
-    exclude_vars = {"RLLM_EXCLUDE"}
-    for name in rllm_exclude:
-        if "*" in name:  # denote a prefix match, e.g. "VLLM*"
-            prefix = name.replace("*", "_")
-            try:
-                forward_prefix.remove(prefix)
-            except ValueError:
-                pass
-        else:
-            exclude_vars.add(name)
-
-    forwarded = {k: v for k, v in os.environ.items() if any(k.startswith(p) for p in forward_prefix) and k not in exclude_vars}
-    return forwarded
-
 
 def get_ppo_ray_runtime_env():
     """Build the runtime_env to pass to ray.init().
@@ -93,7 +38,7 @@ def get_ppo_ray_runtime_env():
     the job config's value wins.
     """
     env = PPO_RAY_RUNTIME_ENV.get("env_vars", {}).copy()
-    env.update(_get_forwarded_env_vars())
+    env.update(get_forwarded_env_vars())
 
     # Parse the job-submission runtime_env (if launched via `ray job submit`)
     try:

--- a/scripts/setup_miles_env.sh
+++ b/scripts/setup_miles_env.sh
@@ -59,6 +59,16 @@ uv pip uninstall --python "$PY" -q sgl-deep-gemm 2>/dev/null || true
 echo "==> megatron-core (the FSDP path uses Megatron's fused cross-entropy) + ninja"
 uv pip install --python "$PY" -q megatron-core ninja
 
+echo "==> flash-attn (required, not optional: see below) -- source build, ~20-40 min"
+# Miles' FSDP path packs samples into one row with attention_mask=None and derives
+# cu_seqlens from packed position_ids. Only a varlen-capable attention kernel honours
+# those boundaries; sdpa/eager silently let samples attend across each other, which
+# corrupts the logprobs and shows up as a huge train/inference gap. Miles' image ships a
+# prebuilt wheel; from source this compiles.
+if ! "$PY" -c "import flash_attn" 2>/dev/null; then
+    MAX_JOBS="${MAX_JOBS:-16}" uv pip install --python "$PY" --no-build-isolation flash-attn
+fi
+
 echo "==> rLLM (editable)"
 uv pip install --python "$PY" -q -e "$RLLM"
 

--- a/scripts/setup_miles_env.sh
+++ b/scripts/setup_miles_env.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Build a venv that can run the rLLM miles backend, without Miles' container image.
+#
+#   bash scripts/setup_miles_env.sh [VENV_DIR] [MILES_DIR] [SGLANG_DIR]
+#
+# Defaults put everything under ~/miles-env. Idempotent: re-running skips finished steps.
+# Validated 2026-08-22 on 8xH100, driver CUDA 12.8, glibc 2.35.
+set -euo pipefail
+
+VENV="${1:-$HOME/miles-env/venv}"
+MILES="${2:-$HOME/miles}"
+SGLANG="${3:-$HOME/miles-env/sglang-miles}"
+RLLM="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Pin these. Both are branch checkouts with no release tags, so an unpinned setup can
+# silently change weight-update or generation behaviour between runs.
+SGLANG_BRANCH=sglang-miles
+TORCH_VERSION=2.11.0          # whatever sglang pins; only the CUDA build differs
+TORCH_CUDA=cu128              # must match the *driver's* CUDA, not the newest available
+KERNEL_CUDA=cu129             # sglang-kernel index; cu13 wheels need driver >= 580
+
+command -v uv >/dev/null || { echo "need uv on PATH"; exit 1; }
+[ -d "$MILES" ] || { echo "no Miles checkout at $MILES -- git clone https://github.com/radixark/miles.git"; exit 1; }
+
+echo "==> venv at $VENV"
+[ -d "$VENV" ] || uv venv --python 3.12 "$VENV"
+PY="$VENV/bin/python"
+
+echo "==> miles requirements"
+# nvidia-resiliency-ext ships only manylinux_2_39 wheels (glibc 2.39 / Ubuntu 24.04) with
+# no sdist, so it cannot install on older glibc. Fault tolerance only; dropping it means
+# --use-fault-tolerance is unavailable.
+grep -v '^nvidia-resiliency-ext' "$MILES/requirements.txt" > /tmp/miles-reqs-$$.txt
+uv pip install --python "$PY" -q --prerelease=allow -r /tmp/miles-reqs-$$.txt
+rm -f /tmp/miles-reqs-$$.txt
+
+echo "==> miles (editable, no deps)"
+uv pip install --python "$PY" -q --no-deps -e "$MILES"
+
+echo "==> sglang: the miles fork, not PyPI"
+# Stock sglang serves generation but has no /begin_weight_update, so weight sync 404s.
+[ -d "$SGLANG/.git" ] || git clone --depth 1 --branch "$SGLANG_BRANCH" --single-branch \
+    https://github.com/sgl-project/sglang.git "$SGLANG"
+# --no-build-isolation: the isolated build env tries to compile a Rust dependency.
+uv pip install --python "$PY" -q --no-deps --no-build-isolation -e "$SGLANG/python"
+
+echo "==> torch/vision/audio for the driver's CUDA ($TORCH_CUDA)"
+uv pip install --python "$PY" -q \
+    --reinstall-package torch --reinstall-package torchvision --reinstall-package torchaudio \
+    --index-url "https://download.pytorch.org/whl/$TORCH_CUDA" \
+    "torch==$TORCH_VERSION" torchvision torchaudio
+
+echo "==> sglang compiled kernels for $KERNEL_CUDA"
+uv pip install --python "$PY" -q --reinstall-package sglang-kernel \
+    --index-url "https://docs.sglang.ai/whl/$KERNEL_CUDA/" sglang-kernel
+# cu13-only, and DeepGEMM needs SM100+ anyway; its presence breaks sglang's import.
+uv pip uninstall --python "$PY" -q sgl-deep-gemm 2>/dev/null || true
+
+echo "==> megatron-core (the FSDP path uses Megatron's fused cross-entropy) + ninja"
+uv pip install --python "$PY" -q megatron-core ninja
+
+echo "==> rLLM (editable)"
+uv pip install --python "$PY" -q -e "$RLLM"
+
+echo
+echo "==> verifying"
+"$PY" - <<'CHECK'
+import importlib, torch
+for m in ("miles.utils.types", "miles.utils.arguments",
+          "miles.ray.rollout.train_data_conversion",
+          "miles.backends.training_utils.data", "miles.ray.placement_group",
+          "sglang.srt.server_args", "sgl_kernel", "megatron.core", "rllm"):
+    importlib.import_module(m)
+    print(f"  ok  {m}")
+assert torch.cuda.is_available(), (
+    f"torch {torch.__version__} cannot see the GPUs: its CUDA build must match the driver "
+    "(nvidia-smi 'CUDA Version'), and cu13 wheels need driver >= 580"
+)
+print(f"  ok  torch {torch.__version__}, {torch.cuda.device_count()} GPUs")
+CHECK
+echo
+echo "Done. Run training with:"
+echo "  PYTHON=$PY bash examples/countdown/unified_trainer/train_countdown_unified_miles.sh"

--- a/tests/test_gateway_capture_flags.py
+++ b/tests/test_gateway_capture_flags.py
@@ -43,3 +43,69 @@ class TestCaptureFlagsCannotBeDisabledByTheClient:
         p = {"logprobs": False}
         _mw(add_logprobs=False, add_return_token_ids=False)._mutate(p)
         assert p["logprobs"] is False and "return_token_ids" not in p
+
+
+class TestWorkerFlavorCrossesProcessBoundary:
+    """The subprocess gateway defaults to worker_flavor="vllm", so the flavor has to be
+    on its command line. It was not, which meant an SGLang run injected vLLM's
+    return_token_ids, captured no token IDs, and only failed later in Step validation
+    with "length mismatch between response_ids and logprobs, got 0, N".
+    """
+
+    def _manager(self, engine_cls_name):
+        from rllm.gateway.manager import GatewayManager
+
+        gw = GatewayManager.__new__(GatewayManager)
+        gw.port = 9451
+        gw.store = "memory"
+        gw.db_path = None
+        gw.model = "Qwen/Qwen3-1.7B"
+        gw.cumulative_token_mode = False
+        gw.renderer_family = "auto"
+        gw.worker_flavor = "sglang" if engine_cls_name == "MilesEngine" else "vllm"
+        return gw
+
+    def test_sglang_flavor_is_on_the_subprocess_command(self):
+        cmd = self._manager("MilesEngine")._gateway_cmd(9451)
+        assert "--worker-flavor" in cmd
+        assert cmd[cmd.index("--worker-flavor") + 1] == "sglang"
+
+    def test_vllm_flavor_is_on_the_subprocess_command(self):
+        cmd = self._manager("VerlEngine")._gateway_cmd(9451)
+        assert cmd[cmd.index("--worker-flavor") + 1] == "vllm"
+
+    def test_cli_parses_worker_flavor_into_the_config(self):
+        """Closes the loop: the flag manager emits must survive arg parsing."""
+        import argparse
+
+        from rllm_model_gateway.server import _load_config
+
+        args = argparse.Namespace(
+            config=None, host=None, port=None, db_path=None, log_level=None,
+            store=None, model=None, worker_flavor="sglang",
+            cumulative_token_mode=False, renderer_family=None,
+        )
+        assert _load_config(args).worker_flavor == "sglang"
+
+
+class TestSglangFlagsMatchMiles:
+    def test_no_stop_trim_not_skip_special_tokens(self):
+        """miles.rollout.session.core sets no_stop_trim=False and never touches
+        skip_special_tokens; sending the latter left special tokens in the agent's text.
+        """
+        from rllm_model_gateway.middleware import SessionRoutingMiddleware
+
+        mw = SessionRoutingMiddleware.__new__(SessionRoutingMiddleware)
+        mw.add_logprobs = True
+        mw.add_return_token_ids = True
+        mw.worker_flavor = "sglang"
+        mw.model = None
+        mw.sessions = None
+
+        payload = {"messages": []}
+        mw._mutate(payload)
+        assert payload["return_meta_info"] is True
+        assert payload["return_prompt_token_ids"] is True
+        assert payload["no_stop_trim"] is False
+        assert "skip_special_tokens" not in payload
+        assert "return_token_ids" not in payload

--- a/tests/test_gateway_capture_flags.py
+++ b/tests/test_gateway_capture_flags.py
@@ -1,0 +1,45 @@
+"""The gateway must not let an agent disable its own trace capture.
+
+Injection used to be `if "logprobs" not in payload`, so an agent sending
+`logprobs: false` kept that value and the resulting trace had no per-token logprobs --
+silently, and on every backend.
+"""
+
+from rllm_model_gateway.middleware import SessionRoutingMiddleware
+
+
+def _mw(**kw):
+    return SessionRoutingMiddleware(app=None, **kw)
+
+
+class TestCaptureFlagsCannotBeDisabledByTheClient:
+    def test_absent_logprobs_is_injected(self):
+        p = {}
+        _mw()._mutate(p)
+        assert p["logprobs"] is True
+
+    def test_client_false_is_overridden(self):
+        p = {"logprobs": False}
+        _mw()._mutate(p)
+        assert p["logprobs"] is True, "an agent could otherwise destroy its own training data"
+
+    def test_client_zero_is_overridden(self):
+        p = {"logprobs": 0}
+        _mw()._mutate(p)
+        assert p["logprobs"] is True
+
+    def test_client_asking_for_more_is_left_alone(self):
+        # completions-style int: honour it rather than downgrading to True
+        p = {"logprobs": 5}
+        _mw()._mutate(p)
+        assert p["logprobs"] == 5
+
+    def test_return_token_ids_gets_the_same_treatment(self):
+        p = {"return_token_ids": False}
+        _mw()._mutate(p)
+        assert p["return_token_ids"] is True
+
+    def test_injection_can_still_be_turned_off_wholesale(self):
+        p = {"logprobs": False}
+        _mw(add_logprobs=False, add_return_token_ids=False)._mutate(p)
+        assert p["logprobs"] is False and "return_token_ids" not in p

--- a/tests/test_miles_against_checkout.py
+++ b/tests/test_miles_against_checkout.py
@@ -1,0 +1,254 @@
+"""Miles backend checks that need a real Miles checkout or install.
+
+Skipped when neither is present, so the suite still runs on a plain rLLM env.
+Point ``MILES_ROOT`` at a Miles checkout (default ``~/miles``) to enable the
+source audit; the conversion test additionally needs ``miles`` importable, which
+means ``ray`` and a Miles checkout on ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+MILES_ROOT = Path(os.environ.get("MILES_ROOT", Path.home() / "miles"))
+
+needs_checkout = pytest.mark.skipif(
+    not (MILES_ROOT / "miles" / "utils" / "arguments.py").exists(),
+    reason=f"no Miles checkout at {MILES_ROOT} (set MILES_ROOT)",
+)
+
+
+def _miles_importable() -> bool:
+    if importlib.util.find_spec("miles") is not None:
+        return True
+    if not (MILES_ROOT / "miles" / "__init__.py").exists():
+        return False
+    import sys
+
+    if str(MILES_ROOT) not in sys.path:
+        sys.path.insert(0, str(MILES_ROOT))
+    try:
+        importlib.import_module("miles.ray.rollout.train_data_conversion")
+        return True
+    except Exception:
+        return False
+
+
+needs_miles = pytest.mark.skipif(not _miles_importable(), reason="miles not importable (needs ray + a Miles checkout)")
+
+
+def _miles_arguments_importable() -> bool:
+    """miles.utils.arguments additionally needs sglang (ServerArgs.add_cli_args)."""
+    if not _miles_importable():
+        return False
+    try:
+        importlib.import_module("miles.utils.arguments")
+        return True
+    except Exception:
+        return False
+
+
+needs_miles_arguments = pytest.mark.skipif(not _miles_arguments_importable(), reason="miles.utils.arguments not importable (needs sglang)")
+
+
+def _rendered_argv_block():
+    from omegaconf import OmegaConf
+
+    import rllm.trainer.config as cfg_pkg
+    from rllm.trainer.miles.miles_config import build_block
+
+    cfg = OmegaConf.load(Path(cfg_pkg.__file__).parent / "rllm" / "backend" / "miles.yaml")
+    for path, value in [
+        ("training.group_size", 8),
+        ("rllm.data.train_batch_size", 16),
+        ("rllm.data.max_prompt_length", 4096),
+        ("rllm.trainer.save_freq", 20),
+        ("rllm.trainer.test_freq", 5),
+        ("rllm.trainer.project_name", "rllm-miles-test"),
+        ("rllm.trainer.experiment_name", "t"),
+    ]:
+        OmegaConf.update(cfg, path, value)
+    return build_block(cfg, total_steps=50)
+
+
+@needs_checkout
+class TestFlagSurfaceMatchesMiles:
+    """Catches flag renames/removals in Miles without needing to import it."""
+
+    def test_every_emitted_flag_exists_in_miles(self):
+        from rllm.trainer.miles._flag_audit import flag_arity_from_source
+
+        flags = flag_arity_from_source(MILES_ROOT)
+        assert len(flags) > 200, f"only found {len(flags)} flags; the audit probably failed to parse"
+
+        block, _ = _rendered_argv_block()
+        unknown = sorted(k for k, v in block.items() if v is not None and k not in flags)
+        assert not unknown, f"flags the bridge emits that Miles does not define: {unknown}"
+
+    def test_assumed_arity_matches_miles(self):
+        from rllm.trainer.miles._flag_audit import flag_arity_from_source
+        from rllm.trainer.miles.miles_config import _infer_arity
+
+        flags = flag_arity_from_source(MILES_ROOT)
+        block, _ = _rendered_argv_block()
+        mismatched = {key: (_infer_arity(value), flags[key]) for key, value in block.items() if value is not None and key in flags and _infer_arity(value) != flags[key]}
+        assert not mismatched, f"arity disagreements (assumed, actual): {mismatched}"
+
+    def test_pinned_flags_all_exist(self):
+        from rllm.trainer.miles._flag_audit import flag_arity_from_source
+        from rllm.trainer.miles.miles_config import PINNED_FLAGS
+
+        flags = flag_arity_from_source(MILES_ROOT)
+        missing = sorted(f for f in PINNED_FLAGS if f not in flags)
+        assert not missing, f"pinned flags missing from Miles: {missing}"
+
+
+@needs_miles
+class TestSamplesFeedMilesConverter:
+    """The transform's output must satisfy Miles' own converter and its assertions."""
+
+    def _train_data(self):
+        from miles.ray.rollout.train_data_conversion import convert_samples_to_train_data
+
+        from rllm.trainer.miles.transform import payloads_to_samples, trajectory_groups_to_payloads
+        from rllm.types import Step, Trajectory, TrajectoryGroup
+
+        def step(prompt, response, advantage):
+            return Step(prompt_ids=list(prompt), response_ids=list(response), logprobs=[-0.5] * len(response), advantage=advantage)
+
+        groups = [
+            TrajectoryGroup(
+                group_id="p0:agent",
+                trajectories=[
+                    # merged two-turn chain: observation token 9 sits inside the response
+                    Trajectory(steps=[step([1, 2], [3, 4], 1.0), step([1, 2, 3, 4, 9], [5], 1.0)], reward=1.0),
+                    Trajectory(steps=[step([1, 2], [6, 7], -1.0)], reward=0.0),
+                ],
+            ),
+            TrajectoryGroup(
+                group_id="p1:agent",
+                trajectories=[
+                    Trajectory(steps=[step([20, 21], [22], 0.5)], reward=1.0),
+                    Trajectory(steps=[step([20, 21], [23, 24], -0.5)], reward=0.0),
+                ],
+            ),
+        ]
+        samples, advantages = payloads_to_samples(trajectory_groups_to_payloads(groups))
+
+        class Args:
+            advantage_estimator = "grpo"
+            rewards_normalization = True
+            grpo_std_normalization = True
+            use_dynamic_global_batch_size = False
+            n_samples_per_prompt = 2
+            rollout_batch_size = 2
+            reward_key = None
+
+        train_data = convert_samples_to_train_data(Args(), samples, metadata={}, custom_convert_samples_to_train_data_func=None, custom_reward_post_process_func=None)
+        train_data["advantages"] = advantages
+        return train_data
+
+    def test_converter_accepts_our_samples(self):
+        data = self._train_data()
+        assert data["response_lengths"] == [4, 2, 1, 2]
+
+    def test_every_per_token_array_equals_response_length(self):
+        # This is the assertion slice_log_prob_with_cp makes on the trainer side; if it
+        # fails there it fails inside a Megatron forward pass, which is a miserable place
+        # to debug. Catch it here instead.
+        data = self._train_data()
+        for i, n in enumerate(data["response_lengths"]):
+            assert len(data["loss_masks"][i]) == n, f"row {i} loss_mask"
+            assert len(data["rollout_log_probs"][i]) == n, f"row {i} rollout_log_probs"
+            assert len(data["advantages"][i]) == n, f"row {i} advantages"
+
+    def test_observation_tokens_are_excluded_from_the_mask_total(self):
+        # Row 0 has 4 response tokens but only 3 action tokens (9 is an observation).
+        data = self._train_data()
+        assert data["rollout_mask_sums"][0] == 3
+        assert data["loss_masks"][0] == [1, 1, 0, 1]
+
+    def test_group_index_drives_grpo_reward_grouping(self):
+        # Two groups of two, each normalized within itself -> symmetric pairs.
+        data = self._train_data()
+        rewards = data["rewards"]
+        assert rewards[0] == pytest.approx(-rewards[1])
+        assert rewards[2] == pytest.approx(-rewards[3])
+        assert rewards[0] > 0 and rewards[1] < 0
+
+    def test_raw_rewards_survive_normalization(self):
+        assert self._train_data()["raw_reward"] == [1.0, 0.0, 1.0, 0.0]
+
+
+@needs_miles_arguments
+class TestConfigBridgeThroughMilesParser:
+    """The bridge's argv must survive Miles' own parse_args and validators.
+
+    These are the checks the static flag audit cannot make: Miles' validators reject
+    combinations (eval_interval without eval datasets, save_interval without --save),
+    and resolve_rollout_function_paths can *overwrite* a pinned rollout function.
+    """
+
+    def _args(self):
+        from omegaconf import OmegaConf
+
+        import rllm.trainer.config as cfg_pkg
+        from rllm.trainer.miles.miles_config import build_miles_args
+
+        cfg = OmegaConf.load(Path(cfg_pkg.__file__).parent / "rllm" / "backend" / "miles.yaml")
+        for path, value in [
+            ("training.group_size", 8),
+            ("rllm.data.train_batch_size", 16),
+            ("rllm.data.max_prompt_length", 4096),
+            ("rllm.trainer.save_freq", 20),
+            ("rllm.trainer.project_name", "rllm-miles-test"),
+            ("rllm.trainer.experiment_name", "t"),
+        ]:
+            OmegaConf.update(cfg, path, value)
+        return build_miles_args(cfg, total_steps=50)
+
+    def test_arity_introspection_finds_the_full_flag_surface(self):
+        from rllm.trainer.miles.miles_config import miles_arity
+
+        # ~1500 at the time of writing: Miles' own flags plus the --sglang-* /
+        # --eval-sglang-* families generated from ServerArgs.add_cli_args.
+        arity = miles_arity(["--rollout-batch-size", "1"])
+        assert len(arity) > 800
+        assert arity["disable_rollout_global_dataset"] == 0
+        assert arity["rollout_function_path"] == 1
+        assert arity["ft_components"] == "+"
+
+    def test_rendered_argv_parses(self):
+        args = self._args()
+        assert args.train_backend == "fsdp"
+        assert args.num_rollout == 50
+        assert args.rollout_batch_size == 16
+        assert args.global_batch_size == 32
+
+    def test_dataset_pin_survives_validation(self):
+        assert self._args().rollout_global_dataset is False
+
+    def test_advantage_pin_survives_validation(self):
+        # With this False, Miles skips its own estimator and the loss reads the
+        # per-token advantages rLLM ships in the batch.
+        assert self._args().compute_advantages_and_returns is False
+
+    def test_rollout_function_pin_is_not_overwritten(self):
+        # resolve_rollout_function_paths substitutes a standard path when this is
+        # unset, and FullyAsyncRolloutFn when --fully-async is on.
+        args = self._args()
+        assert args.rollout_function_path == "miles.rollout.sleep_rollout.sleep"
+        assert args.eval_function_path == "miles.rollout.sleep_rollout.sleep"
+
+    def test_save_dir_is_derived_from_the_run_identity(self):
+        # miles_validate_args requires --save whenever --save-interval is set.
+        assert self._args().save == "checkpoints/rllm-miles-test/t"
+
+    def test_no_critic_and_default_loss(self):
+        args = self._args()
+        assert args.use_critic is False
+        assert args.loss_type == "policy_loss"  # stock kernel reads batch["advantages"]

--- a/tests/test_miles_against_checkout.py
+++ b/tests/test_miles_against_checkout.py
@@ -55,6 +55,25 @@ def _miles_arguments_importable() -> bool:
 needs_miles_arguments = pytest.mark.skipif(not _miles_arguments_importable(), reason="miles.utils.arguments not importable (needs sglang)")
 
 
+def _shipped_cfg():
+    """The shipped miles.yaml with the interpolations base.yaml would supply."""
+    from omegaconf import OmegaConf
+
+    import rllm.trainer.config as cfg_pkg
+
+    cfg = OmegaConf.load(Path(cfg_pkg.__file__).parent / "rllm" / "backend" / "miles.yaml")
+    for path, value in [
+        ("training.group_size", 8),
+        ("rllm.data.train_batch_size", 16),
+        ("rllm.data.max_prompt_length", 4096),
+        ("rllm.trainer.save_freq", 20),
+        ("rllm.trainer.project_name", "rllm-miles-test"),
+        ("rllm.trainer.experiment_name", "t"),
+    ]:
+        OmegaConf.update(cfg, path, value)
+    return cfg
+
+
 def _rendered_argv_block():
     from omegaconf import OmegaConf
 
@@ -194,22 +213,9 @@ class TestConfigBridgeThroughMilesParser:
     """
 
     def _args(self):
-        from omegaconf import OmegaConf
-
-        import rllm.trainer.config as cfg_pkg
         from rllm.trainer.miles.miles_config import build_miles_args
 
-        cfg = OmegaConf.load(Path(cfg_pkg.__file__).parent / "rllm" / "backend" / "miles.yaml")
-        for path, value in [
-            ("training.group_size", 8),
-            ("rllm.data.train_batch_size", 16),
-            ("rllm.data.max_prompt_length", 4096),
-            ("rllm.trainer.save_freq", 20),
-            ("rllm.trainer.project_name", "rllm-miles-test"),
-            ("rllm.trainer.experiment_name", "t"),
-        ]:
-            OmegaConf.update(cfg, path, value)
-        return build_miles_args(cfg, total_steps=50)
+        return build_miles_args(_shipped_cfg(), total_steps=50)
 
     def test_arity_introspection_finds_the_full_flag_surface(self):
         from rllm.trainer.miles.miles_config import miles_arity
@@ -252,3 +258,23 @@ class TestConfigBridgeThroughMilesParser:
         args = self._args()
         assert args.use_critic is False
         assert args.loss_type == "policy_loss"  # stock kernel reads batch["advantages"]
+
+
+@needs_miles_arguments
+class TestPlacementLayout:
+    """The shipped config must describe a placement Miles can actually satisfy."""
+
+    def test_shipped_config_is_a_valid_disaggregated_layout(self):
+        from miles.ray.placement_group import _get_placement_group_layout
+
+        from rllm.trainer.miles.miles_config import build_miles_args
+
+        args = build_miles_args(_shipped_cfg(), total_steps=50)
+        total, rollout_offset = _get_placement_group_layout(args)
+
+        actor_gpus = args.actor_num_nodes * args.actor_num_gpus_per_node
+        # Disaggregated: trainer and engines own separate GPUs, so the total is the sum
+        # and the rollout bundles start after the actor's.
+        assert args.colocate is False
+        assert total == actor_gpus + args.rollout_num_gpus + args.eval_num_gpus
+        assert rollout_offset == actor_gpus

--- a/tests/test_miles_against_checkout.py
+++ b/tests/test_miles_against_checkout.py
@@ -23,16 +23,28 @@ needs_checkout = pytest.mark.skipif(
 
 
 def _miles_importable() -> bool:
-    if importlib.util.find_spec("miles") is not None:
-        return True
-    if not (MILES_ROOT / "miles" / "__init__.py").exists():
-        return False
+    """Whether the module these tests actually use can be imported.
+
+    Deliberately not `find_spec("miles") is not None`: any directory named `miles`
+    without an `__init__.py` (a stray venv, a build artifact) satisfies that as a
+    namespace package, so the gate passed and the tests then failed on
+    `No module named 'miles.ray'`. Import the specific module or skip.
+    """
     import sys
 
+    target = "miles.ray.rollout.train_data_conversion"
+    try:
+        importlib.import_module(target)
+        return True
+    except ImportError:
+        pass
+
+    if not (MILES_ROOT / "miles" / "__init__.py").exists():
+        return False
     if str(MILES_ROOT) not in sys.path:
         sys.path.insert(0, str(MILES_ROOT))
     try:
-        importlib.import_module("miles.ray.rollout.train_data_conversion")
+        importlib.import_module(target)
         return True
     except Exception:
         return False

--- a/tests/test_miles_against_checkout.py
+++ b/tests/test_miles_against_checkout.py
@@ -117,8 +117,32 @@ class TestFlagSurfaceMatchesMiles:
         assert len(flags) > 200, f"only found {len(flags)} flags; the audit probably failed to parse"
 
         block, _ = _rendered_argv_block()
-        unknown = sorted(k for k, v in block.items() if v is not None and k not in flags)
+        # --sglang-* flags are generated from sglang's ServerArgs dataclass when Miles
+        # builds its parser, so a source scan of Miles cannot see them. They get their
+        # own check below, against ServerArgs itself.
+        unknown = sorted(k for k, v in block.items() if v is not None and k not in flags and not k.startswith("sglang_"))
         assert not unknown, f"flags the bridge emits that Miles does not define: {unknown}"
+
+    def test_emitted_sglang_flags_exist_in_server_args(self):
+        """The --sglang-* passthrough is only as stable as sglang's ServerArgs field names.
+
+        Miles derives these flags by walking that dataclass (backends/sglang_utils/
+        arguments.py), so a renamed field silently becomes an unknown flag.
+        """
+        import dataclasses
+
+        pytest.importorskip("sglang")
+        from sglang.srt.server_args import ServerArgs
+
+        from miles.backends.sglang_utils.arguments import _SKIPPED_SERVER_ARGS
+
+        available = {f.name for f in dataclasses.fields(ServerArgs)} - set(_SKIPPED_SERVER_ARGS)
+        block, _ = _rendered_argv_block()
+        emitted = {k[len("sglang_"):] for k, v in block.items() if v is not None and k.startswith("sglang_")}
+        # Router flags are Miles' own, not ServerArgs-derived.
+        emitted = {k for k in emitted if not k.startswith("router_")}
+        missing = sorted(emitted - available)
+        assert not missing, f"--sglang-* flags the bridge emits that sglang's ServerArgs does not define: {missing}"
 
     def test_assumed_arity_matches_miles(self):
         from rllm.trainer.miles._flag_audit import flag_arity_from_source

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -1,0 +1,150 @@
+"""MilesBackend / MilesEngine surface checks that need no GPU."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from omegaconf import OmegaConf
+
+from rllm.trainer.miles.miles_backend import MilesBackend, MilesBatch
+
+
+def _can_import(module: str) -> bool:
+    """Functional gate, not find_spec.
+
+    tests/test_miles_against_checkout.py puts MILES_ROOT on sys.path while it is
+    being collected, so `find_spec("miles")` can succeed in this module even where
+    miles' own dependencies are absent — which would make outcomes depend on
+    collection order. Actually importing the module under test cannot.
+    """
+    try:
+        importlib.import_module(module)
+        return True
+    except Exception:
+        return False
+
+
+needs_miles_data = pytest.mark.skipif(
+    not _can_import("miles.backends.training_utils.data"),
+    reason="miles.backends.training_utils.data not importable (needs sglang + torch)",
+)
+has_miles = _can_import("miles")
+
+
+def _cfg(**rllm_over):
+    base = {
+        "model": {"name": "Qwen/Qwen3-4B"},
+        "rllm": {
+            "async_training": {"enable": False},
+            "data": {"train_batch_size": 8, "max_prompt_length": 1024, "max_response_length": 512},
+            "trainer": {"save_freq": 10, "project_name": "p", "experiment_name": "e"},
+            **rllm_over,
+        },
+        "miles": {},
+    }
+    return OmegaConf.create(base)
+
+
+class TestBackendContract:
+    def test_implements_every_abstract_method(self):
+        assert not MilesBackend.__abstractmethods__
+
+    def test_name_is_miles(self):
+        assert MilesBackend.name == "miles"
+
+    def test_registered_in_the_launcher_table(self):
+        from rllm.trainer.unified_trainer import _BACKEND_LAUNCHERS
+
+        module, cls, extra = _BACKEND_LAUNCHERS["miles"]
+        assert (module, cls, extra) == ("rllm.trainer.miles.miles_launcher", "MilesTrainerLauncher", "miles")
+
+    def test_construction_does_no_heavy_work(self):
+        # __init__ must not import miles or claim GPUs; bring-up happens in
+        # init_rollout_engine, once total_training_steps is known.
+        backend = MilesBackend(config=_cfg())
+        assert backend.actor_model is None
+        assert backend.rollout_manager is None
+        assert backend.miles_args is None
+
+
+class TestValidateConfig:
+    def test_async_training_is_rejected(self):
+        backend = MilesBackend(config=_cfg(async_training={"enable": True}))
+        with pytest.raises((ValueError, ImportError)) as e:
+            backend.validate_config()
+        # ImportError only when miles is absent; either way async must not slip through.
+        if isinstance(e.value, ValueError):
+            assert "Phase 5" in str(e.value)
+
+    def test_pinned_flag_override_is_rejected(self):
+        cfg = _cfg()
+        cfg.miles = {"rollout_function_path": "my.rollout"}
+        backend = MilesBackend(config=cfg)
+        with pytest.raises((ValueError, ImportError)) as e:
+            backend.validate_config()
+        if isinstance(e.value, ValueError):
+            assert "cannot be overridden" in str(e.value)
+
+    @pytest.mark.skipif(has_miles, reason="miles is importable")
+    def test_missing_miles_explains_how_to_install(self):
+        with pytest.raises(ImportError, match="pip install -r requirements.txt"):
+            MilesBackend(config=_cfg()).validate_config()
+
+
+class TestMilesBatch:
+    def test_carries_the_ref_and_metrics(self):
+        batch = MilesBatch(data_ref="ref", sample_indices=[0, 1], num_samples=2, metrics={"batch/miles_samples": 2})
+        assert batch.data_ref == "ref"
+        assert batch.num_samples == 2
+        assert batch.metrics["batch/miles_samples"] == 2
+
+    def test_metrics_default_is_not_shared(self):
+        a, b = MilesBatch(data_ref="x"), MilesBatch(data_ref="y")
+        a.metrics["k"] = 1
+        assert b.metrics == {}
+
+
+class TestPatchContract:
+    """The advantages CP-slice patch is the load-bearing mechanism; guard its shape."""
+
+    @needs_miles_data
+    def test_contract_holds_against_installed_miles(self):
+        from rllm.trainer.miles.patch import assert_cp_slice_contract
+
+        assert_cp_slice_contract()
+
+    @needs_miles_data
+    def test_patch_is_idempotent(self):
+        from miles.backends.training_utils import data as miles_data
+
+        from rllm.trainer.miles.patch import patch_advantages_cp_slice
+
+        patch_advantages_cp_slice()
+        once = miles_data.get_rollout_data
+        patch_advantages_cp_slice()
+        assert miles_data.get_rollout_data is once
+
+    def test_expected_key_tuple_is_documented(self):
+        from rllm.trainer.miles.patch import _EXPECTED_CP_SLICED_KEYS
+
+        assert _EXPECTED_CP_SLICED_KEYS == ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl")
+
+
+class TestEngineIsDecoupledFromVerl:
+    def test_miles_modules_do_not_import_verl(self):
+        # A miles run must not need the verl extra installed.
+        import pathlib
+
+        offenders = []
+        for path in pathlib.Path("rllm/trainer/miles").glob("*.py"):
+            text = path.read_text()
+            if "rllm.trainer.verl" in text or "\nimport verl" in text or "\nfrom verl" in text:
+                offenders.append(path.name)
+        assert not offenders, f"miles modules reference verl: {offenders}"
+
+    def test_engine_does_not_import_verl(self):
+        import pathlib
+
+        text = pathlib.Path("rllm/engine/rollout/miles_engine.py").read_text()
+        assert "verl" not in text

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -109,10 +109,10 @@ class TestPatchContract:
     """The advantages CP-slice patch is the load-bearing mechanism; guard its shape."""
 
     @needs_miles_data
-    def test_contract_holds_against_installed_miles(self):
-        from rllm.trainer.miles.patch import assert_cp_slice_contract
+    def test_all_patch_contracts_hold_against_installed_miles(self):
+        from rllm.trainer.miles.patch import assert_patch_contracts
 
-        assert_cp_slice_contract()
+        assert_patch_contracts()
 
     @needs_miles_data
     def test_patch_is_idempotent(self):
@@ -238,3 +238,14 @@ class TestAdvantagesReachTheTrainWorkers:
 
         patch_respect_disable_compute_advantages()
         assert fsdp_actor.compute_advantages_and_returns.__module__ == "rllm.trainer.miles.patch"
+
+    @needs_miles_data
+    def test_contract_check_fails_when_a_patch_site_disappears(self, monkeypatch):
+        # The guard is only worth having if it actually trips.
+        from miles.ray.rollout import train_data_conversion as tdc
+
+        from rllm.trainer.miles.patch import assert_patch_contracts
+
+        monkeypatch.delattr(tdc, "_package_shards")
+        with pytest.raises(RuntimeError, match="_package_shards is gone"):
+            assert_patch_contracts()

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -148,3 +148,93 @@ class TestEngineIsDecoupledFromVerl:
 
         text = pathlib.Path("rllm/engine/rollout/miles_engine.py").read_text()
         assert "verl" not in text
+
+
+@needs_miles_data
+class TestAdvantagesReachTheTrainWorkers:
+    """The two silent-drop sites between the driver's transform and Miles' loss.
+
+    Both were found only by running end to end: with either one unpatched the run
+    still completes, but the loss quietly uses Miles' own advantages instead of
+    rLLM's, so there is no error to notice.
+    """
+
+    def test_package_shards_forwards_advantages_per_partition(self):
+        from miles.ray.rollout import train_data_conversion as tdc
+
+        from rllm.trainer.miles.patch import patch_package_shards_forwards_advantages
+
+        patch_package_shards_forwards_advantages()
+
+        data = {
+            "tokens": [[1, 2], [3, 4], [5, 6], [7, 8]],
+            "advantages": [[0.1], [0.2], [0.3], [0.4]],
+        }
+        partitions = [[0, 2], [1, 3]]
+
+        class Args:
+            multi_lora_n_adapters = 0
+
+        shards = tdc._package_shards(Args(), data, partitions)
+        assert [s["advantages"] for s in shards] == [[[0.1], [0.3]], [[0.2], [0.4]]]
+
+    def test_package_shards_without_advantages_is_unchanged(self):
+        from miles.ray.rollout import train_data_conversion as tdc
+
+        from rllm.trainer.miles.patch import patch_package_shards_forwards_advantages
+
+        patch_package_shards_forwards_advantages()
+
+        class Args:
+            multi_lora_n_adapters = 0
+
+        shards = tdc._package_shards(Args(), {"tokens": [[1], [2]]}, [[0], [1]])
+        assert all("advantages" not in s for s in shards)
+
+    def test_disable_flag_keeps_driver_advantages(self):
+        from miles.backends.training_utils import loss as miles_loss
+
+        from rllm.trainer.miles.patch import patch_respect_disable_compute_advantages
+
+        patch_respect_disable_compute_advantages()
+
+        class Args:
+            compute_advantages_and_returns = False
+
+        mine = [[0.5, 0.5]]
+        rollout_data = {"advantages": mine}
+        miles_loss.compute_advantages_and_returns(Args(), rollout_data)
+        assert rollout_data["advantages"] is mine, "Miles overwrote rLLM's advantages"
+        assert rollout_data["returns"] is mine, "returns should alias advantages under GRPO"
+
+    def test_flag_on_still_delegates_to_miles(self):
+        from miles.backends.training_utils import loss as miles_loss
+
+        from rllm.trainer.miles.patch import patch_respect_disable_compute_advantages
+
+        patch_respect_disable_compute_advantages()
+        called = {}
+
+        class Args:
+            compute_advantages_and_returns = True
+
+        # The wrapper must not swallow the normal path; a missing "log_probs" key makes
+        # the real implementation return early, which is enough to prove delegation.
+        rollout_data = {"advantages": [[1.0]], "log_probs": None, "values": None}
+        try:
+            miles_loss.compute_advantages_and_returns(Args(), rollout_data)
+            called["ok"] = True
+        except Exception:
+            called["ok"] = True  # reached the real function, which is the point
+        assert called["ok"]
+
+    def test_fsdp_actor_binding_is_repointed(self):
+        # Both actors do `from ...loss import compute_advantages_and_returns`, binding
+        # by value, so patching only the source module would leave the FSDP call site
+        # (which is ungated) pointing at the original.
+        import miles.backends.fsdp_utils.actor as fsdp_actor
+
+        from rllm.trainer.miles.patch import patch_respect_disable_compute_advantages
+
+        patch_respect_disable_compute_advantages()
+        assert fsdp_actor.compute_advantages_and_returns.__module__ == "rllm.trainer.miles.patch"

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -410,3 +410,42 @@ class TestPatchesSurviveImportOrder:
         apply_all_miles_patches()
         assert fsdp_actor.get_rollout_data.__module__ == "rllm.trainer.miles.patch"
         assert fsdp_actor.compute_advantages_and_returns.__module__ == "rllm.trainer.miles.patch"
+
+
+class TestEngineCleanup:
+    """httpx binds connections to the loop that opened them, so the client has to be
+    closed on the trainer's loop -- not Miles' background loop, and not after fit()
+    tore its loop down ("Event loop is closed")."""
+
+    class _Engine:
+        def __init__(self):
+            self.closed = 0
+
+        async def close(self):
+            self.closed += 1
+
+    @pytest.mark.asyncio
+    async def test_on_train_end_closes_the_client(self):
+        from rllm.trainer.unified_trainer import TrainerState
+
+        b = MilesBackend(config=_cfg())
+        b.rollout_engine = self._Engine()
+        await b.on_train_end(TrainerState())
+        assert b.rollout_engine.closed == 1
+
+    @pytest.mark.asyncio
+    async def test_closing_twice_is_a_no_op(self):
+        from rllm.trainer.unified_trainer import TrainerState
+
+        b = MilesBackend(config=_cfg())
+        b.rollout_engine = self._Engine()
+        await b.on_train_end(TrainerState())
+        await b.on_train_end(TrainerState())
+        assert b.rollout_engine.closed == 1
+
+    def test_shutdown_does_not_touch_the_loop(self):
+        # shutdown() is sync; awaiting a close here is what raised "Event loop is closed".
+        b = MilesBackend(config=_cfg())
+        b.rollout_engine = self._Engine()
+        b.shutdown()
+        assert b.rollout_engine.closed == 0

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -449,3 +449,37 @@ class TestEngineCleanup:
         b.rollout_engine = self._Engine()
         b.shutdown()
         assert b.rollout_engine.closed == 0
+
+
+@needs_miles_data
+class TestNoSilentAdvantageFallback:
+    """If rLLM's advantages go missing while Miles' own computation is disabled, the
+    only safe outcome is a loud failure -- recomputing from scalar rewards would train
+    on the wrong signal while the run looks healthy."""
+
+    def test_missing_advantages_raises_instead_of_recomputing(self):
+        from miles.backends.training_utils import loss as miles_loss
+
+        from rllm.trainer.miles.patch import patch_respect_disable_compute_advantages
+
+        patch_respect_disable_compute_advantages()
+
+        class Args:
+            compute_advantages_and_returns = False
+
+        with pytest.raises(RuntimeError, match="did not reach the train worker"):
+            miles_loss.compute_advantages_and_returns(Args(), {"rewards": [1.0], "tokens": [[1]]})
+
+    def test_the_error_names_the_keys_that_did_arrive(self):
+        from miles.backends.training_utils import loss as miles_loss
+
+        from rllm.trainer.miles.patch import patch_respect_disable_compute_advantages
+
+        patch_respect_disable_compute_advantages()
+
+        class Args:
+            compute_advantages_and_returns = False
+
+        with pytest.raises(RuntimeError) as e:
+            miles_loss.compute_advantages_and_returns(Args(), {"rewards": [1.0]})
+        assert "'rewards'" in str(e.value)

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -37,6 +37,7 @@ def _cfg(**rllm_over):
         "model": {"name": "Qwen/Qwen3-4B"},
         "rllm": {
             "async_training": {"enable": False},
+            "workflow": {"raise_on_error": False},
             "data": {"train_batch_size": 8, "max_prompt_length": 1024, "max_response_length": 512},
             "trainer": {"save_freq": 10, "project_name": "p", "experiment_name": "e"},
             **rllm_over,
@@ -69,14 +70,6 @@ class TestBackendContract:
 
 
 class TestValidateConfig:
-    def test_async_training_is_rejected(self):
-        backend = MilesBackend(config=_cfg(async_training={"enable": True}))
-        with pytest.raises((ValueError, ImportError)) as e:
-            backend.validate_config()
-        # ImportError only when miles is absent; either way async must not slip through.
-        if isinstance(e.value, ValueError):
-            assert "Phase 5" in str(e.value)
-
     def test_pinned_flag_override_is_rejected(self):
         cfg = _cfg()
         cfg.miles = {"rollout_function_path": "my.rollout"}
@@ -249,3 +242,171 @@ class TestAdvantagesReachTheTrainWorkers:
         monkeypatch.delattr(tdc, "_package_shards")
         with pytest.raises(RuntimeError, match="_package_shards is gone"):
             assert_patch_contracts()
+
+
+@needs_miles_data
+class TestAsyncTraining:
+    """Async moves weight sync to on_policy_updated and constrains the pass structure."""
+
+    def _backend(self, **async_over):
+        async_cfg = {"enable": True, "mini_batch_size": 4, **async_over}
+        return MilesBackend(config=_cfg(async_training=async_cfg))
+
+    def test_async_is_accepted(self):
+        self._backend().validate_config()
+
+    def test_is_async_flag_tracks_the_config(self):
+        assert self._backend().is_async is True
+        assert MilesBackend(config=_cfg()).is_async is False
+
+    def test_mismatched_fwd_bwd_group_size_is_rejected(self):
+        # Miles takes its optimizer step inside RayTrainGroup.train(), so it cannot
+        # accumulate gradient across several forward-backward passes.
+        with pytest.raises(ValueError, match="cannot accumulate gradient"):
+            self._backend(fwd_bwd_group_size=2).validate_config()
+
+    def test_matching_fwd_bwd_group_size_is_fine(self):
+        self._backend(fwd_bwd_group_size=4).validate_config()
+
+    def test_abort_pause_mode_is_rejected_under_async(self):
+        cfg = _cfg(async_training={"enable": True, "mini_batch_size": 1})
+        cfg.miles = {"pause_generation_mode": "abort"}
+        with pytest.raises(ValueError, match="requeues"):
+            MilesBackend(config=cfg).validate_config()
+
+    def test_retract_pause_mode_is_fine(self):
+        cfg = _cfg(async_training={"enable": True, "mini_batch_size": 1})
+        cfg.miles = {"pause_generation_mode": "retract"}
+        MilesBackend(config=cfg).validate_config()
+
+    def test_abort_pause_mode_is_fine_in_sync_mode(self):
+        # Sync mode drains generation before syncing, so abort costs nothing there.
+        cfg = _cfg()
+        cfg.miles = {"pause_generation_mode": "abort"}
+        MilesBackend(config=cfg).validate_config()
+
+
+class TestWeightSyncPlacement:
+    """Exactly one of on_batch_end / on_policy_updated may publish weights per step."""
+
+    class _Recorder:
+        def __init__(self):
+            self.calls = []
+
+        async def update_weights(self, rollout_id=None):
+            self.calls.append(rollout_id)
+
+        async def save_model(self, rollout_id):
+            pass
+
+    def _state(self):
+        from rllm.trainer.unified_trainer import TrainerState
+
+        return TrainerState(global_step=7)
+
+    def _backend(self, is_async):
+        b = MilesBackend(config=_cfg())
+        b.is_async = is_async
+        b.actor_model = self._Recorder()
+        b.miles_args = type("A", (), {"save_interval": 0})()
+        b.rollout_manager = None
+        return b
+
+    @pytest.mark.asyncio
+    async def test_sync_mode_publishes_in_on_batch_end(self):
+        b = self._backend(is_async=False)
+        state = self._state()
+        await b.on_batch_end(state)
+        await b.on_policy_updated(state)
+        assert b.actor_model.calls == [7], "sync mode should publish exactly once, from on_batch_end"
+
+    @pytest.mark.asyncio
+    async def test_async_mode_publishes_in_on_policy_updated(self):
+        b = self._backend(is_async=True)
+        state = self._state()
+        await b.on_batch_end(state)
+        await b.on_policy_updated(state)
+        assert b.actor_model.calls == [7], "async mode should publish exactly once, from on_policy_updated"
+
+
+class TestAsyncPrerequisites:
+    def test_raise_on_error_true_is_rejected_early(self):
+        # The trainer asserts this only after full GPU bring-up; catching it in
+        # validate_config turns minutes of setup into an immediate error.
+        cfg = _cfg(async_training={"enable": True, "mini_batch_size": 1})
+        cfg.rllm.workflow = {"raise_on_error": True}
+        with pytest.raises(ValueError, match="raise_on_error=false"):
+            MilesBackend(config=cfg).validate_config()
+
+    def test_raise_on_error_false_passes(self):
+        cfg = _cfg(async_training={"enable": True, "mini_batch_size": 1})
+        cfg.rllm.workflow = {"raise_on_error": False}
+        MilesBackend(config=cfg).validate_config()
+
+    def test_sync_mode_does_not_care(self):
+        cfg = _cfg()
+        cfg.rllm.workflow = {"raise_on_error": True}
+        MilesBackend(config=cfg).validate_config()
+
+
+class TestMilesBatchIsSized:
+    """The async loop does `len(backend_batch)` to count trainable sequences."""
+
+    def test_len_is_the_sample_count(self):
+        assert len(MilesBatch(data_ref="r", num_samples=32)) == 32
+
+    def test_empty_batch_has_len_zero(self):
+        b = MilesBatch(data_ref=None, num_samples=0)
+        assert len(b) == 0 and b.is_empty
+
+    @pytest.mark.asyncio
+    async def test_update_policy_skips_an_empty_batch(self):
+        from rllm.trainer.unified_trainer import TrainerState
+
+        b = MilesBackend(config=_cfg())
+        b.actor_model = None  # would explode if update_policy did not return early
+        state = TrainerState(global_step=1)
+        state.backend_batch = MilesBatch(data_ref=None, num_samples=0)
+        await b.update_policy(state)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_update_policy_skips_when_there_is_no_batch(self):
+        from rllm.trainer.unified_trainer import TrainerState
+
+        b = MilesBackend(config=_cfg())
+        b.actor_model = None
+        await b.update_policy(TrainerState(global_step=1))
+
+
+@needs_miles_data
+class TestPatchesSurviveImportOrder:
+    """Miles' actors import these functions by value, so patching the source module
+    only reaches an actor that has not been imported yet. Importing an actor first
+    (assert_patch_contracts does) silently defeated the get_rollout_data patch and the
+    advantages arrived at the loss as plain lists."""
+
+    def test_get_rollout_data_is_repointed_in_the_fsdp_actor(self):
+        import miles.backends.fsdp_utils.actor as fsdp_actor
+
+        from rllm.trainer.miles.patch import patch_advantages_cp_slice
+
+        patch_advantages_cp_slice()
+        assert fsdp_actor.get_rollout_data.__module__ == "rllm.trainer.miles.patch"
+
+    def test_compute_advantages_is_repointed_in_the_fsdp_actor(self):
+        import miles.backends.fsdp_utils.actor as fsdp_actor
+
+        from rllm.trainer.miles.patch import patch_respect_disable_compute_advantages
+
+        patch_respect_disable_compute_advantages()
+        assert fsdp_actor.compute_advantages_and_returns.__module__ == "rllm.trainer.miles.patch"
+
+    def test_applying_everything_leaves_both_repointed(self):
+        # The realistic ordering: contracts assert (importing the actor) then patches.
+        import miles.backends.fsdp_utils.actor as fsdp_actor
+
+        from rllm.trainer.miles.patch import apply_all_miles_patches
+
+        apply_all_miles_patches()
+        assert fsdp_actor.get_rollout_data.__module__ == "rllm.trainer.miles.patch"
+        assert fsdp_actor.compute_advantages_and_returns.__module__ == "rllm.trainer.miles.patch"

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -483,3 +483,41 @@ class TestNoSilentAdvantageFallback:
         with pytest.raises(RuntimeError) as e:
             miles_loss.compute_advantages_and_returns(Args(), {"rewards": [1.0]})
         assert "'rewards'" in str(e.value)
+
+
+class TestOptimizerMetricsReachRLLM:
+    """Miles logs train/loss, train/grad_norm, train/tis inside the worker and returns
+    None from the FSDP actor, so from rLLM's side the optimizer was invisible. The patch
+    stashes log_train_step's dict and rides it back on the existing per-rank return list.
+    """
+
+    def test_rank0_metrics_are_extracted(self):
+        results = [
+            {"miles_train_metrics": [{"train/loss": 0.5, "train/grad_norm": 1.2, "train/step": 7}]},
+            {"miles_train_metrics": []},
+            {"miles_train_metrics": []},
+            {"miles_train_metrics": []},
+        ]
+        m = MilesBackend._optimizer_metrics(results)
+        assert m == {"train/loss": 0.5, "train/grad_norm": 1.2}, "train/step is a counter, not a measurement"
+
+    def test_several_optimizer_steps_are_averaged(self):
+        results = [{"miles_train_metrics": [{"train/loss": 1.0}, {"train/loss": 2.0}]}]
+        assert MilesBackend._optimizer_metrics(results) == {"train/loss": 1.5}
+
+    def test_non_numeric_values_are_skipped(self):
+        results = [{"miles_train_metrics": [{"train/loss": 0.5, "train/outcome": "NORMAL", "train/ok": True}]}]
+        assert MilesBackend._optimizer_metrics(results) == {"train/loss": 0.5}
+
+    def test_megatron_shape_keeps_its_own_keys_out_of_the_way(self):
+        # The megatron actor returns a dict; the patch adds a key rather than replacing it.
+        results = [{"train_step_outcome": "NORMAL", "miles_train_metrics": [{"train/loss": 0.25}]}]
+        assert MilesBackend._optimizer_metrics(results) == {"train/loss": 0.25}
+
+    def test_unpatched_return_yields_nothing(self):
+        # A Miles version whose actors return None must not raise.
+        assert MilesBackend._optimizer_metrics([None, None]) == {}
+        assert MilesBackend._optimizer_metrics(None) == {}
+
+    def test_scalar_return_is_tolerated(self):
+        assert MilesBackend._optimizer_metrics("unexpected") == {}

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -79,8 +79,22 @@ class TestValidateConfig:
         if isinstance(e.value, ValueError):
             assert "cannot be overridden" in str(e.value)
 
-    @pytest.mark.skipif(has_miles, reason="miles is importable")
-    def test_missing_miles_explains_how_to_install(self):
+    def test_missing_miles_explains_how_to_install(self, monkeypatch):
+        """Force the absence rather than skipping when miles happens to be importable.
+
+        The old skipif read a module-level `has_miles` computed at import time, but
+        test_miles_against_checkout inserts MILES_ROOT into sys.path while *it* is
+        collected -- so by the time this ran, miles was importable, no ImportError was
+        raised, and the test failed depending only on which files were collected with it.
+        Setting sys.modules["miles"] = None makes `import miles...` raise ImportError,
+        so the test asserts the message in every environment.
+        """
+        import sys
+
+        for name in [n for n in sys.modules if n == "miles" or n.startswith("miles.")]:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        monkeypatch.setitem(sys.modules, "miles", None)
+
         with pytest.raises(ImportError, match="pip install -r requirements.txt"):
             MilesBackend(config=_cfg()).validate_config()
 

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -133,14 +133,23 @@ class TestEngineIsDecoupledFromVerl:
         for path in pathlib.Path("rllm/trainer/miles").glob("*.py"):
             text = path.read_text()
             if "rllm.trainer.verl" in text or "\nimport verl" in text or "\nfrom verl" in text:
-                offenders.append(path.name)
+                offenders.append(path.name)  # substring is fine here: these are import forms, not the bare word
         assert not offenders, f"miles modules reference verl: {offenders}"
 
     def test_engine_does_not_import_verl(self):
+        # Check imports, not any mention of the word: a comment comparing behaviour to
+        # verl is fine, an import is not.
+        import ast
         import pathlib
 
-        text = pathlib.Path("rllm/engine/rollout/miles_engine.py").read_text()
-        assert "verl" not in text
+        tree = ast.parse(pathlib.Path("rllm/engine/rollout/miles_engine.py").read_text())
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+        assert "verl" not in imported
 
 
 @needs_miles_data

--- a/tests/test_miles_backend.py
+++ b/tests/test_miles_backend.py
@@ -329,6 +329,7 @@ class TestWeightSyncPlacement:
         assert b.actor_model.calls == [7], "async mode should publish exactly once, from on_policy_updated"
 
 
+@needs_miles_data
 class TestAsyncPrerequisites:
     def test_raise_on_error_true_is_rejected_early(self):
         # The trainer asserts this only after full GPU bring-up; catching it in
@@ -486,38 +487,66 @@ class TestNoSilentAdvantageFallback:
 
 
 class TestOptimizerMetricsReachRLLM:
-    """Miles logs train/loss, train/grad_norm, train/tis inside the worker and returns
-    None from the FSDP actor, so from rLLM's side the optimizer was invisible. The patch
-    stashes log_train_step's dict and rides it back on the existing per-rank return list.
-    """
+    """Miles logs train/loss, train/grad_norm, train/tis inside the worker and the FSDP
+    actor returns None, so from rLLM's side the optimizer was invisible. The driver now
+    drains each worker's buffer with __ray_call__."""
 
-    def test_rank0_metrics_are_extracted(self):
-        results = [
-            {"miles_train_metrics": [{"train/loss": 0.5, "train/grad_norm": 1.2, "train/step": 7}]},
-            {"miles_train_metrics": []},
-            {"miles_train_metrics": []},
-            {"miles_train_metrics": []},
-        ]
-        m = MilesBackend._optimizer_metrics(results)
-        assert m == {"train/loss": 0.5, "train/grad_norm": 1.2}, "train/step is a counter, not a measurement"
+    def _backend(self, per_worker, boom=False):
+        b = MilesBackend(config=_cfg())
 
-    def test_several_optimizer_steps_are_averaged(self):
-        results = [{"miles_train_metrics": [{"train/loss": 1.0}, {"train/loss": 2.0}]}]
-        assert MilesBackend._optimizer_metrics(results) == {"train/loss": 1.5}
+        class Handle:
+            def __init__(self, payload):
+                self.payload = payload
 
-    def test_non_numeric_values_are_skipped(self):
-        results = [{"miles_train_metrics": [{"train/loss": 0.5, "train/outcome": "NORMAL", "train/ok": True}]}]
-        assert MilesBackend._optimizer_metrics(results) == {"train/loss": 0.5}
+            class _Call:
+                def __init__(self, payload):
+                    self.payload = payload
 
-    def test_megatron_shape_keeps_its_own_keys_out_of_the_way(self):
-        # The megatron actor returns a dict; the patch adds a key rather than replacing it.
-        results = [{"train_step_outcome": "NORMAL", "miles_train_metrics": [{"train/loss": 0.25}]}]
-        assert MilesBackend._optimizer_metrics(results) == {"train/loss": 0.25}
+                def remote(self, fn):
+                    if isinstance(self.payload, Exception):
+                        raise self.payload
+                    return self.payload
 
-    def test_unpatched_return_yields_nothing(self):
-        # A Miles version whose actors return None must not raise.
-        assert MilesBackend._optimizer_metrics([None, None]) == {}
-        assert MilesBackend._optimizer_metrics(None) == {}
+            @property
+            def __ray_call__(self):
+                return self._Call(self.payload)
 
-    def test_scalar_return_is_tolerated(self):
-        assert MilesBackend._optimizer_metrics("unexpected") == {}
+        b.actor_model = type("G", (), {"_actor_handles": [Handle(p) for p in per_worker]})()
+        return b
+
+    def _patch_ray_get(self, monkeypatch, results):
+        import ray
+
+        monkeypatch.setattr(ray, "get", lambda refs: results)
+
+    def test_rank0_metrics_are_extracted(self, monkeypatch):
+        b = self._backend([None, None])
+        self._patch_ray_get(monkeypatch, [[{"train/loss": 0.5, "train/grad_norm": 1.2, "train/step": 7}], []])
+        assert b._optimizer_metrics() == {"train/loss": 0.5, "train/grad_norm": 1.2}
+
+    def test_several_optimizer_steps_are_averaged(self, monkeypatch):
+        b = self._backend([None])
+        self._patch_ray_get(monkeypatch, [[{"train/loss": 1.0}, {"train/loss": 2.0}]])
+        assert b._optimizer_metrics() == {"train/loss": 1.5}
+
+    def test_non_numeric_values_are_skipped(self, monkeypatch):
+        b = self._backend([None])
+        self._patch_ray_get(monkeypatch, [[{"train/loss": 0.5, "train/outcome": "NORMAL", "train/ok": True}]])
+        assert b._optimizer_metrics() == {"train/loss": 0.5}
+
+    def test_nothing_captured_yields_nothing(self, monkeypatch):
+        b = self._backend([None])
+        self._patch_ray_get(monkeypatch, [[]])
+        assert b._optimizer_metrics() == {}
+
+    def test_no_actor_handles_is_safe(self):
+        b = MilesBackend(config=_cfg())
+        b.actor_model = object()
+        assert b._optimizer_metrics() == {}
+
+    def test_a_failing_drain_never_breaks_the_step(self, monkeypatch):
+        import ray
+
+        b = self._backend([None])
+        monkeypatch.setattr(ray, "get", lambda refs: (_ for _ in ()).throw(RuntimeError("actor died")))
+        assert b._optimizer_metrics() == {}

--- a/tests/test_miles_config.py
+++ b/tests/test_miles_config.py
@@ -217,3 +217,49 @@ class TestRejectedGenerationFlags:
         with pytest.raises(ValueError) as e:
             validate_pinned({"fully_async": True})
         assert "sleep_rollout" in str(e.value)
+
+
+class TestMilesTrainIters:
+    """Miles derives its LR-schedule length from these three flags:
+
+        train_iters = num_rollout * rollout_batch_size * n_samples_per_prompt // global_batch_size
+
+    Zero makes the FSDP scheduler assert; too small silently shortens the schedule.
+    """
+
+    def _cfg(self, *, async_enable=False, mini_batch=4, train_batch=16, n=8):
+        return OmegaConf.create(
+            {
+                "model": {"name": "m"},
+                "rllm": {
+                    "data": {"train_batch_size": 1 if async_enable else train_batch},
+                    "rollout": {"n": n},
+                    "trainer": {"save_freq": 20},
+                    "async_training": {"enable": async_enable, "mini_batch_size": mini_batch},
+                },
+                "miles": {"global_batch_size": mini_batch * n if async_enable else train_batch * n},
+            }
+        )
+
+    def _train_iters(self, block, num_rollout):
+        return num_rollout * block["rollout_batch_size"] * block["n_samples_per_prompt"] // block["global_batch_size"]
+
+    def test_group_size_is_mirrored(self):
+        block, _ = build_block(self._cfg())
+        assert block["n_samples_per_prompt"] == 8
+
+    def test_sync_train_iters_equals_the_step_count(self):
+        block, _ = build_block(self._cfg(), total_steps=60)
+        assert self._train_iters(block, 60) == 60
+
+    def test_async_uses_mini_batch_size_not_the_pinned_train_batch_size(self):
+        # The trainer forces rllm.data.train_batch_size to 1 under async.
+        block, _ = build_block(self._cfg(async_enable=True), total_steps=20)
+        assert block["rollout_batch_size"] == 4
+        assert self._train_iters(block, 20) == 20
+
+    def test_async_train_iters_is_never_zero(self):
+        # The regression that broke the first async run: rollout_batch_size=1 and
+        # n_samples_per_prompt=1 gave 20 * 1 * 1 // 32 == 0.
+        block, _ = build_block(self._cfg(async_enable=True), total_steps=20)
+        assert self._train_iters(block, 20) > 0

--- a/tests/test_miles_config.py
+++ b/tests/test_miles_config.py
@@ -180,6 +180,8 @@ class TestShippedBackendYaml:
         # null entries (ref_load, tensor_model_parallel_size) stay out of argv
         assert "--ref-load" not in argv
         assert "--tensor-model-parallel-size" not in argv
+        # attn_implementation is deliberately unset so Miles' flash_attention_2 default holds
+        assert "--attn-implementation" not in argv
         # empty extra_args must not become a flag
         assert "--extra-args" not in argv
 
@@ -326,3 +328,43 @@ class TestRolloutCorrection:
     def test_on_policy_async_does_not_warn(self, caplog):
         build_block(self._cfg({}, staleness=0.0))
         assert "biased by the policy lag" not in caplog.text
+
+
+class TestAttentionMustHonourPacking:
+    """Miles' FSDP path packs samples into one row and passes attention_mask=None,
+    deriving cu_seqlens from position_ids. An attention impl that ignores cu_seqlens
+    attends across document boundaries -- silently, and it destroys the logprobs."""
+
+    def test_sdpa_with_default_packing_is_rejected(self):
+        from rllm.trainer.miles.miles_config import validate_attention
+
+        with pytest.raises(ValueError, match="packed-sequence boundaries"):
+            validate_attention({"attn_implementation": "sdpa"})
+
+    def test_eager_is_rejected_too(self):
+        from rllm.trainer.miles.miles_config import validate_attention
+
+        with pytest.raises(ValueError, match="packed-sequence boundaries"):
+            validate_attention({"attn_implementation": "eager"})
+
+    def test_flash_attention_2_is_accepted(self):
+        from rllm.trainer.miles.miles_config import validate_attention
+
+        validate_attention({"attn_implementation": "flash_attention_2"})
+
+    def test_unset_defers_to_miles_default(self):
+        from rllm.trainer.miles.miles_config import validate_attention
+
+        validate_attention({})
+
+    def test_sdpa_is_fine_with_bshd_padding(self):
+        from rllm.trainer.miles.miles_config import validate_attention
+
+        validate_attention({"attn_implementation": "sdpa", "qkv_format": "bshd"})
+
+    def test_error_names_the_fix(self):
+        from rllm.trainer.miles.miles_config import validate_attention
+
+        with pytest.raises(ValueError) as e:
+            validate_attention({"attn_implementation": "sdpa"})
+        assert "flash_attention_2" in str(e.value) and "qkv_format=bshd" in str(e.value)

--- a/tests/test_miles_config.py
+++ b/tests/test_miles_config.py
@@ -1,0 +1,219 @@
+"""Miles config bridge: OmegaConf -> argv rendering."""
+
+import pytest
+from omegaconf import OmegaConf
+
+from rllm.trainer.miles.miles_config import (
+    PINNED_FLAGS,
+    build_block,
+    render_argv,
+    validate_pinned,
+)
+
+# Stand-in for the arity map miles_arity() introspects off Miles' own parser.
+ARITY = {
+    "colocate": 0,
+    "disable_rollout_global_dataset": 0,
+    "disable_compute_advantages_and_returns": 0,
+    "hf_checkpoint": 1,
+    "num_rollout": 1,
+    "rollout_num_gpus": 1,
+    "rollout_function_path": 1,
+    "eval_function_path": 1,
+    "eval_prompt_data": "+",
+    "ft_components": "+",
+}
+
+
+class TestRenderArgv:
+    def test_scalar_becomes_flag_and_value(self):
+        assert render_argv({"hf_checkpoint": "Qwen/Qwen3-4B"}, ARITY) == ["--hf-checkpoint", "Qwen/Qwen3-4B"]
+
+    def test_snake_case_key_becomes_kebab_flag(self):
+        assert render_argv({"rollout_num_gpus": 8}, ARITY) == ["--rollout-num-gpus", "8"]
+
+    def test_true_zero_arity_flag_is_emitted_bare(self):
+        assert render_argv({"disable_rollout_global_dataset": True}, ARITY) == ["--disable-rollout-global-dataset"]
+
+    def test_false_zero_arity_flag_is_omitted(self):
+        assert render_argv({"colocate": False}, ARITY) == []
+
+    def test_none_is_omitted_so_miles_default_stands(self):
+        assert render_argv({"num_rollout": None, "hf_checkpoint": "m"}, ARITY) == ["--hf-checkpoint", "m"]
+
+    def test_nargs_flag_takes_every_value(self):
+        assert render_argv({"ft_components": ["rollout", "train"]}, ARITY) == ["--ft-components", "rollout", "train"]
+
+    def test_empty_nargs_list_is_omitted(self):
+        assert render_argv({"ft_components": []}, ARITY) == []
+
+    def test_list_for_scalar_flag_is_rejected(self):
+        with pytest.raises(TypeError, match="single value"):
+            render_argv({"hf_checkpoint": ["a", "b"]}, ARITY)
+
+    def test_scalar_for_nargs_flag_is_rejected(self):
+        with pytest.raises(TypeError, match="takes a list"):
+            render_argv({"ft_components": "rollout"}, ARITY)
+
+    def test_unknown_flag_infers_arity_from_type(self):
+        # Megatron's half of the CLI is not in the introspected map.
+        out = render_argv({"tensor_model_parallel_size": 4, "sequence_parallel": True, "moe_layer_freq": [1, 0]}, ARITY)
+        assert out == ["--tensor-model-parallel-size", "4", "--sequence-parallel", "--moe-layer-freq", "1", "0"]
+
+    def test_no_arity_map_still_renders(self):
+        assert render_argv({"hf_checkpoint": "m", "colocate": False}) == ["--hf-checkpoint", "m"]
+
+
+class TestValidatePinned:
+    def test_overriding_a_pinned_flag_is_rejected(self):
+        with pytest.raises(ValueError, match="cannot be overridden"):
+            validate_pinned({"rollout_function_path": "my.custom.rollout"})
+
+    def test_error_names_every_clash(self):
+        with pytest.raises(ValueError) as e:
+            validate_pinned({"rollout_function_path": "x", "disable_rollout_global_dataset": False})
+        assert "miles.rollout_function_path" in str(e.value)
+        assert "miles.disable_rollout_global_dataset" in str(e.value)
+
+    def test_colocate_is_rejected(self):
+        with pytest.raises(ValueError, match="colocate"):
+            validate_pinned({"colocate": True})
+
+    def test_colocate_false_is_fine(self):
+        validate_pinned({"colocate": False})
+
+    def test_num_epoch_is_rejected_because_miles_asserts_its_own_dataset(self):
+        with pytest.raises(ValueError, match="total_epochs"):
+            validate_pinned({"num_epoch": 3})
+
+    def test_unrelated_flags_pass(self):
+        validate_pinned({"rollout_num_gpus": 8, "train_backend": "fsdp"})
+
+
+class TestBuildBlock:
+    def _cfg(self, **miles):
+        return OmegaConf.create(
+            {
+                "model": {"name": "Qwen/Qwen3-4B"},
+                "rllm": {
+                    "data": {"train_batch_size": 32, "max_prompt_length": 4096},
+                    "trainer": {"save_freq": 20, "test_freq": 5},
+                },
+                "miles": miles,
+            }
+        )
+
+    def test_pinned_flags_are_always_present(self):
+        block, _ = build_block(self._cfg())
+        for flag, value in PINNED_FLAGS.items():
+            assert block[flag] == value
+
+    def test_shared_keys_are_mirrored_from_rllm_namespace(self):
+        block, _ = build_block(self._cfg())
+        assert block["hf_checkpoint"] == "Qwen/Qwen3-4B"
+        assert block["rollout_batch_size"] == 32
+        assert block["rollout_max_prompt_len"] == 4096
+        assert block["save_interval"] == 20
+
+    def test_eval_interval_is_never_mirrored(self):
+        # miles_validate_args: "Evaluation datasets must be configured when
+        # eval_interval is set." rLLM runs validation itself, so Miles must not eval.
+        block, _ = build_block(self._cfg())
+        assert "eval_interval" not in block
+
+    def test_explicit_miles_value_wins_over_shared_key(self):
+        block, _ = build_block(self._cfg(hf_checkpoint="/local/ckpt"))
+        assert block["hf_checkpoint"] == "/local/ckpt"
+
+    def test_total_steps_sets_num_rollout(self):
+        block, _ = build_block(self._cfg(), total_steps=250)
+        assert block["num_rollout"] == 250
+
+    def test_extra_args_are_split_out_not_rendered_as_a_flag(self):
+        block, extra = build_block(self._cfg(extra_args=["--moe-grouped-gemm"]))
+        assert "extra_args" not in block
+        assert extra == ["--moe-grouped-gemm"]
+
+    def test_missing_shared_source_is_simply_absent(self):
+        cfg = OmegaConf.create({"rllm": {}, "miles": {"train_backend": "fsdp"}})
+        block, _ = build_block(cfg)
+        assert "hf_checkpoint" not in block
+        assert block["train_backend"] == "fsdp"
+
+    def test_round_trip_to_argv(self):
+        block, extra = build_block(self._cfg(rollout_num_gpus=8, train_backend="fsdp"), total_steps=100)
+        argv = render_argv(block, ARITY) + extra
+        assert "--disable-rollout-global-dataset" in argv
+        assert "--disable-compute-advantages-and-returns" in argv
+        assert argv[argv.index("--rollout-function-path") + 1] == "miles.rollout.sleep_rollout.sleep"
+        assert argv[argv.index("--num-rollout") + 1] == "100"
+
+
+class TestShippedBackendYaml:
+    """Guards rllm/trainer/config/rllm/backend/miles.yaml against drift."""
+
+    def _load(self):
+        from pathlib import Path
+
+        import rllm.trainer.config as cfg_pkg
+
+        path = Path(cfg_pkg.__file__).parent / "rllm" / "backend" / "miles.yaml"
+        cfg = OmegaConf.load(path)
+        OmegaConf.update(cfg, "training.group_size", 8)  # ??? in the shipped file
+        OmegaConf.update(cfg, "rllm.data.train_batch_size", 16)
+        OmegaConf.update(cfg, "rllm.trainer.project_name", "rllm-miles-test")
+        OmegaConf.update(cfg, "rllm.trainer.experiment_name", "t")
+        return cfg
+
+    def test_yaml_does_not_set_any_pinned_flag(self):
+        # A pinned flag creeping into the shipped yaml would make every run fail.
+        cfg = self._load()
+        build_block(cfg)  # raises if the yaml collides with PINNED_FLAGS
+
+    def test_yaml_renders_to_argv(self):
+        cfg = self._load()
+        block, extra = build_block(cfg, total_steps=50)
+        argv = render_argv(block, ARITY) + extra
+        assert argv[argv.index("--train-backend") + 1] == "fsdp"
+        assert argv[argv.index("--num-rollout") + 1] == "50"
+        assert "--disable-rollout-global-dataset" in argv
+        # null entries (ref_load, tensor_model_parallel_size) stay out of argv
+        assert "--ref-load" not in argv
+        assert "--tensor-model-parallel-size" not in argv
+        # empty extra_args must not become a flag
+        assert "--extra-args" not in argv
+
+    def test_yaml_declares_the_miles_backend(self):
+        assert self._load().rllm.backend == "miles"
+
+
+class TestRejectedGenerationFlags:
+    """Miles flags that configure its own generation path, which rLLM replaces."""
+
+    def test_fully_async_is_rejected_because_it_overrides_the_rollout_pin(self):
+        from rllm.trainer.miles.miles_config import REJECTED_GENERATION_FLAGS
+
+        assert "fully_async" in REJECTED_GENERATION_FLAGS
+        with pytest.raises(ValueError, match="fully_async"):
+            validate_pinned({"fully_async": True})
+
+    def test_multi_lora_is_rejected(self):
+        with pytest.raises(ValueError, match="rollout function of its own"):
+            validate_pinned({"multi_lora": True})
+
+    def test_session_server_is_rejected(self):
+        with pytest.raises(ValueError, match="rLLM owns tokenization"):
+            validate_pinned({"use_session_server": "v2"})
+
+    def test_positive_spelling_of_the_dataset_flag_is_caught(self):
+        # The negated flag is the real one; setting the dest name is a silent no-op otherwise.
+        with pytest.raises(ValueError, match="disable-rollout-global-dataset"):
+            validate_pinned({"rollout_global_dataset": True})
+
+    def test_falsy_values_are_not_rejected(self):
+        validate_pinned({"fully_async": False, "multi_lora": False, "partial_rollout": False})
+
+    def test_error_explains_why_not_just_that(self):
+        with pytest.raises(ValueError) as e:
+            validate_pinned({"fully_async": True})
+        assert "sleep_rollout" in str(e.value)

--- a/tests/test_miles_config.py
+++ b/tests/test_miles_config.py
@@ -263,3 +263,66 @@ class TestMilesTrainIters:
         # n_samples_per_prompt=1 gave 20 * 1 * 1 // 32 == 0.
         block, _ = build_block(self._cfg(async_enable=True), total_steps=20)
         assert self._train_iters(block, 20) > 0
+
+
+class TestRolloutCorrection:
+    """Async trains on data from older weight versions; without TIS the ratio is taken
+    against a fresh pi_old, the update is biased, and the policy can degrade. This was
+    unmapped, so rllm.algorithm.rollout_correction.* was silently ignored."""
+
+    def _cfg(self, correction=None, async_on=True, staleness=0.5):
+        return OmegaConf.create(
+            {
+                "model": {"name": "m"},
+                "rllm": {
+                    "data": {"train_batch_size": 1},
+                    "rollout": {"n": 8},
+                    "trainer": {"save_freq": 20},
+                    "async_training": {"enable": async_on, "mini_batch_size": 32, "staleness_threshold": staleness},
+                    "algorithm": {"rollout_correction": correction or {}},
+                },
+                "miles": {},
+            }
+        )
+
+    def test_token_tis_enables_miles_tis(self):
+        block, _ = build_block(self._cfg({"tis_mode": "token", "tis_cap": 2.0}))
+        assert block["use_tis"] is True
+        assert block["tis_clip"] == 2.0
+
+    def test_tis_cap_is_forwarded(self):
+        block, _ = build_block(self._cfg({"tis_mode": "token", "tis_cap": 1.5}))
+        assert block["tis_clip"] == 1.5
+
+    def test_no_tis_mode_leaves_the_flags_alone(self):
+        block, _ = build_block(self._cfg({"tis_mode": None}))
+        assert "use_tis" not in block
+
+    def test_bypass_mode_uses_rollout_logprobs(self):
+        block, _ = build_block(self._cfg({"bypass_mode": True}))
+        assert block["use_rollout_logprobs"] is True
+
+    def test_bypass_false_leaves_miles_recomputing_pi_old(self):
+        block, _ = build_block(self._cfg({"bypass_mode": False}))
+        assert "use_rollout_logprobs" not in block
+
+    def test_sequence_tis_is_rejected_not_silently_downgraded(self):
+        with pytest.raises(ValueError, match="token-level"):
+            build_block(self._cfg({"tis_mode": "sequence"}))
+
+    def test_explicit_miles_flag_wins(self):
+        cfg = self._cfg({"tis_mode": "token", "tis_cap": 2.0})
+        cfg.miles = {"tis_clip": 3.0}
+        block, _ = build_block(cfg)
+        assert block["tis_clip"] == 3.0
+
+    def test_stale_async_without_correction_warns(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            build_block(self._cfg({}, staleness=1.0))
+        assert "biased by the policy lag" in caplog.text
+
+    def test_on_policy_async_does_not_warn(self, caplog):
+        build_block(self._cfg({}, staleness=0.0))
+        assert "biased by the policy lag" not in caplog.text

--- a/tests/test_miles_config.py
+++ b/tests/test_miles_config.py
@@ -414,3 +414,32 @@ class TestRolloutServerLoggingDefaults:
         """Only the per-request/per-decode floods are silenced; startup diagnostics
         (model load, memory, cuda graph capture) stay visible."""
         assert self._compose().miles.get("sglang_log_level") is None
+
+
+class TestRouterMustBeTransparent:
+    """The Rust sglang_router (0.3.2, measured) re-serializes a chat request through its
+    own struct and drops fields it does not know -- including the sglang-miles-only
+    return_meta_info / return_prompt_token_ids that carry completion token IDs. logprobs
+    survives, so the failure is silent until "length mismatch between response_ids and
+    logprobs, got 0, N". Miles' own router proxies raw bytes.
+    """
+
+    def test_default_is_the_transparent_router(self):
+        from pathlib import Path
+
+        import rllm.trainer.config as cfg_pkg
+
+        cfg = OmegaConf.load(Path(cfg_pkg.__file__).parent / "rllm" / "backend" / "miles.yaml")
+        assert cfg.miles.use_miles_router is True
+
+    def test_disabling_it_is_rejected(self):
+        from rllm.trainer.miles.miles_config import validate_router
+
+        with pytest.raises(ValueError, match="drops trace-capture fields"):
+            validate_router({"use_miles_router": False})
+
+    def test_absent_or_true_is_fine(self):
+        from rllm.trainer.miles.miles_config import validate_router
+
+        validate_router({})
+        validate_router({"use_miles_router": True})

--- a/tests/test_miles_config.py
+++ b/tests/test_miles_config.py
@@ -368,3 +368,49 @@ class TestAttentionMustHonourPacking:
         with pytest.raises(ValueError) as e:
             validate_attention({"attn_implementation": "sdpa"})
         assert "flash_attention_2" in str(e.value) and "qkv_format=bshd" in str(e.value)
+
+
+class TestRolloutServerLoggingDefaults:
+    """SGLang's own defaults drown rLLM's metrics: a "Decode batch" line every 40 steps
+    per engine plus a uvicorn access line per request -- and on the AgentFlow path that
+    is one request per agent turn. Quiet by default in backend/miles.yaml rather than
+    per-script, but still overridable (hence a yaml default, not a PINNED_FLAG).
+    """
+
+    def _compose(self, extra=()):
+        """Compose the way a run does, so a default that only exists in a hand-built
+        config -- or gets clobbered during composition -- shows up as a failure."""
+        from pathlib import Path
+
+        from hydra import compose, initialize_config_dir
+
+        import rllm.trainer.config as cfg_pkg
+
+        with initialize_config_dir(config_dir=str(Path(cfg_pkg.__file__).parent), version_base=None):
+            return compose(
+                config_name="unified",
+                overrides=[
+                    "rllm/backend=miles",
+                    "model.name=Qwen/Qwen3-1.7B",
+                    "training.group_size=8",
+                    "rllm.data.train_batch_size=16",
+                    "rllm.data.max_prompt_length=512",
+                    "rllm.data.max_response_length=2048",
+                    *extra,
+                ],
+            )
+
+    def test_quiet_by_default(self):
+        cfg = self._compose()
+        assert cfg.miles.sglang_log_level_http == "warning"
+        assert cfg.miles.sglang_decode_log_interval == 1000
+
+    def test_still_overridable(self):
+        cfg = self._compose(["miles.sglang_log_level_http=info", "miles.sglang_decode_log_interval=40"])
+        assert cfg.miles.sglang_log_level_http == "info"
+        assert cfg.miles.sglang_decode_log_interval == 40
+
+    def test_general_sglang_log_level_left_alone(self):
+        """Only the per-request/per-decode floods are silenced; startup diagnostics
+        (model load, memory, cuda graph capture) stay visible."""
+        assert self._compose().miles.get("sglang_log_level") is None

--- a/tests/test_miles_engine.py
+++ b/tests/test_miles_engine.py
@@ -1,0 +1,43 @@
+"""MilesEngine sampling params.
+
+A missing top_k let SGLang fall back to the model's generation_config (top_k=20 for
+Qwen3), so the returned logprobs were renormalised over 20 tokens and systematically too
+high. exp(train - rollout) then sat near 0.25 instead of 1.0, and TIS multiplied the
+gradient by that bogus ratio. Nothing surfaced without TIS, because the loss never read
+rollout_log_probs.
+"""
+
+from omegaconf import OmegaConf
+
+from rllm.engine.rollout.miles_engine import MilesEngine
+
+
+class TestSamplingParams:
+    def test_top_k_is_always_sent(self):
+        assert MilesEngine._sampling_from({})["top_k"] == -1
+
+    def test_top_k_defaults_to_disabled_not_omitted(self):
+        # -1 disables truncation; omitting the key is what let the server default win.
+        params = MilesEngine._sampling_from(OmegaConf.create({"temperature": 1.0}))
+        assert params["top_k"] == -1
+
+    def test_config_overrides_the_default(self):
+        params = MilesEngine._sampling_from(OmegaConf.create({"top_k": 50, "temperature": 0.7}))
+        assert params["top_k"] == 50
+        assert params["temperature"] == 0.7
+
+    def test_defaults_are_neutral(self):
+        params = MilesEngine._sampling_from(None)
+        assert params == {"temperature": 1.0, "top_p": 1.0, "top_k": -1}
+
+    def test_none_values_do_not_clobber_defaults(self):
+        params = MilesEngine._sampling_from(OmegaConf.create({"top_p": None}))
+        assert params["top_p"] == 1.0
+
+    def test_unknown_keys_are_dropped(self):
+        params = MilesEngine._sampling_from(OmegaConf.create({"max_tokens": 256, "bogus": 1}))
+        assert "max_tokens" not in params and "bogus" not in params
+
+    def test_optional_knobs_pass_through(self):
+        params = MilesEngine._sampling_from(OmegaConf.create({"min_p": 0.05, "repetition_penalty": 1.1}))
+        assert params["min_p"] == 0.05 and params["repetition_penalty"] == 1.1

--- a/tests/test_miles_gateway.py
+++ b/tests/test_miles_gateway.py
@@ -114,7 +114,10 @@ class TestFlavourInjection:
         SessionRoutingMiddleware(app=None, worker_flavor="sglang")._mutate(p)
         assert p["return_meta_info"] is True
         assert p["return_prompt_token_ids"] is True
-        assert p["skip_special_tokens"] is False
+        # no_stop_trim, matching miles.rollout.session.core; skip_special_tokens was wrong
+        # and would have left special tokens in the agent-visible text.
+        assert p["no_stop_trim"] is False
+        assert "skip_special_tokens" not in p
         assert "return_token_ids" not in p, "SGLang has no such field"
 
     def test_vllm_keeps_return_token_ids(self):

--- a/tests/test_miles_gateway.py
+++ b/tests/test_miles_gateway.py
@@ -42,3 +42,93 @@ class TestMilesEngineExposesAddresses:
         from rllm.engine.rollout import miles_engine
 
         assert "self.server_addresses = [self.router_url]" in inspect.getsource(miles_engine.MilesEngine.__init__)
+
+
+class TestSGLangTraceExtraction:
+    """SGLang has no vLLM-style choices[0].token_ids; completion ids ride in
+    meta_info.output_token_logprobs as [logprob, token_id] pairs."""
+
+    # what an SGLang chat response looks like with return_meta_info + logprobs
+    SGLANG = {
+        "choices": [
+            {
+                "message": {"content": "hi"},
+                "prompt_token_ids": [1, 2, 3],
+                "logprobs": {"content": [{"token": "h", "logprob": -0.5}, {"token": "i", "logprob": -0.25}]},
+                "meta_info": {"output_token_logprobs": [[-0.5, 40, None], [-0.25, 41, None]]},
+            }
+        ]
+    }
+    VLLM = {
+        "choices": [
+            {
+                "message": {"content": "hi"},
+                "prompt_token_ids": [1, 2, 3],
+                "token_ids": [40, 41],
+                "logprobs": {"content": [{"token": "h", "logprob": -0.5}, {"token": "i", "logprob": -0.25}]},
+            }
+        ]
+    }
+
+    def test_completion_ids_from_sglang_meta_info(self):
+        from rllm_model_gateway.data_process import extract_completion_token_ids
+
+        assert extract_completion_token_ids(self.SGLANG) == [40, 41]
+
+    def test_vllm_token_ids_still_win(self):
+        from rllm_model_gateway.data_process import extract_completion_token_ids
+
+        assert extract_completion_token_ids(self.VLLM) == [40, 41]
+
+    def test_prompt_ids_from_the_choice(self):
+        from rllm_model_gateway.data_process import extract_prompt_token_ids
+
+        assert extract_prompt_token_ids(self.SGLANG) == [1, 2, 3]
+
+    def test_logprobs_come_from_meta_info_when_present(self):
+        from rllm_model_gateway.data_process import extract_logprobs
+
+        assert extract_logprobs(self.SGLANG) == [-0.5, -0.25]
+
+    def test_ids_and_logprobs_are_index_aligned(self):
+        from rllm_model_gateway.data_process import extract_completion_token_ids, extract_logprobs
+
+        assert len(extract_completion_token_ids(self.SGLANG)) == len(extract_logprobs(self.SGLANG))
+
+    def test_vllm_logprobs_path_unchanged(self):
+        from rllm_model_gateway.data_process import extract_logprobs
+
+        assert extract_logprobs(self.VLLM) == [-0.5, -0.25]
+
+    def test_missing_meta_info_yields_nothing_rather_than_raising(self):
+        from rllm_model_gateway.data_process import extract_completion_token_ids
+
+        assert extract_completion_token_ids({"choices": [{"message": {}}]}) == []
+
+
+class TestFlavourInjection:
+    def test_sglang_gets_meta_info_flags(self):
+        from rllm_model_gateway.middleware import SessionRoutingMiddleware
+
+        p = {}
+        SessionRoutingMiddleware(app=None, worker_flavor="sglang")._mutate(p)
+        assert p["return_meta_info"] is True
+        assert p["return_prompt_token_ids"] is True
+        assert p["skip_special_tokens"] is False
+        assert "return_token_ids" not in p, "SGLang has no such field"
+
+    def test_vllm_keeps_return_token_ids(self):
+        from rllm_model_gateway.middleware import SessionRoutingMiddleware
+
+        p = {}
+        SessionRoutingMiddleware(app=None, worker_flavor="vllm")._mutate(p)
+        assert p["return_token_ids"] is True
+        assert "return_meta_info" not in p
+
+    def test_manager_sets_flavour_from_the_engine(self):
+        import inspect
+
+        from rllm.gateway.manager import GatewayManager
+
+        src = inspect.getsource(GatewayManager.start)
+        assert 'self.worker_flavor = "sglang" if engine_cls == "MilesEngine" else "vllm"' in src

--- a/tests/test_miles_gateway.py
+++ b/tests/test_miles_gateway.py
@@ -1,0 +1,44 @@
+"""Gateway wiring for the AgentFlow path on the miles backend.
+
+AgentFlow agents talk OpenAI over rLLM's gateway rather than going through MilesEngine's
+token-in/token-out path, so the gateway has to know how to reach Miles' inference
+servers. It dispatches on the engine class name and previously fell through to
+"Unknown engine type ... no workers registered" -- a warning, then a gateway with no
+backend and every agent call failing.
+"""
+
+import inspect
+
+from rllm.gateway.manager import GatewayManager
+
+
+class _FakeEngine:
+    def __init__(self, addresses):
+        self.server_addresses = addresses
+
+
+class TestMilesEngineIsRouted:
+    def test_dispatch_covers_miles_engine(self):
+        src = inspect.getsource(GatewayManager.start)
+        assert '"MilesEngine"' in src, "gateway would register zero workers for MilesEngine"
+
+    def test_router_url_becomes_a_worker_url(self):
+        urls = GatewayManager._http_worker_urls(None, _FakeEngine(["http://10.0.0.1:15000"]))
+        assert urls == ["http://10.0.0.1:15000"]
+
+    def test_bare_host_port_gets_a_scheme(self):
+        # verl hands over host:port; miles hands over a full URL. Both must work.
+        urls = GatewayManager._http_worker_urls(None, _FakeEngine(["10.0.0.1:15000"]))
+        assert urls == ["http://10.0.0.1:15000"]
+
+    def test_several_addresses_all_register(self):
+        urls = GatewayManager._http_worker_urls(None, _FakeEngine(["a:1", "http://b:2"]))
+        assert urls == ["http://a:1", "http://b:2"]
+
+
+class TestMilesEngineExposesAddresses:
+    def test_engine_publishes_its_router(self):
+        # Checked by source, since constructing MilesEngine needs a tokenizer.
+        from rllm.engine.rollout import miles_engine
+
+        assert "self.server_addresses = [self.router_url]" in inspect.getsource(miles_engine.MilesEngine.__init__)

--- a/tests/test_miles_transform.py
+++ b/tests/test_miles_transform.py
@@ -1,0 +1,159 @@
+"""Miles transform: trajectory steps -> merged Miles sample payloads."""
+
+import pytest
+
+from rllm.trainer.miles.transform import (
+    SamplePayload,
+    trajectory_groups_to_payloads,
+    trajectory_to_payloads,
+)
+from rllm.types import Step, Trajectory, TrajectoryGroup
+
+
+def step(prompt_ids, response_ids, advantage=1.0, logprobs=None, lineage_id=None):
+    return Step(
+        prompt_ids=list(prompt_ids),
+        response_ids=list(response_ids),
+        logprobs=logprobs if logprobs is not None else [-0.5] * len(response_ids),
+        advantage=advantage,
+        metadata={"lineage_id": lineage_id} if lineage_id is not None else None,
+    )
+
+
+def traj(*steps, reward=1.0):
+    return Trajectory(steps=list(steps), reward=reward)
+
+
+class TestSingleStep:
+    def test_prompt_is_masked_response_is_not(self):
+        (p,) = trajectory_to_payloads(traj(step([1, 2, 3], [4, 5])))
+        assert p.tokens == [1, 2, 3, 4, 5]
+        assert p.prompt_length == 3
+        assert p.response_length == 2
+        assert p.loss_mask == [1, 1]
+        assert p.rollout_log_probs == [-0.5, -0.5]
+        assert p.advantages == [1.0, 1.0]
+
+    def test_scalar_advantage_is_broadcast_over_response_tokens(self):
+        (p,) = trajectory_to_payloads(traj(step([1], [2, 3, 4], advantage=0.25)))
+        assert p.advantages == [0.25, 0.25, 0.25]
+
+    def test_per_token_advantage_is_used_verbatim(self):
+        (p,) = trajectory_to_payloads(traj(step([1], [2, 3], advantage=[0.1, 0.9])))
+        assert p.advantages == [0.1, 0.9]
+
+    def test_reward_comes_from_the_trajectory(self):
+        (p,) = trajectory_to_payloads(traj(step([1], [2]), reward=0.75))
+        assert p.reward == 0.75
+
+
+class TestMerging:
+    def test_prefix_extension_merges_into_one_sequence(self):
+        # step 2's prompt is step 1's prompt+response plus a new observation.
+        p1 = step([1, 2], [3, 4])
+        p2 = step([1, 2, 3, 4, 9], [5])
+        (p,) = trajectory_to_payloads(traj(p1, p2))
+        assert p.tokens == [1, 2, 3, 4, 9, 5]
+        assert p.prompt_length == 2
+        # response region: [3,4] action, [9] observation, [5] action
+        assert p.loss_mask == [1, 1, 0, 1]
+        assert p.advantages == [1.0, 1.0, 0.0, 1.0]
+        assert p.rollout_log_probs == [-0.5, -0.5, 0.0, -0.5]
+
+    def test_non_extension_starts_a_new_payload(self):
+        payloads = trajectory_to_payloads(traj(step([1, 2], [3]), step([7, 8], [9])))
+        assert len(payloads) == 2
+        assert payloads[0].tokens == [1, 2, 3]
+        assert payloads[1].tokens == [7, 8, 9]
+
+    def test_three_way_chain_stays_one_sequence(self):
+        payloads = trajectory_to_payloads(
+            traj(
+                step([1], [2]),
+                step([1, 2], [3]),
+                step([1, 2, 3], [4]),
+            )
+        )
+        assert len(payloads) == 1
+        assert payloads[0].tokens == [1, 2, 3, 4]
+        assert payloads[0].loss_mask == [1, 1, 1]
+
+    def test_mixed_chain_then_break(self):
+        payloads = trajectory_to_payloads(
+            traj(
+                step([1], [2]),
+                step([1, 2], [3]),
+                step([50], [51]),
+            )
+        )
+        assert [p.tokens for p in payloads] == [[1, 2, 3], [50, 51]]
+
+
+class TestLineagePartitioning:
+    def test_interleaved_lineages_merge_independently(self):
+        payloads = trajectory_to_payloads(
+            traj(
+                step([1], [2], lineage_id="parent"),
+                step([90], [91], lineage_id="sub"),
+                step([1, 2], [3], lineage_id="parent"),
+                step([90, 91], [92], lineage_id="sub"),
+            )
+        )
+        # Without partitioning the interleaving would break both chains into 4.
+        assert len(payloads) == 2
+        assert sorted(p.tokens for p in payloads) == [[1, 2, 3], [90, 91, 92]]
+
+    def test_untagged_steps_form_a_single_partition(self):
+        payloads = trajectory_to_payloads(traj(step([1], [2]), step([1, 2], [3])))
+        assert len(payloads) == 1
+
+
+class TestValidation:
+    def test_logprob_count_must_match_response_tokens(self):
+        with pytest.raises(ValueError, match="logprobs"):
+            trajectory_to_payloads(traj(step([1], [2, 3], logprobs=[-0.1])))
+
+    def test_missing_advantage_is_rejected(self):
+        with pytest.raises(ValueError, match="advantage is None"):
+            trajectory_to_payloads(traj(step([1], [2], advantage=None)))
+
+    def test_per_token_advantage_length_mismatch_is_rejected(self):
+        with pytest.raises(ValueError, match="per-token advantage"):
+            trajectory_to_payloads(traj(step([1], [2, 3], advantage=[0.5])))
+
+    def test_non_integer_tokens_are_rejected(self):
+        with pytest.raises(TypeError, match="flat integer"):
+            trajectory_to_payloads(traj(step([1, {"image": "x"}], [2])))
+
+    def test_step_with_no_response_contributes_only_context(self):
+        # An empty-response step is not trainable on its own...
+        assert trajectory_to_payloads(traj(step([1, 2], []))) == []
+        # ...but its tokens still become context for a step that extends it.
+        (p,) = trajectory_to_payloads(traj(step([1, 2], []), step([1, 2, 7], [8])))
+        assert p.tokens == [1, 2, 7, 8]
+        assert p.loss_mask == [0, 1]
+
+    def test_payload_validate_catches_array_length_drift(self):
+        bad = SamplePayload(tokens=[1, 2, 3], prompt_length=1, loss_mask=[1], rollout_log_probs=[0.0, 0.0], advantages=[0.0, 0.0])
+        with pytest.raises(ValueError, match="loss_mask has length 1"):
+            bad.validate()
+
+    def test_payload_validate_rejects_prompt_longer_than_tokens(self):
+        bad = SamplePayload(tokens=[1], prompt_length=5, loss_mask=[], rollout_log_probs=[], advantages=[])
+        with pytest.raises(ValueError, match="exceeds token count"):
+            bad.validate()
+
+
+class TestGroups:
+    def test_groups_are_preserved_as_nested_lists(self):
+        g1 = TrajectoryGroup(trajectories=[traj(step([1], [2])), traj(step([3], [4]))], group_id="a:agent")
+        g2 = TrajectoryGroup(trajectories=[traj(step([5], [6]))], group_id="b:agent")
+        grouped = trajectory_groups_to_payloads([g1, g2])
+        assert [len(g) for g in grouped] == [2, 1]
+
+    def test_group_with_nothing_trainable_is_dropped(self):
+        empty = TrajectoryGroup(trajectories=[traj(step([1, 2], []))], group_id="empty:agent")
+        good = TrajectoryGroup(trajectories=[traj(step([1], [2]))], group_id="good:agent")
+        grouped = trajectory_groups_to_payloads([empty, good])
+        assert len(grouped) == 1
+        assert grouped[0][0].tokens == [1, 2]

--- a/tests/trainer/verl/test_ray_runtime_env.py
+++ b/tests/trainer/verl/test_ray_runtime_env.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 
 from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
 
-from rllm.trainer.verl.ray_runtime_env import _get_forwarded_env_vars, get_ppo_ray_runtime_env
+from rllm.trainer.ray_init_utils import get_forwarded_env_vars as _get_forwarded_env_vars
+from rllm.trainer.verl.ray_runtime_env import get_ppo_ray_runtime_env
 
 
 def test_forward_basic_env_vars():


### PR DESCRIPTION
Adds `backend="miles"` alongside verl / tinker / fireworks. rLLM's `UnifiedTrainer` keeps
the loop; [Miles](https://github.com/radixark/miles) (slime fork: SGLang rollout +
Megatron-LM/FSDP2 training) owns the GPUs.

Draft because several things are still unexercised — see *Not done* below. Design notes,
environment recipe and the full TODO list live in `design/miles-training-backend.md`.

## Shape

Miles' `train.py` is unused. Its `RolloutManager` is kept alive only as the SGLang fleet,
the router, and the weight-update broker (`update_weights` routes through it), with its
rollout function pinned to `sleep_rollout` so it never generates.

| BackendProtocol | Miles |
|---|---|
| `init_rollout_engine` | `create_placement_groups` / `create_rollout_manager` / `create_training_models`, then `MilesEngine` → SGLang `/generate` (token-in/token-out) |
| `generate_episodes` | rLLM's workflow engine, unchanged |
| `transform_to_backend_batch` | episodes → `list[Sample]` → `convert_samples_to_train_data` |
| `process_backend_batch` | no-op (Miles' actor runs its own forward passes) |
| `update_policy` | `RayTrainGroup.train` |
| `on_batch_end` / `on_policy_updated` | save + weight sync (sync / async respectively) |

Not the TITO session server: rLLM already owns tokenization and loss masks, so routing
through it would install a second tokenizer authority.

## Validated

Countdown, Qwen3-1.7B, 4 FSDP train GPUs + 4 SGLang rollout GPUs on 8xH100.

| `val/countdown/pass@1` | @8 | @16 | @20 | @24 | @40 | @60 |
|---|---|---|---|---|---|---|
| sync | — | — | 0.554 | — | 0.661 | 0.676 |
| async + TIS | 0.455 | 0.504 | — | 0.552 | — | — |

1024 held-out tasks per point (SE ~0.015). Async runs with `staleness_threshold=0.5` and
real overlap (per-step staleness `min < mean < max`).

## Three bugs worth calling out

Each produced a **healthy-looking run** that was training on the wrong thing, so each now
has a permanent guard.

1. **`attn_implementation` must be varlen-capable.** Miles' FSDP path packs several
   samples per row, passes `attention_mask=None`, and derives `cu_seqlens` from packed
   `position_ids`. SDPA ignores `cu_seqlens`, so samples attend across each other — the
   wrong computation, not lower precision. Cost async ~0.08 pass@1 and sync ~0.05 (sync's
   penalty *grows* with training, so short runs understate it). Miles defaults to
   `flash_attention_2` and does not validate the combination. `validate_attention` now
   rejects it; the diagnostic is `tis_abs`, which went 0.830 → 0.012.
2. **Advantages were dropped twice on the way to the loss** — a hardcoded key allowlist in
   the DP split, and the FSDP actor calling `compute_advantages_and_returns`
   unconditionally where only the Megatron actor honours the disable flag. Both patched,
   with the patch wrapper now *raising* rather than silently falling back to Miles' own
   advantages.
3. **`rllm.algorithm.rollout_correction.*` was unmapped**, so `tis_mode` / `tis_cap` were
   accepted by Hydra and discarded.

`assert_patch_contracts` guards all three patch sites and reports when an upstream fix
makes one redundant.

## Notes for review

- **Breaking:** `tinker` moves out of core `dependencies` into the `tinker` extra
  (`tinker-cookbook` caps `transformers<=5.5.4`; Miles needs `==5.12.1`). `backend="tinker"`
  now needs `pip install 'rllm[tinker]'`.
- Two cross-backend refactors, both splittable: the launcher dispatch table, and moving
  ray env-var forwarding into `rllm/trainer/ray_init_utils.py`.
- `rllm/trainer/miles/patch.py` monkey-patches Miles in three places; all three want
  upstreaming so the file can be deleted.
- `scripts/setup_miles_env.sh` builds the env without Miles' container image (only
  `sglang` is missing from its `requirements.txt`, and the FSDP path needs `megatron-core`).

## Not done

Checkpointing has **never executed** (`save_freq=1000` in every run); Miles'
`loss`/`grad_norm` never reach `trainer_state.metrics`; CP>1 is untested (the advantages
patch is identity at CP=1 — the largest correctness gap left); multi-turn only run
single-turn; Megatron backend needs the offline HF→`torch_dist` conversion; ~40% of groups
still lost to uniform-reward filtering.

Tests: 137 with miles importable, 109 + 29 skipped without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)