### PR TITLE
perf(sft): cache Inkling text encoding during preflight

### DIFF
--- a/cookbooks/terminal-rl/benchmark_inkling_preflight.py
+++ b/cookbooks/terminal-rl/benchmark_inkling_preflight.py
@@ -1,0 +1,84 @@
+"""Compare cached/uncached Inkling preflight on canonical JSONL rows, offline.
+
+Uses a locally cached tokenizer and runs every prefix check in both variants.
+No provider client or training job is created. Example:
+
+    python cookbooks/terminal-rl/benchmark_inkling_preflight.py \
+        --train-file train.jsonl --output comparison.json
+
+Requires an installed renderers version that provides InklingRenderer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+from importlib.metadata import version
+from pathlib import Path
+from unittest.mock import patch
+
+from renderers.configs import InklingRendererConfig
+from renderers.inkling import InklingRenderer
+from transformers import AutoTokenizer
+
+from rllm.trainer.sft import tinker_dataset as td
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--train-file", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--sample-count", type=int, default=20)
+    parser.add_argument("--tokenizer", default="thinkingmachines/Inkling-Small")
+    parser.add_argument("--max-length", type=int, default=262144)
+    parser.add_argument("--reasoning-effort", type=float, default=0.99)
+    args = parser.parse_args()
+    with args.train_file.open() as handle:
+        rows = [json.loads(line) for line in handle if line.strip()]
+    if not 1 <= args.sample_count <= len(rows):
+        parser.error(f"--sample-count must be between 1 and {len(rows)}")
+    indices = [0] if args.sample_count == 1 else [round(i * (len(rows) - 1) / (args.sample_count - 1)) for i in range(args.sample_count)]
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer, local_files_only=True)
+    renderer = InklingRenderer(tokenizer, InklingRendererConfig(reasoning_effort=args.reasoning_effort))
+    # Warm tokenizer/runtime initialization before timing either variant.
+    td.conversation_to_datum([{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}], renderer, args.max_length)
+    cache_renderer = td._preflight_renderer
+    records = []
+    totals = {"uncached": 0.0, "cached": 0.0}
+    for sample_index, row_index in enumerate(indices):
+        row = rows[row_index]
+        hashes = []
+        variants = [("uncached", lambda value: value), ("cached", cache_renderer)]
+        # Alternate first variant to limit systematic warm-up/order bias.
+        for variant, wrapper in variants[:: 1 if sample_index % 2 == 0 else -1]:
+            with patch.object(td, "_preflight_renderer", wrapper):
+                started = time.perf_counter()
+                datum = td.conversation_to_datum(row["messages"], renderer, args.max_length, tools=row.get("tools"), overlength_policy="error", validate_prefix_stability=True)
+                elapsed = time.perf_counter() - started
+            payload = {
+                "input_tokens": datum.model_input.to_ints(),
+                "targets": datum.loss_fn_inputs["target_tokens"].data,
+                "weights": datum.loss_fn_inputs["weights"].data,
+            }
+            digest = hashlib.sha256(json.dumps(payload).encode()).hexdigest()
+            hashes.append(digest)
+            totals[variant] += elapsed
+            record = {"variant": variant, "row_index": row_index, "input_tokens": datum.model_input.length, "seconds": elapsed, "datum_sha256": digest}
+            records.append(record)
+            print(json.dumps(record), flush=True)
+        if len(set(hashes)) != 1:
+            raise RuntimeError(f"Cache changed input tokens, targets, or loss weights for row {row_index}")
+    summary = {"rows_compared": len(indices), "seconds": totals, "speedup": totals["uncached"] / totals["cached"]}
+    result = {
+        "summary": summary,
+        "versions": {name: version(name) for name in ("renderers", "tinker", "tinker-cookbook", "transformers")},
+        "records": records,
+    }
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(summary), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/rllm/trainer/sft/tinker_dataset.py
+++ b/rllm/trainer/sft/tinker_dataset.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import math
+from copy import copy
+from functools import lru_cache
 from typing import Literal
 
 import datasets
@@ -18,6 +20,7 @@ import torch
 from tinker_cookbook.renderers import Message
 from tinker_cookbook.supervised.common import datum_from_model_input_weights
 from tinker_cookbook.supervised.types import SupervisedDataset
+from tqdm.auto import tqdm
 
 from rllm.data.sft_schema import SFTMessage, SFTSchemaError, normalize_messages
 from rllm.renderers.types import Renderer
@@ -92,6 +95,25 @@ def _validate_trainable_targets_represented(
             )
 
 
+def _preflight_renderer(renderer: Renderer) -> Renderer:
+    """Cache Inkling text encoding for one row's full/prefix renders.
+
+    Keep every render and comparison: only repeated, context-independent BPE
+    work is reused. A local shallow copy leaves the training renderer untouched
+    and releases the bounded cache after the row. Other renderer families and
+    subclasses retain the generic path; their encoding may depend on context.
+    """
+    try:
+        from renderers.inkling import InklingRenderer
+    except ImportError:
+        return renderer
+    if type(renderer) is not InklingRenderer:
+        return renderer
+    cached = copy(renderer)
+    cached._encode = lru_cache(maxsize=4096)(renderer._encode)
+    return cached
+
+
 def conversation_to_datum(
     conversation: list[Message],
     renderer: Renderer,
@@ -121,6 +143,8 @@ def conversation_to_datum(
         messages = normalize_messages(conversation, default_trainable=default_trainable)
         renderer_messages = [_to_renderer_message(message) for message in messages]
         renderer_tools = _validate_tools(tools)
+        if validate_prefix_stability:
+            renderer = _preflight_renderer(renderer)
         rendered = renderer.render(
             renderer_messages,
             tools=renderer_tools,
@@ -357,7 +381,7 @@ class TinkerSFTDataset(SupervisedDataset):
         """Render every dataset batch once."""
         if len(self) == 0:
             raise SFTConfigError(f"{label} preflight failed: dataset contains no batches.")
-        for batch_idx in range(len(self)):
+        for batch_idx in tqdm(range(len(self)), desc=f"{label} preflight", unit="batch", mininterval=1, disable=None):
             try:
                 if not self.get_batch(batch_idx, validate_prefix_stability=True):
                     raise SFTConfigError("rendered batch is empty")

--- a/tests/trainer/test_sft_inkling_cache.py
+++ b/tests/trainer/test_sft_inkling_cache.py
@@ -1,0 +1,122 @@
+"""Inkling preflight reuses BPE work without caching validation results."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+InklingRenderer = pytest.importorskip("renderers.inkling").InklingRenderer
+
+from rllm.trainer.sft import tinker_dataset as td  # noqa: E402
+from rllm.trainer.sft.backend import SFTConfigError  # noqa: E402
+
+
+class _Tokenizer:
+    """Offline character tokenizer; exercise the real Inkling renderer."""
+
+    unk_token_id = -1
+
+    def __init__(self):
+        self.specials = {}
+
+    def convert_tokens_to_ids(self, token):
+        return self.specials.setdefault(token, 1_000_000 + len(self.specials))
+
+    def encode(self, text, *, add_special_tokens):
+        assert add_special_tokens is False
+        return list(text.encode("utf-8"))
+
+
+@pytest.fixture
+def renderer():
+    return InklingRenderer(_Tokenizer())
+
+
+def _messages():
+    return [
+        {"role": "user", "content": "Inspect the files."},
+        {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "First inspect the directory."}],
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "bash", "arguments": '{"command":"ls"}'}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "one.py"},
+        {"role": "assistant", "content": [{"type": "thinking", "thinking": "There is one file."}, {"type": "text", "text": "Found one.py."}]},
+        {"role": "user", "content": "Confirm completion."},
+        {"role": "assistant", "content": "Done."},
+    ]
+
+
+@pytest.mark.parametrize("last_only", [False, True])
+@pytest.mark.parametrize("loss_reduction", ["none", "sequence_mean"])
+def test_preflight_preserves_datums_and_releases_cache_between_rows(renderer, monkeypatch, last_only, loss_reduction):
+    messages = _messages()
+    tools = [{"type": "function", "function": {"name": "bash", "parameters": {"type": "object", "properties": {"command": {"type": "string"}}}}}]
+    kwargs = {"last_only": last_only, "tools": tools, "loss_reduction": loss_reduction}
+    expected = td.conversation_to_datum(messages, renderer, 262144, **kwargs)
+    calls = Counter()
+    original = renderer._encode
+
+    def encode(text):
+        calls[text] += 1
+        return original(text)
+
+    monkeypatch.setattr(renderer, "_encode", encode)
+    for invocation in range(1, 3):
+        actual = td.conversation_to_datum(messages, renderer, 262144, validate_prefix_stability=True, **kwargs)
+        assert actual.model_input.to_ints() == expected.model_input.to_ints()
+        for field in ("target_tokens", "weights"):
+            assert actual.loss_fn_inputs[field].data == expected.loss_fn_inputs[field].data
+        assert set(calls.values()) == {invocation}, "each text is encoded once per row, with a fresh cache on the next call"
+        assert renderer._encode is encode, "the shared training renderer must remain untouched"
+
+
+@pytest.mark.parametrize("broken_prefix", [2, 4])
+def test_preflight_still_rejects_each_rewritten_prefix(renderer, monkeypatch, broken_prefix):
+    original = InklingRenderer.render
+    seen = []
+
+    def render(self, messages, **kwargs):
+        seen.append(len(messages))
+        rendered = original(self, messages, **kwargs)
+        if len(messages) == broken_prefix:
+            rendered.token_ids[0] += 1
+        return rendered
+
+    monkeypatch.setattr(InklingRenderer, "render", render)
+    with pytest.raises(SFTConfigError, match=f"rendered prefix through trainable message {broken_prefix - 1} is rewritten"):
+        td.conversation_to_datum(_messages(), renderer, 262144, validate_prefix_stability=True)
+    assert seen == [6, *range(2, broken_prefix + 1, 2)]
+
+
+def test_cache_uses_exact_text_and_evicts_beyond_its_bound(renderer, monkeypatch):
+    calls = Counter()
+    original = renderer._encode
+
+    def encode(text):
+        calls[text] += 1
+        return original(text)
+
+    monkeypatch.setattr(renderer, "_encode", encode)
+    cached = td._preflight_renderer(renderer)
+    assert cached._encode("same") == cached._encode("same")
+    assert cached._encode("same ") != cached._encode("same")
+    assert calls == {"same": 1, "same ": 1}
+    for index in range(4096):
+        cached._encode(str(index))
+    assert cached._encode.cache_info().currsize == 4096
+    cached._encode("same")
+    assert calls["same"] == 2
+    td._preflight_renderer(renderer)._encode("same")
+    assert calls["same"] == 3
+
+
+def test_other_renderers_and_inkling_subclasses_are_not_cached():
+    class ContextDependentInkling(InklingRenderer):
+        pass
+
+    for renderer in (object(), ContextDependentInkling(_Tokenizer())):
+        assert td._preflight_renderer(renderer) is renderer


### PR DESCRIPTION
## Summary

Long Inkling SFT trajectories repeatedly tokenize the same text while preflight renders the full conversation and each earlier trainable prefix. Cache those text encodings within one row while continuing to render and compare every prefix. On 20 real training rows, this reduced rendering time from **22.67 s to 1.86 s (12.2x)** with identical input tokens, target tokens, and loss weights for all 20 rows.

## Type of change

- [x] Fix / performance

## What changed

- During explicit prefix-stability preflight, shallow-copy an exact native `InklingRenderer` instance and wrap its context-independent `_encode(text)` in a 4,096-entry LRU cache. The cache is fresh for each row; the shared training renderer is not modified.
- Keep the generic path for other renderer families, Inkling subclasses, and installations without native Inkling support. Keep all rendering, attribution, masking, and prefix checks.
- Display batch progress on interactive terminals.
- Add offline regression tests and a standalone benchmark that compares cached/uncached datum hashes with a locally cached tokenizer.

## Validation

- [x] Targeted tests: `pytest tests/trainer/test_sft_inkling_cache.py tests/trainer/test_sft_preflight.py tests/trainer/test_sft_render_path.py tests/trainer/test_sft_data_semantics.py -q` — **40 passed**.
- [x] Regression evidence against base `a5fa9aa1`: the new suite had **6 failures / 2 passes** before the production patch and **8 passes** afterward. Tests cover reuse, row isolation, exact-text keys, LRU eviction, subclass exclusion, and rejection of both earlier rewritten prefixes.
- [x] Changed-file Ruff lint and format checks using the repository hook version **0.11.4**; `git diff --check`.
- [x] Real-token benchmark: 20 evenly spaced rows from a 370-row canonical JSONL dataset; 18,312–199,568 input tokens per row; every datum hash matched. Cached/uncached execution order alternates to reduce ordering bias. Timings exclude tokenizer loading.

Validation used `renderers==0.1.11`, `tinker==0.28.1`, `tinker-cookbook==0.5.7`, and `transformers==5.5.4`. Native Inkling tests skip when that renderer is unavailable. No provider training job was launched.

Reproduce with a canonical training JSONL and a locally cached Inkling tokenizer:

```bash
PYTHONPATH=. python cookbooks/terminal-rl/benchmark_inkling_preflight.py \
  --train-file /path/to/train.jsonl \
  --sample-count 20 \
  --output /tmp/inkling-preflight-comparison.json
```

## Breaking changes / migration notes

None. This PR targets `terminal-rl` and changes only the preflight cache/progress path, tests, and benchmark. Dependency pins, training recipes, dataset conversion, and checkpoint behavior are outside this change.

## Docs / examples

- [x] Added the standalone benchmark example above and in its module docstring.
