### PR TITLE
feat(harbor): resolve task_path from Task.task_dir

### DIFF
--- a/rllm/integrations/harbor/runtime.py
+++ b/rllm/integrations/harbor/runtime.py
@@ -142,9 +142,9 @@ class HarborRuntime:
         Returns:
             Episode with harbor_reward and harbor_is_correct in artifacts.
         """
-        task_path = task.metadata.get("task_path")
-        if not task_path:
-            raise ValueError(f"Harbor task missing 'task_path' field in task data: {list(task.metadata.keys())}")
+        from rllm.integrations.harbor.utils import resolve_harbor_task_path
+
+        task_path = resolve_harbor_task_path(task)
 
         outcome = await self._run_one(
             task_path=task_path,
@@ -199,9 +199,9 @@ class HarborRuntime:
             timeout = self.session_timeout
 
         async def _run_submission(sub) -> RemoteTaskResult:
-            task_path = sub.task.get("task_path")
-            if not task_path:
-                raise ValueError(f"Submission {sub.session_id} missing 'task_path' in task dict")
+            from rllm.integrations.harbor.utils import resolve_harbor_task_path
+
+            task_path = resolve_harbor_task_path(sub.task)
 
             outcome = await self._run_one(
                 task_path=task_path,

--- a/rllm/integrations/harbor/utils.py
+++ b/rllm/integrations/harbor/utils.py
@@ -68,3 +68,27 @@ def is_harbor_agent(agent_name: str | None) -> bool:
     if agent_name is None:
         return False
     return agent_name.startswith("harbor:")
+
+
+def resolve_harbor_task_path(task) -> str:
+    """Resolve the on-disk Harbor task directory from a Task, row, or dict.
+
+    Prefers ``metadata['task_path']`` (catalog / Harbor rows). Falls back to
+    ``task.task_dir`` so local ``BenchmarkLoader`` tasks work with Harbor
+    runtimes without requiring the row wrapper.
+    """
+    meta = getattr(task, "metadata", None)
+    if meta is None and isinstance(task, dict):
+        meta = task
+    if isinstance(meta, dict):
+        path = meta.get("task_path")
+        if path:
+            return str(path)
+    task_dir = getattr(task, "task_dir", None)
+    if task_dir is not None:
+        return str(task_dir)
+    dataset_dir = getattr(task, "dataset_dir", None)
+    if dataset_dir is not None:
+        return str(dataset_dir)
+    keys = list(meta.keys()) if isinstance(meta, dict) else []
+    raise ValueError(f"Harbor task missing 'task_path' (and no task_dir): {keys}")

--- a/tests/eval/test_harbor_utils.py
+++ b/tests/eval/test_harbor_utils.py
@@ -1,0 +1,36 @@
+"""Harbor task-path resolution and agent-name helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rllm.integrations.harbor.utils import is_harbor_agent, resolve_harbor_task_path
+from rllm.types import Task
+
+
+def test_is_harbor_agent_prefix():
+    assert is_harbor_agent("harbor:claude-code") is True
+    assert is_harbor_agent("claude-code") is False
+    assert is_harbor_agent(None) is False
+
+
+def test_resolve_task_path_prefers_metadata():
+    task = Task(id="t", instruction="x", metadata={"task_path": "/harbor/task"}, dataset_dir=Path("."))
+    assert resolve_harbor_task_path(task) == "/harbor/task"
+
+
+def test_resolve_task_path_falls_back_to_task_dir(tmp_path):
+    task = Task(id="t", instruction="x", metadata={}, dataset_dir=tmp_path, sub_dir=None)
+    assert resolve_harbor_task_path(task) == str(tmp_path)
+
+
+def test_resolve_task_path_from_row_dict():
+    assert resolve_harbor_task_path({"task_path": "/from/row"}) == "/from/row"
+
+
+def test_resolve_task_path_missing_raises():
+    task = Task(id="t", instruction="x", metadata={}, dataset_dir=None)
+    with pytest.raises(ValueError, match="task_path"):
+        resolve_harbor_task_path(task)


### PR DESCRIPTION
## Summary
- Harbor trials can root at a local `BenchmarkLoader` task directory when catalog rows omit `task_path`.
- `HarborRuntime` uses the shared helper instead of requiring `metadata['task_path']` only.

## Test plan
- [x] `pytest tests/eval/test_harbor_utils.py` (5 passed)
- [ ] Existing Harbor eval still resolves catalog `task_path` rows


Made with [Cursor](https://cursor.com)