### PR TITLE
fix(sft): make hosted checkpoint resume actually work (Tinker + Fireworks)

### DIFF
--- a/rllm/trainer/sft/fireworks_backend.py
+++ b/rllm/trainer/sft/fireworks_backend.py
@@ -25,16 +25,19 @@ import os
 import re
 import tempfile
 import time
-from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from omegaconf import DictConfig, OmegaConf
 
 from rllm.trainer.sft.backend import SFTConfigError
 from rllm.trainer.sft.tinker_backend import (
     TinkerSFTBackend,
+    _is_step_boundary,
     build_adam_params,
     build_sft_data,
+    iter_training_batches_from_step,
     resolve_sft_optimizer_settings,
     resolve_training_steps,
     sft_lr_multiplier,
@@ -44,6 +47,29 @@ from rllm.trainer.sft.tinker_backend import (
 logger = logging.getLogger(__name__)
 
 _CONFIG_FILE = Path(__file__).resolve().parent / "config" / "fireworks.yaml"
+
+
+def _fireworks_output_model_id(project: str, experiment: str) -> str:
+    """Return a Fireworks-safe final model ID within the 63-character limit."""
+    model_id = re.sub(r"[^a-z0-9-]+", "-", f"{project}-{experiment}".lower()).strip("-")[:63].rstrip("-")
+    if not model_id:
+        raise SFTConfigError("Fireworks final model ID is empty after sanitization")
+    return model_id
+
+
+@dataclass
+class _SubmittedFireworksBatch:
+    step: int
+    data: list[Any]
+    learning_rate: float
+    started_at: float
+    fb_future: Any
+    opt_future: Any
+
+
+def _configured_policy_job_id(config) -> str | None:
+    value = OmegaConf.select(config, "fireworks_infra.trainers.policy.job_id")
+    return str(value) if value else None
 
 
 class FireworksSFTBackend(TinkerSFTBackend):
@@ -104,6 +130,29 @@ class FireworksSFTBackend(TinkerSFTBackend):
             cfg = OmegaConf.merge(cfg, OmegaConf.create(spec.overrides))
         self._align_shape_with_lora_rank(cfg)
         self._require_consistent_model_swap(base, cfg)
+        user = OmegaConf.to_container(OmegaConf.create(spec.overrides), resolve=False) if spec.overrides else {}
+        user_trainer = user.get("trainer") if isinstance(user, dict) else None
+        explicit_override = isinstance(user_trainer, dict) and user_trainer.get("default_local_dir") is not None
+        self._resume_requested = bool(spec.output_dir) or explicit_override
+        configured_job_id = _configured_policy_job_id(cfg)
+        if configured_job_id is not None and not self._resume_requested:
+            raise SFTConfigError(
+                "Reattaching a Fireworks trainer via fireworks_infra.trainers.policy.job_id requires an explicit --output (or trainer.default_local_dir override) containing its local cursor metadata."
+            )
+        if not self._resume_requested:
+            experiment = (
+                re.sub(
+                    r"[^A-Za-z0-9._-]+",
+                    "-",
+                    str(cfg.trainer.get("experiment_name") or "default"),
+                ).strip("-._")
+                or "default"
+            )
+            cfg.trainer.default_local_dir = os.path.join(
+                str(cfg.trainer.default_local_dir),
+                experiment,
+                self._run_leaf,
+            )
         self._config = cfg
         return cfg
 
@@ -182,14 +231,15 @@ class FireworksSFTBackend(TinkerSFTBackend):
         finally:
             doc_path.unlink(missing_ok=True)
 
-        # cleanup_existing/cleanup_on_close mirror the RL backend: rllm provisions
-        # a fresh trainer per run and tears it down on exit.
+        # Provider trainer state is what makes resume durable across relaunches.
+        # ``infra.close()`` must release local/client handles without deleting a
+        # fresh or reattached trainer after an exception, Ctrl-C, or relaunch.
         return init_fireworks_infra(
             "sft",
             provision_cfg,
             base_url=base_url,
-            cleanup_on_close=True,
-            cleanup_existing=True,
+            cleanup_on_close=False,
+            cleanup_existing=False,
         )
 
     def fit(self) -> None:
@@ -211,16 +261,11 @@ class FireworksSFTBackend(TinkerSFTBackend):
             raise SFTConfigError("FIREWORKS_API_KEY is not set; required for the fireworks SFT backend.")
         base_url = os.environ.get("FIREWORKS_BASE_URL", config.get("fireworks_base_url", "https://api.fireworks.ai"))
 
-        # <local dir>/<experiment>/<run stamp>/ — the template default is a fixed
-        # shared /tmp path, and even an explicit --output collides across
-        # relaunches; a per-run stamp keeps every run's logs/metadata separate.
-        # Safe here: Fireworks SFT resume is server-side (job DCP), not local.
-        run_stamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
-        config.trainer.default_local_dir = os.path.join(
-            config.trainer.default_local_dir,
-            config.trainer.get("experiment_name") or "default",
-            run_stamp,
-        )
+        # A generated path is isolated per backend instance. An explicit path is
+        # stable because Fireworks keeps its exact data cursor locally beside the
+        # run manifest; changing this path would make provider resume ambiguous.
+        if not self._resume_requested and os.path.exists(config.trainer.default_local_dir):
+            raise SFTConfigError("The generated Fireworks run directory already exists; create a new backend instance so a fresh isolated directory can be selected.")
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
         lora_rank = config.model.get("lora_rank", 32)
 
@@ -261,7 +306,32 @@ class FireworksSFTBackend(TinkerSFTBackend):
 
                 # Auto-resume from the newest resumable checkpoint, if any.
                 resume = ckpt.resume()
-                start_step = resume.step if resume else 0
+                if resume is not None:
+                    data_consumed = getattr(resume, "data_consumed", None)
+                    if isinstance(data_consumed, bool) or not isinstance(data_consumed, int) or data_consumed <= 0:
+                        raise SFTConfigError(
+                            "Fireworks found a resumable checkpoint without a positive persisted dataset cursor; "
+                            "refusing to replay training data. Use a new trainer job or restore its dataloader.json."
+                        )
+                    # Fireworks may rename the requested checkpoint (for example
+                    # step-42 to step-0), so its name-derived ``step`` is not a
+                    # data cursor. The raw-row cursor persisted by rLLM is.
+                    start_step = train_dataset.step_for_data_cursor(data_consumed)
+                else:
+                    # A fresh provider job answers resume() with None even when this
+                    # output directory belongs to an interrupted run. The SDK's local
+                    # cursor file is the evidence: refuse to silently retrain from
+                    # scratch under a directory that carries prior progress.
+                    dataloader_path = Path(config.trainer.default_local_dir) / "dataloader.json"
+                    if self._resume_requested and dataloader_path.exists():
+                        raise SFTConfigError(
+                            "This output directory records Fireworks training progress, but the provisioned "
+                            "trainer job has no resumable checkpoint (a new job was created). Set "
+                            "fireworks_infra.trainers.policy.job_id to reattach the original job, or use a new --output."
+                        )
+                    start_step = 0
+                if not 0 <= start_step <= total_steps:
+                    raise SFTConfigError(f"Fireworks checkpoint step {start_step!r} is outside the resolved SFT horizon 0..{total_steps}; use a new trainer job or an intact rLLM checkpoint.")
 
                 logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
 
@@ -276,10 +346,16 @@ class FireworksSFTBackend(TinkerSFTBackend):
                         step=0,
                     )
 
-                # Pipelined sync loop: keep one (fwd_bwd, optim) pair in flight.
-                in_flight: deque = deque()
+                current_epoch: int | None = None
+                pending: _SubmittedFireworksBatch | None = None
 
-                def submit(step: int):
+                def submit_batch(step: int, epoch_idx: int, batch_idx: int):
+                    nonlocal current_epoch
+                    if epoch_idx != current_epoch:
+                        logger.info("Starting epoch %d", epoch_idx)
+                        train_dataset.set_epoch(seed=epoch_idx)
+                        current_epoch = epoch_idx
+                    started_at = time.time()
                     lr = optimizer.learning_rate * sft_lr_multiplier(
                         optimizer.lr_schedule,
                         step,
@@ -295,77 +371,112 @@ class FireworksSFTBackend(TinkerSFTBackend):
                         weight_decay=optimizer.weight_decay,
                         grad_clip_norm=optimizer.grad_clip_norm,
                     )
-                    data = train_dataset.get_batch(step % n_batches)
+                    data = train_dataset.get_batch(batch_idx)
                     fb_fut = client.submit_forward_backward(data, loss_fn="cross_entropy")
                     # Datum weights encode reduction; provider normalization would double-divide token_mean.
                     opt_fut = client.submit_optim_step(adam)
-                    in_flight.append((step, lr, data, fb_fut, opt_fut, time.time()))
+                    return _SubmittedFireworksBatch(
+                        step=step,
+                        data=data,
+                        learning_rate=lr,
+                        started_at=started_at,
+                        fb_future=fb_fut,
+                        opt_future=opt_fut,
+                    )
 
-                def collect():
-                    step, lr, data, fb_fut, opt_fut, t0 = in_flight.popleft()
-                    fb_result = fb_fut.result(timeout=DEFAULT_TIMEOUT_S)
-                    opt_fut.result(timeout=DEFAULT_TIMEOUT_S)
+                def finish_batch(submitted: _SubmittedFireworksBatch):
+                    fb_result = submitted.fb_future.result(timeout=DEFAULT_TIMEOUT_S)
+                    submitted.opt_future.result(timeout=DEFAULT_TIMEOUT_S)
                     # Fireworks exposes only aggregate loss. Divide by the
                     # submitted weight mass, while logging the independent count
                     # of positive-weight tokens (normalization can rescale mass).
+                    n_loss_tokens = count_loss_tokens(submitted.data)
+                    loss_weight = sum_loss_weights(submitted.data)
                     fb_metrics = getattr(fb_result, "metrics", {}) or {}
-                    n_loss_tokens = count_loss_tokens(data)
-                    loss_weight = sum_loss_weights(data)
                     train_loss = (fb_metrics.get("loss:sum", 0.0) / loss_weight) if loss_weight else 0.0
+                    completed_steps = submitted.step + 1
                     metrics = {
-                        "learning_rate": lr,
-                        "progress": min((step + 1) / progress_denominator, 1.0),
-                        "num_sequences": len(data),
+                        "learning_rate": submitted.learning_rate,
+                        "progress": min(completed_steps / progress_denominator, 1.0),
+                        "num_sequences": len(submitted.data),
                         "num_loss_tokens": n_loss_tokens,
                         "train_loss": train_loss,
-                        "time/total": time.time() - t0,
+                        "time/total": time.time() - submitted.started_at,
                     }
-                    completed_steps = step + 1
                     if should_validate_step(
                         completed_steps,
                         eval_every=eval_every,
                         has_validation=val_dataset is not None,
                     ):
                         metrics.update(self._validate(client, val_dataset, DEFAULT_TIMEOUT_S))
+                    if save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps:
+                        logger.info("Saving checkpoint at step %d", completed_steps)
+                        ckpt.save(
+                            f"step-{completed_steps}",
+                            resumable=True,
+                            promotable=False,
+                            data_consumed=train_dataset.data_cursor_for_step(completed_steps),
+                        )
                     tracking_logger.log(data=metrics, step=completed_steps)
-                    logger.info(f"Step {completed_steps}: train_loss={train_loss:.4f}, lr={lr:.2e}")
-                    if save_every > 0 and step % save_every == 0 and step > 0:
-                        logger.info(f"Saving checkpoint at step {step}")
-                        ckpt.save(f"step-{step}", resumable=True, promotable=False)
+                    logger.info(
+                        "Step %d: train_loss=%.4f, lr=%.2e",
+                        completed_steps,
+                        train_loss,
+                        submitted.learning_rate,
+                    )
 
-                for step in range(start_step, total_steps):
-                    if step % n_batches == 0:
-                        train_dataset.set_epoch(seed=step // n_batches)
-                    if in_flight and should_validate_step(
-                        in_flight[0][0] + 1,
+                for step, epoch_idx, batch_idx in iter_training_batches_from_step(
+                    n_batches=n_batches,
+                    total_epochs=total_epochs,
+                    start_step=start_step,
+                    max_steps=max_steps,
+                ):
+                    if pending is None:
+                        pending = submit_batch(step, epoch_idx, batch_idx)
+                        continue
+
+                    if _is_step_boundary(
+                        pending.step + 1,
+                        total_steps,
+                        save_every=save_every,
                         eval_every=eval_every,
                         has_validation=val_dataset is not None,
                     ):
-                        collect()
-                    submit(step)
-                    if len(in_flight) > 1:
-                        collect()
-                while in_flight:
-                    collect()
+                        finish_batch(pending)
+                        pending = submit_batch(step, epoch_idx, batch_idx)
+                    else:
+                        following = submit_batch(step, epoch_idx, batch_idx)
+                        finish_batch(pending)
+                        pending = following
+                if pending is not None:
+                    finish_batch(pending)
 
                 if total_steps > start_step:
                     logger.info(f"Saving final checkpoint at step {total_steps}")
                     # promotable=True writes the servable sampler row that
                     # ``promote_latest`` needs. Without it the weights are a
                     # resumable-only DCP blob, GC'd after the job's ~30-day retention
-                    # window — so promote BEFORE ``finally: infra.close()`` deletes the
+                    # window, so promote it before detaching from the retained
                     # trainer job. Mirrors the RL path and the SDK sft recipe.
-                    ckpt.save(f"step-{total_steps}", resumable=True, promotable=True)
+                    ckpt.save(
+                        f"step-{total_steps}",
+                        resumable=True,
+                        promotable=True,
+                        data_consumed=train_dataset.data_cursor_for_step(total_steps),
+                    )
                     artifact = "LoRA adapter" if lora_rank else "full-weight model"
                     experiment = config.trainer.get("experiment_name") or "default"
-                    output_model_id = re.sub(r"[^a-z0-9-]+", "-", f"{config.trainer.get('project_name', 'rllm-sft')}-{experiment}".lower()).strip("-")[:63]
+                    output_model_id = _fireworks_output_model_id(
+                        config.trainer.get("project_name", "rllm-sft"),
+                        experiment,
+                    )
                     try:
                         model = ckpt.promote_latest(output_model_id, config.model.name)
                         logger.info("Promoted final %s -> %s", artifact, (model or {}).get("name", output_model_id))
                     except Exception:
                         logger.exception(
                             "Final %s promotion failed. The promotable sampler checkpoint for job %s "
-                            "survives job deletion for ~30 days; promote it manually via "
+                            "remains available for manual promotion via "
                             "TrainerJobManager.promote_checkpoint(name=<row from list_checkpoints>, "
                             "output_model_id=%r, base_model=%r).",
                             artifact,

--- a/rllm/trainer/sft/tinker_backend.py
+++ b/rllm/trainer/sft/tinker_backend.py
@@ -12,6 +12,8 @@ import asyncio
 import logging
 import math
 import os
+import re
+import secrets
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -127,6 +129,7 @@ def build_sft_data(config, train_data, val_data):
         resolution.source,
         last_only,
     )
+    config.data.resolved_renderer_name = resolution.name
 
     train_batch_size = config.data.get("train_batch_size", 32)
     val_batch_size = config.data.get("micro_batch_size_per_gpu", train_batch_size)
@@ -201,6 +204,24 @@ def iter_training_batches(
         yield step, epoch, batch
 
 
+def iter_training_batches_from_step(
+    *,
+    n_batches: int,
+    total_epochs: int,
+    start_step: int,
+    max_steps: int | None = None,
+):
+    """Yield the remaining plan from a completed-step (next unseen) cursor."""
+    start_epoch, start_batch = divmod(start_step, n_batches)
+    return iter_training_batches(
+        n_batches=n_batches,
+        total_epochs=total_epochs,
+        start_epoch=start_epoch,
+        start_batch=start_batch,
+        max_steps=max_steps,
+    )
+
+
 def sft_lr_multiplier(
     lr_schedule: str,
     step: int,
@@ -264,6 +285,56 @@ class SFTOptimizerSettings:
     eps: float
     weight_decay: float
     grad_clip_norm: float
+
+
+def _resume_field(resume_info, field: str, default=None):
+    if hasattr(resume_info, "get"):
+        missing = object()
+        value = resume_info.get(field, missing)
+        if value is not missing:
+            return value
+    return getattr(resume_info, field, default)
+
+
+def validate_tinker_resume_cursor(
+    resume_info,
+    *,
+    n_batches: int,
+    total_steps: int,
+) -> int:
+    """Require a complete, consistent next-unseen completed-step cursor."""
+    values: dict[str, int] = {}
+    for field in ("epoch", "batch", "step"):
+        value = _resume_field(resume_info, field)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise SFTConfigError(f"checkpoint loop_state.{field} must be a non-negative integer, got {value!r}.")
+        if value < 0:
+            raise SFTConfigError(f"checkpoint loop_state.{field} must be non-negative, got {value}.")
+        values[field] = value
+    expected_step = values["epoch"] * n_batches + values["batch"]
+    if values["batch"] >= n_batches or values["step"] != expected_step or values["step"] > total_steps:
+        raise SFTConfigError(
+            "Tinker checkpoint cursor is inconsistent with the resolved SFT batch plan "
+            f"(epoch={values['epoch']}, batch={values['batch']}, step={values['step']}, "
+            f"batches_per_epoch={n_batches}, total_steps={total_steps}). Use a new output directory."
+        )
+    return values["step"]
+
+
+def _is_step_boundary(
+    completed_steps: int,
+    total_steps: int,
+    *,
+    save_every: int,
+    eval_every: int,
+    has_validation: bool,
+) -> bool:
+    """Whether the one-ahead pipeline must drain at this model boundary."""
+    return (
+        completed_steps >= total_steps
+        or (has_validation and eval_every > 0 and completed_steps % eval_every == 0)
+        or (save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps)
+    )
 
 
 def resolve_sft_optimizer_settings(optim_cfg, *, total_steps: int) -> SFTOptimizerSettings:
@@ -355,8 +426,8 @@ class TinkerSFTBackend(SFTBackend):
     def __init__(self, spec):
         super().__init__(spec)
         self._config: DictConfig | None = None
-
-    # -- contract -----------------------------------------------------------
+        self._run_leaf = f"{time.strftime('%Y%m%d_%H%M%S', time.gmtime())}-{secrets.token_hex(4)}"
+        self._resume_requested = False
 
     def validate_spec(self) -> None:
         if self.spec.tokenize_method == "hf_template":
@@ -423,6 +494,24 @@ class TinkerSFTBackend(SFTBackend):
             cfg = OmegaConf.merge(cfg, OmegaConf.create({"trainer": {"default_local_dir": spec.output_dir}}))
         if spec.overrides:
             cfg = OmegaConf.merge(cfg, OmegaConf.create(spec.overrides))
+        user = OmegaConf.to_container(OmegaConf.create(spec.overrides), resolve=False) if spec.overrides else {}
+        user_trainer = user.get("trainer") if isinstance(user, dict) else None
+        explicit_override = isinstance(user_trainer, dict) and user_trainer.get("default_local_dir") is not None
+        self._resume_requested = bool(spec.output_dir) or explicit_override
+        if not self._resume_requested:
+            experiment = (
+                re.sub(
+                    r"[^A-Za-z0-9._-]+",
+                    "-",
+                    str(cfg.trainer.get("experiment_name") or "default"),
+                ).strip("-._")
+                or "default"
+            )
+            cfg.trainer.default_local_dir = os.path.join(
+                str(cfg.trainer.default_local_dir),
+                experiment,
+                self._run_leaf,
+            )
         self._config = cfg
         return cfg
 
@@ -466,12 +555,11 @@ class TinkerSFTBackend(SFTBackend):
         from rllm.utils.tracking import Tracking
 
         config = self._config
+        if not self._resume_requested and os.path.exists(config.trainer.default_local_dir):
+            raise SFTConfigError("The generated Tinker run directory already exists; create a new backend instance so a fresh isolated directory can be selected.")
         os.makedirs(config.trainer.default_local_dir, exist_ok=True)
         tokenizer, train_dataset, val_dataset = build_sft_data(config, self.spec.train_dataset, self.spec.val_dataset)
 
-        resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir)
-        start_epoch = resume_info.get("epoch", 0) if resume_info else 0
-        start_batch = resume_info.get("batch", 0) if resume_info else 0
         n_batches = len(train_dataset)
         total_epochs = config.trainer.get("total_epochs", 1)
         max_steps = config.trainer.get("max_steps")
@@ -480,6 +568,17 @@ class TinkerSFTBackend(SFTBackend):
         optimizer = resolve_sft_optimizer_settings(config.get("optim", {}), total_steps=total_steps)
         save_every = config.trainer.get("save_freq", 20)
         eval_every = config.trainer.get("test_freq", 10)
+
+        resume_info = checkpoint_utils.get_last_checkpoint(config.trainer.default_local_dir) if self._resume_requested else None
+        start_step = (
+            validate_tinker_resume_cursor(
+                resume_info,
+                n_batches=n_batches,
+                total_steps=total_steps,
+            )
+            if resume_info is not None
+            else 0
+        )
 
         service_client = tinker.ServiceClient(base_url=config.get("tinker_base_url", None))
 
@@ -496,9 +595,20 @@ class TinkerSFTBackend(SFTBackend):
         # Wrap the loop so tracking_logger.finish() runs even on failure: the 'ui'
         # backend tees stdout/stderr and holds an open session until finish().
         try:
+            user_metadata: dict[str, str] = {}
+            checkpoint_utils.add_renderer_name_to_user_metadata(
+                user_metadata,
+                config.data.get("resolved_renderer_name"),
+            )
             if resume_info:
                 logger.info(f"Resuming from checkpoint: {resume_info}")
-                training_client = await service_client.create_training_client_from_state_async(resume_info["state_path"])
+                state_path = _resume_field(resume_info, "state_path")
+                if not isinstance(state_path, str) or not state_path:
+                    raise SFTConfigError("Tinker checkpoint is missing a provider state_path; use a new output directory.")
+                training_client = await service_client.create_training_client_from_state_with_optimizer_async(
+                    state_path,
+                    user_metadata=user_metadata,
+                )
             else:
                 logger.info("Starting training from scratch")
                 training_client = await service_client.create_lora_training_client_async(
@@ -507,6 +617,7 @@ class TinkerSFTBackend(SFTBackend):
                     train_unembed=OmegaConf.select(config, "model.train_unembed", default=True),
                     train_attn=OmegaConf.select(config, "model.train_attn", default=True),
                     train_mlp=OmegaConf.select(config, "model.train_mlp", default=True),
+                    user_metadata=user_metadata,
                 )
             logger.info(f"Training for {n_batches} batches x {total_epochs} epochs = {total_steps} steps")
 
@@ -514,15 +625,21 @@ class TinkerSFTBackend(SFTBackend):
                 0,
                 eval_every=eval_every,
                 has_validation=val_dataset is not None,
-                include_initial=start_epoch == 0 and start_batch == 0,
+                include_initial=start_step == 0,
             ):
                 initial_metrics: dict[str, Any] = {}
                 with timed("validation", initial_metrics):
                     initial_metrics.update(await self._validate(training_client, val_dataset, compute_mean_nll))
                 tracking_logger.log(data=initial_metrics, step=0)
 
-            async def submit_batch(epoch_idx: int, batch_idx: int) -> _SubmittedBatch:
-                step = epoch_idx * n_batches + batch_idx
+            current_epoch: int | None = None
+
+            async def submit_batch(step: int, epoch_idx: int, batch_idx: int) -> _SubmittedBatch:
+                nonlocal current_epoch
+                if epoch_idx != current_epoch:
+                    logger.info(f"Starting epoch {epoch_idx}")
+                    train_dataset.set_epoch(seed=epoch_idx)
+                    current_epoch = epoch_idx
                 batch_start_time = time.time()
                 metrics: dict[str, Any] = {"epoch": epoch_idx, "progress": step / progress_denominator}
                 learning_rate = optimizer.learning_rate * sft_lr_multiplier(
@@ -549,20 +666,19 @@ class TinkerSFTBackend(SFTBackend):
 
                 fwd_bwd_future = await training_client.forward_backward_async(data, loss_fn="cross_entropy")
                 optim_step_future = await training_client.optim_step_async(adam_params)
-                return _SubmittedBatch(fwd_bwd_future, optim_step_future, metrics, data, step, epoch_idx, batch_idx, batch_start_time)
+                return _SubmittedBatch(
+                    fwd_bwd_future=fwd_bwd_future,
+                    optim_step_future=optim_step_future,
+                    metrics=metrics,
+                    data=data,
+                    step=step,
+                    epoch_idx=epoch_idx,
+                    batch_idx=batch_idx,
+                    batch_start_time=batch_start_time,
+                )
 
             async def finish_batch(submitted: _SubmittedBatch) -> None:
                 metrics = submitted.metrics
-                metrics["progress"] = min((submitted.step + 1) / progress_denominator, 1.0)
-                if save_every > 0 and submitted.step % save_every == 0 and submitted.step > 0:
-                    with timed("save_checkpoint", metrics):
-                        await checkpoint_utils.save_checkpoint_async(
-                            training_client=training_client,
-                            name=f"{submitted.step:06d}",
-                            log_path=config.trainer.default_local_dir,
-                            loop_state={"epoch": submitted.epoch_idx, "batch": submitted.batch_idx},
-                            kind="both",
-                        )
                 with timed("step", metrics):
                     fwd_bwd_result = await submitted.fwd_bwd_future.result_async()
                     await submitted.optim_step_future.result_async()
@@ -579,6 +695,7 @@ class TinkerSFTBackend(SFTBackend):
                 metrics["time/total"] = time.time() - submitted.batch_start_time
 
                 completed_steps = submitted.step + 1
+                metrics["progress"] = min(completed_steps / progress_denominator, 1.0)
                 if should_validate_step(
                     completed_steps,
                     eval_every=eval_every,
@@ -588,37 +705,51 @@ class TinkerSFTBackend(SFTBackend):
                         val_metrics = await self._validate(training_client, val_dataset, compute_mean_nll)
                     metrics.update(val_metrics)
 
+                if save_every > 0 and completed_steps % save_every == 0 and completed_steps < total_steps:
+                    next_epoch, next_batch = divmod(completed_steps, n_batches)
+                    with timed("save_checkpoint", metrics):
+                        await checkpoint_utils.save_checkpoint_async(
+                            training_client=training_client,
+                            name=f"{completed_steps:06d}",
+                            log_path=config.trainer.default_local_dir,
+                            loop_state={
+                                "epoch": next_epoch,
+                                "batch": next_batch,
+                                "step": completed_steps,
+                            },
+                            kind="both",
+                        )
+
                 tracking_logger.log(data=metrics, step=completed_steps)
                 logger.info(f"Step {completed_steps}: train_nll={train_nll:.4f}, lr={metrics['learning_rate']:.2e}")
 
             pending: _SubmittedBatch | None = None
-            current_epoch: int | None = None
-            for _step, epoch_idx, batch_idx in iter_training_batches(
+            for step, epoch_idx, batch_idx in iter_training_batches_from_step(
                 n_batches=n_batches,
                 total_epochs=total_epochs,
-                start_epoch=start_epoch,
-                start_batch=start_batch,
+                start_step=start_step,
                 max_steps=max_steps,
             ):
-                if epoch_idx != current_epoch:
-                    logger.info(f"Starting epoch {epoch_idx}")
-                    train_dataset.set_epoch(seed=epoch_idx)
-                    current_epoch = epoch_idx
-                if pending is not None and should_validate_step(
+                if pending is None:
+                    pending = await submit_batch(step, epoch_idx, batch_idx)
+                    continue
+
+                if _is_step_boundary(
                     pending.step + 1,
+                    total_steps,
+                    save_every=save_every,
                     eval_every=eval_every,
                     has_validation=val_dataset is not None,
                 ):
                     await finish_batch(pending)
-                    pending = None
-                submitted = await submit_batch(epoch_idx, batch_idx)
-                if pending is not None:
+                    pending = await submit_batch(step, epoch_idx, batch_idx)
+                else:
+                    following = await submit_batch(step, epoch_idx, batch_idx)
                     await finish_batch(pending)
-                pending = submitted
+                    pending = following
             if pending is not None:
                 await finish_batch(pending)
 
-            start_step = start_epoch * n_batches + start_batch
             if start_step < total_steps:
                 final_epoch, final_batch = divmod(total_steps, n_batches)
                 await checkpoint_utils.save_checkpoint_async(
@@ -626,7 +757,12 @@ class TinkerSFTBackend(SFTBackend):
                     name="final",
                     log_path=config.trainer.default_local_dir,
                     kind="both",
-                    loop_state={"epoch": final_epoch, "batch": final_batch},
+                    loop_state={
+                        "epoch": final_epoch,
+                        "batch": final_batch,
+                        "step": total_steps,
+                        "final": True,
+                    },
                 )
             else:
                 logger.info("Training was already complete; nothing to do")

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -315,7 +315,7 @@ class TinkerSFTDataset(SupervisedDataset):
 
         # Every epoch is derived from this stable source order. This makes the
         # sequence rendered during preflight identical to the sequence consumed
-        # during training, without letting preflight mutate training state.
+        # during training and resume, without letting preflight mutate state.
         self._source_dataset = self.dataset
 
         logger.info(f"Loaded {len(self.dataset)} examples from {source}")
@@ -372,6 +372,31 @@ class TinkerSFTDataset(SupervisedDataset):
         if self.drop_last:
             return len(self.dataset) // self.batch_size
         return math.ceil(len(self.dataset) / self.batch_size)
+
+    def data_cursor_for_step(self, completed_steps: int) -> int:
+        """Return the raw-row cursor after ``completed_steps`` batches."""
+        if isinstance(completed_steps, bool) or not isinstance(completed_steps, int) or completed_steps < 0:
+            raise SFTConfigError(f"Completed SFT steps must be a non-negative integer, got {completed_steps!r}.")
+        batches_per_epoch = len(self)
+        if batches_per_epoch == 0:
+            return 0
+        completed_epochs, batches_in_epoch = divmod(completed_steps, batches_per_epoch)
+        rows_per_epoch = len(self._source_dataset)
+        return completed_epochs * rows_per_epoch + min(batches_in_epoch * self.batch_size, rows_per_epoch)
+
+    def step_for_data_cursor(self, data_consumed: int) -> int:
+        """Invert :meth:`data_cursor_for_step` at exact batch boundaries."""
+        if isinstance(data_consumed, bool) or not isinstance(data_consumed, int) or data_consumed < 0:
+            raise SFTConfigError(f"Checkpoint data cursor must be a non-negative integer, got {data_consumed!r}.")
+        rows_per_epoch = len(self._source_dataset)
+        if rows_per_epoch == 0:
+            return 0
+        completed_epochs, rows_in_epoch = divmod(data_consumed, rows_per_epoch)
+        batches_in_epoch = math.ceil(rows_in_epoch / self.batch_size)
+        step = completed_epochs * len(self) + batches_in_epoch
+        if self.data_cursor_for_step(step) != data_consumed:
+            raise SFTConfigError(f"Checkpoint data cursor {data_consumed} is not an exact SFT batch boundary; use a new trainer job or an intact rLLM checkpoint.")
+        return step
 
 
 def create_tinker_sft_datasets(

--- a/tests/trainer/test_sft_resume.py
+++ b/tests/trainer/test_sft_resume.py
@@ -1,0 +1,586 @@
+"""Exact hosted-SFT checkpointing and resume, exercised on fakes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+tinker = pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+from rllm.data import Dataset  # noqa: E402
+from rllm.trainer.sft import SFTSpec  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+from rllm.trainer.sft.fireworks_backend import (  # noqa: E402
+    FireworksSFTBackend,
+    _fireworks_output_model_id,
+)
+from rllm.trainer.sft.tinker_backend import (  # noqa: E402
+    TinkerSFTBackend,
+    iter_training_batches_from_step,
+    validate_tinker_resume_cursor,
+)
+from rllm.trainer.sft.tinker_dataset import TinkerSFTDataset  # noqa: E402
+
+
+class _TokenRenderer:
+    def render(self, messages, *, tools=None, add_generation_prompt=False):
+        from rllm.renderers.types import RenderedTokens
+
+        del tools, add_generation_prompt
+        token = int(messages[-1]["content"])
+        return RenderedTokens(
+            token_ids=[0, token, 0],
+            message_indices=[-1, 1, -1],
+        )
+
+
+def test_fireworks_output_model_id_trims_truncation_separator():
+    model_id = _fireworks_output_model_id(
+        "rllm-deepswe-sft",
+        "deepswe-n3super-b2-lr2.0e-4-e10-constant-wu10-dbac8cfdc-r987e71f8",
+    )
+
+    assert model_id == "rllm-deepswe-sft-deepswe-n3super-b2-lr2-0e-4-e10-constant-wu10"
+    assert len(model_id) <= 63
+    assert not model_id.endswith("-")
+
+
+def _source(size: int = 7) -> Dataset:
+    return Dataset(
+        data=[
+            {
+                "messages": [
+                    {"role": "user", "content": "q", "trainable": False},
+                    {"role": "assistant", "content": str(index), "trainable": True},
+                ]
+            }
+            for index in range(size)
+        ],
+        name="resume-order",
+        split="train",
+    )
+
+
+def _ordered_batches(dataset, *, total_epochs: int, start_step: int = 0):
+    batches = []
+    current_epoch = None
+    for _, epoch, batch in iter_training_batches_from_step(
+        n_batches=len(dataset),
+        total_epochs=total_epochs,
+        start_step=start_step,
+    ):
+        if epoch != current_epoch:
+            dataset.set_epoch(seed=epoch)
+            current_epoch = epoch
+        datums = dataset.get_batch(batch)
+        batches.append(tuple(datum.model_input.to_ints()[1] for datum in datums))
+    return batches
+
+
+def test_resumed_epoch_order_matches_uninterrupted_next_batches():
+    source = _source()
+    uninterrupted = TinkerSFTDataset(source, _TokenRenderer(), batch_size=3)
+    full_order = _ordered_batches(uninterrupted, total_epochs=3)
+
+    resumed = TinkerSFTDataset(source, _TokenRenderer(), batch_size=3)
+    assert _ordered_batches(resumed, total_epochs=3, start_step=4) == full_order[4:]
+
+
+def test_raw_row_cursor_round_trips_partial_batches_and_epochs():
+    # drop_last=False keeps the trailing partial batch; the default (True,
+    # since #870) trains full batches only and is covered separately below.
+    dataset = TinkerSFTDataset(_source(5), _TokenRenderer(), batch_size=2, drop_last=False)
+    cursors = [0, 2, 4, 5, 7, 9, 10]
+    assert [dataset.data_cursor_for_step(step) for step in range(7)] == cursors
+    assert [dataset.step_for_data_cursor(cursor) for cursor in cursors] == list(range(7))
+
+    for cursor in (-1, 1, 3, 6):
+        with pytest.raises(SFTConfigError, match="cursor.*non-negative|cursor.*exact"):
+            dataset.step_for_data_cursor(cursor)
+
+
+def test_raw_row_cursor_round_trips_dropped_tail_batches():
+    # Default batching (drop_last=True) trains floor(rows/batch) batches per
+    # epoch while an epoch still consumes every source row.
+    dataset = TinkerSFTDataset(_source(5), _TokenRenderer(), batch_size=2)
+    cursors = [0, 2, 5, 7, 10, 12]
+    assert [dataset.data_cursor_for_step(step) for step in range(6)] == cursors
+    assert [dataset.step_for_data_cursor(cursor) for cursor in cursors] == list(range(6))
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        {"epoch": 0, "batch": 2, "step": 1},
+        {"epoch": 0, "batch": 3, "step": 3},
+        {"epoch": 0, "batch": 1},
+    ],
+)
+def test_tinker_cursor_rejects_off_by_one_or_incomplete_state(cursor):
+    with pytest.raises(SFTConfigError, match="inconsistent|loop_state.step"):
+        validate_tinker_resume_cursor(cursor, n_batches=3, total_steps=3)
+
+
+@pytest.mark.parametrize(
+    ("backend_cls", "default_root"),
+    [
+        (TinkerSFTBackend, "/tmp/rllm-tinker-sft-checkpoints"),
+        (FireworksSFTBackend, "/tmp/rllm-fireworks-sft-checkpoints"),
+    ],
+)
+def test_default_paths_are_isolated_and_explicit_path_is_resume_identity(tmp_path, backend_cls, default_root):
+    first = backend_cls(SFTSpec(train_dataset=_source(), experiment="same"))
+    second = backend_cls(SFTSpec(train_dataset=_source(), experiment="same"))
+    assert first.checkpoint_dir != second.checkpoint_dir
+    assert first.checkpoint_dir.startswith(f"{default_root}/same/")
+
+    explicit_path = str(tmp_path / "resume")
+    explicit = backend_cls(SFTSpec(train_dataset=_source(), output_dir=explicit_path))
+    assert explicit.checkpoint_dir == explicit_path
+
+
+def test_fireworks_reattach_requires_explicit_cursor_directory():
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            overrides={"fireworks_infra": {"trainers": {"policy": {"job_id": "job-1"}}}},
+        )
+    )
+    with pytest.raises(SFTConfigError, match=r"job_id requires.*explicit --output"):
+        backend.build_config()
+
+
+@pytest.mark.parametrize(
+    ("case", "job_id"),
+    [("fresh-run-failure", None), ("reattached-run", "job-1")],
+)
+def test_fireworks_provision_never_requests_trainer_deletion(monkeypatch, tmp_path, case, job_id):
+    provision_module = pytest.importorskip("training.provision")
+
+    overrides = {}
+    if job_id is not None:
+        overrides = {"fireworks_infra": {"trainers": {"policy": {"job_id": job_id}}}}
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path / case),
+            overrides=overrides,
+        )
+    )
+    config = backend.build_config()
+    provision_config = object()
+    returned_infra = object()
+    call = {}
+
+    monkeypatch.setattr(
+        provision_module,
+        "load_yaml_provision",
+        lambda **_kwargs: ("sft", provision_config),
+    )
+
+    def init_fireworks_infra(mode, config_arg, **kwargs):
+        call.update(mode=mode, config=config_arg, **kwargs)
+        return returned_infra
+
+    monkeypatch.setattr(provision_module, "init_fireworks_infra", init_fireworks_infra)
+
+    assert backend._provision(config, "fake-key", "https://example.invalid") is returned_infra
+    assert call["mode"] == "sft"
+    assert call["config"] is provision_config
+    assert call["cleanup_on_close"] is False
+    assert call["cleanup_existing"] is False
+
+
+def _one_datum():
+    import torch
+    from tinker_cookbook.supervised.common import datum_from_model_input_weights
+
+    return datum_from_model_input_weights(
+        tinker.ModelInput.from_ints([1, 2, 3]),
+        torch.tensor([0.0, 1.0, 0.0]),
+        max_length=None,
+        reduction="none",
+    )
+
+
+class _HostedDataset:
+    def __init__(self, events, batches=3, *, batch_size=1, row_count=None):
+        self.events = events
+        self.batches = batches
+        self.batch_size = batch_size
+        self.dataset = [object()] * (row_count if row_count is not None else batches * batch_size)
+        self.datum = _one_datum()
+        self.training_batches = []
+        self.preflighting = False
+
+    def __len__(self):
+        return self.batches
+
+    def get_batch(self, index):
+        if not self.preflighting:
+            self.training_batches.append(index)
+            self.events.append(f"batch-{index}")
+        return [self.datum]
+
+    def set_epoch(self, seed):
+        self.events.append(f"epoch-{seed}")
+
+    def preflight(self, label="train", planned_batches=None):
+        self.preflighting = True
+        self.events.append(f"preflight-{label}")
+        try:
+            if planned_batches is not None:
+                for _epoch, batch in planned_batches:
+                    self.get_batch(batch)
+            else:
+                for batch in range(self.batches):
+                    self.get_batch(batch)
+        finally:
+            self.preflighting = False
+
+    def data_cursor_for_step(self, completed_steps):
+        completed_epochs, batches_in_epoch = divmod(completed_steps, self.batches)
+        rows_in_epoch = min(batches_in_epoch * self.batch_size, len(self.dataset))
+        return completed_epochs * len(self.dataset) + rows_in_epoch
+
+    def step_for_data_cursor(self, data_consumed):
+        completed_epochs, rows_in_epoch = divmod(data_consumed, len(self.dataset))
+        batches_in_epoch = (rows_in_epoch + self.batch_size - 1) // self.batch_size
+        step = completed_epochs * self.batches + batches_in_epoch
+        if self.data_cursor_for_step(step) != data_consumed:
+            raise SFTConfigError("checkpoint cursor is not exact")
+        return step
+
+
+class _AsyncFuture:
+    def __init__(self, value, events, event):
+        self.value = value
+        self.events = events
+        self.event = event
+
+    async def result_async(self):
+        self.events.append(self.event)
+        return self.value
+
+
+class _TinkerTrainingClient:
+    def __init__(self, events, datum):
+        self.events = events
+        self.datum = datum
+        self.submitted = 0
+
+    def _output(self):
+        weights = self.datum.loss_fn_inputs["weights"]
+        logprobs = tinker.TensorData(
+            data=[-1.0] * len(weights.data),
+            dtype=weights.dtype,
+            shape=list(weights.shape),
+        )
+        return SimpleNamespace(loss_fn_outputs=[{"logprobs": logprobs}])
+
+    async def forward_backward_async(self, data, loss_fn):
+        del data, loss_fn
+        step = self.submitted
+        self.submitted += 1
+        self.events.append(f"submit-{step}")
+        return _AsyncFuture(self._output(), self.events, f"finish-fb-{step}")
+
+    async def optim_step_async(self, adam):
+        del adam
+        step = self.submitted - 1
+        return _AsyncFuture(SimpleNamespace(metrics={}), self.events, f"finish-opt-{step}")
+
+
+class _Tracking:
+    def __init__(self, **kwargs):
+        del kwargs
+
+    def log(self, data, step):
+        del data, step
+
+    def finish(self):
+        pass
+
+
+def test_tinker_checkpoint_drains_pipeline_and_records_next_unseen_cursor(monkeypatch, tmp_path):
+    from tinker_cookbook import checkpoint_utils, display
+
+    import rllm.trainer.sft.tinker_backend as module
+    import rllm.utils.tracking as tracking_module
+
+    events = []
+    train = _HostedDataset(events)
+    training_client = _TinkerTrainingClient(events, train.datum)
+    saves = []
+
+    class _Service:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        async def create_lora_training_client_async(self, **kwargs):
+            del kwargs
+            return training_client
+
+    async def save_checkpoint(**kwargs):
+        events.append(f"save-{kwargs['name']}")
+        saves.append(kwargs)
+
+    monkeypatch.setattr(module, "build_sft_data", lambda *_: (object(), train, None))
+    monkeypatch.setattr(tinker, "ServiceClient", _Service)
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: None)
+    monkeypatch.setattr(checkpoint_utils, "save_checkpoint_async", save_checkpoint)
+    monkeypatch.setattr(display, "colorize_example", lambda *_: "example")
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 3, "save_freq": 2, "test_freq": -1}},
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    asyncio.run(backend._fit_async())
+
+    assert events.index("finish-opt-1") < events.index("save-000002") < events.index("submit-2")
+    assert events.index("finish-opt-2") < events.index("save-final")
+    assert saves[0]["loop_state"]["epoch"] == 0
+    assert saves[0]["loop_state"]["batch"] == 2
+    assert saves[0]["loop_state"]["step"] == 2
+    assert saves[1]["loop_state"]["step"] == 3
+    assert saves[1]["loop_state"]["final"] is True
+    assert all(save["kind"] == "both" for save in saves)
+
+
+def test_tinker_resume_restores_optimizer_and_starts_at_next_unseen_batch(monkeypatch, tmp_path):
+    from tinker_cookbook import checkpoint_utils, display
+
+    import rllm.trainer.sft.tinker_backend as module
+    import rllm.utils.tracking as tracking_module
+
+    events = []
+    train = _HostedDataset(events)
+    training_client = _TinkerTrainingClient(events, train.datum)
+
+    class _Checkpoint:
+        state_path = "tinker://run/weights/step"
+
+        def get(self, key, default=None):
+            return {
+                "epoch": 0,
+                "batch": 2,
+                "step": 2,
+            }.get(key, default)
+
+    class _Rest:
+        async def get_weights_info_by_tinker_path(self, path):
+            assert path == "tinker://run/weights/step"
+            return SimpleNamespace(
+                base_model="Qwen/Qwen3.5-4B",
+                lora_rank=32,
+                train_unembed=True,
+                train_attn=True,
+                train_mlp=True,
+            )
+
+        async def get_training_run_by_tinker_path_async(self, path):
+            assert path == "tinker://run/weights/step"
+            return SimpleNamespace(user_metadata={checkpoint_utils.RENDERER_NAME_METADATA_KEY: "qwen3_5"})
+
+    class _Service:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def create_rest_client(self):
+            return _Rest()
+
+        async def create_training_client_from_state_with_optimizer_async(self, path, **kwargs):
+            del kwargs
+            events.append("resume-with-optimizer")
+            assert path == "tinker://run/weights/step"
+            return training_client
+
+        async def create_training_client_from_state_async(self, *args, **kwargs):
+            del args, kwargs
+            pytest.fail("weights-only resume must never be used")
+
+    async def save_checkpoint(**kwargs):
+        events.append(f"save-{kwargs['name']}")
+
+    monkeypatch.setattr(module, "build_sft_data", lambda *_: (object(), train, None))
+    monkeypatch.setattr(tinker, "ServiceClient", _Service)
+    monkeypatch.setattr(checkpoint_utils, "get_last_checkpoint", lambda *_: _Checkpoint())
+    monkeypatch.setattr(checkpoint_utils, "save_checkpoint_async", save_checkpoint)
+    monkeypatch.setattr(display, "colorize_example", lambda *_: "example")
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+
+    backend = TinkerSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path),
+            overrides={"trainer": {"max_steps": 3, "save_freq": -1, "test_freq": -1}},
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    asyncio.run(backend._fit_async())
+
+    assert "resume-with-optimizer" in events
+    assert train.training_batches == [2]
+
+
+class _SyncFuture:
+    def __init__(self, value, events, event):
+        self.value = value
+        self.events = events
+        self.event = event
+
+    def result(self, timeout=None):
+        del timeout
+        self.events.append(self.event)
+        return self.value
+
+
+class _FireworksClient:
+    def __init__(self, events):
+        self.events = events
+        self.submitted = 0
+
+    def submit_forward_backward(self, data, loss_fn):
+        del data, loss_fn
+        step = self.submitted
+        self.submitted += 1
+        self.events.append(f"submit-{step}")
+        result = SimpleNamespace(metrics={"response_tokens": 1, "loss:sum": 1.0})
+        return _SyncFuture(result, self.events, f"finish-fb-{step}")
+
+    def submit_optim_step(self, adam):
+        del adam
+        step = self.submitted - 1
+        return _SyncFuture(None, self.events, f"finish-opt-{step}")
+
+
+class _FireworksCheckpoints:
+    def __init__(self, events, *, data_consumed=None, provider_step=0):
+        self.events = events
+        self.data_consumed = data_consumed
+        self.provider_step = provider_step
+        self.saves = []
+        self.log_path = None
+
+    def resume(self):
+        if self.data_consumed is None:
+            return None
+        return SimpleNamespace(step=self.provider_step, data_consumed=self.data_consumed)
+
+    def save(self, name, **kwargs):
+        self.events.append(f"save-{name}")
+        self.saves.append((name, kwargs))
+
+    def promote_latest(self, output_model_id, base_model):
+        del base_model
+        return {"name": output_model_id}
+
+
+def _run_fireworks(monkeypatch, tmp_path, *, data_consumed=None, provider_step=0):
+    checkpoint_module = pytest.importorskip("training.utils.checkpoints")
+
+    import rllm.trainer.sft.fireworks_backend as module
+    import rllm.utils.tracking as tracking_module
+
+    events = []
+    # Five rows at batch size three yields cursors 0 -> 3 -> 5 -> 8 across
+    # the partial final batch and the next epoch.
+    train = _HostedDataset(events, batches=2, batch_size=3, row_count=5)
+    client = _FireworksClient(events)
+    checkpoints = _FireworksCheckpoints(
+        events,
+        data_consumed=data_consumed,
+        provider_step=provider_step,
+    )
+    infra = SimpleNamespace(
+        policy=client,
+        service=object(),
+        policy_job_id="fake-job",
+        close=lambda: events.append("infra-close"),
+    )
+
+    overrides = {"trainer": {"max_steps": 3, "save_freq": 2, "test_freq": -1}}
+    if data_consumed is not None:
+        overrides["fireworks_infra"] = {"trainers": {"policy": {"job_id": "fake-job"}}}
+    backend = FireworksSFTBackend(
+        SFTSpec(
+            train_dataset=_source(),
+            output_dir=str(tmp_path),
+            epochs=2,
+            overrides=overrides,
+        )
+    )
+    config = backend.build_config()
+    config.data.resolved_renderer_name = "qwen3_5"
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake")
+    monkeypatch.setattr(module, "build_sft_data", lambda *_: (None, train, None))
+    monkeypatch.setattr(backend, "_provision", lambda *_: infra)
+    monkeypatch.setattr(tracking_module, "Tracking", _Tracking)
+
+    def checkpoint_factory(*_args, **kwargs):
+        checkpoints.log_path = kwargs["log_path"]
+        return checkpoints
+
+    monkeypatch.setattr(checkpoint_module, "TrainingCheckpoints", checkpoint_factory)
+    backend.fit()
+    return events, train, checkpoints
+
+
+def test_fireworks_checkpoint_drains_pipeline_and_persists_raw_cursor(monkeypatch, tmp_path):
+    events, _train, checkpoints = _run_fireworks(monkeypatch, tmp_path)
+    assert checkpoints.log_path == str(tmp_path)
+    assert events.index("finish-opt-1") < events.index("save-step-2") < events.index("submit-2")
+    assert events.index("finish-opt-2") < events.index("save-step-3")
+    assert checkpoints.saves == [
+        (
+            "step-2",
+            {"resumable": True, "promotable": False, "data_consumed": 5},
+        ),
+        (
+            "step-3",
+            {"resumable": True, "promotable": True, "data_consumed": 8},
+        ),
+    ]
+
+
+def test_fireworks_resume_ignores_provider_renamed_step_and_uses_raw_cursor(monkeypatch, tmp_path):
+    events, train, checkpoints = _run_fireworks(
+        monkeypatch,
+        tmp_path,
+        data_consumed=5,
+        provider_step=999,
+    )
+    assert train.training_batches == [0]
+    assert "epoch-1" in events
+    assert "batch-1" not in events
+    assert checkpoints.saves[-1][1]["data_consumed"] == 8
+
+
+def test_fireworks_relaunch_without_job_id_refuses_silent_retrain(monkeypatch, tmp_path):
+    # A relaunch under the same --output provisions a NEW trainer job whose
+    # resume() is empty; the local dataloader.json left by the previous run is
+    # the evidence that silent from-scratch retraining would lose progress.
+    (tmp_path / "dataloader.json").write_text(json.dumps({"step-2": {"data_consumed": 5}}))
+    with pytest.raises(SFTConfigError, match="no resumable checkpoint"):
+        _run_fireworks(monkeypatch, tmp_path, data_consumed=None)
+
+
+def test_fireworks_resume_rejects_non_boundary_raw_cursor(monkeypatch, tmp_path):
+    with pytest.raises(SFTConfigError, match="cursor is not exact"):
+        _run_fireworks(
+            monkeypatch,
+            tmp_path,
+            data_consumed=1,
+            provider_step=1,
+        )

--- a/tests/trainer/test_sft_validation.py
+++ b/tests/trainer/test_sft_validation.py
@@ -263,6 +263,9 @@ class _LoopDataset:
     def preflight(self, **_kwargs):
         pass
 
+    def data_cursor_for_step(self, completed_steps):
+        return completed_steps
+
 
 class _LoopTinkerClient:
     def __init__(self, events):


### PR DESCRIPTION
The minimal bugfix companion to #865 (whose cookbook is now standalone). An adversarial audit of the upstream resume paths found they have never worked correctly on either hosted backend; this PR fixes exactly those defects and nothing else — the resume-contract/fingerprint validation layer from the original branch is deliberately excluded and can be reviewed separately.

## The seven defects (all confirmed against upstream code)

| # | upstream behavior | fix |
|---|---|---|
| 1 | Tinker resume crashes (`CheckpointRecord` indexed as dict); once patched, the weights-only restore API **silently zeroes Adam moments** | `create_training_client_from_state_with_optimizer_async` + state_path guard |
| 2 | Every Fireworks resume **double-trains one batch** (`step-N` saved after N applied, resume restarts at N) | next-unseen naming `step-{completed_steps}` |
| 3 | Mid-epoch resume serves the epoch remainder **unshuffled** (`set_epoch` only at epoch boundaries) — rows repeated and skipped | re-derive the seeded shuffle on any epoch entry |
| 4 | One-ahead pipeline can leave a checkpoint holding **more updates than its cursor claims** | `_is_step_boundary` drains before save/eval/final |
| 5 | Fireworks provisioning **deletes the trainer job and its resumable checkpoints** on close/reattach | `cleanup_on_close=False`, `cleanup_existing=False` |
| 6 | Tinker **blindly auto-resumes** from the shared default dir | explicit-resume gate; per-instance generated dirs |
| 7 | Provider may rename `step-42` → `step-0`; upstream trusts the name and silently restarts | persist rLLM's raw-row cursor (`data_consumed`), invert exactly via `step_for_data_cursor`; refuse silent from-scratch retrain when an `--output` carries prior local cursor state |

`data_cursor_for_step` / `step_for_data_cursor` on `TinkerSFTDataset` are the shared row-cursor inversion (honors `drop_last` both ways).

## Tests

`tests/trainer/test_sft_resume.py` (new, 18 tests) pins each fix on fakes — the weights-only API failing the test outright, provider-renamed steps ignored, drain ordering asserted on both backends, trainer deletion never requested, cursor round-trips under both `drop_last` settings. `test_sft_validation.py` gains 3 lines (loop fake cursor method).

Suite: `tests/trainer` + `tests/cli` (minus optional-verl collection): **303 passed**; remaining failures are byte-identical on clean `terminal-rl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)