### PR TITLE
docs(cli): mark SkillsBench/Claw-Eval as eval-only and warn on train

### DIFF
--- a/docs/datasets/overview.mdx
+++ b/docs/datasets/overview.mdx
@@ -85,14 +85,18 @@ Datasets in this category use the `search` agent, which requires a search backen
 
 Most agentic datasets are sandboxed — they ship per-task Dockerfiles and shell verifiers. See [Sandboxes](/core-concepts/sandbox) for how to pick `--sandbox-backend` and [Tasks (Harbor-compatible)](/core-concepts/tasks) for the on-disk format.
 
+<Warning>
+`claw_eval`, `skillsbench`, and `skillsbench-no-skills` are evaluation-only by project intent. Today, `rllm train <name>` may reuse the same task pool for training and validation; this is not a held-out split. For generalization experiments, create your own train/test split and [register a custom dataset](/datasets/byo-dataset).
+</Warning>
+
 | Dataset | Description | Size | Source | Default agent |
 |---------|-------------|------|--------|---------------|
 | `bfcl` | BFCL: Berkeley Function Calling Leaderboard (exec_simple) | test | [gorilla-llm/Berkeley-Function-Calling-Leaderboard](https://huggingface.co/datasets/gorilla-llm/Berkeley-Function-Calling-Leaderboard) | `react` |
 | `multichallenge` | MultiChallenge: Multi-turn conversation evaluation | test | [nmayorga7/multichallenge](https://huggingface.co/datasets/nmayorga7/multichallenge) | `react` |
-| `claw_eval` | Claw-Eval: 161 personal-assistant agent tasks in sandbox workspaces (LLM-judge graded) | 161 general | [claw-eval/Claw-Eval](https://huggingface.co/datasets/claw-eval/Claw-Eval) | `zeroclaw` |
+| `claw_eval` | **Eval-only.** Claw-Eval: 161 personal-assistant agent tasks in sandbox workspaces (LLM-judge graded) | 161 general | [claw-eval/Claw-Eval](https://huggingface.co/datasets/claw-eval/Claw-Eval) | `zeroclaw` |
 | `rllm-swesmith` | SWE-smith filtered: solvable bug-fixing tasks across 105 Python repos (in-sandbox pytest grading) | ~4.7K train | [kylemontgomery/swesmith-filtered](https://huggingface.co/datasets/kylemontgomery/swesmith-filtered) | `mini-swe-agent` |
-| `skillsbench` | SkillsBench: 91 expert-curated agentic tasks measuring skill use (per-task `tests/test.sh` verifier) | 91 train | [benchflow/skillsbench](https://huggingface.co/datasets/benchflow/skillsbench) | `claude-code` |
-| `skillsbench-no-skills` | SkillsBench baseline without the per-task `skills/` tree, for measuring skills-augmentation gain | 91 train | [benchflow/skillsbench](https://huggingface.co/datasets/benchflow/skillsbench) | `claude-code` |
+| `skillsbench` | **Eval-only.** SkillsBench: 91 expert-curated agentic tasks measuring skill use (per-task `tests/test.sh` verifier) | 91 train | [benchflow/skillsbench](https://huggingface.co/datasets/benchflow/skillsbench) | `claude-code` |
+| `skillsbench-no-skills` | **Eval-only.** SkillsBench baseline without the per-task `skills/` tree, for measuring skills-augmentation gain | 91 train | [benchflow/skillsbench](https://huggingface.co/datasets/benchflow/skillsbench) | `claude-code` |
 
 ### Harbor packages (no registry entry)
 

--- a/rllm/cli/train.py
+++ b/rllm/cli/train.py
@@ -24,6 +24,18 @@ from rllm.cli._ui import console, fail, info_panel
 _CONFIG_PKG = Path(__file__).resolve().parent.parent / "trainer" / "config"
 
 
+def _warn_eval_only_dataset(name: str) -> None:
+    """Warn without blocking when RL training uses an evaluation-only dataset."""
+    console.print(
+        f"  [yellow]Warning:[/] [val]{name}[/] is catalogued as evaluation-only. "
+        "Default training and validation may use the same task pool, not a held-out split.\n"
+        "  For RL with a proper split, register a custom dataset "
+        "([bold]https://docs.rllm-project.com/datasets/byo-dataset[/]) or pass explicit "
+        "[bold]--train-dataset[/] / [bold]--val-dataset[/] and "
+        "[bold]--train-split[/] / [bold]--val-split[/]."
+    )
+
+
 # ---------------------------------------------------------------------------
 # 1. build_train_config  — CLI flags → OmegaConf DictConfig
 # ---------------------------------------------------------------------------
@@ -280,6 +292,9 @@ def _run_train(
                 console.print(f"  [success]Found Harbor dataset:[/] [val]{harbor_name}[/]")
                 benchmark = harbor_name
 
+        if catalog_entry and catalog_entry.get("eval_only"):
+            _warn_eval_only_dataset(benchmark)
+
         # ---- Docker check for Harbor datasets (local backends only) ----
         from rllm.gateway.tunnel import is_local_sandbox_backend
 
@@ -345,6 +360,9 @@ def _run_train(
         # ---- Resolve catalog entries for train + val datasets ----
         train_entry = _resolve_dataset_entry(train_ds_name, catalog, benchmark, catalog_entry)
         val_entry = _resolve_dataset_entry(val_ds_name, catalog, benchmark, catalog_entry)
+
+        if train_ds_name != benchmark and train_entry and train_entry.get("eval_only"):
+            _warn_eval_only_dataset(train_ds_name)
 
         # ---- Resolve train/val splits ----
         if train_split is None:

--- a/rllm/registry/datasets.json
+++ b/rllm/registry/datasets.json
@@ -10,6 +10,7 @@
         "general"
       ],
       "eval_split": "general",
+      "eval_only": true,
       "default_agent": "zeroclaw",
       "reward_fn": "claw_eval_reward_fn"
     },
@@ -34,6 +35,7 @@
         "train"
       ],
       "eval_split": "train",
+      "eval_only": true,
       "default_agent": "claude-code"
     },
     "skillsbench-no-skills": {
@@ -48,6 +50,7 @@
         "train"
       ],
       "eval_split": "train",
+      "eval_only": true,
       "default_agent": "claude-code"
     },
     "gsm8k": {

--- a/tests/cli/test_train_command.py
+++ b/tests/cli/test_train_command.py
@@ -239,6 +239,47 @@ class TestTrainCommand:
         # Experiment name defaults to the benchmark name.
         assert call_kwargs["config"].rllm.trainer.experiment_name == "test_math"
 
+    @pytest.mark.parametrize(
+        ("eval_only_name", "extra_args"),
+        [
+            ("test_math", []),
+            ("eval_math", ["--train-dataset", "eval_math"]),
+        ],
+        ids=["benchmark", "explicit_train_dataset"],
+    )
+    def test_train_warns_for_eval_only_catalog_entry(self, runner, tmp_rllm_home, mock_train_dataset, eval_only_name, extra_args):
+        """Training remains allowed, but eval-only benchmark and train entries warn."""
+        from rllm.data import DatasetRegistry
+
+        DatasetRegistry.register_dataset("eval_math", mock_train_dataset[0], split="train")
+        catalog = {
+            "datasets": {
+                "test_math": {"default_agent": "math", "reward_fn": "math_reward_fn", "eval_split": "test"},
+                "eval_math": {"eval_only": False},
+            }
+        }
+        catalog["datasets"][eval_only_name]["eval_only"] = True
+        mock_trainer = MagicMock()
+
+        with (
+            patch("rllm.cli.train.load_dataset_catalog", return_value=catalog),
+            patch("rllm.eval.agent_loader.load_agent", return_value=_MockAgentFlow()),
+            patch("rllm.eval.evaluator_loader.resolve_evaluator_from_catalog", return_value=_MockEvaluator()),
+            patch("rllm.trainer.AgentTrainer", return_value=mock_trainer),
+        ):
+            result = runner.invoke(cli, ["train", "test_math", "--model", "test-model", *extra_args])
+
+        assert result.exit_code == 0, result.output
+        assert f"{eval_only_name} is catalogued as evaluation-only" in result.output
+        assert "same task pool" in result.output
+        assert "not a held-out split" in result.output
+        assert "register a custom dataset" in result.output
+        assert "--train-dataset" in result.output
+        assert "--val-dataset" in result.output
+        assert "--train-split" in result.output
+        assert "--val-split" in result.output
+        mock_trainer.train.assert_called_once()
+
     def test_train_explicit_agent_and_evaluator(self, runner, tmp_rllm_home, mock_train_dataset):
         """Train with explicit --agent and --evaluator should use them."""
         catalog = {"datasets": {"test_math": {"eval_split": "test"}}}


### PR DESCRIPTION
## Summary
Implements the **docs + light CLI warning** slice of #901, following @jeffreysijuntan's clarification that SkillsBench / Claw-Eval are evaluation-only (users who want RL should register their own train/eval splits).

- Add `eval_only: true` to `claw_eval`, `skillsbench`, and `skillsbench-no-skills` in the dataset catalog
- Document eval-only intent in `docs/datasets/overview.mdx` with a link to BYO datasets
- Emit a non-blocking warning from `rllm train` when the benchmark or `--train-dataset` resolves to an eval-only catalog entry
- Add focused CLI unit tests for the warning path

## Out of scope
Deterministic train/held-out partition manifests (mentioned in the issue thread). FYI @cyyecao-lappland — this PR is intentionally limited to the docs/guard path.

## Test plan
- [x] Focused `tests/cli/test_train_command.py` cases for eval-only warning (94 CLI tests reported passing locally during Codex run)
- [x] Maintainer review of warning copy + docs wording

Tracks #901.