### PR TITLE
fix: use a zero baseline for single-rollout groups in reinforce_plus_plus_baseline

### DIFF
--- a/rllm/trainer/algorithms/advantage.py
+++ b/rllm/trainer/algorithms/advantage.py
@@ -101,7 +101,13 @@ def calculate_reinforce_plus_plus_baseline_advantages(rewards: list[np.ndarray],
 
     centered_rewards_by_group: list[np.ndarray] = []
     for group_rewards in rewards:
-        centered_rewards_by_group.append(group_rewards - np.mean(group_rewards))
+        if len(group_rewards) > 1:
+            centered_rewards_by_group.append(group_rewards - np.mean(group_rewards))
+        else:
+            # A single rollout is its own mean: subtracting it would zero the
+            # advantage (and the policy-gradient signal) for every group when
+            # rollout.n == 1, so the baseline is 0 as documented.
+            centered_rewards_by_group.append(np.asarray(group_rewards, dtype=float))
 
     all_centered_rewards = np.concatenate(centered_rewards_by_group)
     batch_std = np.std(all_centered_rewards)

--- a/tests/unified_trainer/test_reinforce_plus_plus_baseline.py
+++ b/tests/unified_trainer/test_reinforce_plus_plus_baseline.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from rllm.trainer.algorithms.advantage import calculate_reinforce_plus_plus_baseline_advantages
+
+
+def _advantages(rewards):
+    advantages, returns = calculate_reinforce_plus_plus_baseline_advantages(rewards, algorithm_config=None)
+    assert all(np.array_equal(a, r) for a, r in zip(advantages, returns, strict=True))
+    return advantages
+
+
+def test_single_rollout_groups_keep_a_reward_signal():
+    """With rollout.n == 1 every group has one reward; the baseline is 0, not the reward itself (#916)."""
+    rewards = [np.array([1.0]), np.array([0.0]), np.array([0.5])]
+
+    advantages = _advantages(rewards)
+
+    flat = np.concatenate(advantages)
+    assert not np.allclose(flat, 0.0)
+    # Whitening keeps the order and sign of the rewards.
+    assert flat[0] > flat[2] > flat[1]
+    assert flat[1] == pytest.approx(0.0)
+
+
+def test_multi_rollout_groups_use_the_group_mean_baseline():
+    rewards = [np.array([1.0, 0.0]), np.array([0.5, 0.5])]
+
+    advantages = _advantages(rewards)
+
+    # Centered by the group mean, then whitened by the batch std.
+    assert advantages[0][0] > 0 > advantages[0][1]
+    assert advantages[0][0] == pytest.approx(-advantages[0][1])
+    assert np.allclose(advantages[1], 0.0)
+
+
+def test_mixed_group_sizes():
+    rewards = [np.array([1.0, 0.0]), np.array([2.0])]
+
+    advantages = _advantages(rewards)
+
+    assert advantages[0][0] == pytest.approx(-advantages[0][1])
+    assert advantages[1][0] > 0
+
+
+def test_empty_input():
+    assert calculate_reinforce_plus_plus_baseline_advantages([], algorithm_config=None) == ([], [])


### PR DESCRIPTION
## Summary

Fixes #916. `calculate_reinforce_plus_plus_baseline_advantages` documents "per-group mean baseline when group size > 1, else baseline = 0", but always subtracted the group mean. With `rollout.n = 1` every group holds a single reward, `r - mean([r])` is `0`, and every advantage was silently zero: the run kept going with no reward-derived policy-gradient signal at all. Groups with more than one rollout are unchanged.

## Type of change

- [x] Fix

## What changed

- `rllm/trainer/algorithms/advantage.py`: only groups with more than one rollout are centered by their mean; a single rollout keeps its reward (baseline 0), as the docstring says. Batch-std whitening is unchanged.
- `tests/unified_trainer/test_reinforce_plus_plus_baseline.py`: single-rollout groups keep a non-zero, order-preserving signal (fails on `main`, all advantages were 0), multi-rollout groups still use the group-mean baseline, mixed group sizes, empty input.

I went with the documented behavior rather than rejecting `rollout.n < 2`, since the docstring already promises it and the function is registered for that estimator; happy to switch to a config-time `ValueError` if you prefer that.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Targeted tests: `pytest tests/unified_trainer/test_reinforce_plus_plus_baseline.py` — 4 passed with the change, 2 failed on `main`. Note: my environment does not have `rllm[train]`, so importing `rllm.trainer` (which pulls in the unified trainer) was not possible; I ran the test module against the function loaded from `advantage.py` directly with numpy. It runs normally in CI where the extras are installed.
- [x] `ruff check` / `ruff format --check` on both files.
