### PR TITLE
fix: reap the sandbox process after a code-reward timeout kill

### DIFF
--- a/rllm/rewards/code_reward.py
+++ b/rllm/rewards/code_reward.py
@@ -121,6 +121,7 @@ def check_correctness(tests: list[dict[str, str]] | dict[str, list[str]], code: 
 
         if process.is_alive():
             process.kill()
+            process.join()
         test_results_list = list(test_results)
 
         detailed_results: dict[str, Any] = {"all_passed": False, "test_results": [], "total_tests": num_tests, "passed_tests": 0}
@@ -232,6 +233,7 @@ def lcb_check_correctness_v2(sample, generation, timeout=6, debug=False):
 
         if p.is_alive():
             p.kill()
+            p.join()
         if not result:
             in_outs = json.loads(sample["input_output"])
             # consider that all tests failed

--- a/tests/rewards/test_code_reward.py
+++ b/tests/rewards/test_code_reward.py
@@ -1,7 +1,28 @@
+import os
+import time
+
 import pytest
 
+import rllm.rewards.code_reward as code_reward_module
 from rllm.rewards import RewardConfig, RewardType
-from rllm.rewards.code_reward import RewardCodeFn
+from rllm.rewards.code_reward import RewardCodeFn, check_correctness, lcb_check_correctness_v2
+
+
+def _child_process_states(parent_pid):
+    """States of the immediate child processes of parent_pid, read from /proc."""
+    states = []
+    for pid_str in os.listdir("/proc"):
+        if not pid_str.isdigit():
+            continue
+        try:
+            with open(f"/proc/{pid_str}/stat") as f:
+                after_comm = f.read().rsplit(")", 1)[1].split()
+        except (FileNotFoundError, ProcessLookupError):
+            continue
+        state, ppid = after_comm[0], after_comm[1]
+        if ppid == str(parent_pid):
+            states.append(state)
+    return states
 
 
 class TestCodeReward:
@@ -441,3 +462,34 @@ def test_longest_subsequence_empty_list():
         task_info = {"problem": "", "problem_type": RewardType.CODE, "data_source": "kodcode", "ground_truth": tests}
         output = reward(task_info, model_response)
         assert output.is_correct
+
+
+class TestCodeRewardTimeoutCleanup:
+    """A timeout on the sandboxed process must not leave a zombie behind."""
+
+    def test_check_correctness_reaps_killed_process_on_timeout(self):
+        def hanging_test_fn(tests, test, debug=False, timeout=1):
+            time.sleep(30)
+            return [True]
+
+        pid = os.getpid()
+        result, _ = check_correctness({"inputs": ["1\n"], "outputs": ["1\n"]}, "print(1)", hanging_test_fn, timeout_per_test=1, max_tests=15)
+        time.sleep(0.5)  # let the kernel finish updating the child's state after the kill signal
+
+        assert result is False
+        assert "Z" not in _child_process_states(pid)
+
+    def test_lcb_check_correctness_v2_reaps_killed_process_on_timeout(self, monkeypatch):
+        def hanging_run_test(sample, test=None, debug=False, timeout=6):
+            time.sleep(30)
+            return [1], {}
+
+        monkeypatch.setattr(code_reward_module, "lcb_run_test", hanging_run_test)
+
+        pid = os.getpid()
+        sample = [{"input": "1\n", "output": "1\n", "testtype": "stdin"}]
+        result, _ = lcb_check_correctness_v2(sample, "print(1)", timeout=1)
+        time.sleep(0.5)
+
+        assert result is False
+        assert "Z" not in _child_process_states(pid)


### PR DESCRIPTION
## Summary

`check_correctness` and `lcb_check_correctness_v2` both `kill()` the sandbox process on
timeout but never `join()` it afterward, so it sits as a zombie until the worker exits.
Added the missing `join()` right after each `kill()`.

## Type of change

- [x] Fix

## What changed

- `process.join()` after `process.kill()` in `check_correctness`
- `p.join()` after `p.kill()` in `lcb_check_correctness_v2`, same pattern

## Validation

- [x] `pre-commit run --files rllm/rewards/code_reward.py tests/rewards/test_code_reward.py`
- [x] Targeted tests: `pytest tests/rewards/test_code_reward.py`
- [x] Manual validation performed

Validation details:
- Two new tests force a timeout with a hanging `test_fn`/`run_test` and read `/proc` for
  the child's state afterward. On main the child is still there at `Z`; with the join()
  added it's gone. The rest of `tests/rewards/test_code_reward.py` is unchanged and green,
  except `test_reward_kodcode`, which needs numpy/pandas in the sandboxed subprocess and my
  container doesn't have those installed, unrelated to this change.

## Breaking changes / migration notes

- None

## Docs / examples

- [x] Not needed

## Related issues / PRs

- Fixes #915

One thing from the issue thread I deliberately left out: `how2how2how2-arch` pointed out that
`kill()` only signals the direct child, so if the generated code under test forks or shells
out, those grandchildren get reparented and keep running past this fix. True, and worth doing,
but it's a different change (starting the process in its own session, killing the group), so
I kept this PR to the zombie itself.

