### PR TITLE
fix: preserve hierarchical task IDs in GRPO grouping

### DIFF
--- a/docs/core-concepts/episodes-trajectories-steps.mdx
+++ b/docs/core-concepts/episodes-trajectories-steps.mdx
@@ -66,6 +66,8 @@ class Trajectory(BaseModel):
 
 The `name` field identifies which agent produced this trajectory. During training, trajectories are grouped by `{task_id}:{trajectory.name}` for advantage computation — GRPO compares trajectories within the same group to determine which rollouts were better than average.
 
+When you use default trajectory grouping, trajectory names must not contain `:`. The final colon separates the task ID from the trajectory name.
+
 ## Episode
 
 An Episode is the top-level container for a complete rollout on a single task. Its ID encodes both the task and rollout index.
@@ -82,12 +84,16 @@ class Episode(BaseModel):
     metadata: dict                        # Arbitrary extra data
 ```
 
-The `task_id` and `rollout_idx` properties parse the ID string:
+The `task_id` and `rollout_idx` properties split the ID at the final colon. Task IDs may contain `:`; the final segment is the rollout index:
 
 ```python
 episode = Episode(id="gsm8k_42:3")
 episode.task_id     # "gsm8k_42"
 episode.rollout_idx # "3"
+
+episode = Episode(id="aeread:integration-v1:case01:s1200:0")
+episode.task_id     # "aeread:integration-v1:case01:s1200"
+episode.rollout_idx # "0"
 ```
 
 ## How they connect

--- a/rllm/trainer/algorithms/transform.py
+++ b/rllm/trainer/algorithms/transform.py
@@ -112,6 +112,12 @@ def _build_trajectory_groups(episodes: list[Episode], compact_filtering_config: 
     Returns:
         List of TrajectoryGroups
     """
+    # Group IDs use the final colon to separate the task ID from the trajectory name.
+    for episode in episodes:
+        for trajectory in episode.trajectories:
+            if ":" in trajectory.name:
+                raise ValueError(f"Trajectory name {trajectory.name!r} must not contain ':' when using default trajectory grouping (episode {episode.id!r}).")
+
     trajectories_by_name: dict[str, list[Trajectory]] = defaultdict(list)
     metadata_by_name: dict[str, list[dict]] = defaultdict(list)
 

--- a/rllm/types.py
+++ b/rllm/types.py
@@ -331,11 +331,11 @@ class Episode(BaseModel):
 
     @property
     def task_id(self) -> str:
-        return self.id.split(":")[0]
+        return self.id.rsplit(":", 1)[0]
 
     @property
     def rollout_idx(self) -> str:
-        return self.id.split(":")[1]
+        return self.id.rsplit(":", 1)[1]
 
     @property
     def info(self) -> dict:
@@ -402,11 +402,11 @@ class TrajectoryGroup(BaseModel):
 
     @property
     def group_role(self) -> str:
-        return self.group_id.split(":")[1] if ":" in self.group_id[:-1] else "all_groups"
+        return self.group_id.rsplit(":", 1)[1] if ":" in self.group_id[:-1] else "all_groups"
 
     @property
     def task_id(self) -> str:
-        return self.group_id.split(":")[0]
+        return self.group_id.rsplit(":", 1)[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unified_trainer/test_trajectory_grouping.py
+++ b/tests/unified_trainer/test_trajectory_grouping.py
@@ -1,0 +1,125 @@
+"""CPU regressions for colon-containing task IDs and GRPO grouping (#829)."""
+
+import pytest
+
+from rllm.trainer.algorithms.advantage import collect_reward_and_advantage_from_trajectory_groups
+from rllm.trainer.algorithms.config import AlgorithmConfig, TransformConfig, rLLMAdvantageEstimator
+from rllm.trainer.algorithms.transform import transform_episodes_to_trajectory_groups
+from rllm.types import Episode, Step, Trajectory, TrajectoryGroup
+from rllm.workflows.workflow import TerminationReason
+
+
+@pytest.mark.parametrize(
+    "episode_id, task_id, rollout_idx",
+    [
+        ("aeread:integration-v1:case01:s1200:0", "aeread:integration-v1:case01:s1200", "0"),
+        ("task:0", "task", "0"),
+        ("task:12", "task", "12"),
+        ("123e4567-e89b-12d3-a456-426614174000:1", "123e4567-e89b-12d3-a456-426614174000", "1"),
+        ("task::0", "task:", "0"),
+        ("task:", "task", ""),
+        ("task:custom", "task", "custom"),
+    ],
+)
+def test_episode_id_parsing(episode_id, task_id, rollout_idx):
+    episode = Episode(id=episode_id)
+
+    assert episode.task_id == task_id
+    assert episode.rollout_idx == rollout_idx
+
+
+def test_default_episode_keeps_bare_uuid_behavior():
+    episode = Episode()
+
+    assert ":" not in episode.id
+    assert episode.task_id == episode.id
+    with pytest.raises(IndexError):
+        _ = episode.rollout_idx
+
+
+@pytest.mark.parametrize(
+    "group_id, task_id, group_role",
+    [
+        ("aeread:integration-v1:case01:s1200:solver", "aeread:integration-v1:case01:s1200", "solver"),
+        ("task:solver", "task", "solver"),
+        ("task::solver", "task:", "solver"),
+        ("bare", "bare", "all_groups"),
+        ("task:", "task", "all_groups"),
+        ("", "", "all_groups"),
+    ],
+)
+def test_trajectory_group_id_parsing(group_id, task_id, group_role):
+    group = TrajectoryGroup(group_id=group_id, trajectories=[])
+
+    assert group.task_id == task_id
+    assert group.group_role == group_role
+
+
+@pytest.mark.parametrize("names", [("solver",), ("solver", "judge")])
+def test_transform_groups_by_full_task_id_and_trajectory_name(names):
+    task_ids = ["aeread:integration-v1:case01:s1200", "aeread:integration-v1:case02:s1200", "aeread", "other:case01"]
+    episodes = [
+        Episode(
+            id=f"{task_id}:{rollout_idx}",
+            trajectories=[Trajectory(name=name, steps=[Step()], reward=rollout_idx) for name in names],
+            termination_reason=TerminationReason.ENV_DONE,
+            is_correct=bool(rollout_idx),
+        )
+        for task_id in task_ids
+        for rollout_idx in range(2)
+    ]
+
+    groups, metrics = transform_episodes_to_trajectory_groups(episodes, TransformConfig())
+
+    assert len(groups) == len(task_ids) * len(names)
+    assert metrics["groups/num_groups"] == len(groups)
+    assert metrics["groups/avg_group_size"] == 2
+    assert metrics["groups/num_trajs_after_filter"] == len(episodes) * len(names)
+    by_id = {group.group_id: group for group in groups}
+    for task_idx, task_id in enumerate(task_ids):
+        for name_idx, name in enumerate(names):
+            group = by_id[f"{task_id}:{name}"]
+            assert group.task_id == task_id
+            assert group.group_role == name
+            assert len(group.trajectories) == 2
+            assert group.metadata == [{"task_id": task_id, "rollout_idx": str(i), "termination_reason": TerminationReason.ENV_DONE, "is_correct": bool(i)} for i in range(2)]
+            for rollout_idx in range(2):
+                assert group.trajectories[rollout_idx] is episodes[2 * task_idx + rollout_idx].trajectories[name_idx]
+
+
+@pytest.mark.parametrize("name", ["b:c", ":solver", "solver:"])
+def test_default_grouping_rejects_colon_in_trajectory_name(name):
+    # (task='a:b', name='c') and (task='a', name='b:c') serialize identically.
+    episodes = [
+        Episode(id="a:b:0", trajectories=[Trajectory(name="c", steps=[Step()], reward=0.0)]),
+        Episode(id="a:0", trajectories=[Trajectory(name=name, steps=[Step()], reward=0.0)]),
+    ]
+
+    with pytest.raises(ValueError, match="Trajectory name .* must not contain ':'") as exc_info:
+        transform_episodes_to_trajectory_groups(episodes, TransformConfig())
+    assert repr(name) in str(exc_info.value)
+
+
+@pytest.mark.parametrize("use_role_override", [False, True])
+def test_grpo_advantages_are_centered_per_hierarchical_task(use_role_override):
+    episodes = [
+        Episode(
+            id=f"aeread:integration-v1:{case}:s1200:{rollout_idx}",
+            trajectories=[Trajectory(name="solver", steps=[Step()], reward=reward)],
+        )
+        for case, rewards in [("case01", [0.0, 2.0]), ("case02", [100.0, 102.0])]
+        for rollout_idx, reward in enumerate(rewards)
+    ]
+    groups, _ = transform_episodes_to_trajectory_groups(episodes, TransformConfig())
+    config = AlgorithmConfig(norm_adv_by_std_in_grpo=False)
+    if use_role_override:
+        config = AlgorithmConfig(
+            norm_adv_by_std_in_grpo=False,
+            estimator=rLLMAdvantageEstimator.REINFORCE,
+            estimator_map={"solver": rLLMAdvantageEstimator.GRPO},
+        )
+
+    metrics = collect_reward_and_advantage_from_trajectory_groups(groups, config)
+
+    assert [episode.trajectories[0].steps[0].advantage for episode in episodes] == pytest.approx([-1.0, 1.0, -1.0, 1.0])
+    assert metrics["advantage/solver/mean"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
Fixes #829: dataset/task IDs containing `:` were left-split in `Episode.task_id` / `TrajectoryGroup` accessors, so GRPO silently merged unrelated tasks into one group.

**Option A (minimal):**
- Parse episode and group IDs with `rsplit(":", 1)` (final colon is the separator)
- Reject default-path trajectory names that contain `:` (avoids ambiguous `a:b:c` serializations)
- Document the contract in `docs/core-concepts/episodes-trajectories-steps.mdx`
- Add CPU regressions in `tests/unified_trainer/test_trajectory_grouping.py` (grouping + real collector GRPO advantages `[-1, 1, -1, 1]`)

Producer wire format (`task_id:rollout_idx`) is unchanged.

## Test plan
- [x] Focused CPU suite reported **33 passed** locally (includes new trajectory-grouping / GRPO regressions)
- [ ] CI pre-commit / review on this PR